### PR TITLE
fix(tests): stabilize trust summary stale memory fixtures

### DIFF
--- a/tests/unit/tools/surrealdb/test_trust_summary.py
+++ b/tests/unit/tools/surrealdb/test_trust_summary.py
@@ -68,9 +68,11 @@ def _run_lookups():
 
     mem_list = _load_jsonl("agent_memories.jsonl")
     mem_input = [_normalize_memory_row(r) for r in mem_list]
+    # Align freshness reference with fixture materialization (stale_after=7d).
     mem_result = read_memory_v1(
         mem_input,
         MemoryReadRequest(mode="by_scope", scope="wave14", limit=200),
+        now=FIXED_NOW,
     )
 
     return ev_result, cl_result, dec_result, mem_result


### PR DESCRIPTION
## Summary

Closes #3793

Refs #3750
Refs #3752

Stabilizes `TestTrustSummaryWithFixtureData` by passing the same `FIXED_NOW` reference instant to `read_memory_v1` that `materialize_fixture_records` already uses for fixture timestamps.

## Root cause

Fixture memory rows are materialized with `created_at` anchored to `FIXED_NOW` (2026-06-29) and `stale_after=7d`. `read_memory_v1` defaulted to wall-clock `cdb_utcnow()`, so once real time crossed the 7-day boundary the memory was classified stale (`trust_level=stale`, score 0.05), dropping `composite_score` from 0.7825 to 0.5925 and surfacing `stale_memory` / `stale_or_disputed_context` gates.

## Delivered

- Pass `now=FIXED_NOW` into `read_memory_v1` inside `_run_lookups()`.
- Short comment documenting the alignment requirement.

## Validation

- `pytest tests/unit/tools/surrealdb/test_trust_summary.py -q` — 15 passed
- `pytest tests/unit/tools/surrealdb -q` — 15 passed
- `git diff --check` — clean
- No skip/xfail/score weakening

## Non-goals

- No change to trust scoring semantics in `trust_summary.py`
- No Dependabot PR merges in this slice (#3750/#3752)
- No production clock injection beyond existing `read_memory_v1(now=...)` API

## Safety boundaries

- Test-only change; LR remains NO-GO; no runtime/DB/MCP/live impact

## Restunsicherheiten

- Other unit tests using Wave-14 fixtures without explicit `now=` may drift similarly if they rely on relative freshness; out of scope unless CI surfaces them
