### PR TITLE
docs(security): document os-layer CVE probe for gzip and libacl

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_OS_LAYER_3756-3765_CVE-41992_CVE-54369_VERIFY_2026-07-06.md
+++ b/docs/evidence/security/CDB_SECURITY_OS_LAYER_3756-3765_CVE-41992_CVE-54369_VERIFY_2026-07-06.md
@@ -1,0 +1,174 @@
+# OS-layer Security Probe — Issues #3756–#3765 / CVE-2026-41992 & CVE-2026-54369
+
+**Stand:** 2026-07-06 (UTC)  
+**Parent epic:** [#2289](https://github.com/jannekbuengener/Claire_de_Binare/issues/2289)  
+**Related trackers:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513) · [#3802](https://github.com/jannekbuengener/Claire_de_Binare/issues/3802) (gzip) · [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803) (libacl1)  
+**Main @ probe:** `40244c2b2bb7fb4649ae28f26ee5e0e3be89db0b`  
+**Scope guard:** Trivy probe + evidence only. Kein Dockerfile-/Digest-Diff, kein LR-Go, keine Alert-Dismissals, keine Issue-Closures.
+
+---
+
+## Executive summary
+
+| Cluster | Issues | CVE | Package | Installed | Fixed (Trivy/Debian) | Verdict |
+|---------|--------|-----|---------|-----------|---------------------|---------|
+| gzip / GNU gzip LZH | #3756–#3763 | CVE-2026-41992 | `gzip` | `1.13-1` | **empty** | **UPSTREAM_BLOCKED** |
+| libacl / ACL symlink | #3765 (+ OS-layer on all Trixie services) | CVE-2026-54369 | `libacl1` | `2.3.2-2+b1` | **empty** (upstream fix: acl **>= 2.4.0**) | **UPSTREAM_BLOCKED** |
+
+**Remediation in this slice:** Kein Dockerfile-/Digest-Diff. Fixability-Probes zeigen, dass weder ein neuer `python:3.14-slim-trixie`-Digest noch `apt-get upgrade -y` eine fixed Version für `gzip` oder `libacl1` liefert. Beobachtung bis Debian Trixie Security-Updates veröffentlicht.
+
+---
+
+## Issue cluster #3756–#3763 (CVE-2026-41992 / gzip)
+
+All eight issues share:
+
+- **Subject:** `cve-2026-41992`
+- **Severity:** HIGH (`code_scanning`)
+- **Readout:** `2026-07-06T07:51:20Z`
+- **Labels:** `type:security`, `status:blocked`, `triage:offen`
+- **Root cause class:** Debian Trixie OS package `gzip@1.13-1` in pinned `python:3.14-slim-trixie` base
+
+| Issue | Service | Fingerprint |
+|-------|---------|-------------|
+| [#3756](https://github.com/jannekbuengener/Claire_de_Binare/issues/3756) | `cdb_allocation` | `e5a66c49b0d370c0` |
+| [#3757](https://github.com/jannekbuengener/Claire_de_Binare/issues/3757) | `cdb_db_writer` | `540525a4ed1da3f0` |
+| [#3758](https://github.com/jannekbuengener/Claire_de_Binare/issues/3758) | `cdb_execution` | `b0846a81d7770b96` |
+| [#3759](https://github.com/jannekbuengener/Claire_de_Binare/issues/3759) | `cdb_market` | `0e9b7da3085f0a51` |
+| [#3760](https://github.com/jannekbuengener/Claire_de_Binare/issues/3760) | `cdb_regime` | `6ea5cf489786dc2b` |
+| [#3761](https://github.com/jannekbuengener/Claire_de_Binare/issues/3761) | `cdb_risk` | `1be57717c1fec087` |
+| [#3762](https://github.com/jannekbuengener/Claire_de_Binare/issues/3762) | `cdb_signal` | `5009cce0d109a48c` |
+| [#3763](https://github.com/jannekbuengener/Claire_de_Binare/issues/3763) | `cdb_ws` | `d763f738a9a378a4` |
+
+**Cluster verdict:** Gemeinsamer **gzip / Debian-Trixie-Base-Image-Cluster**. Ein Fixpfad (Base-Digest-Refresh + Debian-Security-Backport) betrifft alle acht Services gleichzeitig.
+
+---
+
+## Issue #3765 (CVE-2026-54369 / libacl1)
+
+| Field | Value |
+|-------|-------|
+| Issue | [#3765](https://github.com/jannekbuengener/Claire_de_Binare/issues/3765) |
+| Service (GH readout) | `cdb_allocation` |
+| Fingerprint | `ad87df84440fa999` |
+| CVE | CVE-2026-54369 |
+| Package | `libacl1` |
+
+**Scanner note:** GitHub Code Scanning flagged only `cdb_allocation` for this CVE in the 2026-07-06 readout. Trivy probe on `cdb_risk` (representative built image) and the unpinned base image shows `libacl1@2.3.2-2+b1` in the **same OS layer** for all `python:3.14-slim-trixie` services. Operational cluster scope is therefore the shared Trixie base, not allocation-specific application code.
+
+---
+
+## Docker / base-image finding
+
+Pinned base (eight scope Dockerfiles @ `origin/main` `40244c2b`):
+
+- `python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1`
+
+Sources: `services/{allocation,db_writer,execution,market,regime,risk,signal,ws}/Dockerfile`
+
+All eight Dockerfiles run `apt-get update && apt-get upgrade -y` before service layers — prior pattern from #2289 slices; **does not close** these CVEs.
+
+Out of scope (different base):
+
+- `services/candles/Dockerfile` — `python:3.14-slim-bookworm`
+- `services/reports/Dockerfile` — `python:3.14-slim-bookworm`
+
+---
+
+## Security probe / Trivy evidence
+
+| Field | Value |
+|-------|-------|
+| Tool | Trivy `0.72.0` |
+| Vuln DB | Updated `2026-07-06T08:09:55Z` |
+| Command | `trivy image --severity HIGH,CRITICAL --format json <image>` |
+
+### Images probed
+
+| Image | Build | Digest / tag |
+|-------|-------|--------------|
+| `cdb-risk-probe:3756-3765` | `docker build -f services/risk/Dockerfile -t cdb-risk-probe:3756-3765 .` | `sha256:24b0761e4fc06225d39b0d946f475cf4fea5450e5ca6ebbd66e16f2ebaa0d8a5` |
+| `python:3.14-slim-trixie@sha256:b877e50…` | `docker pull` (baseline) | `sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1` |
+
+`cdb_allocation` full image build blocked locally by Docker context sender error on `.tmp\pytest-cdb` (Access denied). OS-layer CVE presence is confirmed via built `cdb_risk` probe + base image scan (same base digest and `apt-get upgrade` path).
+
+### CVE-2026-41992 (gzip)
+
+| Target | Package | Installed | FixedVersion | Severity | Layer |
+|--------|---------|-----------|--------------|----------|-------|
+| `cdb-risk-probe:3756-3765` | `gzip` | `1.13-1` | **empty** | HIGH | `sha256:e95a6c7ea7d49b37920899b023ecd0e32796c976c1748491f76cae53ba86d13a` |
+| `python:3.14-slim-trixie@sha256:b877e50…` | `gzip` | `1.13-1` | **empty** | HIGH | same OS layer |
+
+### CVE-2026-54369 (libacl1)
+
+| Target | Package | Installed | FixedVersion | Severity | Layer |
+|--------|---------|-----------|--------------|----------|-------|
+| `cdb-risk-probe:3756-3765` | `libacl1` | `2.3.2-2+b1` | **empty** | HIGH | `sha256:e95a6c7ea7d49b37920899b023ecd0e32796c976c1748491f76cae53ba86d13a` |
+| `python:3.14-slim-trixie@sha256:b877e50…` | `libacl1` | `2.3.2-2+b1` | **empty** | HIGH | same OS layer |
+
+Upstream advisory text (Trivy/NVD): fix requires **acl >= 2.4.0**. Debian Trixie candidate remains `2.3.2-2+b1`.
+
+### Fixability probes
+
+| Probe | Result |
+|-------|--------|
+| `docker pull python:3.14-slim-trixie` (2026-07-06) | Digest **unchanged**: `sha256:b877e50…` |
+| `apt-get update && apt-get upgrade -y` in base | `gzip` Candidate **1.13-1**; `libacl1` Candidate **2.3.2-2+b1** — no upgrade |
+| Trivy `FixedVersion` on both CVEs | **empty** on all probed images |
+
+**Conclusion:** `FIXABLE_NOW_DIGEST_REFRESH` and `FIXABLE_NOW_APT_UPGRADE` **rejected**. Verdict: **UPSTREAM_BLOCKED**.
+
+### Exploitability note (CDB context)
+
+- **gzip CVE-2026-41992:** LZH decompression global buffer overflow; requires crafted LZW+LZH file sequence in `gzip -d`. CDB services do not expose gzip decompression on attacker-controlled inputs in normal runtime paths. OS-layer indirect exposure.
+- **libacl CVE-2026-54369:** Local symlink traversal in libacl pathname functions; requires local attacker controlling path components in privileged caller context. Container runs as non-root service users; no known CDB path invokes libacl on attacker-controlled paths. OS-layer indirect exposure.
+
+Trivy/GitHub severity remains HIGH; this slice documents fixability and cluster mapping only.
+
+---
+
+## Decision
+
+**UPSTREAM_BLOCKED** — observe under parent trackers until Debian Trixie publishes security-fixed `gzip` and `libacl1`/`acl` packages.
+
+### Re-triage triggers
+
+Reopen remediation slice when **all** are true per CVE cluster:
+
+1. Debian Trixie publishes fixed OS packages (Trivy `FixedVersion` non-empty), **and**
+2. `docker build` + `trivy image` on representative scope service shows target CVE **absent**, **and**
+3. Corresponding GitHub Code Scanning alerts transition to **closed/fixed**.
+
+Until then: track under [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513), [#3802](https://github.com/jannekbuengener/Claire_de_Binare/issues/3802), [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803); **no alert dismissals** without separate Human-GO.
+
+---
+
+## Parent / tracker issues
+
+| Cluster | Parent | Child alerts |
+|---------|--------|--------------|
+| gzip / CVE-2026-41992 | [#3802](https://github.com/jannekbuengener/Claire_de_Binare/issues/3802) | #3756–#3763 |
+| libacl1 / CVE-2026-54369 | [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803) | #3765 (+ shared Trixie OS layer) |
+
+---
+
+## Safety boundaries
+
+- No alert dismissals.
+- No security issue closures (#3756–#3765 remain OPEN).
+- No Dockerfile, workflow, dependency, or runtime changes.
+- No LR / live-readiness / live-trading / Echtgeld implication.
+- PR #3755 (Grafana) untouched.
+
+---
+
+## Validation commands (this slice)
+
+```bash
+docker pull python:3.14-slim-trixie
+docker run --rm python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 \
+  bash -c "apt-get update -qq && apt-get upgrade -y -qq && apt-cache policy gzip libacl1"
+docker build -f services/risk/Dockerfile -t cdb-risk-probe:3756-3765 .
+trivy image --severity HIGH,CRITICAL --format json cdb-risk-probe:3756-3765
+trivy image --severity HIGH,CRITICAL --format json python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+```


### PR DESCRIPTION
## Summary

Trivy probe evidence for OS-layer CVEs on `python:3.14-slim-trixie` service images:
- **CVE-2026-41992** (`gzip@1.13-1`) — cluster #3756–#3763 → UPSTREAM_BLOCKED
- **CVE-2026-54369** (`libacl1@2.3.2-2+b1`) — #3765 (+ shared Trixie layer) → UPSTREAM_BLOCKED

Refs #3756
Refs #3757
Refs #3758
Refs #3759
Refs #3760
Refs #3761
Refs #3762
Refs #3763
Refs #3765

## Delivered

- Evidence doc: `docs/evidence/security/CDB_SECURITY_OS_LAYER_3756-3765_CVE-41992_CVE-54369_VERIFY_2026-07-06.md`
- Parent cluster issues: #3802 (gzip), #3803 (libacl1)
- Issue comments on #3756–#3765 (posted separately)

## Scanner Evidence

| Image | gzip CVE-2026-41992 | libacl CVE-2026-54369 |
|-------|---------------------|------------------------|
| `cdb-risk-probe:3756-3765` | `1.13-1`, FixedVersion empty | `2.3.2-2+b1`, FixedVersion empty |
| `python:3.14-slim-trixie@sha256:b877e50…` | same | same |

Trivy `0.72.0`, vuln DB `2026-07-06T08:09:55Z`.

## Decision

**UPSTREAM_BLOCKED** — no Dockerfile/digest remediation in this slice; observe until Debian Trixie security updates.

## Non-goals

- No Dockerfile, workflow, dependency, or runtime changes
- No alert dismissals or security issue closures
- PR #3755 untouched

## Safety boundaries

- LR remains NO-GO; no live/echtgeld implication
- No BLUE/RED runtime changes
- No secrets in evidence

## Restunsicherheiten

- `cdb_allocation` full image build blocked locally (Docker context `.tmp/pytest-cdb`); OS-layer presence confirmed via `cdb_risk` probe + base image scan (same digest and `apt-get upgrade` path).