### PR TITLE
[CONTEXT][TESTS][P1] Hybrid retrieval / vector query regression suite (#3777)

### DIFF
--- a/docs/surrealdb/context-intelligence/external-reference-scan.md
+++ b/docs/surrealdb/context-intelligence/external-reference-scan.md
@@ -114,9 +114,23 @@ This scan evaluates two external reference repositories for usability within the
 | **Link Extraction** | ✅ Many references to external tools | ✅ Structured lists with URLs |
 | **Ranking** | ⚠️ No explicit ranking, manual sort | ✅ Community sort (Stars), partially categorized |
 | **Stale-Knowledge Detection** | ⚠️ Many temporary URLs (marked with `*`) | ✅ Active maintenance, regular updates |
-| **Retrieval Regressions** | ⚠️ No tests defined | ⚠️ No tests defined |
+| **Retrieval Regressions** | ⚠️ No tests defined | ✅ Synthetic fixture corpus (#3777) |
 
 **Recommendation:** `awesome-python` is more suitable as test corpus due to clear structure and active maintenance. `the-book-of-secret-knowledge` is useful as reference but less structured for automated tests.
+
+### Retrieval regression corpus (#3777)
+
+Hybrid retrieval ranking regressions use a **synthetic, CDB-owned fixture corpus** — no external repository content is copied into CI.
+
+| Item | Path |
+|------|------|
+| Regression tests | `tests/unit/surrealdb/test_hybrid_retrieval_regression.py` |
+| Fixture corpus | `tests/fixtures/surrealdb/hybrid_retrieval_ranking/regression_corpus_v1.json` |
+| Ranking module | `tools/surrealdb/hybrid_retrieval_ranking.py` |
+| BM25 contract | `artifacts/surrealdb/context_fulltext_bm25_contract.json` |
+| SurrealQL hybrid proof | `infrastructure/surrealdb/hybrid_retrieval_fixtures.surql` |
+
+**Corpus provenance:** Structure inspired by `awesome-python` category/list layout (reference-only). License of the external list (CC0-1.0) applies only to that external project; the regression fixture is synthetic with fixed IDs, scores, and graph distances. **No network** and **no live SurrealDB** in standard CI.
 
 ---
 

--- a/tests/fixtures/surrealdb/hybrid_retrieval_ranking/regression_corpus_v1.json
+++ b/tests/fixtures/surrealdb/hybrid_retrieval_ranking/regression_corpus_v1.json
@@ -1,0 +1,149 @@
+{
+  "schema_version": "hybrid-retrieval-regression-corpus/v1",
+  "corpus_provenance": {
+    "origin": "synthetic",
+    "structure_inspired_by": "awesome-python (reference-only; no external content copied)",
+    "license": "N/A — CDB-owned synthetic fixture",
+    "reference_doc": "docs/surrealdb/context-intelligence/external-reference-scan.md",
+    "network_required": false,
+    "live_surrealdb_required": false
+  },
+  "query_context": {
+    "query": "redis connection pooling",
+    "as_of": "2026-06-15T12:00:00Z",
+    "hybrid_mode": "hybrid_ranked",
+    "retrieval_modes": ["full_text", "vector_search", "graph_traversal"],
+    "context_search_status": "fixture-only"
+  },
+  "candidates": [
+    {
+      "result_id": "reg-primary-redis",
+      "source_ref": "doc_chunk:redis-pool-primary",
+      "title": "Redis connection pooling",
+      "summary": "Synthetic primary BM25 + graph match for redis pooling.",
+      "confidence": 0.91,
+      "freshness": 0.88,
+      "source_match": 0.94,
+      "graph_distance": 0,
+      "evidence_strength": "strong",
+      "scope_match": 0.85,
+      "memory_trust": 0.8,
+      "retrieval_mode": "hybrid_ranked",
+      "matched_on": ["full_text", "graph_traversal", "vector_search"],
+      "vector_score": 0.93
+    },
+    {
+      "result_id": "reg-secondary-redis",
+      "source_ref": "doc_chunk:redis-pool-secondary",
+      "title": "Redis client reuse patterns",
+      "summary": "Secondary redis pooling doc with moderate keyword overlap.",
+      "confidence": 0.78,
+      "freshness": 0.75,
+      "source_match": 0.72,
+      "graph_distance": 2,
+      "evidence_strength": "moderate",
+      "scope_match": 0.7,
+      "memory_trust": 0.65,
+      "retrieval_mode": "hybrid_ranked",
+      "matched_on": ["full_text", "graph_traversal"],
+      "vector_score": 0.81
+    },
+    {
+      "result_id": "reg-graph-near-weak-keyword",
+      "source_ref": "doc_chunk:graph-near-weak",
+      "title": "Adjacent cache topic",
+      "summary": "Graph-neighbor with weak BM25 but high vector similarity.",
+      "confidence": 0.7,
+      "freshness": 0.72,
+      "source_match": 0.38,
+      "graph_distance": 1,
+      "evidence_strength": "moderate",
+      "scope_match": 0.55,
+      "memory_trust": 0.6,
+      "retrieval_mode": "hybrid_ranked",
+      "matched_on": ["graph_traversal", "vector_search"],
+      "vector_score": 0.97
+    },
+    {
+      "result_id": "reg-irrelevant-trading",
+      "source_ref": "doc_chunk:unrelated-trading",
+      "title": "Live order execution controls",
+      "summary": "Unrelated trading runtime topic; should demote.",
+      "confidence": 0.35,
+      "freshness": 0.4,
+      "source_match": 0.11,
+      "graph_distance": 9,
+      "evidence_strength": "weak",
+      "scope_match": 0.15,
+      "memory_trust": "weak",
+      "retrieval_mode": "full_text",
+      "matched_on": ["keyword"],
+      "vector_score": 0.22
+    },
+    {
+      "result_id": "reg-tie-aaa",
+      "source_ref": "doc_chunk:tie-aaa",
+      "title": "Tie candidate A",
+      "summary": "Deterministic tie-break lower source_ref.",
+      "confidence": 0.7,
+      "freshness": 0.7,
+      "source_match": 0.7,
+      "graph_distance_score": 0.7,
+      "evidence_strength": 0.7,
+      "scope_match": 0.7,
+      "memory_trust": 0.7,
+      "retrieval_mode": "hybrid_ranked",
+      "matched_on": ["full_text"]
+    },
+    {
+      "result_id": "reg-tie-aab",
+      "source_ref": "doc_chunk:tie-aab",
+      "title": "Tie candidate B",
+      "summary": "Deterministic tie-break higher source_ref.",
+      "confidence": 0.7,
+      "freshness": 0.7,
+      "source_match": 0.7,
+      "graph_distance_score": 0.7,
+      "evidence_strength": 0.7,
+      "scope_match": 0.7,
+      "memory_trust": 0.7,
+      "retrieval_mode": "hybrid_ranked",
+      "matched_on": ["full_text"],
+      "vector_score": 0.95
+    },
+    {
+      "result_id": "reg-bm25-only-strong",
+      "source_ref": "doc_chunk:bm25-only",
+      "title": "Keyword-only redis pooling note",
+      "summary": "Strong BM25 signal without graph_distance factor.",
+      "confidence": 0.82,
+      "freshness": 0.8,
+      "source_match": 0.89,
+      "evidence_strength": "strong",
+      "scope_match": 0.75,
+      "memory_trust": 0.7,
+      "retrieval_mode": "full_text",
+      "matched_on": ["full_text"]
+    }
+  ],
+  "expected_ranking": {
+    "order": [
+      "reg-primary-redis",
+      "reg-bm25-only-strong",
+      "reg-secondary-redis",
+      "reg-tie-aaa",
+      "reg-tie-aab",
+      "reg-graph-near-weak-keyword",
+      "reg-irrelevant-trading"
+    ],
+    "pinned_scores": {
+      "reg-primary-redis": 0.912,
+      "reg-bm25-only-strong": 0.7595,
+      "reg-secondary-redis": 0.7175,
+      "reg-tie-aaa": 0.7,
+      "reg-tie-aab": 0.7,
+      "reg-graph-near-weak-keyword": 0.6265,
+      "reg-irrelevant-trading": 0.232
+    }
+  }
+}

--- a/tests/unit/surrealdb/test_hybrid_retrieval_regression.py
+++ b/tests/unit/surrealdb/test_hybrid_retrieval_regression.py
@@ -1,0 +1,300 @@
+"""Hybrid retrieval regression suite (#3777).
+
+Refs #3771. Fixture-backed regression coverage for hybrid retrieval ranking:
+BM25/fulltext (source_match proxy), vector/HNSW contract signals, graph-distance
+ranking, combined stable order, tie-breakers, and no-silent-drift pins.
+
+In-memory/fixture only — no live SurrealDB or network in standard CI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tools.surrealdb.hybrid_retrieval_ranking import (
+    DEFAULT_RANKING_WEIGHTS,
+    RANKING_FACTORS,
+    compute_ranking_explanation,
+    graph_distance_to_score,
+    rank_retrieval_results,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REGRESSION_CORPUS_PATH = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "surrealdb"
+    / "hybrid_retrieval_ranking"
+    / "regression_corpus_v1.json"
+)
+BM25_CONTRACT_PATH = (
+    REPO_ROOT / "artifacts" / "surrealdb" / "context_fulltext_bm25_contract.json"
+)
+HYBRID_SURQL_FIXTURE = REPO_ROOT / "infrastructure" / "surrealdb" / "hybrid_retrieval_fixtures.surql"
+EXTERNAL_REFERENCE_SCAN = (
+    REPO_ROOT / "docs" / "surrealdb" / "context-intelligence" / "external-reference-scan.md"
+)
+VECTOR_PROOF_MODULE = REPO_ROOT / "tools" / "surrealdb" / "graph_vector_proof_cli.py"
+
+
+def _load_regression_corpus() -> dict[str, Any]:
+    return json.loads(REGRESSION_CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(name="regression_corpus")
+def fixture_regression_corpus() -> dict[str, Any]:
+    return _load_regression_corpus()
+
+
+@pytest.fixture(name="ranked_regression")
+def fixture_ranked_regression(regression_corpus: dict[str, Any]) -> list[dict[str, Any]]:
+    return rank_retrieval_results(
+        regression_corpus["candidates"],
+        query_context=regression_corpus["query_context"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corpus provenance / CI safety
+# ---------------------------------------------------------------------------
+
+
+def test_regression_corpus_is_synthetic_without_network(regression_corpus: dict[str, Any]) -> None:
+    provenance = regression_corpus["corpus_provenance"]
+    assert provenance["origin"] == "synthetic"
+    assert provenance["network_required"] is False
+    assert provenance["live_surrealdb_required"] is False
+    assert "awesome-python" in provenance["structure_inspired_by"]
+    assert provenance["license"].startswith("N/A")
+
+
+def test_regression_corpus_contains_no_secret_indicators(regression_corpus: dict[str, Any]) -> None:
+    blob = json.dumps(regression_corpus)
+    for indicator in (
+        "api_key",
+        "api_secret",
+        "REDIS_PASSWORD",
+        "POSTGRES_PASSWORD",
+        "MEXC_API_KEY",
+        "MEXC_API_SECRET",
+    ):
+        assert indicator not in blob
+
+
+def test_standard_ci_no_live_db_module_import_only() -> None:
+    """Ranking module is pure Python; no SurrealDB SDK or HTTP client imports."""
+    import tools.surrealdb.hybrid_retrieval_ranking as mod
+
+    source = Path(mod.__file__).read_text(encoding="utf-8")
+    assert "import surrealdb" not in source
+    assert "from surrealdb" not in source
+    assert "import requests" not in source
+    assert "import httpx" not in source
+
+
+# ---------------------------------------------------------------------------
+# Deterministic ranking regression
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_ranking_fixture_matches_pinned_order(
+    ranked_regression: list[dict[str, Any]],
+    regression_corpus: dict[str, Any],
+) -> None:
+    expected = regression_corpus["expected_ranking"]["order"]
+    assert [row["result_id"] for row in ranked_regression] == expected
+
+
+def test_deterministic_ranking_repeatable(regression_corpus: dict[str, Any]) -> None:
+    candidates = regression_corpus["candidates"]
+    query_context = regression_corpus["query_context"]
+    first = rank_retrieval_results(candidates, query_context=query_context)
+    second = rank_retrieval_results(candidates, query_context=query_context)
+    assert [r["result_id"] for r in first] == [r["result_id"] for r in second]
+    assert [r["score"] for r in first] == [r["score"] for r in second]
+
+
+def test_no_silent_drift_pinned_scores(
+    ranked_regression: list[dict[str, Any]],
+    regression_corpus: dict[str, Any],
+) -> None:
+    pinned = regression_corpus["expected_ranking"]["pinned_scores"]
+    for row in ranked_regression:
+        result_id = row["result_id"]
+        assert row["score"] == pinned[result_id], (
+            f"Score drift for {result_id}: got {row['score']}, expected {pinned[result_id]}"
+        )
+
+
+def test_weight_change_would_break_pinned_top_score() -> None:
+    """Guards against silent DEFAULT_RANKING_WEIGHTS drift on primary fixture row."""
+    corpus = _load_regression_corpus()
+    primary = next(
+        c for c in corpus["candidates"] if c["result_id"] == "reg-primary-redis"
+    )
+    explanation = compute_ranking_explanation(
+        primary, query_context=corpus["query_context"]
+    )
+    assert explanation["final_score"] == corpus["expected_ranking"]["pinned_scores"]["reg-primary-redis"]
+    assert explanation["weights"] == DEFAULT_RANKING_WEIGHTS
+
+
+# ---------------------------------------------------------------------------
+# BM25 / fulltext signal contract (source_match proxy in ranking v1)
+# ---------------------------------------------------------------------------
+
+
+def test_bm25_signal_contract_source_match_influences_ranking(
+    ranked_regression: list[dict[str, Any]],
+) -> None:
+    primary = next(r for r in ranked_regression if r["result_id"] == "reg-primary-redis")
+    secondary = next(
+        r for r in ranked_regression if r["result_id"] == "reg-secondary-redis"
+    )
+    assert primary["ranking_explanation"]["factor_scores"]["source_match"] > secondary[
+        "ranking_explanation"
+    ]["factor_scores"]["source_match"]
+    assert ranked_regression.index(primary) < ranked_regression.index(secondary)
+
+
+def test_bm25_contract_artifact_declares_bm25_score_function() -> None:
+    contract = json.loads(BM25_CONTRACT_PATH.read_text(encoding="utf-8"))
+    for cat_name, cat_data in contract.get("indexable_categories", {}).items():
+        assert cat_data.get("score_function") == "BM25", (
+            f"Category {cat_name} must declare BM25 score_function"
+        )
+
+
+def test_hybrid_surql_fixture_declares_bm25_and_rrf_fields() -> None:
+    text = HYBRID_SURQL_FIXTURE.read_text(encoding="utf-8")
+    assert "bm25_score" in text
+    assert "search::rrf" in text
+
+
+# ---------------------------------------------------------------------------
+# Vector / HNSW contract (fixture-only; deferred weight in ranking v1)
+# ---------------------------------------------------------------------------
+
+
+def test_vector_signal_contract_deferred_in_ranking_v1(
+    regression_corpus: dict[str, Any],
+) -> None:
+    with_vector = next(
+        c for c in regression_corpus["candidates"] if c["result_id"] == "reg-tie-aab"
+    )
+    without_vector = {
+        k: v for k, v in with_vector.items() if k != "vector_score"
+    }
+    score_with = rank_retrieval_results([with_vector])[0]["score"]
+    score_without = rank_retrieval_results([without_vector])[0]["score"]
+    assert score_with == score_without
+
+    explanation = compute_ranking_explanation(with_vector)
+    assert any("deferred" in c for c in explanation["caveats"])
+
+
+def test_vector_pipeline_contract_module_exists_for_hnsw_proof() -> None:
+    assert VECTOR_PROOF_MODULE.exists()
+    text = VECTOR_PROOF_MODULE.read_text(encoding="utf-8")
+    assert "vector_pipeline_contract" in text
+    assert "embedding_dimension" in text
+
+
+# ---------------------------------------------------------------------------
+# Graph distance contract
+# ---------------------------------------------------------------------------
+
+
+def test_graph_distance_contract_closer_nodes_score_higher() -> None:
+    assert graph_distance_to_score(0) > graph_distance_to_score(3)
+    assert graph_distance_to_score(3) > graph_distance_to_score(9)
+
+
+def test_graph_distance_contract_influences_combined_ranking(
+    ranked_regression: list[dict[str, Any]],
+) -> None:
+    primary = next(r for r in ranked_regression if r["result_id"] == "reg-primary-redis")
+    secondary = next(
+        r for r in ranked_regression if r["result_id"] == "reg-secondary-redis"
+    )
+    irrelevant = next(
+        r for r in ranked_regression if r["result_id"] == "reg-irrelevant-trading"
+    )
+    assert primary["ranking_explanation"]["factor_scores"]["graph_distance"] > secondary[
+        "ranking_explanation"
+    ]["factor_scores"]["graph_distance"]
+    assert secondary["ranking_explanation"]["factor_scores"]["graph_distance"] > irrelevant[
+        "ranking_explanation"
+    ]["factor_scores"]["graph_distance"]
+    assert ranked_regression.index(primary) < ranked_regression.index(secondary)
+
+
+def test_hybrid_surql_fixture_includes_graph_traversal_input() -> None:
+    text = HYBRID_SURQL_FIXTURE.read_text(encoding="utf-8")
+    assert "->chunk_mentions_symbol->code_symbol" in text
+    assert "$graph" in text
+
+
+# ---------------------------------------------------------------------------
+# Combined ranking + demotion + tie-break
+# ---------------------------------------------------------------------------
+
+
+def test_combined_ranking_contract_stable_hybrid_order(
+    ranked_regression: list[dict[str, Any]],
+    regression_corpus: dict[str, Any],
+) -> None:
+    hybrid_rows = [
+        r
+        for r in ranked_regression
+        if r["result_id"] in regression_corpus["expected_ranking"]["order"]
+    ]
+    assert len(hybrid_rows) == len(regression_corpus["candidates"])
+    assert [r["result_id"] for r in hybrid_rows] == regression_corpus["expected_ranking"]["order"]
+
+
+def test_irrelevant_document_demoted_to_last(
+    ranked_regression: list[dict[str, Any]],
+) -> None:
+    assert ranked_regression[-1]["result_id"] == "reg-irrelevant-trading"
+    assert ranked_regression[0]["score"] > ranked_regression[-1]["score"] * 3
+
+
+def test_tie_breaker_stability_by_source_ref(
+    ranked_regression: list[dict[str, Any]],
+) -> None:
+    tie_ids = [
+        r["result_id"]
+        for r in ranked_regression
+        if r["result_id"].startswith("reg-tie-")
+    ]
+    assert tie_ids == ["reg-tie-aaa", "reg-tie-aab"]
+    tie_a = next(r for r in ranked_regression if r["result_id"] == "reg-tie-aaa")
+    tie_b = next(r for r in ranked_regression if r["result_id"] == "reg-tie-aab")
+    assert tie_a["score"] == tie_b["score"]
+
+
+# ---------------------------------------------------------------------------
+# External reference documentation
+# ---------------------------------------------------------------------------
+
+
+def test_external_reference_doc_documents_regression_corpus() -> None:
+    text = EXTERNAL_REFERENCE_SCAN.read_text(encoding="utf-8")
+    assert "regression_corpus_v1.json" in text
+    assert "test_hybrid_retrieval_regression.py" in text
+    assert "synthetic" in text.lower() or "Synthetic" in text
+    assert "CC0-1.0" in text or "awesome-python" in text
+
+
+def test_ranking_factors_cover_hybrid_contract_surface() -> None:
+    assert "source_match" in RANKING_FACTORS
+    assert "graph_distance" in RANKING_FACTORS
+    assert len(RANKING_FACTORS) == 7


### PR DESCRIPTION
## Summary

Closes #3777
Refs #3771

Adds a fixture-backed hybrid retrieval regression suite covering BM25/fulltext (`source_match` proxy), vector/HNSW contract signals (deferred weight in ranking v1), graph-distance ranking, combined stable order, tie-breakers, and pinned no-silent-drift scores.

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true (MCP `context_briefing` → unknown_tool)
- repo_fallback_used: true
- repo_fallback_reason: tool_blocked
- context_tool_status: blocked
- context_trust_level: none
- records_found: none

## Delivered

- `tests/unit/surrealdb/test_hybrid_retrieval_regression.py` — 20 contract/regression tests
- `tests/fixtures/surrealdb/hybrid_retrieval_ranking/regression_corpus_v1.json` — synthetic deterministic corpus with pinned order/scores
- `docs/surrealdb/context-intelligence/external-reference-scan.md` — corpus provenance + test paths documented

## Validation

- `git diff --check` — clean
- `pytest -q tests/unit/surrealdb/test_hybrid_retrieval_regression.py` — 20 passed
- `pytest -q tests/unit/surrealdb/test_hybrid_retrieval_ranking.py tests/unit/surrealdb/test_context_fulltext_bm25_contract.py tests/unit/surrealdb/test_graph_vector_proof_red_3486.py` — 49 passed
- `ruff check tests/unit/surrealdb/test_hybrid_retrieval_regression.py` — clean

## Non-goals

- No new retrieval architecture
- No #3776 local_only DB harness
- No #3779 stale-doc drift suite
- No live SurrealDB or network in CI
- No runtime BLUE/RED changes

## Safety Boundaries

- LR NO-GO; no live/Echtgeld scope
- Fixture-only CI; no productive DB writes
- No secrets or trading runtime data in fixtures
- Vector weighting remains deferred per ranking v1 contract

## Remaining uncertainty

- SurrealQL RRF path (`hybrid_retrieval_fixtures.surql`) is contract-tested via file presence only; live DB proof remains #3776 scope.
