### PR TITLE
feat(arvp): execute pack-a wave1 shape replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 !services/validation/strategy_backtest_runner.py
 !services/validation/rmr_backtest_runner.py
 !services/validation/momentum_backtest_runner.py
+!services/validation/donchian_breakout_backtest_runner.py
+!services/validation/breakout_trend_filter_backtest_runner.py
 !cdb_agent_sdk/tests/**/*.py
 !cdb_agent_sdk/tests/**/*.js
 debug_*.py

--- a/core/replay/pack_a_breakout_common.py
+++ b/core/replay/pack_a_breakout_common.py
@@ -1,0 +1,227 @@
+"""Shared Pack-A breakout helpers for Donchian and trend-filter variants.
+
+Frozen parameters per docs/evidence/arvp_pack_a_breakout_baseline_spec_3748.md §7.2–7.3.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from core.replay.historical_bridge import ONE_MINUTE_MS, PRIMARY_BREAKOUT_SYMBOL
+
+DONCHIAN_BREAKOUT_STRATEGY_ID = "donchian_breakout_v1"
+BREAKOUT_TREND_FILTER_STRATEGY_ID = "breakout_trend_filter_v1"
+PACK_A_SYMBOL = PRIMARY_BREAKOUT_SYMBOL
+
+ENTRY_CHANNEL_BARS = 20
+EXIT_CHANNEL_BARS = 10
+MIN_MINUTES_BETWEEN_ENTRIES = 30
+TREND_EMA_PERIOD_5M = 20
+FIVE_MINUTE_MS = 5 * ONE_MINUTE_MS
+
+ORDER_SIZE = 1.0
+ORDER_BOOK_DEPTH_MULT = 10_000.0
+
+
+class PackABreakoutError(ValueError):
+    """Raised when Pack-A breakout input is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class DonchianBreakoutConfig:
+    entry_channel_bars: int = ENTRY_CHANNEL_BARS
+    exit_channel_bars: int = EXIT_CHANNEL_BARS
+    min_minutes_between_entries: int = MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.entry_channel_bars <= 0:
+            raise PackABreakoutError("entry_channel_bars must be > 0")
+        if self.exit_channel_bars <= 0:
+            raise PackABreakoutError("exit_channel_bars must be > 0")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
+@dataclass(frozen=True, slots=True)
+class BreakoutTrendFilterConfig(DonchianBreakoutConfig):
+    trend_ema_period_5m: int = TREND_EMA_PERIOD_5M
+
+    def validate(self) -> None:
+        super().validate()
+        if self.trend_ema_period_5m <= 0:
+            raise PackABreakoutError("trend_ema_period_5m must be > 0")
+
+
+def donchian_warmup_candles(config: DonchianBreakoutConfig | None = None) -> int:
+    active = config or DonchianBreakoutConfig()
+    active.validate()
+    return max(active.entry_channel_bars, active.exit_channel_bars)
+
+
+def breakout_trend_warmup_candles(
+    config: BreakoutTrendFilterConfig | None = None,
+) -> int:
+    active = config or BreakoutTrendFilterConfig()
+    active.validate()
+    # Need enough 1m bars to form trend_ema_period completed 5m bars plus Donchian lookback.
+    min_5m_bars = active.trend_ema_period_5m
+    min_1m_for_5m = min_5m_bars * 5
+    return max(donchian_warmup_candles(active), min_1m_for_5m)
+
+
+def _required_float(row: dict[str, Any], key: str) -> float:
+    value = row.get(key)
+    if value is None or isinstance(value, bool):
+        raise PackABreakoutError(f"missing required field: {key}")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise PackABreakoutError(f"invalid numeric field: {key}") from exc
+
+
+def _required_int(row: dict[str, Any], key: str) -> int:
+    value = row.get(key)
+    if value is None or isinstance(value, bool):
+        raise PackABreakoutError(f"missing required field: {key}")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise PackABreakoutError(f"invalid integer field: {key}") from exc
+
+
+def validate_pack_a_candle_series(
+    candles: Sequence[dict[str, Any]], *, expected_symbol: str = PACK_A_SYMBOL
+) -> None:
+    if not candles:
+        raise PackABreakoutError("historical candle series must not be empty")
+
+    previous_ts_ms: int | None = None
+    for index, row in enumerate(candles):
+        symbol = str(row.get("symbol") or "").upper()
+        if symbol != expected_symbol:
+            raise PackABreakoutError(
+                f"unexpected symbol at index {index}: {symbol or '<missing>'}"
+            )
+        ts_ms = _required_int(row, "ts_ms")
+        if previous_ts_ms is not None:
+            if ts_ms <= previous_ts_ms:
+                raise PackABreakoutError("candles must be strictly increasing by ts_ms")
+            if ts_ms - previous_ts_ms != ONE_MINUTE_MS:
+                raise PackABreakoutError(
+                    "candles must have strict 1m cadence (delta 60000 ms)"
+                )
+        previous_ts_ms = ts_ms
+        _required_float(row, "high")
+        _required_float(row, "low")
+        _required_float(row, "close")
+
+
+def compute_donchian_channels(
+    highs: Sequence[float],
+    lows: Sequence[float],
+    *,
+    entry_channel_bars: int,
+    exit_channel_bars: int,
+) -> tuple[list[float | None], list[float | None]]:
+    """Upper/lower Donchian channels using prior closed bars only (exclusive of index)."""
+    upper: list[float | None] = [None] * len(highs)
+    lower: list[float | None] = [None] * len(highs)
+    for index in range(len(highs)):
+        if index >= entry_channel_bars:
+            window = highs[index - entry_channel_bars : index]
+            upper[index] = max(window)
+        if index >= exit_channel_bars:
+            window = lows[index - exit_channel_bars : index]
+            lower[index] = min(window)
+    return upper, lower
+
+
+def _ema(values: Sequence[float], period: int) -> list[float | None]:
+    if period <= 0:
+        raise PackABreakoutError("EMA period must be > 0")
+    result: list[float | None] = [None] * len(values)
+    if len(values) < period:
+        return result
+    seed = sum(values[:period]) / period
+    result[period - 1] = seed
+    multiplier = 2.0 / (period + 1)
+    ema_val = seed
+    for index in range(period, len(values)):
+        ema_val = (values[index] - ema_val) * multiplier + ema_val
+        result[index] = ema_val
+    return result
+
+
+def _collect_completed_5m_closes(
+    ts_ms_values: Sequence[int], closes: Sequence[float]
+) -> list[tuple[int, float]]:
+    """Return (end_ts_ms, close) for each completed 5m bar in chronological order."""
+    if len(ts_ms_values) != len(closes):
+        raise PackABreakoutError("ts_ms and closes length mismatch")
+
+    completed: list[tuple[int, float]] = []
+    bucket_start: int | None = None
+    bucket_close: float | None = None
+    bars_in_bucket = 0
+
+    for ts_ms, close in zip(ts_ms_values, closes, strict=True):
+        aligned_start = ts_ms - (ts_ms % FIVE_MINUTE_MS)
+        if bucket_start is None or aligned_start != bucket_start:
+            if bucket_start is not None and bars_in_bucket == 5 and bucket_close is not None:
+                completed.append((ts_ms - ONE_MINUTE_MS, bucket_close))
+            bucket_start = aligned_start
+            bucket_close = close
+            bars_in_bucket = 1
+        else:
+            bucket_close = close
+            bars_in_bucket += 1
+
+    return completed
+
+
+def build_trend_gate_series(
+    ts_ms_values: Sequence[int],
+    closes: Sequence[float],
+    *,
+    trend_ema_period_5m: int,
+) -> list[bool | None]:
+    """True when last completed 5m close > EMA(trend_ema_period_5m) on 5m series."""
+    completed = _collect_completed_5m_closes(ts_ms_values, closes)
+    if not completed:
+        return [None] * len(closes)
+
+    closes_5m = [value for _, value in completed]
+    end_ts_5m = [end_ts for end_ts, _ in completed]
+    ema_5m = _ema(closes_5m, trend_ema_period_5m)
+
+    gate: list[bool | None] = [None] * len(closes)
+    completed_idx = -1
+    for index, ts_ms in enumerate(ts_ms_values):
+        while (
+            completed_idx + 1 < len(end_ts_5m)
+            and end_ts_5m[completed_idx + 1] <= ts_ms
+        ):
+            completed_idx += 1
+        if completed_idx < 0:
+            continue
+        ema_val = ema_5m[completed_idx]
+        close_5m = closes_5m[completed_idx]
+        if ema_val is None:
+            continue
+        gate[index] = close_5m > ema_val
+    return gate
+
+
+def cooldown_allows_entry(
+    ts_ms: int,
+    last_entry_ts_ms: int | None,
+    *,
+    min_minutes_between_entries: int,
+) -> bool:
+    if last_entry_ts_ms is None:
+        return True
+    return ts_ms - last_entry_ts_ms >= min_minutes_between_entries * ONE_MINUTE_MS

--- a/docs/evidence/arvp_pack_a_wave1_shape_replay_3780.md
+++ b/docs/evidence/arvp_pack_a_wave1_shape_replay_3780.md
@@ -1,0 +1,207 @@
+# ARVP Pack-A Wave-1 Shape/Replay Evidence (#3780)
+
+Status Class: offline shape/replay execute (no promotion, no paper claim)
+Issue: #3780
+Parent: #1900
+Spec: #3748
+Live-Readiness: **NO-GO**
+Echtgeld: **not authorized**
+ranking_ready: **false**
+natural_paper_evidence: **false**
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+tools_or_queries:
+  - git fetch/status/rev-parse; gh issue view 3780,3748,3747,3742,1900
+  - MCP cdb_context_briefing attempted — unknown_tool on context_briefing alias
+  - run_pack_a_wave1_shape_replay_3780.py offline replay execution
+records_or_results:
+  - context_brain_attempted=true; context_brain_used=false; context_available=false
+  - repo_fallback_reason=tool_blocked; records_found=none
+  - HEAD=7939465ba608e26805aaf479e69aaf87c42c2194
+  - dataset_sha256=3be2430b5e30845b1db8d3330fc5e6b5d2b322dabf834db4bc2efaad379b30a7
+repo_crosscheck:
+  - docs/evidence/arvp_pack_a_breakout_baseline_spec_3748.md
+  - services/validation/strategy_replay_runner.py
+  - core/replay/scenario_packs.py
+impact_on_plan:
+  - Implemented minimal Donchian + Breakout+Trend adapters; executed Top-3 offline.
+limitations:
+  - No SurrealDB records; B1 friction gap unchanged; #3035 formal report not re-emitted.
+  - deterministic_replay_ok two-pass only for primary_breakout_v1.
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: tool_blocked
+context_tool_status: partial
+context_trust_level: none
+records_found: none
+```
+
+## Scope and Human-GO boundary
+
+- Offline replay only; no Docker paper runtime; no fresh-paper observation.
+- ranking_ready=false; no natural_paper_evidence; LR NO-GO unchanged.
+- PB1 PARKED reference only — no rescue/promotion.
+
+## Dataset and quality gate
+
+| Field | Value |
+|-------|-------|
+| path | `artifacts/backtests/primary_breakout_v1/20260418-212643/dataset.candles.json` |
+| sha256 | `3be2430b5e30845b1db8d3330fc5e6b5d2b322dabf834db4bc2efaad379b30a7` |
+| symbol | BTCUSDT |
+| timeframe | 1m |
+| #3035 report | not re-emitted — technical replay validity only (WARNING banner) |
+
+## Execution matrix
+
+| strategy_id | role | scenarios | exit | verdict | sub_status |
+|-------------|------|-----------|------|---------|------------|
+| `primary_breakout_v1` | PARKED reference anchor | baseline,pessimistic_execution,feed_gap | 0 | **PASS** | NOT_RANKING_READY |
+| `donchian_breakout_v1` | external breakout benchmark | baseline,pessimistic_execution,feed_gap | 0 | **PASS** | NOT_RANKING_READY |
+| `breakout_trend_filter_v1` | breakout + trend gate comparison | baseline,pessimistic_execution,feed_gap | 0 | **PASS** | NOT_RANKING_READY |
+
+## Scenario results (summary)
+
+### `primary_breakout_v1`
+
+- artifact_root: `D:\Dev\Workspaces\Repos\Claire_de_Binare\artifacts\replay_reports\pack_a_wave1_3780\primary_breakout_v1`
+- manifest: `D:\Dev\Workspaces\Repos\Claire_de_Binare\artifacts\replay_reports\pack_a_wave1_3780\primary_breakout_v1\pack_a_wave1_primary_breakout_v1\scenario_group_manifest.json`
+- dataset_fingerprint: `619bee3a98e144327e0fe6a0c3ad871bd90e528bae56a9330229310bd37f8bf1`
+
+```json
+{
+  "failed_count": 0,
+  "group_fingerprint": "619bee3a98e144327e0fe6a0c3ad871bd90e528bae56a9330229310bd37f8bf1",
+  "group_id": "pack_a_wave1_primary_breakout_v1",
+  "scenarios": {
+    "baseline": {
+      "closed_trades_total": 22,
+      "fee_adjusted_return_r": null,
+      "max_drawdown_r": 0.022599448094972167,
+      "ranking_ready": false,
+      "run_id": "bt-b70fe2a4d0ffa5d5",
+      "signals_total": 44
+    },
+    "feed_gap": {
+      "closed_trades_total": 22,
+      "fee_adjusted_return_r": null,
+      "max_drawdown_r": 0.022599448094972167,
+      "ranking_ready": false,
+      "run_id": "bt-b3eaf255c7b8847b",
+      "signals_total": 44
+    },
+    "pessimistic_execution": {
+      "closed_trades_total": 22,
+      "fee_adjusted_return_r": null,
+      "max_drawdown_r": 0.09599382134120939,
+      "ranking_ready": false,
+      "run_id": "bt-d8a225e60396f6f0",
+      "signals_total": 44
+    }
+  },
+  "succeeded_count": 3
+}
+```
+
+### `donchian_breakout_v1`
+
+- artifact_root: `D:\Dev\Workspaces\Repos\Claire_de_Binare\artifacts\replay_reports\pack_a_wave1_3780\donchian_breakout_v1`
+- manifest: `D:\Dev\Workspaces\Repos\Claire_de_Binare\artifacts\replay_reports\pack_a_wave1_3780\donchian_breakout_v1\pack_a_wave1_donchian_breakout_v1\scenario_group_manifest.json`
+- dataset_fingerprint: `5f4bcf8d9de0a7ad89b4f2db2a81d8925c008126ee3cfc50aa7953e96ab965cd`
+
+```json
+{
+  "failed_count": 0,
+  "group_fingerprint": "5f4bcf8d9de0a7ad89b4f2db2a81d8925c008126ee3cfc50aa7953e96ab965cd",
+  "group_id": "pack_a_wave1_donchian_breakout_v1",
+  "scenarios": {
+    "baseline": {
+      "closed_trades_total": 257,
+      "fee_adjusted_return_r": -0.5343919736115524,
+      "max_drawdown_r": 0.2518220297440353,
+      "ranking_ready": false,
+      "run_id": "c6c9f0ee-d45e-51ee-bf80-c8b5244ba12c",
+      "signals_total": 257
+    },
+    "feed_gap": {
+      "closed_trades_total": 257,
+      "fee_adjusted_return_r": -0.5343919736115524,
+      "max_drawdown_r": 0.2518220297440353,
+      "ranking_ready": false,
+      "run_id": "1cfebf0e-40dc-5740-92ea-1ca42be52d65",
+      "signals_total": 257
+    },
+    "pessimistic_execution": {
+      "closed_trades_total": 257,
+      "fee_adjusted_return_r": -1.814294411804425,
+      "max_drawdown_r": 1.506798159070276,
+      "ranking_ready": false,
+      "run_id": "c049d0be-05d0-58f1-8321-da9ba06644ab",
+      "signals_total": 257
+    }
+  },
+  "succeeded_count": 3
+}
+```
+
+### `breakout_trend_filter_v1`
+
+- artifact_root: `D:\Dev\Workspaces\Repos\Claire_de_Binare\artifacts\replay_reports\pack_a_wave1_3780\breakout_trend_filter_v1`
+- manifest: `D:\Dev\Workspaces\Repos\Claire_de_Binare\artifacts\replay_reports\pack_a_wave1_3780\breakout_trend_filter_v1\pack_a_wave1_breakout_trend_filter_v1\scenario_group_manifest.json`
+- dataset_fingerprint: `102b75b96c87912412da8a1d0a96239f0ad48f624cc6a1617f2f9bb8988e3d1a`
+
+```json
+{
+  "failed_count": 0,
+  "group_fingerprint": "102b75b96c87912412da8a1d0a96239f0ad48f624cc6a1617f2f9bb8988e3d1a",
+  "group_id": "pack_a_wave1_breakout_trend_filter_v1",
+  "scenarios": {
+    "baseline": {
+      "closed_trades_total": 196,
+      "fee_adjusted_return_r": -0.3848198624310175,
+      "max_drawdown_r": 0.18497702709796682,
+      "ranking_ready": false,
+      "run_id": "bac30548-485b-5dc8-8410-38a1abb233ef",
+      "signals_total": 196
+    },
+    "feed_gap": {
+      "closed_trades_total": 196,
+      "fee_adjusted_return_r": -0.3848198624310175,
+      "max_drawdown_r": 0.18497702709796682,
+      "ranking_ready": false,
+      "run_id": "317aab23-b7e6-52ab-82bf-fec15d024ee1",
+      "signals_total": 196
+    },
+    "pessimistic_execution": {
+      "closed_trades_total": 196,
+      "fee_adjusted_return_r": -1.3610456916799083,
+      "max_drawdown_r": 1.1277676132807168,
+      "ranking_ready": false,
+      "run_id": "254beabf-5394-5f33-952d-633c95339d86",
+      "signals_total": 196
+    }
+  },
+  "succeeded_count": 3
+}
+```
+
+## Deterministic rerun parity
+
+- Scenario group manifests with `failed_count=0` treated as deterministic rerun OK for this slice.
+- Pack-A Donchian/Bo+Trend runners use single-pass reports (`deterministic_replay_ok=false` by design).
+- PB1 retains native two-pass determinism check when run standalone.
+
+## Limitations
+
+- B1 same-venue friction evidence missing (#3747) — economics advisory only.
+- ranking_ready=false for all candidates.
+- No §5.2.4 / Product-Complete / natural_paper_evidence claim.
+- LR remains NO-GO.
+
+Generated: 2026-07-06T10:08:45.263541+00:00

--- a/scripts/profitability/run_pack_a_wave1_shape_replay_3780.py
+++ b/scripts/profitability/run_pack_a_wave1_shape_replay_3780.py
@@ -1,0 +1,368 @@
+"""Execute Pack-A wave-1 offline shape/replay for issue #3780.
+
+Safety boundaries:
+- offline file-backed replay only
+- no Docker / no paper runtime
+- ranking_ready=false
+- no natural_paper_evidence claim
+"""
+
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from core.replay.pack_a_breakout_common import (
+    BREAKOUT_TREND_FILTER_STRATEGY_ID,
+    DONCHIAN_BREAKOUT_STRATEGY_ID,
+)
+from services.validation.strategy_replay_runner import ARVPReplayConfig, run_arvp_replay
+
+ISSUE = "#3780"
+PARENT_ISSUE = "#1900"
+SPEC_ISSUE = "#3748"
+LR_STATUS = "NO-GO"
+RANKING_READY = False
+
+PINNED_DATASET = (
+    REPO_ROOT
+    / "artifacts"
+    / "backtests"
+    / "primary_breakout_v1"
+    / "20260418-212643"
+    / "dataset.candles.json"
+)
+OUTPUT_ROOT = REPO_ROOT / "artifacts" / "replay_reports" / "pack_a_wave1_3780"
+MANIFEST_PATH = OUTPUT_ROOT / "pack_a_wave1_manifest.json"
+EVIDENCE_DOC = (
+    REPO_ROOT / "docs" / "evidence" / "arvp_pack_a_wave1_shape_replay_3780.md"
+)
+
+SCENARIO_IDS = ("baseline", "pessimistic_execution", "feed_gap")
+
+PACK_A_CANDIDATES: tuple[tuple[str, str, str], ...] = (
+    ("primary_breakout_v1", "primary_breakout_runner_v1", "PARKED reference anchor"),
+    (DONCHIAN_BREAKOUT_STRATEGY_ID, "donchian_breakout_runner_v1", "external breakout benchmark"),
+    (
+        BREAKOUT_TREND_FILTER_STRATEGY_ID,
+        "breakout_trend_filter_runner_v1",
+        "breakout + trend gate comparison",
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateResult:
+    strategy_id: str
+    role: str
+    exit_code: int
+    artifact_root: str
+    dataset_fingerprint: str | None
+    scenario_manifest_path: str | None
+    deterministic_rerun_ok: bool
+    verdict: str
+    sub_status: str
+    metrics_summary: dict[str, Any]
+
+
+def _git_head() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=REPO_ROOT,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _summarize_metrics(manifest_path: Path) -> dict[str, Any]:
+    manifest = _load_json(manifest_path)
+    summary: dict[str, Any] = {
+        "group_id": manifest.get("group_id"),
+        "group_fingerprint": manifest.get("group_fingerprint"),
+        "failed_count": manifest.get("failed_count"),
+        "succeeded_count": manifest.get("succeeded_count"),
+        "scenarios": {},
+    }
+    manifest_dir = manifest_path.parent
+    for result in manifest.get("scenario_results", []):
+        scenario_id = result.get("scenario_id")
+        if not scenario_id:
+            continue
+        metrics_path = manifest_dir / f"{scenario_id}_metrics.json"
+        if metrics_path.is_file():
+            payload = _load_json(metrics_path)
+            summary["scenarios"][scenario_id] = {
+                "run_id": payload.get("run_id"),
+                "signals_total": payload.get("metrics", {}).get("signals_total"),
+                "closed_trades_total": payload.get("metrics", {}).get(
+                    "closed_trades_total"
+                ),
+                "fee_adjusted_return_r": payload.get("metrics", {}).get(
+                    "fee_adjusted_return_r"
+                ),
+                "max_drawdown_r": payload.get("metrics", {}).get("max_drawdown_r"),
+                "ranking_ready": payload.get("metrics", {}).get("ranking_ready", False),
+            }
+        else:
+            summary["scenarios"][scenario_id] = {
+                "run_id": result.get("run_id"),
+                "exit_code": result.get("exit_code"),
+            }
+    return summary
+
+
+def _run_candidate(strategy_id: str, adapter_id: str, role: str) -> CandidateResult:
+    out_dir = OUTPUT_ROOT / strategy_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    config = ARVPReplayConfig(
+        dataset_source="file",
+        input_candles_file=str(PINNED_DATASET),
+        strategy_id=strategy_id,
+        symbol="BTCUSDT",
+        adapter_id=adapter_id,
+        output_directory=str(out_dir),
+        scenario_ids=SCENARIO_IDS,
+        scenario_group_id=f"pack_a_wave1_{strategy_id}",
+    )
+    config.validate()
+    exit_code = run_arvp_replay(config)
+
+    manifests = sorted(out_dir.glob("**/scenario_group_manifest.json"))
+    manifest_path = manifests[-1] if manifests else None
+    dataset_fingerprint = None
+    metrics_summary: dict[str, Any] = {}
+    deterministic_rerun_ok = False
+    if manifest_path is not None:
+        manifest = _load_json(manifest_path)
+        dataset_fingerprint = manifest.get("group_fingerprint")
+        metrics_summary = _summarize_metrics(manifest_path)
+        deterministic_rerun_ok = manifest.get("failed_count", 1) == 0 and exit_code == 0
+
+    if exit_code != 0 or not deterministic_rerun_ok:
+        verdict = "FAIL"
+    else:
+        verdict = "PASS"
+
+    return CandidateResult(
+        strategy_id=strategy_id,
+        role=role,
+        exit_code=exit_code,
+        artifact_root=str(out_dir),
+        dataset_fingerprint=dataset_fingerprint,
+        scenario_manifest_path=str(manifest_path) if manifest_path else None,
+        deterministic_rerun_ok=deterministic_rerun_ok,
+        verdict=verdict,
+        sub_status="NOT_RANKING_READY",
+        metrics_summary=metrics_summary,
+    )
+
+
+def _render_evidence_doc(
+    *,
+    head_sha: str,
+    dataset_sha256: str,
+    results: list[CandidateResult],
+) -> str:
+    lines = [
+        "# ARVP Pack-A Wave-1 Shape/Replay Evidence (#3780)",
+        "",
+        f"Status Class: offline shape/replay execute (no promotion, no paper claim)",
+        f"Issue: {ISSUE}",
+        f"Parent: {PARENT_ISSUE}",
+        f"Spec: {SPEC_ISSUE}",
+        f"Live-Readiness: **{LR_STATUS}**",
+        f"Echtgeld: **not authorized**",
+        f"ranking_ready: **false**",
+        f"natural_paper_evidence: **false**",
+        "",
+        "## Brain Evidence",
+        "",
+        "```text",
+        "brain_source: repo-only",
+        "brain_status: not-used",
+        "tools_or_queries:",
+        "  - git fetch/status/rev-parse; gh issue view 3780,3748,3747,3742,1900",
+        "  - MCP cdb_context_briefing attempted — unknown_tool on context_briefing alias",
+        "  - run_pack_a_wave1_shape_replay_3780.py offline replay execution",
+        "records_or_results:",
+        "  - context_brain_attempted=true; context_brain_used=false; context_available=false",
+        "  - repo_fallback_reason=tool_blocked; records_found=none",
+        f"  - HEAD={head_sha}",
+        f"  - dataset_sha256={dataset_sha256}",
+        "repo_crosscheck:",
+        "  - docs/evidence/arvp_pack_a_breakout_baseline_spec_3748.md",
+        "  - services/validation/strategy_replay_runner.py",
+        "  - core/replay/scenario_packs.py",
+        "impact_on_plan:",
+        "  - Implemented minimal Donchian + Breakout+Trend adapters; executed Top-3 offline.",
+        "limitations:",
+        "  - No SurrealDB records; B1 friction gap unchanged; #3035 formal report not re-emitted.",
+        "  - deterministic_replay_ok two-pass only for primary_breakout_v1.",
+        "context_brain_attempted: true",
+        "context_brain_used: false",
+        "context_available: false",
+        "repo_fallback_used: true",
+        "repo_fallback_reason: tool_blocked",
+        "context_tool_status: partial",
+        "context_trust_level: none",
+        "records_found: none",
+        "```",
+        "",
+        "## Scope and Human-GO boundary",
+        "",
+        "- Offline replay only; no Docker paper runtime; no fresh-paper observation.",
+        "- ranking_ready=false; no natural_paper_evidence; LR NO-GO unchanged.",
+        "- PB1 PARKED reference only — no rescue/promotion.",
+        "",
+        "## Dataset and quality gate",
+        "",
+        f"| Field | Value |",
+        f"|-------|-------|",
+        f"| path | `{PINNED_DATASET.relative_to(REPO_ROOT).as_posix()}` |",
+        f"| sha256 | `{dataset_sha256}` |",
+        f"| symbol | BTCUSDT |",
+        f"| timeframe | 1m |",
+        f"| #3035 report | not re-emitted — technical replay validity only (WARNING banner) |",
+        "",
+        "## Execution matrix",
+        "",
+        "| strategy_id | role | scenarios | exit | verdict | sub_status |",
+        "|-------------|------|-----------|------|---------|------------|",
+    ]
+    for result in results:
+        lines.append(
+            f"| `{result.strategy_id}` | {result.role} | {','.join(SCENARIO_IDS)} | "
+            f"{result.exit_code} | **{result.verdict}** | {result.sub_status} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Scenario results (summary)",
+            "",
+        ]
+    )
+    for result in results:
+        lines.append(f"### `{result.strategy_id}`")
+        lines.append("")
+        lines.append(f"- artifact_root: `{result.artifact_root}`")
+        if result.scenario_manifest_path:
+            lines.append(f"- manifest: `{result.scenario_manifest_path}`")
+        lines.append(f"- dataset_fingerprint: `{result.dataset_fingerprint}`")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(result.metrics_summary, indent=2, sort_keys=True))
+        lines.append("```")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Deterministic rerun parity",
+            "",
+            "- Scenario group manifests with `failed_count=0` treated as deterministic rerun OK for this slice.",
+            "- Pack-A Donchian/Bo+Trend runners use single-pass reports (`deterministic_replay_ok=false` by design).",
+            "- PB1 retains native two-pass determinism check when run standalone.",
+            "",
+            "## Limitations",
+            "",
+            "- B1 same-venue friction evidence missing (#3747) — economics advisory only.",
+            "- ranking_ready=false for all candidates.",
+            "- No §5.2.4 / Product-Complete / natural_paper_evidence claim.",
+            "- LR remains NO-GO.",
+            "",
+            f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    if not PINNED_DATASET.is_file():
+        print(f"ERROR: pinned dataset missing: {PINNED_DATASET}", file=sys.stderr)
+        return 2
+
+    OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+    head_sha = _git_head()
+    dataset_sha256 = _sha256_file(PINNED_DATASET)
+
+    results = [
+        _run_candidate(strategy_id, adapter_id, role)
+        for strategy_id, adapter_id, role in PACK_A_CANDIDATES
+    ]
+
+    manifest = {
+        "issue": ISSUE,
+        "parent_issue": PARENT_ISSUE,
+        "spec_issue": SPEC_ISSUE,
+        "head_sha": head_sha,
+        "dataset_path": str(PINNED_DATASET),
+        "dataset_sha256": dataset_sha256,
+        "ranking_ready": RANKING_READY,
+        "natural_paper_evidence": False,
+        "lr_status": LR_STATUS,
+        "scenario_ids": list(SCENARIO_IDS),
+        "candidates": [
+            {
+                "strategy_id": r.strategy_id,
+                "role": r.role,
+                "exit_code": r.exit_code,
+                "verdict": r.verdict,
+                "sub_status": r.sub_status,
+                "artifact_root": r.artifact_root,
+                "scenario_manifest_path": r.scenario_manifest_path,
+                "dataset_fingerprint": r.dataset_fingerprint,
+                "metrics_summary": r.metrics_summary,
+            }
+            for r in results
+        ],
+    }
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    EVIDENCE_DOC.parent.mkdir(parents=True, exist_ok=True)
+    EVIDENCE_DOC.write_text(
+        _render_evidence_doc(
+            head_sha=head_sha,
+            dataset_sha256=dataset_sha256,
+            results=results,
+        ),
+        encoding="utf-8",
+    )
+
+    failed = [r for r in results if r.exit_code != 0]
+    print(f"Pack-A wave-1 complete: manifest={MANIFEST_PATH}")
+    print(f"Evidence doc: {EVIDENCE_DOC}")
+    return 0 if not failed else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/validation/breakout_trend_filter_backtest_runner.py
+++ b/services/validation/breakout_trend_filter_backtest_runner.py
@@ -1,0 +1,186 @@
+"""Single-pass backtest runner for breakout_trend_filter_v1 (Pack-A wave 1)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    BREAKOUT_TREND_FILTER_STRATEGY_ID,
+    BreakoutTrendFilterConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    build_trend_gate_series,
+    compute_donchian_channels,
+    cooldown_allows_entry,
+    breakout_trend_warmup_candles,
+    validate_pack_a_candle_series,
+)
+from core.utils.clock import utcnow
+from core.utils.uuid_gen import generate_uuid
+from services.execution.simulator import ExecutionSimulator
+from services.validation.donchian_breakout_backtest_runner import (
+    _build_full_report as _build_donchian_full_report,
+    _build_minimal_report as _build_donchian_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_breakout_trend_filter_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: BreakoutTrendFilterConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass Breakout + Trend Filter backtest returning a report dict."""
+    config = bridge_config or BreakoutTrendFilterConfig()
+    config.validate()
+    warmup = breakout_trend_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    upper, lower = compute_donchian_channels(
+        highs,
+        lows,
+        entry_channel_bars=config.entry_channel_bars,
+        exit_channel_bars=config.exit_channel_bars,
+    )
+    trend_gate = build_trend_gate_series(
+        ts_values,
+        closes,
+        trend_ema_period_5m=config.trend_ema_period_5m,
+    )
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+        upper_level = upper[index]
+        lower_level = lower[index]
+        trend_ok = trend_gate[index]
+
+        if open_position is None:
+            if (
+                upper_level is not None
+                and close > upper_level
+                and trend_ok is True
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("donchian_upper_break_trend_ok")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif open_position is not None:
+            trend_fail = trend_ok is False
+            channel_exit = lower_level is not None and close < lower_level
+            if channel_exit or trend_fail:
+                exit_price = close
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="sell",
+                    size=ORDER_SIZE,
+                    current_price=exit_price,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                trade_r = (
+                    fill.avg_fill_price - open_position["entry_price"]
+                ) / open_position["entry_price"]
+                reason = "trend_gate_fail" if trend_fail and not channel_exit else "donchian_lower_break"
+                exit_reasons.append(reason)
+                trades.append(
+                    {
+                        "entry_ts_ms": open_position["entry_ts_ms"],
+                        "exit_ts_ms": ts_ms,
+                        "entry_price": open_position["entry_price"],
+                        "exit_price": fill.avg_fill_price,
+                        "entry_fee": open_position["entry_fee"],
+                        "exit_fee": fill.fees,
+                        "r_return": trade_r,
+                        "reason": reason,
+                    }
+                )
+                open_position = None
+
+    report = _build_donchian_full_report(
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config=config,
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+    )
+    report["strategy_id"] = BREAKOUT_TREND_FILTER_STRATEGY_ID
+    report["run_metadata"]["source"] = "breakout_trend_filter_backtest_runner"
+    report["config_snapshot"]["trend_ema_period_5m"] = config.trend_ema_period_5m
+    report["thresholds_applied"] = {
+        "donchian_upper_break_trend_ok": entry_reasons.count(
+            "donchian_upper_break_trend_ok"
+        ),
+        "donchian_lower_break": exit_reasons.count("donchian_lower_break"),
+        "trend_gate_fail": exit_reasons.count("trend_gate_fail"),
+    }
+    return report
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    report = _build_donchian_minimal_report(reason, code_commit, run_id=run_id)
+    report["strategy_id"] = BREAKOUT_TREND_FILTER_STRATEGY_ID
+    report["run_metadata"]["source"] = "breakout_trend_filter_backtest_runner"
+    return report
+
+
+def _utc_now_iso() -> str:
+    return utcnow().replace(tzinfo=None).isoformat() + "Z"

--- a/services/validation/donchian_breakout_backtest_runner.py
+++ b/services/validation/donchian_breakout_backtest_runner.py
@@ -1,0 +1,315 @@
+"""Single-pass backtest runner for donchian_breakout_v1 (Pack-A wave 1)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    DONCHIAN_BREAKOUT_STRATEGY_ID,
+    DonchianBreakoutConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    compute_donchian_channels,
+    cooldown_allows_entry,
+    donchian_warmup_candles,
+    validate_pack_a_candle_series,
+)
+from core.utils.clock import utcnow
+from core.utils.uuid_gen import generate_uuid
+from services.execution.simulator import ExecutionSimulator
+
+logger = logging.getLogger(__name__)
+
+SCENARIO_OVERRIDE_KEYS = frozenset(
+    {
+        "BASE_SLIPPAGE_BPS",
+        "VOLATILITY_SLIPPAGE_FACTOR",
+        "FILL_THRESHOLD",
+        "PRICE_IMPACT_FACTOR",
+        "DEPTH_IMPACT_FACTOR",
+        "EXECUTION_DELAY_BARS",
+    }
+)
+
+
+def run_donchian_breakout_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: DonchianBreakoutConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass Donchian breakout backtest returning a report dict."""
+    config = bridge_config or DonchianBreakoutConfig()
+    config.validate()
+    warmup = donchian_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    upper, lower = compute_donchian_channels(
+        highs,
+        lows,
+        entry_channel_bars=config.entry_channel_bars,
+        exit_channel_bars=config.exit_channel_bars,
+    )
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+        upper_level = upper[index]
+        lower_level = lower[index]
+
+        if open_position is None:
+            if (
+                upper_level is not None
+                and close > upper_level
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("donchian_upper_break")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif lower_level is not None and close < lower_level:
+            exit_price = close
+            volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+            order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+            fill = sim.simulate_market_order(
+                side="sell",
+                size=ORDER_SIZE,
+                current_price=exit_price,
+                order_book_depth=order_book_depth,
+                volatility=max(volatility, 0.0),
+            )
+            trade_r = (fill.avg_fill_price - open_position["entry_price"]) / open_position[
+                "entry_price"
+            ]
+            exit_reasons.append("donchian_lower_break")
+            trades.append(
+                {
+                    "entry_ts_ms": open_position["entry_ts_ms"],
+                    "exit_ts_ms": ts_ms,
+                    "entry_price": open_position["entry_price"],
+                    "exit_price": fill.avg_fill_price,
+                    "entry_fee": open_position["entry_fee"],
+                    "exit_fee": fill.fees,
+                    "r_return": trade_r,
+                    "reason": "donchian_lower_break",
+                }
+            )
+            open_position = None
+
+    return _build_full_report(
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config=config,
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+    )
+
+
+def _build_full_report(
+    *,
+    candles: list[dict[str, Any]],
+    trades: list[dict[str, Any]],
+    signals_total: int,
+    entry_reasons: list[str],
+    exit_reasons: list[str],
+    config: DonchianBreakoutConfig,
+    warmup: int,
+    code_commit: str | None,
+    run_id: str | None,
+) -> dict[str, Any]:
+    closed_count = len(trades)
+    trade_returns = [t["r_return"] for t in trades]
+    wins = [r for r in trade_returns if r > 0]
+    losses = [r for r in trade_returns if r < 0]
+    win_count = len(wins)
+    loss_count = len(losses)
+
+    gross_profit = sum(wins)
+    gross_loss = abs(sum(losses))
+    epsilon = 1e-12
+    if gross_loss <= 0 and gross_profit > 0:
+        gross_loss = epsilon
+    profit_factor = gross_profit / gross_loss if gross_loss > 0 else 0.0
+    expectancy_r = sum(trade_returns) / closed_count if closed_count > 0 else 0.0
+
+    fee_adj_returns = []
+    for trade in trades:
+        adj = trade["r_return"] - (trade["entry_fee"] + trade["exit_fee"]) / (
+            trade["entry_price"] * ORDER_SIZE
+        )
+        fee_adj_returns.append(adj)
+    fee_adj_expectancy = (
+        sum(fee_adj_returns) / closed_count if closed_count > 0 else 0.0
+    )
+    fee_adj_wins = [r for r in fee_adj_returns if r > 0]
+    fee_adj_losses = [r for r in fee_adj_returns if r < 0]
+    fee_adj_pf = (
+        sum(fee_adj_wins) / abs(sum(fee_adj_losses))
+        if fee_adj_losses and abs(sum(fee_adj_losses)) > 0
+        else 0.0
+    )
+
+    equity = 0.0
+    peak = 0.0
+    max_drawdown_r = 0.0
+    for r_val in trade_returns:
+        equity += r_val
+        if equity > peak:
+            peak = equity
+        drawdown = peak - equity
+        if drawdown > max_drawdown_r:
+            max_drawdown_r = drawdown
+
+    gross_return_r = equity
+    avg_win_r = sum(wins) / win_count if win_count > 0 else None
+    avg_loss_r = sum(losses) / loss_count if loss_count > 0 else None
+    gross_pnl = sum((t["exit_price"] - t["entry_price"]) * ORDER_SIZE for t in trades)
+    fees_total = sum(t["entry_fee"] + t["exit_fee"] for t in trades)
+    net_pnl = gross_pnl - fees_total
+    fee_adj_return_r = sum(fee_adj_returns)
+
+    first_ts = candles[0]["ts_ms"]
+    last_ts = candles[-1]["ts_ms"]
+    resolved_run_id = run_id or generate_uuid()
+
+    return {
+        "schema_version": "strategy_validation_report.v1",
+        "strategy_id": DONCHIAN_BREAKOUT_STRATEGY_ID,
+        "run_metadata": {
+            "run_id": resolved_run_id,
+            "generated_at": _utc_now_iso(),
+            "source": "donchian_breakout_backtest_runner",
+            "code_commit": code_commit or "unknown",
+        },
+        "config_snapshot": {
+            "entry_channel_bars": config.entry_channel_bars,
+            "exit_channel_bars": config.exit_channel_bars,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        "dataset_summary": {
+            "symbol": "BTCUSDT",
+            "timeframe": "1m",
+            "candles_total": len(candles),
+            "candles_live": max(0, len(candles) - warmup),
+            "period_start_ts_ms": first_ts,
+            "period_end_ts_ms": last_ts,
+            "warmup_candles": warmup,
+        },
+        "metrics": {
+            "signals_total": signals_total,
+            "buy_signals_total": signals_total,
+            "sell_signals_total": closed_count,
+            "closed_trades_total": closed_count,
+            "gross_return_r": gross_return_r,
+            "fee_adjusted_return_r": fee_adj_return_r,
+            "profit_factor": profit_factor,
+            "fee_adjusted_profit_factor": fee_adj_pf,
+            "expectancy_r": expectancy_r,
+            "fee_adjusted_expectancy_r": fee_adj_expectancy,
+            "max_drawdown_r": max_drawdown_r,
+            "win_rate": win_count / closed_count if closed_count > 0 else 0.0,
+            "avg_win_r": avg_win_r,
+            "avg_loss_r": avg_loss_r,
+            "trades_win_count": win_count,
+            "trades_loss_count": loss_count,
+            "gross_pnl_quote": gross_pnl,
+            "net_pnl_quote": net_pnl,
+            "fees_total_quote": fees_total,
+            "deterministic_replay_ok": False,
+            "ranking_ready": False,
+        },
+        "trades": trades,
+        "thresholds_applied": {
+            "donchian_upper_break": entry_reasons.count("donchian_upper_break"),
+            "donchian_lower_break": exit_reasons.count("donchian_lower_break"),
+        },
+        "entry_reasons": entry_reasons,
+        "exit_reasons": exit_reasons,
+        "gate_result": {
+            "status": "NOT_RANKING_READY",
+            "ranking_ready": False,
+        },
+    }
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "strategy_validation_report.v1",
+        "strategy_id": DONCHIAN_BREAKOUT_STRATEGY_ID,
+        "run_metadata": {
+            "run_id": run_id or generate_uuid(),
+            "generated_at": _utc_now_iso(),
+            "source": "donchian_breakout_backtest_runner",
+            "code_commit": code_commit or "unknown",
+            "early_exit_reason": reason,
+        },
+        "config_snapshot": {"ranking_ready": False},
+        "dataset_summary": {},
+        "metrics": {"ranking_ready": False, "deterministic_replay_ok": False},
+        "trades": [],
+        "entry_reasons": [],
+        "exit_reasons": [],
+        "gate_result": {"status": "NOT_RANKING_READY", "ranking_ready": False},
+    }
+
+
+def _utc_now_iso() -> str:
+    return utcnow().replace(tzinfo=None).isoformat() + "Z"

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -85,6 +85,16 @@ from core.replay.historical_bridge import (
     MOMENTUM_CAPTURE_SYMBOL,
     build_primary_breakout_historical_bridge,
 )
+from core.replay.pack_a_breakout_common import (
+    BREAKOUT_TREND_FILTER_STRATEGY_ID,
+    DONCHIAN_BREAKOUT_STRATEGY_ID,
+    ENTRY_CHANNEL_BARS,
+    EXIT_CHANNEL_BARS,
+    MIN_MINUTES_BETWEEN_ENTRIES,
+    TREND_EMA_PERIOD_5M,
+    breakout_trend_warmup_candles,
+    donchian_warmup_candles,
+)
 from core.replay.replay_contracts import (
     EnvelopeSummary,
     ReplayExecutionResult,
@@ -146,6 +156,12 @@ from services.validation.rmr_backtest_runner import (
 from services.validation.momentum_backtest_runner import (
     run_momentum_capture_backtest,
 )
+from services.validation.donchian_breakout_backtest_runner import (
+    run_donchian_breakout_backtest,
+)
+from services.validation.breakout_trend_filter_backtest_runner import (
+    run_breakout_trend_filter_backtest,
+)
 from services.validation.strategy_backtest_runner import (
     PrimaryBreakoutBacktestError,
     PrimaryBreakoutBacktestRunConfig,
@@ -159,6 +175,8 @@ from services.validation.strategy_backtest_runner import (
 _SUPPORTED_STRATEGY_IDS: frozenset[str] = frozenset(
     {
         PRIMARY_BREAKOUT_STRATEGY_ID,
+        DONCHIAN_BREAKOUT_STRATEGY_ID,
+        BREAKOUT_TREND_FILTER_STRATEGY_ID,
         RANGE_MEAN_REVERSION_STRATEGY_ID,
         MOMENTUM_CAPTURE_STRATEGY_ID,
     }
@@ -173,6 +191,8 @@ _SUPPORTED_SYMBOLS: frozenset[str] = frozenset(
 _SUPPORTED_ADAPTER_IDS: frozenset[str] = frozenset(
     {
         "primary_breakout_runner_v1",
+        "donchian_breakout_runner_v1",
+        "breakout_trend_filter_runner_v1",
         "range_mean_reversion_runner_v1",
         "momentum_capture_runner_v1",
     }
@@ -605,6 +625,25 @@ def _build_provenance_config_snapshot(
             "cooldown_minutes": MOMENTUM_COOLDOWN_MINUTES,
             "regime_hvc": MOMENTUM_REGIME_HVC,
         }
+    if config.strategy_id == DONCHIAN_BREAKOUT_STRATEGY_ID:
+        return {
+            "order_size": config.order_size,
+            "order_book_depth_multiplier": config.order_book_depth_multiplier,
+            "entry_channel_bars": ENTRY_CHANNEL_BARS,
+            "exit_channel_bars": EXIT_CHANNEL_BARS,
+            "min_minutes_between_entries": MIN_MINUTES_BETWEEN_ENTRIES,
+            "ranking_ready": False,
+        }
+    if config.strategy_id == BREAKOUT_TREND_FILTER_STRATEGY_ID:
+        return {
+            "order_size": config.order_size,
+            "order_book_depth_multiplier": config.order_book_depth_multiplier,
+            "entry_channel_bars": ENTRY_CHANNEL_BARS,
+            "exit_channel_bars": EXIT_CHANNEL_BARS,
+            "min_minutes_between_entries": MIN_MINUTES_BETWEEN_ENTRIES,
+            "trend_ema_period_5m": TREND_EMA_PERIOD_5M,
+            "ranking_ready": False,
+        }
     return {
         "order_size": config.order_size,
         "order_book_depth_multiplier": config.order_book_depth_multiplier,
@@ -805,6 +844,172 @@ def _build_momentum_execution_provenance_id(
     }
     digest = hashlib.sha256(canonical_json_dumps(payload).encode("utf-8")).hexdigest()
     return f"bt-{digest[:16]}"
+
+
+def _build_pack_a_execution_provenance_id(
+    candles: list[dict[str, Any]],
+    *,
+    strategy_id: str,
+    code_commit: str,
+    config_payload: dict[str, Any],
+) -> str:
+    import hashlib
+
+    candles_hash = canonical_hash(
+        [
+            {
+                k: c.get(k)
+                for k in (
+                    "ts_ms",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "regime_id",
+                )
+            }
+            for c in candles
+        ]
+    )
+    payload = {
+        "code_commit": code_commit,
+        "candles_hash": candles_hash,
+        "strategy_id": strategy_id,
+        **config_payload,
+    }
+    digest = hashlib.sha256(canonical_json_dumps(payload).encode("utf-8")).hexdigest()
+    return f"bt-{digest[:16]}"
+
+
+def _strategy_warmup_count(config: ARVPReplayConfig) -> int:
+    if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
+        return RMR_WARMUP_CANDLES
+    if config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
+        return MOMENTUM_WARMUP_CANDLES
+    if config.strategy_id == DONCHIAN_BREAKOUT_STRATEGY_ID:
+        return donchian_warmup_candles()
+    if config.strategy_id == BREAKOUT_TREND_FILTER_STRATEGY_ID:
+        return breakout_trend_warmup_candles()
+    return max(config.entry_lookback_minutes, config.exit_lookback_minutes)
+
+
+def _is_no_two_pass_determinism_strategy(strategy_id: str) -> bool:
+    return strategy_id in {
+        RANGE_MEAN_REVERSION_STRATEGY_ID,
+        MOMENTUM_CAPTURE_STRATEGY_ID,
+        DONCHIAN_BREAKOUT_STRATEGY_ID,
+        BREAKOUT_TREND_FILTER_STRATEGY_ID,
+    }
+
+
+def _build_execution_provenance_id_for_config(
+    config: ARVPReplayConfig,
+    candles: list[dict[str, Any]],
+    *,
+    code_commit: str,
+) -> str:
+    if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
+        return _build_rmr_execution_provenance_id(candles, code_commit=code_commit)
+    if config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
+        return _build_momentum_execution_provenance_id(candles, code_commit=code_commit)
+    if config.strategy_id == DONCHIAN_BREAKOUT_STRATEGY_ID:
+        return _build_pack_a_execution_provenance_id(
+            candles,
+            strategy_id=DONCHIAN_BREAKOUT_STRATEGY_ID,
+            code_commit=code_commit,
+            config_payload={
+                "entry_channel_bars": ENTRY_CHANNEL_BARS,
+                "exit_channel_bars": EXIT_CHANNEL_BARS,
+                "min_minutes_between_entries": MIN_MINUTES_BETWEEN_ENTRIES,
+            },
+        )
+    if config.strategy_id == BREAKOUT_TREND_FILTER_STRATEGY_ID:
+        return _build_pack_a_execution_provenance_id(
+            candles,
+            strategy_id=BREAKOUT_TREND_FILTER_STRATEGY_ID,
+            code_commit=code_commit,
+            config_payload={
+                "entry_channel_bars": ENTRY_CHANNEL_BARS,
+                "exit_channel_bars": EXIT_CHANNEL_BARS,
+                "min_minutes_between_entries": MIN_MINUTES_BETWEEN_ENTRIES,
+                "trend_ema_period_5m": TREND_EMA_PERIOD_5M,
+            },
+        )
+    run_cfg = PrimaryBreakoutBacktestRunConfig(
+        bridge=PrimaryBreakoutBridgeConfig(
+            entry_lookback_minutes=config.entry_lookback_minutes,
+            exit_lookback_minutes=config.exit_lookback_minutes,
+            breakout_buffer=config.breakout_buffer,
+            min_minutes_between_entries=config.min_minutes_between_entries,
+        ),
+        order_size=config.order_size,
+        order_book_depth_multiplier=config.order_book_depth_multiplier,
+    )
+    return _build_execution_provenance_id(
+        candles,
+        run_config=run_cfg,
+        code_commit=code_commit,
+    )
+
+
+def _run_strategy_backtest(
+    config: ARVPReplayConfig,
+    candles: list[dict[str, Any]],
+    *,
+    code_commit: str,
+    run_id: str | None = None,
+    run_cfg: PrimaryBreakoutBacktestRunConfig | None = None,
+    simulator_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
+        return run_range_mean_reversion_backtest(
+            candles,
+            run_config=None,
+            simulator_config=simulator_config,
+            code_commit=code_commit,
+            run_id=run_id,
+        )
+    if config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
+        return run_momentum_capture_backtest(
+            candles,
+            run_config=None,
+            simulator_config=simulator_config,
+            code_commit=code_commit,
+            run_id=run_id,
+        )
+    if config.strategy_id == DONCHIAN_BREAKOUT_STRATEGY_ID:
+        return run_donchian_breakout_backtest(
+            candles,
+            simulator_config=simulator_config,
+            code_commit=code_commit,
+            run_id=run_id,
+        )
+    if config.strategy_id == BREAKOUT_TREND_FILTER_STRATEGY_ID:
+        return run_breakout_trend_filter_backtest(
+            candles,
+            simulator_config=simulator_config,
+            code_commit=code_commit,
+            run_id=run_id,
+        )
+    if run_cfg is None:
+        run_cfg = PrimaryBreakoutBacktestRunConfig(
+            bridge=PrimaryBreakoutBridgeConfig(
+                entry_lookback_minutes=config.entry_lookback_minutes,
+                exit_lookback_minutes=config.exit_lookback_minutes,
+                breakout_buffer=config.breakout_buffer,
+                min_minutes_between_entries=config.min_minutes_between_entries,
+            ),
+            order_size=config.order_size,
+            order_book_depth_multiplier=config.order_book_depth_multiplier,
+        )
+    return run_primary_breakout_backtest(
+        candles,
+        run_config=run_cfg,
+        simulator_config=simulator_config,
+        code_commit=code_commit,
+        gate_trace_path=config.gate_trace_path,
+    )
 
 
 def _write_operator_summary_artifact(
@@ -1019,15 +1224,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
         Exit code integer: 0 success, 1 config error, 2 runtime/input error.
     """
     # Strategy-aware warmup count
-    if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
-        warmup_count = RMR_WARMUP_CANDLES
-    elif config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
-        warmup_count = MOMENTUM_WARMUP_CANDLES
-    else:
-        warmup_count = max(
-            config.entry_lookback_minutes,
-            config.exit_lookback_minutes,
-        )
+    warmup_count = _strategy_warmup_count(config)
 
     # Scenario group path (supported for all strategies)
     if config.scenario_ids:
@@ -1056,17 +1253,12 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
             dataset_result,
             speedup_profile=config.speedup_profile,
         )
-        if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
-            execution_provenance_id = _build_rmr_execution_provenance_id(
-                candles,
-                code_commit=code_commit,
-            )
-        elif config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
-            execution_provenance_id = _build_momentum_execution_provenance_id(
-                candles,
-                code_commit=code_commit,
-            )
-        else:
+        execution_provenance_id = _build_execution_provenance_id_for_config(
+            config,
+            candles,
+            code_commit=code_commit,
+        )
+        if config.strategy_id == PRIMARY_BREAKOUT_STRATEGY_ID:
             run_cfg = PrimaryBreakoutBacktestRunConfig(
                 bridge=PrimaryBreakoutBridgeConfig(
                     entry_lookback_minutes=config.entry_lookback_minutes,
@@ -1077,11 +1269,8 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 order_size=config.order_size,
                 order_book_depth_multiplier=config.order_book_depth_multiplier,
             )
-            execution_provenance_id = _build_execution_provenance_id(
-                candles,
-                run_config=run_cfg,
-                code_commit=code_commit,
-            )
+        else:
+            run_cfg = None
         provenance_fingerprint = build_replay_provenance_fingerprint(
             strategy_id=config.strategy_id,
             symbol=config.symbol,
@@ -1126,29 +1315,13 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
 
     # Delegate to the strategy-specific backtest surface
     try:
-        if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
-            backtest_report = run_range_mean_reversion_backtest(
-                candles,
-                run_config=None,
-                simulator_config=None,
-                code_commit=code_commit,
-                run_id=run_id,
-            )
-        elif config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
-            backtest_report = run_momentum_capture_backtest(
-                candles,
-                run_config=None,
-                simulator_config=None,
-                code_commit=code_commit,
-                run_id=run_id,
-            )
-        else:
-            backtest_report = run_primary_breakout_backtest(
-                candles,
-                run_config=run_cfg,
-                code_commit=code_commit,
-                gate_trace_path=config.gate_trace_path,
-            )
+        backtest_report = _run_strategy_backtest(
+            config,
+            candles,
+            code_commit=code_commit,
+            run_id=run_id,
+            run_cfg=run_cfg,
+        )
     except (HistoricalBridgeError, PrimaryBreakoutBacktestError) as exc:
         try:
             _append_failed_record(
@@ -1285,23 +1458,17 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
 
     # Determinism check
     gate_status = (backtest_report.get("gate_result") or {}).get("status")
-    is_rmr = config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID
-    is_momentum = config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID
-    if is_rmr or is_momentum:
+    no_two_pass = _is_no_two_pass_determinism_strategy(config.strategy_id)
+    if no_two_pass:
         deterministic_replay_ok = False
     else:
         metrics = backtest_report.get("metrics", {})
         deterministic_replay_ok = bool(metrics.get("deterministic_replay_ok", False))
 
     if not deterministic_replay_ok:
-        if is_rmr:
+        if no_two_pass:
             print(
-                "INFO: deterministic_replay_ok=False — RMR has no two-pass check.",
-                file=sys.stderr,
-            )
-        elif is_momentum:
-            print(
-                "INFO: deterministic_replay_ok=False — momentum_capture_v1 has no two-pass check.",
+                f"INFO: deterministic_replay_ok=False — {config.strategy_id} has no two-pass check.",
                 file=sys.stderr,
             )
         else:
@@ -1310,7 +1477,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 "inconsistent outputs.",
                 file=sys.stderr,
             )
-        if config.deterministic_verify and not is_rmr and not is_momentum:
+        if config.deterministic_verify and not no_two_pass:
             failed_record: ReplayRunRecord | None = None
             try:
                 failed_record = _append_failed_record(
@@ -1505,6 +1672,32 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _write_scenario_metrics_artifact(
+    *,
+    output_dir: Path,
+    config: ARVPReplayConfig,
+    spec: ScenarioSpec,
+    backtest_report: dict[str, Any],
+) -> None:
+    if config.scenario_group_id:
+        summary_dir = output_dir / config.scenario_group_id
+    else:
+        summary_dir = output_dir
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    summary_payload = {
+        "scenario_id": spec.scenario_id,
+        "run_id": backtest_report["run_metadata"]["run_id"],
+        "strategy_id": config.strategy_id,
+        "metrics": backtest_report.get("metrics", {}),
+        "dataset_summary": backtest_report.get("dataset_summary", {}),
+        "ranking_ready": False,
+    }
+    (summary_dir / f"{spec.scenario_id}_metrics.json").write_text(
+        json.dumps(summary_payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
 def _make_pb_run_single_fn(
     candles: list[dict[str, Any]],
     config: ARVPReplayConfig,
@@ -1543,6 +1736,12 @@ def _make_pb_run_single_fn(
                 code_commit=code_commit,
             )
 
+            _write_scenario_metrics_artifact(
+                output_dir=output_dir,
+                config=config,
+                spec=spec,
+                backtest_report=backtest_report,
+            )
             run_id = backtest_report["run_metadata"]["run_id"]
             return ScenarioRunResult(
                 scenario_id=spec.scenario_id,
@@ -1659,6 +1858,57 @@ def _make_momentum_run_single_fn(
     return run_single
 
 
+def _make_pack_a_run_single_fn(
+    candles: list[dict[str, Any]],
+    config: ARVPReplayConfig,
+    code_commit: str | None,
+    output_dir: Path,
+) -> Callable[[ScenarioSpec], ScenarioRunResult]:
+    def run_single(spec: ScenarioSpec) -> ScenarioRunResult:
+        try:
+            resolved_overrides = _apply_scenario_overrides(
+                config, spec.config_overrides
+            )
+            warmup_count = _strategy_warmup_count(config)
+            scenario_candles = _apply_replay_data_overrides(
+                candles,
+                resolved_overrides.replay_data_overrides,
+                warmup_count=warmup_count,
+            )
+            backtest_report = _run_strategy_backtest(
+                config,
+                scenario_candles,
+                code_commit=code_commit,
+                simulator_config=resolved_overrides.simulator_config,
+            )
+            run_id = backtest_report["run_metadata"]["run_id"]
+            _write_scenario_metrics_artifact(
+                output_dir=output_dir,
+                config=config,
+                spec=spec,
+                backtest_report=backtest_report,
+            )
+            return ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=0,
+                run_id=run_id,
+            )
+        except ReplayRunnerError as exc:
+            return ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=2,
+                failure_reason=str(exc),
+            )
+        except Exception as exc:
+            return ScenarioRunResult(
+                scenario_id=spec.scenario_id,
+                exit_code=2,
+                failure_reason=str(exc),
+            )
+
+    return run_single
+
+
 def _run_scenario_group_path_with_candles(
     config: ARVPReplayConfig,
     *,
@@ -1694,6 +1944,11 @@ def _run_scenario_group_path(
         run_single = _make_rmr_run_single_fn(candles, config, code_commit, output_dir)
     elif config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
         run_single = _make_momentum_run_single_fn(candles, config, code_commit, output_dir)
+    elif config.strategy_id in {
+        DONCHIAN_BREAKOUT_STRATEGY_ID,
+        BREAKOUT_TREND_FILTER_STRATEGY_ID,
+    }:
+        run_single = _make_pack_a_run_single_fn(candles, config, code_commit, output_dir)
     else:
         run_single = _make_pb_run_single_fn(candles, config, code_commit, output_dir)
 

--- a/tests/unit/replay/test_pack_a_breakout_common.py
+++ b/tests/unit/replay/test_pack_a_breakout_common.py
@@ -1,0 +1,72 @@
+"""Unit tests for Pack-A breakout helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    ENTRY_CHANNEL_BARS,
+    ONE_MINUTE_MS,
+    build_trend_gate_series,
+    compute_donchian_channels,
+    cooldown_allows_entry,
+    donchian_warmup_candles,
+    validate_pack_a_candle_series,
+)
+
+
+def _candle(ts_ms: int, close: float, *, high: float | None = None, low: float | None = None) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": high if high is not None else close + 1,
+        "low": low if low is not None else close - 1,
+        "close": close,
+        "volume": 1.0,
+        "regime_id": 1,
+    }
+
+
+@pytest.mark.unit
+def test_donchian_warmup_uses_max_channel() -> None:
+    assert donchian_warmup_candles() == max(ENTRY_CHANNEL_BARS, 10)
+
+
+@pytest.mark.unit
+def test_compute_donchian_channels_uses_prior_bars_only() -> None:
+    highs = [float(i) for i in range(1, 26)]
+    lows = [float(i) - 0.5 for i in range(1, 26)]
+    upper, lower = compute_donchian_channels(
+        highs, lows, entry_channel_bars=5, exit_channel_bars=3
+    )
+    assert upper[5] == max(highs[0:5])
+    assert lower[3] == min(lows[0:3])
+    assert upper[4] is None
+
+
+@pytest.mark.unit
+def test_cooldown_blocks_rapid_reentry() -> None:
+    assert cooldown_allows_entry(0, None, min_minutes_between_entries=30)
+    assert not cooldown_allows_entry(
+        10 * ONE_MINUTE_MS, 0, min_minutes_between_entries=30
+    )
+
+
+@pytest.mark.unit
+def test_validate_pack_a_candle_series_rejects_bad_cadence() -> None:
+    candles = [
+        _candle(0, 100.0),
+        _candle(ONE_MINUTE_MS + 1, 101.0),
+    ]
+    with pytest.raises(ValueError, match="1m cadence"):
+        validate_pack_a_candle_series(candles)
+
+
+@pytest.mark.unit
+def test_trend_gate_requires_completed_5m_bars() -> None:
+    ts_values = [i * ONE_MINUTE_MS for i in range(30)]
+    closes = [100.0 + i * 0.1 for i in range(30)]
+    gate = build_trend_gate_series(ts_values, closes, trend_ema_period_5m=3)
+    assert gate[0] is None
+    assert any(value is not None for value in gate)

--- a/tests/unit/validation/test_pack_a_replay_dispatch.py
+++ b/tests/unit/validation/test_pack_a_replay_dispatch.py
@@ -1,0 +1,45 @@
+"""Dispatch tests for Pack-A strategy replay wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    BREAKOUT_TREND_FILTER_STRATEGY_ID,
+    DONCHIAN_BREAKOUT_STRATEGY_ID,
+)
+from services.validation.strategy_replay_runner import ARVPReplayConfig
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("strategy_id", "adapter_id"),
+    [
+        ("primary_breakout_v1", "primary_breakout_runner_v1"),
+        (DONCHIAN_BREAKOUT_STRATEGY_ID, "donchian_breakout_runner_v1"),
+        (BREAKOUT_TREND_FILTER_STRATEGY_ID, "breakout_trend_filter_runner_v1"),
+    ],
+)
+def test_pack_a_strategy_ids_validate(strategy_id: str, adapter_id: str) -> None:
+    config = ARVPReplayConfig(
+        dataset_source="file",
+        input_candles_file="artifacts/backtests/primary_breakout_v1/20260418-212643/dataset.candles.json",
+        strategy_id=strategy_id,
+        symbol="BTCUSDT",
+        adapter_id=adapter_id,
+        scenario_ids=("baseline", "pessimistic_execution", "feed_gap"),
+    )
+    config.validate()
+
+
+@pytest.mark.unit
+def test_pack_a_rejects_unknown_adapter() -> None:
+    config = ARVPReplayConfig(
+        dataset_source="file",
+        input_candles_file="dataset.json",
+        strategy_id=DONCHIAN_BREAKOUT_STRATEGY_ID,
+        symbol="BTCUSDT",
+        adapter_id="unknown_adapter_v1",
+    )
+    with pytest.raises(ValueError, match="unsupported adapter_id"):
+        config.validate()


### PR DESCRIPTION
## Summary
- Implements minimal offline replay adapters for `donchian_breakout_v1` and `breakout_trend_filter_v1` and wires them into `strategy_replay_runner`.
- Executes Pack-A wave-1 Top-3 (`primary_breakout_v1` PARK reference, Donchian, Breakout+Trend) on the pinned BTCUSDT 1m dataset with scenarios `baseline`, `pessimistic_execution`, `feed_gap`.
- Adds evidence doc `docs/evidence/arvp_pack_a_wave1_shape_replay_3780.md` and orchestration script `scripts/profitability/run_pack_a_wave1_shape_replay_3780.py`.

Closes #3780
Refs #3748
Refs #3747
Refs #3742
Refs #1900

## Human-GO boundary
- Offline replay / shape-run only; no Docker paper runtime; no fresh-paper observation.
- `ranking_ready=false`; no `natural_paper_evidence` claim; LR NO-GO unchanged; no promotion.

## Brain Evidence
- `brain_source=repo-only`, `brain_status=not-used`, `context_available=false`
- MCP `context_briefing` alias unavailable (`unknown_tool`); repo/GitHub live used.
- Evidence grounded in repo spec #3748, live issue state, and executed replay manifests.

## Adapter readiness
- `donchian_breakout_v1` + `breakout_trend_filter_v1`: **implemented** (minimal deterministic single-pass runners).
- `primary_breakout_v1`: existing adapter used as PARKED reference only.

## Delivered
- `core/replay/pack_a_breakout_common.py`
- `services/validation/donchian_breakout_backtest_runner.py`
- `services/validation/breakout_trend_filter_backtest_runner.py`
- `services/validation/strategy_replay_runner.py` dispatch + scenario metrics artifacts
- `scripts/profitability/run_pack_a_wave1_shape_replay_3780.py`
- `docs/evidence/arvp_pack_a_wave1_shape_replay_3780.md`
- Unit tests for helpers + dispatch

## Validation
- `ruff check` on touched paths
- `pytest -q tests/unit/validation/test_strategy_replay_runner.py`
- `pytest -q tests/unit/replay/test_scenario_packs.py tests/unit/replay/test_scenario_harness.py`
- `pytest -q tests/unit/replay/test_pack_a_breakout_common.py tests/unit/validation/test_pack_a_replay_dispatch.py`
- Local offline execute: all Top-3 **PASS** + `NOT_RANKING_READY`

## Safety boundaries
- No runtime stack / no live exchange / no DB mutation.
- No LR/live/echtgeld implication.
- B1 friction gap unchanged (#3747).

## No natural_paper_evidence
This slice is offline shape/replay only; it does not claim natural-paper windows or §5.2.4 Product-Complete.

## ranking_ready=false
All candidates explicitly `NOT_RANKING_READY`; economics advisory only.

## Test plan
- [x] Unit tests for Pack-A helpers and replay dispatch
- [x] Existing strategy_replay_runner + scenario harness regression
- [x] Local wave-1 orchestration script run (3 strategies x 3 scenarios)