### PR TITLE
docs(security): Grafana 13.1.0 CVE-42504 verify evidence (#3764)

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md
+++ b/docs/evidence/security/CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md
@@ -1,0 +1,98 @@
+# Grafana 13.1.0 verify-before-merge — Issue #3764 / CVE-2026-42504
+
+**Stand:** 2026-07-06 (UTC)  
+**Scope:** Trivy image probe only. No `docker compose up`, no runtime mutation, no alert dismissals, no issue closure.  
+**Related PR:** [#3755](https://github.com/jannekbuengener/Claire_de_Binare/pull/3755) (Dependabot `grafana/grafana` 13.0.3 → 13.1.0)  
+**Related issue:** [#3764](https://github.com/jannekbuengener/Claire_de_Binare/issues/3764)  
+**Fingerprint (readout):** `bc41affecdbcf679`
+
+---
+
+## Executive verdict
+
+| Question | Result |
+|----------|--------|
+| Does `grafana/grafana:13.1.0-ubuntu` clear CVE-2026-42504 on the bundled Elasticsearch plugin path? | **NO** |
+| PR #3755 merge as security remediation for #3764? | **NO — HOLD_UPSTREAM_BLOCKED** |
+| Infra hygiene (semver minor bump) without security clearance? | Optional later; **not merged in this slice** |
+
+---
+
+## Scan parameters
+
+| Field | Value |
+|-------|-------|
+| Tool | Trivy `0.72.0` |
+| Vuln DB | Updated `2026-07-06` (fresh download at scan time) |
+| Command | `trivy image --severity HIGH,CRITICAL --format json <image>` |
+| Images probed | `grafana/grafana:13.1.0-ubuntu`, `grafana/grafana:13.0.3-ubuntu` (baseline) |
+| Target digest (13.1.0) | `sha256:41b0dc13bb4f6a63ae2facb6112bfa40db59c797e0b70f9d6795d838de04537b` (matches PR #3755 pin) |
+| Target digest (13.0.3) | `sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084` (current main pin) |
+
+---
+
+## CVE-2026-42504 findings
+
+### `grafana/grafana:13.1.0-ubuntu` (PR #3755 target)
+
+| Target | Package | Installed | Fixed in | Severity |
+|--------|---------|-----------|----------|----------|
+| `usr/share/grafana/data/plugins-bundled/elasticsearch/gpx_grafana_elasticsearch_datasource_linux_amd64` | `stdlib` (Go) | `v1.26.3` | `1.25.11`, `1.26.4` | HIGH |
+| `usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `stdlib` (Go) | `v1.25.7` | `1.25.11`, `1.26.4` | HIGH |
+
+The **Issue #3764** affected component path matches the Elasticsearch plugin row exactly.
+
+### `grafana/grafana:13.0.3-ubuntu` (current main baseline)
+
+| Target | Package | Installed | Fixed in | Severity |
+|--------|---------|-----------|----------|----------|
+| `usr/share/grafana/data/plugins-bundled/elasticsearch/gpx_grafana_elasticsearch_datasource_linux_amd64` | `stdlib` (Go) | `v1.26.3` | `1.25.11`, `1.26.4` | HIGH |
+
+---
+
+## Comparison / interpretation
+
+- Bumping `13.0.3-ubuntu` → `13.1.0-ubuntu` **does not remove** CVE-2026-42504 from the Elasticsearch bundled plugin binary.
+- Installed Go stdlib version on the alert path remains **`v1.26.3`** (below fix floor **`1.26.4`**).
+- 13.1.0 additionally exposes CVE-2026-42504 on the Zipkin bundled plugin (new scan surface vs 13.0.3 baseline).
+- Root cause class aligns with prior batch matrix `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md`: upstream Go stdlib rebuild required in bundled binaries/plugins.
+
+---
+
+## PR #3755 scope check
+
+- Diff touches **only** `infrastructure/compose/compose.red.yml` (Grafana image pin).
+- PR branch status at probe time: `BEHIND` main (pre-merge update would be required if ever merged).
+- CI checks on last run: green (not re-run after main advanced).
+
+---
+
+## Decision
+
+**HOLD_UPSTREAM_BLOCKED** — do not merge #3755 as CVE-2026-42504 remediation for #3764.
+
+### Re-triage trigger
+
+Merge or pin update only after Trivy (or equivalent) shows **no CVE-2026-42504** on:
+
+`usr/share/grafana/data/plugins-bundled/elasticsearch/gpx_grafana_elasticsearch_datasource_linux_amd64`
+
+in a scan-verified `grafana/grafana` release image.
+
+---
+
+## Safety boundaries
+
+- LR: NO-GO
+- No alert dismissals
+- Issue #3764 remains open
+- No BLUE/RED runtime changes in this slice
+
+---
+
+## Validation performed
+
+- `gh pr view 3755`, `gh pr diff 3755`, `gh issue view 3764`
+- `docker pull grafana/grafana:13.1.0-ubuntu`
+- Local Trivy JSON scan + structured parse for `CVE-2026-42504` and elasticsearch plugin path
+- Cross-check with `CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md`


### PR DESCRIPTION
## Summary

Trivy verify-before-merge evidence for PR #3755 / Issue #3764.

**Verdict:** HOLD_UPSTREAM_BLOCKED — CVE-2026-42504 remains on bundled elasticsearch plugin in 13.1.0-ubuntu.

## Non-goals
- Does not merge PR #3755
- No alert dismissals or issue closure

Refs #3764

Made with [Cursor](https://cursor.com)