### PR TITLE
ops(evidence): add external supervisor proof scaffold for #3733

### DIFF
--- a/docs/evidence/evidence_harvester_host_resilience_tiers.md
+++ b/docs/evidence/evidence_harvester_host_resilience_tiers.md
@@ -1,0 +1,91 @@
+# Evidence Harvester Host-Resilience Tiers (#3733)
+
+Status: Phase 1 scaffold merged — **no Tier-1 runtime proof in this slice**.
+LR remains **NO-GO**. No Live-Go, no Echtgeld-Go.
+
+Parent issue [#3345](https://github.com/jannekbuengener/Claire_de_Binare/issues/3345)
+remains **OPEN** (`HOLD_3345_DAEMON_BRIDGE_EVIDENCE_OPEN`) until
+[#3733](https://github.com/jannekbuengener/Claire_de_Binare/issues/3733) delivers
+Tier-1 proof **or** an accepted formal requirement downgrade.
+
+Child [#3362](https://github.com/jannekbuengener/Claire_de_Binare/issues/3362) is
+**CLOSED** — Slice-E `>=72h` PASS proves in-process coordinator continuity only,
+not deployment-ready external auto-resume across all host events.
+
+## Tier model
+
+| Tier | Scenario | Phase 1 status | Proof requirement |
+|------|----------|----------------|-------------------|
+| **Tier 1** | Coordinator process killed during sleep window | Scaffold only | Controlled kill → external supervisor `RELAUNCH_RESUME` → `sleep_resumed` + continued cycles. Requires separate **Operator Runtime-GO**. |
+| **Tier 2** | Shell / IDE close while detached coordinator runs | Covered by Slice-E pattern | Documented; no new proof required in #3733 Phase 1. |
+| **Tier 3** | Host sleep / hibernate / reboot across evidence window | **Not proven** | Explicit limitation in Phase 1. Future path: Windows Task + boot readiness (#3733 Phase 2+ or separate Ops GO). |
+
+## Phase 1 deliverables (engineering scaffold)
+
+- `tools/evidence_harvester/supervisor.py`
+  - `coordinator_pid.json` record + PID liveness probe
+  - `supervision_state.json` durable poll/relaunch state
+  - `plan-external`, `supervise-external`, `record-coordinator-pid` CLI
+  - injectable subprocess resume launcher (fail-closed without `--explicit`)
+- `scripts/evidence_harvester_supervisor.ps1` — safe default `plan`; execution requires `-Explicit`
+- Unit tests under `tests/unit/tools/evidence_harvester/test_supervisor_external.py`
+
+## Artifact contracts
+
+### `coordinator_pid.json`
+
+Written by `record-coordinator-pid` or external launcher after coordinator spawn.
+
+| Field | Meaning |
+|-------|---------|
+| `schema_version` | `cdb.evidence_harvester.coordinator_pid.v1` |
+| `run_id` | Must match `runner_state.json` `run_id` |
+| `pid` | OS process id for liveness probe |
+| `recorded_at_utc` | UTC timestamp |
+
+Stale PID (`run_id` mismatch) is treated as dead for supervision decisions.
+
+### `supervision_state.json`
+
+Written during external supervision polls.
+
+| Field | Meaning |
+|-------|---------|
+| `schema_version` | `cdb.evidence_harvester.supervision_state.v1` |
+| `run_id` | Active run id |
+| `artifact_dir` | Absolute artifact directory |
+| `coordinator_pid` | Last known coordinator pid (nullable) |
+| `poll_count` | Completed wait polls |
+| `relaunch_count` | Resume relaunches performed |
+| `last_decision` | Latest `decide_supervision` payload |
+| `last_error` | Non-empty on stale PID or probe errors |
+| `updated_at_utc` | UTC timestamp |
+
+## Closure linkage
+
+### #3733 closes when
+
+- Tier-1 runtime proof artifacts exist under
+  `artifacts/evidence_harvester/host_resilience_proof/<run_id>/`, **or**
+- A formal downgrade ADR is merged and accepted by issue semantics.
+
+Phase 1 alone does **not** close #3733.
+
+### #3345 becomes closure-ready when
+
+- #3733 is **CLOSED** with proof or accepted downgrade, and
+- Parent reconcile criteria from PR #3734 remain satisfied.
+
+## Safety boundaries
+
+- Fixture/dry research only
+- No Windows Task install in Phase 1
+- No Docker / BLUE+RED / DB / MCP mutation
+- No new `>=72h` coordinator run
+- LR **NO-GO** unchanged
+
+## References
+
+- [`docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md`](../runbooks/CDB_EVIDENCE_HARVESTER_OPS.md)
+- [`tools/evidence_harvester/README.md`](../../tools/evidence_harvester/README.md)
+- Slice-E PASS: `artifacts/evidence_harvester/72h_ops_validation/slice-e-20260701T204615Z/`

--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -372,9 +372,42 @@ python -m tools.evidence_harvester.supervisor status ^
 `supervise` runs the poll/relaunch loop in-process and is fail-closed behind
 `--explicit` (without it, only the plan is printed). The loop is fully injectable
 (`launcher`, `process_alive_fn`, `now_fn`, `sleep_fn`) and bounded by
-`--max-relaunch-count` and optional `--max-polls`. Real external supervision
-(subprocess spawn / scheduled wake probe) remains a Slice-E operational wrapper
-that requires its own Runtime-GO.
+`--max-relaunch-count` and optional `--max-polls`.
+
+### External supervisor scaffold (#3733 Phase 1)
+
+Phase 1 adds out-of-process supervision **scaffold only** — no Tier-1 runtime
+proof in the merge slice. See
+[`docs/evidence/evidence_harvester_host_resilience_tiers.md`](../evidence/evidence_harvester_host_resilience_tiers.md).
+
+| Artifact / command | Purpose |
+|---|---|
+| `coordinator_pid.json` | PID record for injectable liveness probe |
+| `supervision_state.json` | Poll/relaunch durable state |
+| `plan-external` | Safe plan JSON (default) |
+| `supervise-external --explicit` | PID probe + subprocess resume launcher |
+| `record-coordinator-pid` | Write PID record after detached coordinator start |
+
+PowerShell wrapper (safe default `plan`):
+
+```powershell
+.\scripts\evidence_harvester_supervisor.ps1 -Action plan `
+    -ArtifactDir artifacts\evidence_harvester\72h_ops_validation\<run_id> `
+    -Fixture artifacts\evidence_harvester\24h_dry_run\collector_input.json `
+    -Iterations 293 -Pretty
+```
+
+Read-only status with PID probe:
+
+```powershell
+python -m tools.evidence_harvester.supervisor status `
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> `
+    --use-pid-probe --pretty
+```
+
+Execution (`supervise-external`) requires `--explicit` and a separate **Operator
+Runtime-GO**. LR remains **NO-GO**. #3345 stays **OPEN** until Tier-1 proof or
+accepted downgrade closes #3733.
 
 ## Safety Boundaries
 

--- a/scripts/evidence_harvester_supervisor.ps1
+++ b/scripts/evidence_harvester_supervisor.ps1
@@ -1,0 +1,97 @@
+param(
+    [ValidateSet('plan', 'status', 'supervise', 'record-pid')]
+    [string]$Action = 'plan',
+    [string]$ArtifactDir,
+    [string]$Fixture,
+    [int]$Iterations = 0,
+    [int]$CadenceSeconds = 900,
+    [int]$MaxRestartCount = 3,
+    [int]$RestartBackoffSeconds = 30,
+    [int]$MaxRelaunchCount = 5,
+    [int]$PollSeconds = 60,
+    [int]$MaxPolls = 0,
+    [int]$Pid = 0,
+    [string]$PythonExecutable = 'python',
+    [switch]$UsePidProbe,
+    [switch]$AssumeProcessAlive,
+    [switch]$Explicit,
+    [switch]$Pretty
+)
+
+$moduleArgs = @('-m', 'tools.evidence_harvester.supervisor')
+
+if ($Pretty) {
+    $moduleArgs += '--pretty'
+}
+
+switch ($Action) {
+    'plan' {
+        if (-not $ArtifactDir -or -not $Fixture -or $Iterations -le 0) {
+            throw 'plan requires -ArtifactDir, -Fixture, and -Iterations.'
+        }
+        $moduleArgs += @(
+            'plan-external',
+            '--artifact-dir', $ArtifactDir,
+            '--fixture', $Fixture,
+            '--iterations', $Iterations,
+            '--cadence-seconds', $CadenceSeconds,
+            '--max-restart-count', $MaxRestartCount,
+            '--restart-backoff-seconds', $RestartBackoffSeconds,
+            '--max-relaunch-count', $MaxRelaunchCount,
+            '--poll-seconds', $PollSeconds
+        )
+        if ($Explicit) {
+            $moduleArgs += '--explicit'
+        }
+    }
+    'status' {
+        if (-not $ArtifactDir) {
+            throw 'status requires -ArtifactDir.'
+        }
+        $moduleArgs += @('status', '--artifact-dir', $ArtifactDir)
+        if ($UsePidProbe) {
+            $moduleArgs += '--use-pid-probe'
+        }
+        if ($AssumeProcessAlive) {
+            $moduleArgs += '--assume-process-alive'
+        }
+        $moduleArgs += @('--max-relaunch-count', $MaxRelaunchCount)
+    }
+    'supervise' {
+        if (-not $ArtifactDir -or -not $Fixture -or $Iterations -le 0) {
+            throw 'supervise requires -ArtifactDir, -Fixture, and -Iterations.'
+        }
+        if (-not $Explicit) {
+            throw 'supervise requires -Explicit. Default mode remains plan-only.'
+        }
+        $moduleArgs += @(
+            'supervise-external',
+            '--artifact-dir', $ArtifactDir,
+            '--fixture', $Fixture,
+            '--iterations', $Iterations,
+            '--cadence-seconds', $CadenceSeconds,
+            '--max-restart-count', $MaxRestartCount,
+            '--restart-backoff-seconds', $RestartBackoffSeconds,
+            '--max-relaunch-count', $MaxRelaunchCount,
+            '--poll-seconds', $PollSeconds,
+            '--python-executable', $PythonExecutable,
+            '--explicit'
+        )
+        if ($MaxPolls -gt 0) {
+            $moduleArgs += @('--max-polls', $MaxPolls)
+        }
+    }
+    'record-pid' {
+        if (-not $ArtifactDir -or $Pid -le 0) {
+            throw 'record-pid requires -ArtifactDir and -Pid.'
+        }
+        $moduleArgs += @(
+            'record-coordinator-pid',
+            '--artifact-dir', $ArtifactDir,
+            '--pid', $Pid
+        )
+    }
+}
+
+& $PythonExecutable @moduleArgs
+exit $LASTEXITCODE

--- a/tests/unit/tools/evidence_harvester/test_boot.py
+++ b/tests/unit/tools/evidence_harvester/test_boot.py
@@ -171,7 +171,7 @@ def test_render_operator_handoff_includes_install_instructions(
     assert "Windows Task Scheduler" in output
     assert "Docker-based background runner" in output
     assert "Infra-Mutation-Gate" in output
-    assert "3362" in output
+    assert "3733" in output
     assert "No LR-Go" in output
 
 

--- a/tests/unit/tools/evidence_harvester/test_supervisor_external.py
+++ b/tests/unit/tools/evidence_harvester/test_supervisor_external.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.evidence_harvester.coordinator import CoordinatorSummary
+from tools.evidence_harvester.supervisor import (
+    COORDINATOR_PID_FILENAME,
+    SUPERVISION_STATE_FILENAME,
+    SUPERVISION_STATE_SCHEMA,
+    SupervisorError,
+    build_subprocess_resume_launcher,
+    main,
+    parse_args,
+    probe_process_alive,
+    read_coordinator_pid_record,
+    read_supervision_state,
+    resolve_coordinator_process_alive,
+    write_coordinator_pid_record,
+    write_supervision_state,
+)
+
+
+def _write_runner_state(artifact_dir: Path, *, run_id: str = "run-a") -> None:
+    payload = {
+        "schema_version": "cdb.evidence_harvester.runner_state.v1",
+        "run_id": run_id,
+        "total_cycles_completed": 1,
+        "coordinator_status": "sleeping",
+        "next_cycle_due_at_utc": "2026-06-30T11:00:00Z",
+    }
+    (artifact_dir / "runner_state.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+@pytest.mark.unit
+def test_probe_process_alive_uses_injected_probe() -> None:
+    assert probe_process_alive(42, probe_fn=lambda pid: pid == 42) is True
+    assert probe_process_alive(42, probe_fn=lambda pid: pid == 99) is False
+
+
+@pytest.mark.unit
+def test_probe_process_alive_rejects_non_positive_pid() -> None:
+    assert probe_process_alive(0) is False
+    assert probe_process_alive(-1) is False
+
+
+@pytest.mark.unit
+def test_write_and_read_coordinator_pid_record(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    record = write_coordinator_pid_record(
+        artifact_dir, pid=12345, run_id="run-a", recorded_at_utc="2026-07-05T10:00:00Z"
+    )
+    assert record.pid == 12345
+    assert read_coordinator_pid_record(artifact_dir) == record
+    assert (artifact_dir / COORDINATOR_PID_FILENAME).exists()
+
+
+@pytest.mark.unit
+def test_write_coordinator_pid_record_rejects_invalid_pid(tmp_path: Path) -> None:
+    with pytest.raises(SupervisorError):
+        write_coordinator_pid_record(tmp_path, pid=0, run_id="run-a")
+
+
+@pytest.mark.unit
+def test_resolve_process_alive_missing_pid_record(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    alive, reason = resolve_coordinator_process_alive(artifact_dir)
+    assert alive is False
+    assert reason == "missing_coordinator_pid_record"
+
+
+@pytest.mark.unit
+def test_resolve_process_alive_stale_run_id(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_runner_state(artifact_dir, run_id="run-a")
+    write_coordinator_pid_record(artifact_dir, pid=100, run_id="run-b")
+    alive, reason = resolve_coordinator_process_alive(
+        artifact_dir, probe_fn=lambda pid: True
+    )
+    assert alive is False
+    assert reason == "stale_coordinator_pid_run_id_mismatch"
+
+
+@pytest.mark.unit
+def test_resolve_process_alive_dead_pid(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_runner_state(artifact_dir)
+    write_coordinator_pid_record(artifact_dir, pid=100, run_id="run-a")
+    alive, reason = resolve_coordinator_process_alive(
+        artifact_dir, probe_fn=lambda pid: False
+    )
+    assert alive is False
+    assert reason == "coordinator_pid_not_alive"
+
+
+@pytest.mark.unit
+def test_resolve_process_alive_live_pid(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_runner_state(artifact_dir)
+    write_coordinator_pid_record(artifact_dir, pid=100, run_id="run-a")
+    alive, reason = resolve_coordinator_process_alive(
+        artifact_dir, probe_fn=lambda pid: True
+    )
+    assert alive is True
+    assert reason == "coordinator_pid_alive"
+
+
+@pytest.mark.unit
+def test_supervision_state_contract(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    record = write_supervision_state(
+        artifact_dir,
+        run_id="run-a",
+        coordinator_pid=100,
+        poll_count=2,
+        relaunch_count=1,
+        last_decision={"action": "WAIT", "reason": "coordinator process alive"},
+        last_error="",
+        updated_at_utc="2026-07-05T10:00:00Z",
+    )
+    assert record.schema_version == SUPERVISION_STATE_SCHEMA
+    loaded = read_supervision_state(artifact_dir)
+    assert loaded == record
+    assert (artifact_dir / SUPERVISION_STATE_FILENAME).exists()
+
+
+@pytest.mark.unit
+def test_build_subprocess_resume_launcher_uses_injected_popen(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_runner_state(artifact_dir)
+    mock_proc = MagicMock()
+    mock_proc.pid = 4242
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd: list[str], **kwargs: object) -> MagicMock:
+        popen_calls.append(cmd)
+        return mock_proc
+
+    launcher = build_subprocess_resume_launcher(
+        repo_root=tmp_path,
+        fixture_path=tmp_path / "fixture.json",
+        artifact_dir=artifact_dir,
+        iterations=10,
+        cadence_seconds=900,
+        max_restart_count=3,
+        restart_backoff_seconds=30,
+        popen_fn=fake_popen,
+    )
+    summary = launcher()
+    assert summary.status == "LAUNCHED"
+    assert popen_calls
+    assert "resume-fixture-window" in popen_calls[0]
+    pid_record = read_coordinator_pid_record(artifact_dir)
+    assert pid_record is not None
+    assert pid_record.pid == 4242
+
+
+@pytest.mark.unit
+def test_supervise_external_without_explicit_prints_plan(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text("{}", encoding="utf-8")
+    exit_code = main(
+        [
+            "supervise-external",
+            "--artifact-dir",
+            str(tmp_path / "run"),
+            "--fixture",
+            str(fixture),
+            "--iterations",
+            "10",
+        ]
+    )
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert exit_code == 0
+    assert payload["status"] == "planned"
+    assert payload["explicit"] is False
+
+
+@pytest.mark.unit
+def test_plan_external_default_is_safe_plan(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text("{}", encoding="utf-8")
+    exit_code = main(
+        [
+            "--pretty",
+            "plan-external",
+            "--artifact-dir",
+            str(tmp_path / "run"),
+            "--fixture",
+            str(fixture),
+            "--iterations",
+            "10",
+        ]
+    )
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert exit_code == 0
+    assert payload["status"] == "planned"
+    assert payload["mode"] == "supervise-external"
+
+
+@pytest.mark.unit
+def test_parse_args_supervise_external_requires_explicit_by_default() -> None:
+    args = parse_args(
+        [
+            "supervise-external",
+            "--artifact-dir",
+            "runs/x",
+            "--fixture",
+            "f.json",
+            "--iterations",
+            "288",
+        ]
+    )
+    assert args.command == "supervise-external"
+    assert args.explicit is False
+
+
+@pytest.mark.unit
+def test_record_coordinator_pid_requires_runner_state(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    with pytest.raises(SupervisorError):
+        main(
+            [
+                "record-coordinator-pid",
+                "--artifact-dir",
+                str(artifact_dir),
+                "--pid",
+                "1234",
+            ]
+        )
+
+
+@pytest.mark.unit
+def test_record_coordinator_pid_writes_record(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_runner_state(artifact_dir)
+    exit_code = main(
+        [
+            "record-coordinator-pid",
+            "--artifact-dir",
+            str(artifact_dir),
+            "--pid",
+            "1234",
+        ]
+    )
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert exit_code == 0
+    assert payload["record"]["pid"] == 1234
+    assert read_coordinator_pid_record(artifact_dir) is not None

--- a/tools/evidence_harvester/README.md
+++ b/tools/evidence_harvester/README.md
@@ -581,13 +581,43 @@ pwsh -NoProfile -File .\scripts\evidence_harvester_boot.ps1 -Action status -Pret
 - No Docker start/stop, runtime start, DB mutation, secrets access, or network write
 - `install-plan` prints steps but does not execute them
 - Docker mutation requires separate Infra-Mutation-Gate approval
-- Windows Task install requires separate GO (see #3362 OPS validation)
+- Windows Task install requires separate GO (see #3733 Operator Runtime-GO)
 - No LR-Go, no Live-Go, no Echtgeld-Go
 
 ### Related issues
 
 - #3360 — boot readiness (this module)
-- #3362 — OPS validation (Windows Task installation and Docker enablement)
+- #3362 — OPS validation (`>=72h` dry proof; CLOSED via Slice-E PASS)
+- #3733 — external supervisor scaffold + host-resilience tiers (OPEN)
+
+## External Supervisor Scaffold (#3733 Phase 1)
+
+Out-of-process supervision for sleep-stall recovery. Phase 1 is **scaffold +
+tests + docs only** — Tier-1 runtime proof requires a separate Operator
+Runtime-GO. LR remains **NO-GO**. #3345 stays **OPEN** until #3733 closes.
+
+Tier model:
+[`docs/evidence/evidence_harvester_host_resilience_tiers.md`](../docs/evidence/evidence_harvester_host_resilience_tiers.md)
+
+Safe plan (default):
+
+```powershell
+.\scripts\evidence_harvester_supervisor.ps1 -Action plan `
+    -ArtifactDir artifacts\evidence_harvester\72h_ops_validation\<run_id> `
+    -Fixture artifacts\evidence_harvester\24h_dry_run\collector_input.json `
+    -Iterations 293 -Pretty
+```
+
+Read-only status with PID probe:
+
+```powershell
+python -m tools.evidence_harvester.supervisor status `
+    --artifact-dir artifacts\evidence_harvester\72h_ops_validation\<run_id> `
+    --use-pid-probe --pretty
+```
+
+Execution requires `-Explicit` on the PowerShell wrapper or `--explicit` on
+`supervise-external`. No Windows Task install in Phase 1.
 
 ## Future-gated live reads
 

--- a/tools/evidence_harvester/boot.py
+++ b/tools/evidence_harvester/boot.py
@@ -270,7 +270,7 @@ def _check_scheduler_script(
                     check_id="B004",
                     check_name=f"Scheduler script missing: {rel_path}",
                     severity="warn",
-                    message=f"Script not found: {resolved}. Install via 3362 OPS validation.",
+                    message=f"Script not found: {resolved}. Install via #3733 / Operator Runtime-GO.",
                     artifact=rel_path,
                 )
             )
@@ -576,7 +576,7 @@ def _render_operator_handoff_md(report: BootReadinessReport) -> str:
         "   python -m tools.evidence_harvester.boot status --pretty",
         "   ```",
         "",
-        "2. **Install Windows Task Scheduler** (requires 3362 OPS validation GO):",
+        "2. **Install Windows Task Scheduler** (requires #3733 / Operator Runtime-GO):",
         "",
         "   ```powershell",
         "   python -m tools.evidence_harvester.scheduler install --fixture <path> --explicit",
@@ -587,7 +587,7 @@ def _render_operator_handoff_md(report: BootReadinessReport) -> str:
         "   - Verify `docker_available` is True in boot readiness.",
         "   - Use `boot install-plan` to see the full command surface before any Docker action.",
         "   - Do not start Docker stack from the boot module — Docker mutation requires explicit",
-        "     Infra-Mutation-Gate approval (see #3362 OPS validation runbook).",
+        "     Infra-Mutation-Gate approval (see #3733 host-resilience tiers doc).",
         "",
         "4. **Verify scheduled task runs**:",
         "",
@@ -604,7 +604,7 @@ def _render_operator_handoff_md(report: BootReadinessReport) -> str:
         "",
         "## Reboot-Resilience",
         "",
-        "After the Windows Task is installed (3362), the task survives reboots automatically:",
+        "After the Windows Task is installed (#3733 / Operator Runtime-GO), the task survives reboots automatically:",
         "- Windows Task Scheduler starts the harvester daily at the configured time.",
         "- The boot module can be run at any time to verify readiness post-reboot.",
         "- If Docker is used instead, a Docker restart policy or Windows scheduled task",
@@ -813,7 +813,7 @@ def _build_install_plan_payload(
             {
                 "step": "install-windows-task",
                 "command": "python -m tools.evidence_harvester.scheduler install --fixture <path> --explicit",
-                "requires_go": "3362 OPS_VALIDATION",
+                "requires_go": "#3733 Operator Runtime-GO",
             },
             {
                 "step": "start-docker-stack",
@@ -824,7 +824,7 @@ def _build_install_plan_payload(
         "safety": [
             "Plan-only. No action taken.",
             "No Docker/runtime/DB/secrets mutation.",
-            "Each step requires its own GO gate (3362 OPS_VALIDATION, Infra-Mutation-Gate).",
+            "Each step requires its own GO gate (#3733 Operator Runtime-GO, Infra-Mutation-Gate).",
             "No LR-Go / No Live-Go / No Echtgeld-Go.",
         ],
     }

--- a/tools/evidence_harvester/supervisor.py
+++ b/tools/evidence_harvester/supervisor.py
@@ -11,6 +11,11 @@ without spawning any process, installing an OS scheduler, or touching Docker /
 DB / Redis / secrets. The CLI ``supervise`` path is fail-closed behind
 ``--explicit``; the read-only ``status`` path never mutates anything.
 
+Phase 1 (#3733) adds an external out-of-process scaffold: PID record/probe,
+``supervision_state.json``, subprocess resume launcher, and
+``supervise-external`` / ``plan-external`` commands. Runtime proof remains a
+separate Operator Runtime-GO slice.
+
 Boundaries: dry/fixture research only. LR NO-GO. No Live-Go, no Echtgeld-Go.
 """
 
@@ -18,6 +23,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
+import sys
 import time
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -38,6 +46,10 @@ from .coordinator import (
 from .runner import RunnerState
 
 SUPERVISION_SCHEMA = "cdb.evidence_harvester.supervision.v1"
+COORDINATOR_PID_SCHEMA = "cdb.evidence_harvester.coordinator_pid.v1"
+SUPERVISION_STATE_SCHEMA = "cdb.evidence_harvester.supervision_state.v1"
+COORDINATOR_PID_FILENAME = "coordinator_pid.json"
+SUPERVISION_STATE_FILENAME = "supervision_state.json"
 
 DEFAULT_MAX_RELAUNCH_COUNT = 5
 DEFAULT_POLL_SECONDS = 60
@@ -53,6 +65,36 @@ _TERMINAL_STATUSES = frozenset({"failed", "fatal_stop"})
 
 class SupervisorError(ValueError):
     pass
+
+
+ProcessAliveProbe = Callable[[int], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class CoordinatorPidRecord:
+    schema_version: str
+    run_id: str
+    pid: int
+    recorded_at_utc: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class SupervisionStateRecord:
+    schema_version: str
+    run_id: str
+    artifact_dir: str
+    coordinator_pid: int | None
+    poll_count: int
+    relaunch_count: int
+    last_decision: dict[str, Any]
+    last_error: str
+    updated_at_utc: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,6 +140,144 @@ def _parse_ts(value: str) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=UTC)
     return parsed.astimezone(UTC)
+
+
+def default_process_alive_probe(pid: int) -> bool:
+    """Return True when ``pid`` appears to be a live OS process."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def probe_process_alive(
+    pid: int,
+    *,
+    probe_fn: ProcessAliveProbe | None = None,
+) -> bool:
+    probe = probe_fn or default_process_alive_probe
+    return probe(pid)
+
+
+def _coordinator_pid_path(artifact_dir: Path) -> Path:
+    return artifact_dir / COORDINATOR_PID_FILENAME
+
+
+def _supervision_state_path(artifact_dir: Path) -> Path:
+    return artifact_dir / SUPERVISION_STATE_FILENAME
+
+
+def read_coordinator_pid_record(artifact_dir: Path) -> CoordinatorPidRecord | None:
+    path = _coordinator_pid_path(artifact_dir)
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return CoordinatorPidRecord(
+        schema_version=str(payload.get("schema_version", "")),
+        run_id=str(payload.get("run_id", "")),
+        pid=int(payload["pid"]),
+        recorded_at_utc=str(payload.get("recorded_at_utc", "")),
+    )
+
+
+def write_coordinator_pid_record(
+    artifact_dir: Path,
+    *,
+    pid: int,
+    run_id: str,
+    recorded_at_utc: str | None = None,
+) -> CoordinatorPidRecord:
+    if pid <= 0:
+        raise SupervisorError("coordinator pid must be positive")
+    record = CoordinatorPidRecord(
+        schema_version=COORDINATOR_PID_SCHEMA,
+        run_id=run_id,
+        pid=pid,
+        recorded_at_utc=recorded_at_utc
+        or _now_utc().isoformat().replace("+00:00", "Z"),
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    _coordinator_pid_path(artifact_dir).write_text(
+        json.dumps(record.to_dict(), sort_keys=True, ensure_ascii=True),
+        encoding="utf-8",
+    )
+    return record
+
+
+def read_supervision_state(artifact_dir: Path) -> SupervisionStateRecord | None:
+    path = _supervision_state_path(artifact_dir)
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    coordinator_pid = payload.get("coordinator_pid")
+    return SupervisionStateRecord(
+        schema_version=str(payload.get("schema_version", "")),
+        run_id=str(payload.get("run_id", "")),
+        artifact_dir=str(payload.get("artifact_dir", "")),
+        coordinator_pid=(int(coordinator_pid) if coordinator_pid is not None else None),
+        poll_count=int(payload.get("poll_count", 0)),
+        relaunch_count=int(payload.get("relaunch_count", 0)),
+        last_decision=dict(payload.get("last_decision", {})),
+        last_error=str(payload.get("last_error", "")),
+        updated_at_utc=str(payload.get("updated_at_utc", "")),
+    )
+
+
+def write_supervision_state(
+    artifact_dir: Path,
+    *,
+    run_id: str,
+    coordinator_pid: int | None,
+    poll_count: int,
+    relaunch_count: int,
+    last_decision: Mapping[str, Any],
+    last_error: str = "",
+    updated_at_utc: str | None = None,
+) -> SupervisionStateRecord:
+    record = SupervisionStateRecord(
+        schema_version=SUPERVISION_STATE_SCHEMA,
+        run_id=run_id,
+        artifact_dir=str(artifact_dir.resolve()),
+        coordinator_pid=coordinator_pid,
+        poll_count=poll_count,
+        relaunch_count=relaunch_count,
+        last_decision=dict(last_decision),
+        last_error=last_error,
+        updated_at_utc=updated_at_utc or _now_utc().isoformat().replace("+00:00", "Z"),
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    _supervision_state_path(artifact_dir).write_text(
+        json.dumps(record.to_dict(), sort_keys=True, ensure_ascii=True),
+        encoding="utf-8",
+    )
+    return record
+
+
+def resolve_coordinator_process_alive(
+    artifact_dir: Path,
+    *,
+    probe_fn: ProcessAliveProbe | None = None,
+    assume_process_alive: bool | None = None,
+) -> tuple[bool, str]:
+    """Resolve coordinator liveness from explicit assumption or PID record."""
+    if assume_process_alive is not None:
+        return assume_process_alive, "assumed_process_alive"
+
+    pid_record = read_coordinator_pid_record(artifact_dir)
+    if pid_record is None:
+        return False, "missing_coordinator_pid_record"
+
+    state = _read_runner_state(artifact_dir)
+    if state is not None and pid_record.run_id and pid_record.run_id != state.run_id:
+        return False, "stale_coordinator_pid_run_id_mismatch"
+
+    alive = probe_process_alive(pid_record.pid, probe_fn=probe_fn)
+    if alive:
+        return True, "coordinator_pid_alive"
+    return False, "coordinator_pid_not_alive"
 
 
 def decide_supervision(
@@ -190,6 +370,8 @@ def supervise_loop(
     poll_seconds: int = DEFAULT_POLL_SECONDS,
     max_relaunch_count: int = DEFAULT_MAX_RELAUNCH_COUNT,
     max_polls: int | None = None,
+    initial_relaunch_count: int = 0,
+    on_poll: Callable[[SupervisionDecision, int, int], None] | None = None,
 ) -> SupervisionResult:
     """Poll durable state and relaunch the coordinator in resume mode on stall.
 
@@ -201,8 +383,10 @@ def supervise_loop(
         raise SupervisorError("poll_seconds must be >= 0")
     if max_relaunch_count < 0:
         raise SupervisorError("max_relaunch_count must be >= 0")
+    if initial_relaunch_count < 0:
+        raise SupervisorError("initial_relaunch_count must be >= 0")
 
-    relaunch_count = 0
+    relaunch_count = initial_relaunch_count
     polls = 0
     decisions: list[dict[str, Any]] = []
 
@@ -218,21 +402,38 @@ def supervise_loop(
             max_relaunch_count,
         )
         decisions.append(decision.to_dict())
+        if on_poll is not None:
+            on_poll(decision, polls, relaunch_count)
 
         if decision.action == ACTION_DONE:
             return _build_result(
-                "DONE", artifact_dir, relaunch_count,
-                max_relaunch_count, polls, decisions, state,
+                "DONE",
+                artifact_dir,
+                relaunch_count,
+                max_relaunch_count,
+                polls,
+                decisions,
+                state,
             )
         if decision.action == ACTION_STOP_FATAL:
             return _build_result(
-                "STOP_FATAL", artifact_dir, relaunch_count,
-                max_relaunch_count, polls, decisions, state,
+                "STOP_FATAL",
+                artifact_dir,
+                relaunch_count,
+                max_relaunch_count,
+                polls,
+                decisions,
+                state,
             )
         if decision.action == ACTION_STOP_LIMIT:
             return _build_result(
-                "STOP_LIMIT", artifact_dir, relaunch_count,
-                max_relaunch_count, polls, decisions, state,
+                "STOP_LIMIT",
+                artifact_dir,
+                relaunch_count,
+                max_relaunch_count,
+                polls,
+                decisions,
+                state,
             )
         if decision.action == ACTION_RELAUNCH_RESUME:
             relaunch_count += 1
@@ -242,8 +443,13 @@ def supervise_loop(
         polls += 1
         if max_polls is not None and polls >= max_polls:
             return _build_result(
-                "WAIT_TIMEOUT", artifact_dir, relaunch_count,
-                max_relaunch_count, polls, decisions, state,
+                "WAIT_TIMEOUT",
+                artifact_dir,
+                relaunch_count,
+                max_relaunch_count,
+                polls,
+                decisions,
+                state,
             )
         if poll_seconds:
             sleep_fn(poll_seconds)
@@ -274,6 +480,123 @@ def _resume_launcher(
     return _launch
 
 
+def build_subprocess_resume_launcher(
+    *,
+    repo_root: Path,
+    fixture_path: Path,
+    artifact_dir: Path,
+    iterations: int,
+    cadence_seconds: int,
+    max_restart_count: int,
+    restart_backoff_seconds: int,
+    python_executable: str | None = None,
+    popen_fn: Callable[..., Any] | None = None,
+    write_pid: bool = True,
+) -> Callable[[], CoordinatorSummary]:
+    """Spawn ``resume-fixture-window`` as a detached subprocess resume launcher."""
+
+    def _launch() -> CoordinatorSummary:
+        executable = python_executable or sys.executable
+        cmd = [
+            executable,
+            "-m",
+            "tools.evidence_harvester.coordinator",
+            "resume-fixture-window",
+            "--fixture",
+            str(fixture_path),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--iterations",
+            str(iterations),
+            "--cadence-seconds",
+            str(cadence_seconds),
+            "--max-restart-count",
+            str(max_restart_count),
+            "--restart-backoff-seconds",
+            str(restart_backoff_seconds),
+        ]
+        popen = popen_fn or subprocess.Popen
+        proc = popen(
+            cmd,
+            cwd=str(repo_root),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        state = _read_runner_state(artifact_dir)
+        run_id = state.run_id if state is not None else artifact_dir.name
+        if write_pid:
+            write_coordinator_pid_record(artifact_dir, pid=proc.pid, run_id=run_id)
+        return CoordinatorSummary(
+            status="LAUNCHED",
+            artifact_dir=str(artifact_dir),
+            completed_cycles=state.total_cycles_completed if state else 0,
+            recovery_events_written=0,
+            restart_count=0,
+            max_restart_count=max_restart_count,
+            final_validation_started=False,
+            stop_reason="external_subprocess_resume_launch",
+        )
+
+    return _launch
+
+
+def _external_supervision_plan(
+    *,
+    artifact_dir: Path,
+    fixture_path: Path,
+    iterations: int,
+    cadence_seconds: int,
+    max_restart_count: int,
+    restart_backoff_seconds: int,
+    max_relaunch_count: int,
+    poll_seconds: int,
+    explicit: bool,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SUPERVISION_SCHEMA,
+        "mode": "supervise-external",
+        "artifact_dir": str(artifact_dir),
+        "fixture": str(fixture_path),
+        "iterations": iterations,
+        "cadence_seconds": cadence_seconds,
+        "max_restart_count": max_restart_count,
+        "restart_backoff_seconds": restart_backoff_seconds,
+        "max_relaunch_count": max_relaunch_count,
+        "poll_seconds": poll_seconds,
+        "explicit": explicit,
+        "pid_record_path": str(_coordinator_pid_path(artifact_dir)),
+        "supervision_state_path": str(_supervision_state_path(artifact_dir)),
+        "safety": "dry/fixture only; LR NO-GO; no Live-Go; no Echtgeld-Go",
+    }
+
+
+def _make_supervision_state_writer(
+    artifact_dir: Path,
+) -> Callable[[SupervisionDecision, int, int], None]:
+    def _write(decision: SupervisionDecision, polls: int, relaunch_count: int) -> None:
+        state = _read_runner_state(artifact_dir)
+        pid_record = read_coordinator_pid_record(artifact_dir)
+        run_id = state.run_id if state is not None else artifact_dir.name
+        pid = pid_record.pid if pid_record is not None else None
+        _, liveness_reason = resolve_coordinator_process_alive(artifact_dir)
+        last_error = (
+            liveness_reason
+            if liveness_reason == "stale_coordinator_pid_run_id_mismatch"
+            else ""
+        )
+        write_supervision_state(
+            artifact_dir,
+            run_id=run_id,
+            coordinator_pid=pid,
+            poll_count=polls,
+            relaunch_count=relaunch_count,
+            last_decision=decision.to_dict(),
+            last_error=last_error,
+        )
+
+    return _write
+
+
 def _format_json(payload: Mapping[str, Any], pretty: bool) -> str:
     return json.dumps(
         payload,
@@ -291,24 +614,135 @@ def _cmd_status(args: argparse.Namespace) -> int:
     artifact_dir = args.artifact_dir.resolve()
     state = _read_runner_state(artifact_dir)
     events = _read_coordinator_events(artifact_dir)
-    process_alive = bool(args.assume_process_alive)
+    if args.use_pid_probe:
+        process_alive, liveness_reason = resolve_coordinator_process_alive(artifact_dir)
+        assumed_process_alive = None
+    else:
+        process_alive = bool(args.assume_process_alive)
+        liveness_reason = "assumed_process_alive"
+        assumed_process_alive = process_alive
+    persisted = read_supervision_state(artifact_dir)
     decision = decide_supervision(
         state,
         events,
         _now_utc(),
         process_alive,
-        relaunch_count=0,
+        relaunch_count=(persisted.relaunch_count if persisted is not None else 0),
         max_relaunch_count=args.max_relaunch_count,
     )
     payload = {
         "schema_version": SUPERVISION_SCHEMA,
         "mode": "status",
         "artifact_dir": str(artifact_dir),
-        "assumed_process_alive": process_alive,
+        "use_pid_probe": bool(args.use_pid_probe),
+        "assumed_process_alive": assumed_process_alive,
+        "liveness_reason": liveness_reason,
+        "supervision_state": (persisted.to_dict() if persisted is not None else None),
         "decision": decision.to_dict(),
     }
     _emit(payload, args.pretty)
     return 0
+
+
+def _cmd_plan_external(args: argparse.Namespace) -> int:
+    artifact_dir = args.artifact_dir.resolve()
+    fixture_path = args.fixture.resolve()
+    plan = _external_supervision_plan(
+        artifact_dir=artifact_dir,
+        fixture_path=fixture_path,
+        iterations=args.iterations,
+        cadence_seconds=args.cadence_seconds,
+        max_restart_count=args.max_restart_count,
+        restart_backoff_seconds=args.restart_backoff_seconds,
+        max_relaunch_count=args.max_relaunch_count,
+        poll_seconds=args.poll_seconds,
+        explicit=bool(args.explicit),
+    )
+    plan["status"] = "planned"
+    plan["note"] = (
+        "External out-of-process supervision scaffold (#3733). Re-run "
+        "supervise-external with --explicit only under Operator Runtime-GO."
+    )
+    _emit(plan, args.pretty)
+    return 0
+
+
+def _cmd_record_coordinator_pid(args: argparse.Namespace) -> int:
+    artifact_dir = args.artifact_dir.resolve()
+    state = _read_runner_state(artifact_dir)
+    if state is None:
+        raise SupervisorError(
+            "record-coordinator-pid requires runner_state.json in artifact dir"
+        )
+    record = write_coordinator_pid_record(
+        artifact_dir,
+        pid=args.pid,
+        run_id=state.run_id,
+        recorded_at_utc=args.recorded_at_utc,
+    )
+    payload = {
+        "schema_version": SUPERVISION_SCHEMA,
+        "mode": "record-coordinator-pid",
+        "record": record.to_dict(),
+    }
+    _emit(payload, args.pretty)
+    return 0
+
+
+def _cmd_supervise_external(args: argparse.Namespace) -> int:
+    artifact_dir = args.artifact_dir.resolve()
+    fixture_path = args.fixture.resolve()
+    plan = _external_supervision_plan(
+        artifact_dir=artifact_dir,
+        fixture_path=fixture_path,
+        iterations=args.iterations,
+        cadence_seconds=args.cadence_seconds,
+        max_restart_count=args.max_restart_count,
+        restart_backoff_seconds=args.restart_backoff_seconds,
+        max_relaunch_count=args.max_relaunch_count,
+        poll_seconds=args.poll_seconds,
+        explicit=bool(args.explicit),
+    )
+    if not args.explicit:
+        plan["status"] = "planned"
+        plan["note"] = "Re-run with --explicit to execute external supervision."
+        _emit(plan, args.pretty)
+        return 0
+
+    if not fixture_path.exists():
+        raise SupervisorError(f"fixture path does not exist: {fixture_path}")
+    if _read_runner_state(artifact_dir) is None:
+        raise SupervisorError(
+            "supervise-external --explicit requires an existing run to resume"
+        )
+
+    persisted = read_supervision_state(artifact_dir)
+    launcher = build_subprocess_resume_launcher(
+        repo_root=_repo_root(),
+        fixture_path=fixture_path,
+        artifact_dir=artifact_dir,
+        iterations=args.iterations,
+        cadence_seconds=args.cadence_seconds,
+        max_restart_count=args.max_restart_count,
+        restart_backoff_seconds=args.restart_backoff_seconds,
+        python_executable=args.python_executable,
+    )
+    result = supervise_loop(
+        artifact_dir=artifact_dir,
+        launcher=launcher,
+        process_alive_fn=lambda: resolve_coordinator_process_alive(artifact_dir)[0],
+        poll_seconds=args.poll_seconds,
+        max_relaunch_count=args.max_relaunch_count,
+        max_polls=args.max_polls,
+        initial_relaunch_count=(
+            persisted.relaunch_count if persisted is not None else 0
+        ),
+        on_poll=_make_supervision_state_writer(artifact_dir),
+    )
+    payload = result.to_dict()
+    payload["mode"] = "supervise-external"
+    _emit(payload, args.pretty)
+    return 0 if result.status in ("DONE", "WAIT_TIMEOUT") else 1
 
 
 def _cmd_supervise(args: argparse.Namespace) -> int:
@@ -328,7 +762,9 @@ def _cmd_supervise(args: argparse.Namespace) -> int:
     }
     if not args.explicit:
         plan["status"] = "planned"
-        plan["note"] = "Re-run with --explicit to execute in-process resume supervision."
+        plan["note"] = (
+            "Re-run with --explicit to execute in-process resume supervision."
+        )
         _emit(plan, args.pretty)
         return 0
 
@@ -361,6 +797,26 @@ def _cmd_supervise(args: argparse.Namespace) -> int:
     return 0 if result.status in ("DONE", "WAIT_TIMEOUT") else 1
 
 
+def _add_external_supervision_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--artifact-dir", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--iterations", type=int, required=True)
+    parser.add_argument("--cadence-seconds", type=int, default=DEFAULT_CADENCE_SECONDS)
+    parser.add_argument(
+        "--max-restart-count", type=int, default=DEFAULT_MAX_RESTART_COUNT
+    )
+    parser.add_argument(
+        "--restart-backoff-seconds",
+        type=int,
+        default=DEFAULT_RESTART_BACKOFF_SECONDS,
+    )
+    parser.add_argument(
+        "--max-relaunch-count", type=int, default=DEFAULT_MAX_RELAUNCH_COUNT
+    )
+    parser.add_argument("--poll-seconds", type=int, default=DEFAULT_POLL_SECONDS)
+    parser.add_argument("--max-polls", type=int, default=None)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
@@ -386,6 +842,50 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-relaunch-count",
         type=int,
         default=DEFAULT_MAX_RELAUNCH_COUNT,
+    )
+    status_parser.add_argument(
+        "--use-pid-probe",
+        action="store_true",
+        help="Resolve coordinator liveness from coordinator_pid.json.",
+    )
+
+    plan_external_parser = subparsers.add_parser(
+        "plan-external",
+        help="Safe plan for external out-of-process supervision (#3733).",
+    )
+    _add_external_supervision_args(plan_external_parser)
+    plan_external_parser.add_argument(
+        "--explicit",
+        action="store_true",
+        help="Echo explicit flag in plan payload only; does not execute.",
+    )
+
+    record_pid_parser = subparsers.add_parser(
+        "record-coordinator-pid",
+        help="Record coordinator PID for external liveness probing.",
+    )
+    record_pid_parser.add_argument("--artifact-dir", type=Path, required=True)
+    record_pid_parser.add_argument("--pid", type=int, required=True)
+    record_pid_parser.add_argument("--recorded-at-utc", type=str, default=None)
+
+    external_parser = subparsers.add_parser(
+        "supervise-external",
+        help=(
+            "Out-of-process supervision with PID probe and subprocess resume "
+            "(fail-closed behind --explicit)."
+        ),
+    )
+    _add_external_supervision_args(external_parser)
+    external_parser.add_argument(
+        "--python-executable",
+        type=str,
+        default=None,
+        help="Python executable for detached resume subprocess.",
+    )
+    external_parser.add_argument(
+        "--explicit",
+        action="store_true",
+        help="Required to execute external supervision.",
     )
 
     supervise_parser = subparsers.add_parser(
@@ -428,6 +928,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.command == "status":
         return _cmd_status(args)
+    if args.command == "plan-external":
+        return _cmd_plan_external(args)
+    if args.command == "record-coordinator-pid":
+        return _cmd_record_coordinator_pid(args)
+    if args.command == "supervise-external":
+        return _cmd_supervise_external(args)
     if args.command == "supervise":
         return _cmd_supervise(args)
     raise SupervisorError(f"Unsupported command: {args.command}")


### PR DESCRIPTION
## Summary
- Extend \supervisor.py\ with PID liveness probe, \coordinator_pid.json\ / \supervision_state.json\ contracts, injectable subprocess resume launcher, and fail-closed \plan-external\ / \supervise-external\ / \ecord-coordinator-pid\ CLI commands.
- Add \scripts/evidence_harvester_supervisor.ps1\ (default safe \plan\; execution requires \-Explicit\).
- Add host-resilience tier doc and update OPS runbook, README, and boot gate text (#3362 -> #3733 Operator Runtime-GO).
- Add 15 unit tests in \	est_supervisor_external.py\; existing harvester suite green (282 tests).

## Phase 1 boundaries
- **No** Tier-1 runtime proof execution in this PR.
- **No** Windows Task install, host sleep/reboot, new 72h run, Docker/DB/MCP mutation.
- **Does not close** #3733 (Tier-1 proof or formal downgrade still required) or #3345.
- LR **NO-GO** unchanged.

## Test plan
- [x] \python -m pytest tests/unit/tools/evidence_harvester -q\ (282 passed)
- [x] \uff check tools/evidence_harvester tests/unit/tools/evidence_harvester\
- [x] \lack --check\ on changed Python files
- [x] \git diff --check\

## Follow-up
Phase 2 requires separate Operator Runtime-GO for Tier-1 kill->resume proof under \rtifacts/evidence_harvester/host_resilience_proof/\.

Refs #3733
Refs #3345

Made with [Cursor](https://cursor.com)