### PR TITLE
fix(evidence): harden Windows supervisor resume launcher for #3733

### DIFF
--- a/docs/evidence/evidence_harvester_host_resilience_tiers.md
+++ b/docs/evidence/evidence_harvester_host_resilience_tiers.md
@@ -1,6 +1,10 @@
 # Evidence Harvester Host-Resilience Tiers (#3733)
 
-Status: Phase 1 scaffold merged — **no Tier-1 runtime proof in this slice**.
+Status: Phase 1 scaffold merged; **Tier-1 first runtime proof failed** on Windows
+(`tier1-20260705T104800Z`); Windows resume launcher hardening landed in follow-up
+PR (detached `Popen`, launch evidence). **Tier-1 re-proof pending** separate
+Operator Runtime-GO.
+
 LR remains **NO-GO**. No Live-Go, no Echtgeld-Go.
 
 Parent issue [#3345](https://github.com/jannekbuengener/Claire_de_Binare/issues/3345)
@@ -16,7 +20,7 @@ not deployment-ready external auto-resume across all host events.
 
 | Tier | Scenario | Phase 1 status | Proof requirement |
 |------|----------|----------------|-------------------|
-| **Tier 1** | Coordinator process killed during sleep window | Scaffold only | Controlled kill → external supervisor `RELAUNCH_RESUME` → `sleep_resumed` + continued cycles. Requires separate **Operator Runtime-GO**. |
+| **Tier 1** | Coordinator process killed during sleep window | Scaffold + Windows launcher fix | Controlled kill → external supervisor `RELAUNCH_RESUME` → `run_resumed` + continued cycles. Requires separate **Operator Runtime-GO**. First proof `tier1-20260705T104800Z` **FAIL** (relaunch ok, detached resume child did not emit `run_resumed`). Retry with cadence **120s**, kill during cycle-1 sleep. |
 | **Tier 2** | Shell / IDE close while detached coordinator runs | Covered by Slice-E pattern | Documented; no new proof required in #3733 Phase 1. |
 | **Tier 3** | Host sleep / hibernate / reboot across evidence window | **Not proven** | Explicit limitation in Phase 1. Future path: Windows Task + boot readiness (#3733 Phase 2+ or separate Ops GO). |
 
@@ -27,6 +31,8 @@ not deployment-ready external auto-resume across all host events.
   - `supervision_state.json` durable poll/relaunch state
   - `plan-external`, `supervise-external`, `record-coordinator-pid` CLI
   - injectable subprocess resume launcher (fail-closed without `--explicit`)
+- Windows-hardened detached resume `Popen` (`DETACHED_PROCESS`, new process group,
+  breakaway from job) + `resume_launch_evidence.jsonl` per relaunch
 - `scripts/evidence_harvester_supervisor.ps1` — safe default `plan`; execution requires `-Explicit`
 - Unit tests under `tests/unit/tools/evidence_harvester/test_supervisor_external.py`
 

--- a/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
+++ b/docs/runbooks/CDB_EVIDENCE_HARVESTER_OPS.md
@@ -385,7 +385,8 @@ proof in the merge slice. See
 | `coordinator_pid.json` | PID record for injectable liveness probe |
 | `supervision_state.json` | Poll/relaunch durable state |
 | `plan-external` | Safe plan JSON (default) |
-| `supervise-external --explicit` | PID probe + subprocess resume launcher |
+| `supervise-external --explicit` | PID probe + detached subprocess resume launcher |
+| `resume_launch_evidence.jsonl` | Per-relaunch argv/cwd/pid/launch_error audit trail |
 | `record-coordinator-pid` | Write PID record after detached coordinator start |
 
 PowerShell wrapper (safe default `plan`):
@@ -408,6 +409,20 @@ python -m tools.evidence_harvester.supervisor status `
 Execution (`supervise-external`) requires `--explicit` and a separate **Operator
 Runtime-GO**. LR remains **NO-GO**. #3345 stays **OPEN** until Tier-1 proof or
 accepted downgrade closes #3733.
+
+**Tier-1 retry parameters (recommended after Windows launcher fix):**
+
+| Parameter | Value |
+|---|---|
+| `cadence-seconds` | **120** (avoid killing before cycle-1 sleep settles) |
+| Kill timing | During cycle-1 sleep, after `sleep_started` and before `next_cycle_due_at_utc` |
+| Proof dir | `artifacts/evidence_harvester/host_resilience_proof/tier1-retry-<UTC>/` |
+| Pass criteria | `relaunch_count >= 1`, supervisor-spawned `run_resumed`, post-resume PASS cycle |
+
+First canonical proof run `tier1-20260705T104800Z` **FAIL** — stall detection and
+`relaunch_count=1` worked; subprocess resume child exited without `run_resumed`
+(manual identical `Popen` control succeeded). See
+[`docs/evidence/evidence_harvester_host_resilience_tiers.md`](../evidence/evidence_harvester_host_resilience_tiers.md).
 
 ## Safety Boundaries
 

--- a/scripts/evidence_harvester_supervisor.ps1
+++ b/scripts/evidence_harvester_supervisor.ps1
@@ -10,7 +10,7 @@ param(
     [int]$MaxRelaunchCount = 5,
     [int]$PollSeconds = 60,
     [int]$MaxPolls = 0,
-    [int]$Pid = 0,
+    [int]$CoordinatorPid = 0,
     [string]$PythonExecutable = 'python',
     [switch]$UsePidProbe,
     [switch]$AssumeProcessAlive,
@@ -82,13 +82,13 @@ switch ($Action) {
         }
     }
     'record-pid' {
-        if (-not $ArtifactDir -or $Pid -le 0) {
-            throw 'record-pid requires -ArtifactDir and -Pid.'
+        if (-not $ArtifactDir -or $CoordinatorPid -le 0) {
+            throw 'record-pid requires -ArtifactDir and -CoordinatorPid.'
         }
         $moduleArgs += @(
             'record-coordinator-pid',
             '--artifact-dir', $ArtifactDir,
-            '--pid', $Pid
+            '--pid', $CoordinatorPid
         )
     }
 }

--- a/tests/unit/tools/evidence_harvester/test_supervisor_external.py
+++ b/tests/unit/tools/evidence_harvester/test_supervisor_external.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -9,9 +10,11 @@ import pytest
 from tools.evidence_harvester.coordinator import CoordinatorSummary
 from tools.evidence_harvester.supervisor import (
     COORDINATOR_PID_FILENAME,
+    RESUME_LAUNCH_EVIDENCE_FILENAME,
     SUPERVISION_STATE_FILENAME,
     SUPERVISION_STATE_SCHEMA,
     SupervisorError,
+    _build_detached_subprocess_popen_kwargs,
     build_subprocess_resume_launcher,
     main,
     parse_args,
@@ -142,10 +145,11 @@ def test_build_subprocess_resume_launcher_uses_injected_popen(tmp_path: Path) ->
     _write_runner_state(artifact_dir)
     mock_proc = MagicMock()
     mock_proc.pid = 4242
-    popen_calls: list[list[str]] = []
+    mock_proc.poll.return_value = None
+    popen_calls: list[dict[str, object]] = []
 
     def fake_popen(cmd: list[str], **kwargs: object) -> MagicMock:
-        popen_calls.append(cmd)
+        popen_calls.append({"cmd": cmd, "kwargs": kwargs})
         return mock_proc
 
     launcher = build_subprocess_resume_launcher(
@@ -161,10 +165,78 @@ def test_build_subprocess_resume_launcher_uses_injected_popen(tmp_path: Path) ->
     summary = launcher()
     assert summary.status == "LAUNCHED"
     assert popen_calls
-    assert "resume-fixture-window" in popen_calls[0]
+    assert "resume-fixture-window" in popen_calls[0]["cmd"]
+    kwargs = popen_calls[0]["kwargs"]
+    assert kwargs["cwd"] == str(tmp_path.resolve())
+    assert kwargs["stdin"] is not None
+    assert kwargs["shell"] is False
+    assert kwargs["env"] is not None
     pid_record = read_coordinator_pid_record(artifact_dir)
     assert pid_record is not None
     assert pid_record.pid == 4242
+    evidence_path = artifact_dir / RESUME_LAUNCH_EVIDENCE_FILENAME
+    assert evidence_path.exists()
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8").splitlines()[0])
+    assert evidence["pid"] == 4242
+    assert evidence["detached"] is True
+
+
+@pytest.mark.unit
+def test_build_detached_subprocess_popen_kwargs_contract(tmp_path: Path) -> None:
+    stderr_path = tmp_path / "run" / "resume.stderr.log"
+    kwargs = _build_detached_subprocess_popen_kwargs(
+        repo_root=tmp_path,
+        stderr_path=stderr_path,
+    )
+    assert kwargs["cwd"] == str(tmp_path.resolve())
+    assert kwargs["shell"] is False
+    assert kwargs["stdin"] is not None
+    assert kwargs["stdout"] is not None
+    assert kwargs["env"] is not None
+    if os.name == "nt":
+        assert kwargs.get("creationflags", 0) != 0
+    else:
+        assert kwargs["start_new_session"] is True
+        assert kwargs["close_fds"] is True
+
+
+@pytest.mark.unit
+def test_build_subprocess_resume_launcher_skips_pid_on_immediate_exit(
+    tmp_path: Path,
+) -> None:
+    artifact_dir = tmp_path / "run"
+    artifact_dir.mkdir()
+    _write_runner_state(artifact_dir)
+    mock_proc = MagicMock()
+    mock_proc.pid = 9999
+    mock_proc.poll.return_value = 1
+
+    launcher = build_subprocess_resume_launcher(
+        repo_root=tmp_path,
+        fixture_path=tmp_path / "fixture.json",
+        artifact_dir=artifact_dir,
+        iterations=10,
+        cadence_seconds=900,
+        max_restart_count=3,
+        restart_backoff_seconds=30,
+        popen_fn=lambda cmd, **kwargs: mock_proc,
+    )
+    summary = launcher()
+    assert "child_exited_immediately" in summary.stop_reason
+    assert read_coordinator_pid_record(artifact_dir) is None
+
+
+@pytest.mark.unit
+def test_supervisor_ps1_avoids_automatic_pid_param_collision() -> None:
+    script_path = (
+        Path(__file__).resolve().parents[4]
+        / "scripts"
+        / "evidence_harvester_supervisor.ps1"
+    )
+    content = script_path.read_text(encoding="utf-8")
+    assert "[int]$Pid" not in content
+    assert "$CoordinatorPid" in content
+    assert "-CoordinatorPid" in content
 
 
 @pytest.mark.unit

--- a/tools/evidence_harvester/supervisor.py
+++ b/tools/evidence_harvester/supervisor.py
@@ -50,6 +50,14 @@ COORDINATOR_PID_SCHEMA = "cdb.evidence_harvester.coordinator_pid.v1"
 SUPERVISION_STATE_SCHEMA = "cdb.evidence_harvester.supervision_state.v1"
 COORDINATOR_PID_FILENAME = "coordinator_pid.json"
 SUPERVISION_STATE_FILENAME = "supervision_state.json"
+RESUME_LAUNCH_EVIDENCE_FILENAME = "resume_launch_evidence.jsonl"
+
+_WINDOWS_DETACHED_FLAGS = (
+    getattr(subprocess, "DETACHED_PROCESS", 0)
+    | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    | getattr(subprocess, "CREATE_BREAKAWAY_FROM_JOB", 0)
+)
 
 DEFAULT_MAX_RELAUNCH_COUNT = 5
 DEFAULT_POLL_SECONDS = 60
@@ -480,6 +488,41 @@ def _resume_launcher(
     return _launch
 
 
+def _build_detached_subprocess_popen_kwargs(
+    *,
+    repo_root: Path,
+    stderr_path: Path,
+) -> dict[str, Any]:
+    """Build ``Popen`` kwargs for a coordinator resume child detached from the supervisor."""
+    stderr_path.parent.mkdir(parents=True, exist_ok=True)
+    kwargs: dict[str, Any] = {
+        "cwd": str(repo_root.resolve()),
+        "env": os.environ.copy(),
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": stderr_path.open("ab"),
+        "shell": False,
+    }
+    if os.name == "nt":
+        if _WINDOWS_DETACHED_FLAGS:
+            kwargs["creationflags"] = _WINDOWS_DETACHED_FLAGS
+    else:
+        kwargs["start_new_session"] = True
+        kwargs["close_fds"] = True
+    return kwargs
+
+
+def _append_resume_launch_evidence(
+    artifact_dir: Path, payload: Mapping[str, Any]
+) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    path = artifact_dir / RESUME_LAUNCH_EVIDENCE_FILENAME
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(dict(payload), sort_keys=True, ensure_ascii=True) + "\n"
+        )
+
+
 def build_subprocess_resume_launcher(
     *,
     repo_root: Path,
@@ -496,6 +539,7 @@ def build_subprocess_resume_launcher(
     """Spawn ``resume-fixture-window`` as a detached subprocess resume launcher."""
 
     def _launch() -> CoordinatorSummary:
+        started_at_utc = _now_utc().isoformat().replace("+00:00", "Z")
         executable = python_executable or sys.executable
         cmd = [
             executable,
@@ -503,9 +547,9 @@ def build_subprocess_resume_launcher(
             "tools.evidence_harvester.coordinator",
             "resume-fixture-window",
             "--fixture",
-            str(fixture_path),
+            str(fixture_path.resolve()),
             "--artifact-dir",
-            str(artifact_dir),
+            str(artifact_dir.resolve()),
             "--iterations",
             str(iterations),
             "--cadence-seconds",
@@ -515,17 +559,51 @@ def build_subprocess_resume_launcher(
             "--restart-backoff-seconds",
             str(restart_backoff_seconds),
         ]
-        popen = popen_fn or subprocess.Popen
-        proc = popen(
-            cmd,
-            cwd=str(repo_root),
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+        stderr_path = artifact_dir / (
+            "resume_launch_"
+            f"{started_at_utc.replace('-', '').replace(':', '')}.stderr.log"
         )
-        state = _read_runner_state(artifact_dir)
-        run_id = state.run_id if state is not None else artifact_dir.name
-        if write_pid:
-            write_coordinator_pid_record(artifact_dir, pid=proc.pid, run_id=run_id)
+        popen_kwargs = _build_detached_subprocess_popen_kwargs(
+            repo_root=repo_root,
+            stderr_path=stderr_path,
+        )
+        launch_error = ""
+        child_pid = 0
+        immediate_exit_code: int | None = None
+        popen = popen_fn or subprocess.Popen
+        try:
+            proc = popen(cmd, **popen_kwargs)
+            child_pid = int(proc.pid)
+            immediate_exit_code = proc.poll()
+            if immediate_exit_code is not None:
+                launch_error = f"child_exited_immediately:rc={immediate_exit_code}"
+        except OSError as exc:
+            launch_error = f"popen_failed:{exc.__class__.__name__}"
+            raise SupervisorError(f"resume subprocess launch failed: {exc}") from exc
+        finally:
+            state = _read_runner_state(artifact_dir)
+            run_id = state.run_id if state is not None else artifact_dir.name
+            _append_resume_launch_evidence(
+                artifact_dir,
+                {
+                    "schema_version": "cdb.evidence_harvester.resume_launch.v1",
+                    "started_at_utc": started_at_utc,
+                    "run_id": run_id,
+                    "argv": cmd,
+                    "cwd": str(repo_root.resolve()),
+                    "pid": child_pid,
+                    "immediate_exit_code": immediate_exit_code,
+                    "launch_error": launch_error,
+                    "stderr_log": str(stderr_path),
+                    "detached": True,
+                    "platform": os.name,
+                },
+            )
+        if write_pid and child_pid > 0 and immediate_exit_code is None:
+            write_coordinator_pid_record(artifact_dir, pid=child_pid, run_id=run_id)
+        stop_reason = "external_subprocess_resume_launch"
+        if launch_error:
+            stop_reason = f"{stop_reason}:{launch_error}"
         return CoordinatorSummary(
             status="LAUNCHED",
             artifact_dir=str(artifact_dir),
@@ -534,7 +612,7 @@ def build_subprocess_resume_launcher(
             restart_count=0,
             max_restart_count=max_restart_count,
             final_validation_started=False,
-            stop_reason="external_subprocess_resume_launch",
+            stop_reason=stop_reason,
         )
 
     return _launch


### PR DESCRIPTION
## Brain Evidence

brain_source: repo-only
brain_status: not-used
tools_or_queries:
- `gh issue view 3733/3345`, `gh pr view 3735`
- Proof artifacts: `artifacts/evidence_harvester/host_resilience_proof/tier1-20260705T104800Z/`
- `pytest tests/unit/tools/evidence_harvester -q` (285 PASS local)
records_or_results:
- Canonical Tier-1 FAIL: `relaunch_count=1`, no supervisor-spawned `run_resumed`; manual identical Popen succeeded
repo_crosscheck:
- `tools/evidence_harvester/supervisor.py` — `build_subprocess_resume_launcher`
- PR #3735 @ `24a20473`
impact_on_plan:
- Code/docs fix only; Tier-1 runtime re-proof deferred (no RUNTIME-GO in this session)
limitations:
- Fix not validated by new Tier-1 proof run in this PR

## Summary

- Harden `build_subprocess_resume_launcher` for Windows: detached `Popen` (new process group, breakaway from job, no window), explicit cwd/env/stdin, stderr log file instead of DEVNULL swallowing
- Append `resume_launch_evidence.jsonl` per relaunch (argv, cwd, pid, immediate exit, launch_error)
- Skip writing `coordinator_pid.json` when child exits immediately (avoids stale dead PID blocking retry)
- Fix PowerShell wrapper param collision: `$Pid` → `$CoordinatorPid`
- Document Tier-1 first proof FAIL + recommended retry params (cadence=120, kill during cycle-1 sleep)

## Root cause

Tier-1 proof `tier1-20260705T104800Z`: stall detection and relaunch counter worked, but supervisor subprocess resume did not produce `run_resumed`. Manual detached `Popen` with identical argv succeeded → launcher process/session handling on Windows, not coordinator resume logic.

## Delivered

| Area | Change |
|------|--------|
| `supervisor.py` | Detached popen kwargs + launch evidence |
| `evidence_harvester_supervisor.ps1` | `$CoordinatorPid` param |
| Tests | +3 unit tests (popen contract, immediate exit, PS param) |
| Docs | tiers + OPS runbook retry guidance |

## Validation

- `pytest tests/unit/tools/evidence_harvester -q` → **285 PASS**
- `ruff check tools/evidence_harvester tests/unit/tools/evidence_harvester` → PASS
- `black --check` on touched Python files → PASS
- `scripts/evidence_harvester_supervisor.ps1 -Action plan ...` → loads and emits plan JSON

## Runtime proof status

**Pending** — no `RUNTIME-GO #3733 Tier-1 Proof` in this session. Re-run Tier-1 after merge under Operator Runtime-GO.

## Non-goals

- No Tier-1 re-proof in this PR
- No Windows Task install, host sleep/reboot, new 72h run
- Does not close #3733 or #3345

## Safety boundaries

LR **NO-GO** unchanged. No Docker/DB/MCP mutation. No secrets.

## Restunsicherheiten

Detached flags may behave differently under Task Scheduler vs interactive agent shell; Tier-1 retry required for closure evidence.

Refs #3733
Refs #3345

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the external supervision relaunch path used for Tier-1 host-resilience proof on Windows; behavior may still differ under Task Scheduler vs interactive shells until re-proof runs.
> 
> **Overview**
> Addresses a **failed Tier-1 Windows proof** (`tier1-20260705T104800Z`): relaunch fired but the supervisor-spawned resume child never produced `run_resumed`, while manual detached `Popen` with the same argv worked.
> 
> **`build_subprocess_resume_launcher`** now spawns `resume-fixture-window` with platform-specific **detached** `Popen` (Windows creation flags / Unix new session), explicit cwd/env/stdin, and **stderr log files** instead of discarding output. Each relaunch appends **`resume_launch_evidence.jsonl`** (argv, pid, immediate exit, errors). **`coordinator_pid.json`** is **not** written when the child exits immediately, so a dead PID does not block retries.
> 
> **`evidence_harvester_supervisor.ps1`** renames **`$Pid` → `$CoordinatorPid`** to avoid PowerShell’s automatic `$PID` collision. Docs record the first proof **FAIL**, Tier-1 **re-proof pending**, and recommended retry settings (e.g. **120s** cadence, kill during cycle-1 sleep).
> 
> Unit tests cover detached kwargs, immediate-exit behavior, and the PS param fix. **No new Tier-1 runtime proof** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 682714799e52cf2c2c6e700b7eeaa9756dd4c87d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->