### PR TITLE
test(surrealdb): read-only query harness local_only (#3776)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ else
   SECRETS_PATH ?= $(HOME)/Documents/.secrets/.cdb
 endif
 
-.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close onboarding-doctor context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-smoke context-smoke-db context-graph-vector-proof context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor context-certify context-live-invoke context-live-invoke-full audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down surreal-validate
+.PHONY: help test test-unit test-integration test-e2e test-local test-local-stress test-local-performance test-local-lifecycle test-local-cli test-local-chaos test-local-backup test-full-system test-coverage docker-up docker-down docker-health systemcheck daily-check backup backup-postgres-only restore backup-health paper-trading-start paper-trading-logs paper-trading-stop replay-shadow-run rollback cleanup mcp-config-validate security-scan pre-close onboarding-doctor context-env-check context-query-config-init context-up context-down context-status context-logs context-restart context-schema-apply context-schema-check context-reset-local context-scan context-import-dry-run context-import-local context-query-smoke context-readonly-query-harness context-smoke context-smoke-db context-graph-vector-proof context-memory-db-proof context-claim-evidence-proof context-memory-rediscovery-proof context-doctor context-certify context-live-invoke context-live-invoke-full audit-trail-t3-bootstrap audit-trail-t3-proof audit-trail-t3-status audit-trail-t3-down surreal-validate
 
 help:
 	@echo "Claire de Binare - Test Commands"
@@ -103,6 +103,7 @@ help:
 	@echo "  make context-import-dry-run  - Import planen, kein DB-Write"
 	@echo "  make context-import-local    - Context-Daten in lokale SurrealDB importieren"
 	@echo "  make context-query-smoke     - Lese-Query-Smoke (graceful fail)"
+	@echo "  make context-readonly-query-harness - Read-only query harness unit contract (#3776)"
 	@echo "  make context-smoke           - Komplette lokale Pipeline (smoke test)"
 	@echo "  make context-smoke-db        - Hard fail-closed DB-backed smoke (#2460)"
 	@echo "  make context-graph-vector-proof - Isolated Graph + Vector capability proof (no Docker)"
@@ -513,6 +514,12 @@ context-query-smoke:
 	@$(PYTHON) -m tools.surrealdb.context_query --config infrastructure/config/surrealdb/context_query.local.example.yaml show-drift 2>&1 || echo "[NOTE] show-drift: Container nicht laufend oder keine Daten"
 	@$(PYTHON) -m tools.surrealdb.context_query --config infrastructure/config/surrealdb/context_query.local.example.yaml find-artifact 2>&1 || echo "[NOTE] find-artifact: Container nicht laufend oder keine Daten"
 	@echo "[OK] Context query smoke abgeschlossen"
+
+context-readonly-query-harness:
+	@echo "=== Read-only Context Query Harness (#3776) ==="
+	@echo "NOTE: Unit contract only. local_only integration requires CDB_RUN_REAL_SURREALDB_READONLY_QUERY=1"
+	@$(PYTHON) -m pytest -q tests/unit/surrealdb/test_context_readonly_query_harness.py
+	@echo "[OK] context-readonly-query-harness: unit contract passed (LR: NO-GO)"
 
 context-smoke:
 	@echo "=== Context Smoke: vollstaendige lokale Pipeline ==="

--- a/docs/surrealdb/context-readonly-query-harness.md
+++ b/docs/surrealdb/context-readonly-query-harness.md
@@ -1,0 +1,87 @@
+# SurrealDB read-only context query harness (#3776)
+
+Local-only integration surface for read-only Context Intelligence queries against
+`surrealdb-local`. Standard CI does **not** require a live SurrealDB instance.
+
+## Scope
+
+| In scope | Out of scope |
+| --- | --- |
+| `local_only` read-only query probes | Productive SurrealDB writes |
+| Namespace/DB isolation contract | Retrieval ranking regression (#3777) |
+| Fail-closed repo-fallback posture | Stale-doc drift suite (#3779) |
+| Unit/adapter tests without live DB | MCP live mutation |
+
+## Safety defaults
+
+- `MUTATION_ALLOWED=False` (module constant in `tools/mcp/memory_write_intent_tools.py`)
+- Harness module has **no** productive write imports (`context_importer`, write gates, smoke writers)
+- LR remains **NO-GO**; no trading-state tables, no secrets in fixtures
+
+## Test layers
+
+| Layer | Marker | Live DB | Command |
+| --- | --- | --- | --- |
+| Unit contract | `unit` + `contract` | No | `pytest -q tests/unit/surrealdb/test_context_readonly_query_harness.py` |
+| Local integration | `local_only` | Opt-in | see below |
+
+### Standard CI
+
+`.github/workflows/ci.yaml` runs:
+
+```bash
+pytest -v -m "not e2e and not local_only" ...
+```
+
+`local_only` tests are excluded from required CI.
+
+### Local read-only harness (opt-in)
+
+Prerequisites:
+
+1. Local SurrealDB on `http://127.0.0.1:8010`
+2. `infrastructure/config/surrealdb/context_query.local.yaml` (see `make context-query-config-init`)
+3. Secrets dir with `SURREALDB_ENV` (`SECRETS_PATH` or canon store)
+4. Opt-in env flag: `CDB_RUN_REAL_SURREALDB_READONLY_QUERY=1`
+
+```bash
+# Unit contract (CI-safe)
+pytest -q tests/unit/surrealdb/test_context_readonly_query_harness.py
+
+# Local integration (skipped unless env + DB ready)
+export CDB_RUN_REAL_SURREALDB_READONLY_QUERY=1
+pytest -q -m local_only tests/local/surrealdb/test_context_readonly_query_harness.py
+
+# Or all local_only tests
+make test-local
+```
+
+PowerShell:
+
+```powershell
+$env:CDB_RUN_REAL_SURREALDB_READONLY_QUERY = "1"
+pytest -q -m local_only tests/local/surrealdb/test_context_readonly_query_harness.py
+```
+
+## Harness contract
+
+Module: `tools/surrealdb/context_readonly_query_harness.py`
+
+| Case | Behavior |
+| --- | --- |
+| `local_only` marker | Local integration file marked `pytest.mark.local_only` |
+| Standard CI exclusion | Verified via `standard_ci_excludes_local_only()` |
+| Read-only default | Classifier denies `CREATE`/`UPSERT` before HTTP |
+| Unreachable DB | `classify_db_evidence_posture()` → `repo-only`, no false DB claims |
+| Namespace isolation | `cdb_context_local` / `cdb_context_intel` envelope |
+| No productive write path | Static import guard on harness module |
+| Adapter modes | `embedded`, `file`, `mem` (unit); `live` (local_only only) |
+
+## Related surfaces
+
+- `tools/surrealdb/context_query.py` — read-only query adapter + classifier
+- `tests/local/surrealdb/test_memory_db_read_proof.py` — memory read proof (separate opt-in flag)
+- `tests/local/tools/mcp/test_wave14_real_surrealdb_smoke.py` — Wave-14 MCP smoke (write seed + cleanup)
+
+Issue: [#3776](https://github.com/jannekbuengener/Claire_de_Binare/issues/3776)
+Parent: [#3771](https://github.com/jannekbuengener/Claire_de_Binare/issues/3771)

--- a/docs/surrealdb/context-readonly-query-harness.md
+++ b/docs/surrealdb/context-readonly-query-harness.md
@@ -16,7 +16,7 @@ Local-only integration surface for read-only Context Intelligence queries agains
 
 - `MUTATION_ALLOWED=False` (module constant in `tools/mcp/memory_write_intent_tools.py`)
 - Harness module has **no** productive write imports (`context_importer`, write gates, smoke writers)
-- LR remains **NO-GO**; no trading-state tables, no secrets in fixtures
+- LR remains **NO-GO**; no trading-state tables, no sensitive values in fixtures
 
 ## Test layers
 

--- a/tests/local/surrealdb/test_context_readonly_query_harness.py
+++ b/tests/local/surrealdb/test_context_readonly_query_harness.py
@@ -1,0 +1,147 @@
+"""Opt-in local-only read-only SurrealDB context query harness (#3776).
+
+Runs only when:
+- ``CDB_RUN_REAL_SURREALDB_READONLY_QUERY=1``
+- ``infrastructure/config/surrealdb/context_query.local.yaml`` exists
+- secrets path resolves (CDB canon, overridable via env)
+- local SurrealDB answers on ``127.0.0.1:8010``
+
+Read-only probes only — no importer, no UPSERT, no MCP write tools.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import urllib.error
+import urllib.request
+
+import pytest
+
+from tools.surrealdb import context_readonly_query_harness as harness
+from tools.surrealdb.context_query import WriteDeniedError
+
+pytestmark = pytest.mark.local_only
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_QUERY_CONFIG_PATH = _REPO_ROOT / harness.QUERY_CONFIG_REL
+_LOCAL_SURR_URLS = (
+    f"{harness.LOCAL_SURR_URL}/health",
+    f"{harness.LOCAL_SURR_URL}/version",
+)
+
+
+def _http_status(url: str) -> int | None:
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            return int(response.status)
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def _candidate_secrets_paths() -> list[Path]:
+    candidates: list[Path] = []
+    for env_key in ("CDB_CONTEXT_SECRETS_PATH", "SECRETS_PATH"):
+        raw = os.environ.get(env_key, "").strip()
+        if raw:
+            candidates.append(Path(raw))
+    if os.name == "nt":
+        userprofile = os.environ.get("USERPROFILE", "").strip()
+        if userprofile:
+            candidates.append(Path(userprofile) / "Documents" / ".secrets" / ".cdb")
+    else:
+        candidates.append(Path.home() / "Documents" / ".secrets" / ".cdb")
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        ordered.append(path)
+    return ordered
+
+
+def _resolve_secrets_path() -> Path | None:
+    for candidate in _candidate_secrets_paths():
+        try:
+            if candidate.is_dir():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def _require_local_opt_in() -> Path:
+    if os.environ.get(harness.ENV_REAL_SURREALDB_READONLY_QUERY) != "1":
+        pytest.skip(
+            "real surrealdb-local read-only harness disabled; "
+            f"set {harness.ENV_REAL_SURREALDB_READONLY_QUERY}=1"
+        )
+    if not _QUERY_CONFIG_PATH.exists():
+        pytest.skip(f"missing local query config: {harness.QUERY_CONFIG_REL}")
+    secrets_dir = _resolve_secrets_path()
+    if secrets_dir is None:
+        pytest.skip(
+            "missing secrets dir for surrealdb-local auth "
+            "(set CDB_CONTEXT_SECRETS_PATH or SECRETS_PATH, or provide canon secrets store)"
+        )
+    if not (secrets_dir / "SURREALDB_ENV").is_file():
+        pytest.skip("missing required secrets file SURREALDB_ENV in secrets dir")
+    for url in _LOCAL_SURR_URLS:
+        status = _http_status(url)
+        if status != 200:
+            pytest.skip(f"local SurrealDB preflight failed for {url} (status={status})")
+    return secrets_dir
+
+
+def _assert_no_secret_leak(payload: dict, *, secrets_path: Path) -> None:
+    rendered = json.dumps(payload, sort_keys=True, default=str)
+    assert "Authorization" not in rendered
+    assert "Basic " not in rendered
+    assert "SURREAL_PASS" not in rendered
+    assert "SURREAL_USER" not in rendered
+    assert str(secrets_path) not in rendered
+
+
+def test_readonly_harness_skips_without_env_flag() -> None:
+    if os.environ.get(harness.ENV_REAL_SURREALDB_READONLY_QUERY) == "1":
+        pytest.skip("env flag set; covered by live probe test")
+    with pytest.raises(pytest.skip.Exception):
+        _require_local_opt_in()
+
+
+def test_readonly_query_probe_against_local_db() -> None:
+    secrets_path = _require_local_opt_in()
+    adapter = harness.build_live_adapter(
+        config_path=_QUERY_CONFIG_PATH,
+        secrets_path=secrets_path,
+        hard_mode=True,
+    )
+    isolation = harness.build_isolation()
+    assert adapter._namespace == isolation.namespace
+    assert adapter._database == isolation.database
+
+    probe = harness.run_readonly_probe(adapter)
+    assert probe["read_only"] is True
+    assert probe["classification"]["allowed"] is True
+    assert probe["adapter_status"] == "surrealdb-local"
+
+    posture = harness.classify_db_evidence_posture(
+        db_reachable=True,
+        record_source="surrealdb-local",
+        record_ids=[f"probe:{probe['row_count']}"],
+    )
+    assert posture["db_claims_allowed"] is True
+    _assert_no_secret_leak(probe, secrets_path=secrets_path)
+
+
+def test_write_probe_denied_before_http() -> None:
+    secrets_path = _require_local_opt_in()
+    adapter = harness.build_live_adapter(
+        config_path=_QUERY_CONFIG_PATH,
+        secrets_path=secrets_path,
+        hard_mode=True,
+    )
+    with pytest.raises(WriteDeniedError):
+        harness.run_readonly_probe(adapter, query=harness.HARNESS_WRITE_PROBE)

--- a/tests/unit/surrealdb/test_context_readonly_query_harness.py
+++ b/tests/unit/surrealdb/test_context_readonly_query_harness.py
@@ -1,0 +1,213 @@
+"""Contract tests for SurrealDB read-only query integration harness (#3776).
+
+Fixture/adapter backed — no live SurrealDB in standard CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.mcp.memory_write_intent_tools import MUTATION_ALLOWED
+from tools.surrealdb import context_readonly_query_harness as harness
+from tools.surrealdb.context_query import WriteDeniedError, classify_statement
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLE_CONFIG = REPO_ROOT / "infrastructure/config/surrealdb/context_query.local.example.yaml"
+LOCAL_TEST_FILE = REPO_ROOT / "tests/local/surrealdb/test_context_readonly_query_harness.py"
+CI_YAML = REPO_ROOT / ".github/workflows/ci.yaml"
+PYTEST_INI = REPO_ROOT / "pytest.ini"
+
+
+# ---------------------------------------------------------------------------
+# Safety / CI contract
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_allowed_false_default() -> None:
+    assert MUTATION_ALLOWED is False
+    flags = harness.harness_safety_flags()
+    assert flags["MUTATION_ALLOWED"] is False
+    assert flags["read_only_default"] is True
+    assert flags["productive_write_path"] is False
+
+
+def test_standard_ci_excludes_local_only() -> None:
+    evidence = harness.standard_ci_excludes_local_only()
+    assert evidence["pytest_marker_registered"] is True
+    assert evidence["ci_excludes_local_only"] is True
+    assert evidence["ok"] is True
+    assert "not local_only" in CI_YAML.read_text(encoding="utf-8")
+    assert "local_only:" in PYTEST_INI.read_text(encoding="utf-8")
+
+
+def test_local_only_marker_present_on_local_integration_file() -> None:
+    source = LOCAL_TEST_FILE.read_text(encoding="utf-8")
+    assert "pytest.mark.local_only" in source
+    assert harness.ENV_REAL_SURREALDB_READONLY_QUERY in source
+
+
+def test_harness_has_no_productive_write_path() -> None:
+    violations = harness.assert_harness_has_no_productive_write_path()
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed / repo-fallback posture
+# ---------------------------------------------------------------------------
+
+
+def test_unreachable_db_fail_closed_repo_fallback() -> None:
+    posture = harness.classify_db_evidence_posture(
+        db_reachable=False,
+        record_source="surrealdb-local",
+        record_ids=["evidence_ref:abc"],
+    )
+    assert posture["db_claims_allowed"] is False
+    assert posture["brain_source"] == "repo-only"
+    assert posture["brain_status"] == "not-used"
+    assert posture["repo_fallback_used"] is True
+    assert posture["repo_fallback_reason"] == "unavailable"
+
+
+def test_unreachable_db_blocks_false_db_backed_claim() -> None:
+    blocked = harness.assert_repo_only_db_claim_blocked(
+        db_reachable=False,
+        record_source=None,
+        claimed_brain_source="surrealdb-local",
+    )
+    assert blocked is True
+
+
+def test_db_backed_posture_requires_records_and_source() -> None:
+    posture = harness.classify_db_evidence_posture(
+        db_reachable=True,
+        record_source="surrealdb-local",
+        record_ids=["evidence_ref:deadbeef"],
+    )
+    assert posture["db_claims_allowed"] is True
+    assert posture["brain_source"] == "surrealdb-local"
+
+
+def test_preflight_fail_closed_without_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(harness.ENV_REAL_SURREALDB_READONLY_QUERY, raising=False)
+    result = harness.check_readonly_query_preconditions(confirm=False)
+    assert result["ok"] is False
+    assert any(harness.ENV_REAL_SURREALDB_READONLY_QUERY in err for err in result["errors"])
+
+
+def test_preflight_ok_with_confirm_when_health_and_config_ok(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(harness.ENV_REAL_SURREALDB_READONLY_QUERY, raising=False)
+    fake_root = tmp_path / "repo"
+    config_dir = fake_root / harness.QUERY_CONFIG_REL.parent
+    config_dir.mkdir(parents=True)
+    (config_dir / harness.QUERY_CONFIG_REL.name).write_text(
+        "schema_version: context-query-local/v0\n", encoding="utf-8"
+    )
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "SURREALDB_ENV").write_text(
+        "SURREAL_USER=x\nSURREAL_PASS=y\n", encoding="utf-8"
+    )
+    with (
+        patch.object(harness, "repo_root", return_value=fake_root),
+        patch.object(harness, "http_status", return_value=200),
+        patch.object(harness, "resolve_secrets_path", return_value=secrets),
+    ):
+        result = harness.check_readonly_query_preconditions(confirm=True)
+    assert result["ok"] is True
+    assert result["db_reachable"] is True
+
+
+# ---------------------------------------------------------------------------
+# Namespace isolation
+# ---------------------------------------------------------------------------
+
+
+def test_namespace_isolation_contract() -> None:
+    isolation = harness.build_isolation(run_tag="run3776")
+    assert isolation.namespace == harness.HARNESS_NAMESPACE
+    assert isolation.database == harness.HARNESS_DATABASE
+    headers = isolation.as_headers()
+    assert headers["surreal-ns"] == harness.HARNESS_NAMESPACE
+    assert headers["surreal-db"] == harness.HARNESS_DATABASE
+    assert headers["surreal-url"] == harness.LOCAL_SURR_URL
+
+
+def test_write_probe_denied_by_classifier() -> None:
+    with pytest.raises(WriteDeniedError):
+        classify_statement(harness.HARNESS_WRITE_PROBE)
+
+
+# ---------------------------------------------------------------------------
+# Adapter modes: embedded / file / mem (no live DB)
+# ---------------------------------------------------------------------------
+
+
+def test_embedded_mode_returns_empty_results() -> None:
+    adapter = harness.build_adapter_for_mode("embedded")
+    result = harness.run_readonly_probe(adapter)
+    assert result["row_count"] == 0
+    assert result["read_only"] is True
+
+
+def test_mem_mode_returns_fixture_rows() -> None:
+    adapter = harness.build_adapter_for_mode(
+        "mem",
+        mem_rows=[{"artifact_id": "repo_artifact:abc", "source_path": "core/x.py"}],
+    )
+    result = harness.run_readonly_probe(adapter, query="SELECT * FROM repo_artifact LIMIT 1")
+    assert result["row_count"] == 1
+
+
+def test_mem_mode_denies_write_probe() -> None:
+    adapter = harness.build_adapter_for_mode("mem")
+    with pytest.raises(WriteDeniedError):
+        harness.run_readonly_probe(adapter, query=harness.HARNESS_WRITE_PROBE)
+
+
+def test_file_mode_loads_example_config_namespace() -> None:
+    adapter = harness.build_adapter_for_mode("file", config_path=EXAMPLE_CONFIG)
+    assert adapter.namespace == "cdb_context_local"
+    assert adapter.database == "cdb_context_intel"
+    result = harness.run_readonly_probe(adapter)
+    assert result["classification"]["allowed"] is True
+
+
+def test_live_mode_unreachable_soft_returns_empty_with_repo_fallback_posture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    secrets = tmp_path / "secrets"
+    secrets.mkdir()
+    (secrets / "SURREALDB_ENV").write_text(
+        "SURREAL_USER=x\nSURREAL_PASS=y\n", encoding="utf-8"
+    )
+    adapter = harness.build_live_adapter(
+        config_path=EXAMPLE_CONFIG,
+        secrets_path=secrets,
+        hard_mode=False,
+    )
+    import urllib.error
+
+    mock_opener = MagicMock()
+    mock_opener.open.side_effect = urllib.error.URLError("connection refused")
+    with patch("tools.surrealdb.context_query.urllib.request.build_opener", return_value=mock_opener):
+        rows = adapter.execute(harness.HARNESS_PROBE_QUERY)
+    assert rows == []
+    posture = harness.classify_db_evidence_posture(
+        db_reachable=False,
+        record_source="surrealdb-local",
+        record_ids=None,
+    )
+    assert posture["db_claims_allowed"] is False
+    assert harness.assert_repo_only_db_claim_blocked(
+        db_reachable=False,
+        record_source=None,
+        claimed_brain_source="surrealdb-local",
+    )

--- a/tools/surrealdb/context_readonly_query_harness.py
+++ b/tools/surrealdb/context_readonly_query_harness.py
@@ -1,0 +1,312 @@
+"""Read-only SurrealDB context query integration harness (#3776).
+
+Local-only test surface for read-only context queries against surrealdb-local.
+No productive writes, no MCP mutation, no trading-state tables.
+
+LR remains NO-GO.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from tools.mcp.memory_write_intent_tools import MUTATION_ALLOWED
+from tools.surrealdb.context_query import (
+    QueryAdapter,
+    SurrealDBLocalQueryAdapter,
+    WriteDeniedError,
+    classify_statement,
+    load_config,
+)
+from tools.surrealdb.memory_db_proof_local_dev import (
+    LOCAL_DB,
+    LOCAL_NS,
+    LOCAL_SURR_URL,
+    QUERY_CONFIG_REL,
+    http_status,
+    repo_root,
+    resolve_secrets_path,
+)
+from tools.surrealdb.context_query import _load_query_credentials
+
+SCHEMA_VERSION = "context-readonly-query-harness/v1"
+ENV_REAL_SURREALDB_READONLY_QUERY = "CDB_RUN_REAL_SURREALDB_READONLY_QUERY"
+
+HARNESS_NAMESPACE = LOCAL_NS
+HARNESS_DATABASE = LOCAL_DB
+HARNESS_ALLOWED_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+_LOCAL_HEALTH_URLS = (
+    f"{LOCAL_SURR_URL}/health",
+    f"{LOCAL_SURR_URL}/version",
+)
+
+HARNESS_PROBE_QUERY = "SELECT * FROM repo_artifact LIMIT 0"
+HARNESS_WRITE_PROBE = "CREATE agent_memory:test SET content = 'denied'"
+
+TestMode = Literal["embedded", "file", "mem", "live"]
+
+_FORBIDDEN_WRITE_IMPORTS = frozenset(
+    {
+        "context_importer",
+        "memory_write_gate",
+        "memory_write_path_v1",
+        "memory_write_path_t4",
+        "memory_db_write_smoke",
+    }
+)
+
+
+@dataclass(frozen=True)
+class HarnessIsolation:
+    """Namespace/database isolation contract for local read-only probes."""
+
+    namespace: str
+    database: str
+    surreal_url: str
+    run_tag: str | None = None
+
+    def as_headers(self) -> dict[str, str]:
+        return {
+            "surreal-ns": self.namespace,
+            "surreal-db": self.database,
+            "surreal-url": self.surreal_url.rstrip("/"),
+        }
+
+
+class MemQueryAdapter(QueryAdapter):
+    """In-memory read-only adapter for harness unit tests (no network)."""
+
+    status = "mem-readonly"
+
+    def __init__(
+        self,
+        rows: list[dict[str, Any]] | None = None,
+        *,
+        namespace: str = HARNESS_NAMESPACE,
+        database: str = HARNESS_DATABASE,
+    ) -> None:
+        super().__init__(config=None)
+        self._rows = list(rows or [])
+        self.namespace = namespace
+        self.database = database
+
+    def execute(self, query: str) -> list[dict[str, Any]]:
+        classification = self.classify(query)
+        if not classification.allowed:
+            raise WriteDeniedError(classification.reason)
+        if "LIMIT 0" in query.upper():
+            return []
+        return list(self._rows)
+
+
+def harness_safety_flags() -> dict[str, bool]:
+    return {
+        "MUTATION_ALLOWED": bool(MUTATION_ALLOWED),
+        "read_only_default": True,
+        "productive_write_path": False,
+    }
+
+
+def build_isolation(*, run_tag: str | None = None) -> HarnessIsolation:
+    """Return the canonical local read-only isolation envelope."""
+
+    return HarnessIsolation(
+        namespace=HARNESS_NAMESPACE,
+        database=HARNESS_DATABASE,
+        surreal_url=LOCAL_SURR_URL,
+        run_tag=run_tag,
+    )
+
+
+def classify_db_evidence_posture(
+    *,
+    db_reachable: bool,
+    record_source: str | None = None,
+    record_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fail-closed posture for DB-backed claims (#3776)."""
+
+    has_records = bool(record_ids)
+    if db_reachable and record_source == "surrealdb-local" and has_records:
+        return {
+            "evidence_posture": "db_backed",
+            "brain_source": "surrealdb-local",
+            "brain_status": "partial",
+            "db_claims_allowed": True,
+            "repo_fallback_used": False,
+            "repo_fallback_reason": "none",
+            "record_ids": list(record_ids or ()),
+        }
+    return {
+        "evidence_posture": "repo_only",
+        "brain_source": "repo-only",
+        "brain_status": "not-used",
+        "db_claims_allowed": False,
+        "repo_fallback_used": True,
+        "repo_fallback_reason": "unavailable" if not db_reachable else "insufficient_evidence",
+        "record_ids": [],
+    }
+
+
+def assert_repo_only_db_claim_blocked(
+    *,
+    db_reachable: bool,
+    record_source: str | None,
+    claimed_brain_source: str,
+) -> bool:
+    posture = classify_db_evidence_posture(
+        db_reachable=db_reachable,
+        record_source=record_source,
+        record_ids=["placeholder"] if record_source == "surrealdb-local" else None,
+    )
+    if posture["db_claims_allowed"]:
+        return False
+    return claimed_brain_source in {"surrealdb-local", "used", "db_backed"}
+
+
+def check_readonly_query_preconditions(*, confirm: bool = False) -> dict[str, Any]:
+    """Fail-closed preflight for local read-only query harness (no pytest)."""
+
+    errors: list[str] = []
+    if os.environ.get(ENV_REAL_SURREALDB_READONLY_QUERY) != "1" and not confirm:
+        errors.append(
+            f"set {ENV_REAL_SURREALDB_READONLY_QUERY}=1 or pass --confirm on CLI/Makefile"
+        )
+
+    root = repo_root()
+    query_config = root / QUERY_CONFIG_REL
+    if not query_config.is_file():
+        errors.append(f"missing local query config: {QUERY_CONFIG_REL}")
+
+    secrets_path = resolve_secrets_path()
+    if secrets_path is None:
+        errors.append(
+            "missing secrets dir (CDB_CONTEXT_SECRETS_PATH, SECRETS_PATH, or canon store)"
+        )
+    elif not (secrets_path / "SURREALDB_ENV").is_file():
+        errors.append("missing SURREALDB_ENV in secrets dir")
+
+    db_reachable = True
+    for url in _LOCAL_HEALTH_URLS:
+        status = http_status(url)
+        if status != 200:
+            db_reachable = False
+            errors.append(
+                f"local SurrealDB preflight failed for {url} (status={status})"
+            )
+
+    isolation = build_isolation()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": not errors,
+        "errors": errors,
+        "db_reachable": db_reachable and not errors,
+        "query_config_path": str(query_config) if query_config.is_file() else None,
+        "secrets_path_configured": secrets_path is not None,
+        "isolation": isolation.as_headers(),
+        "safety_flags": harness_safety_flags(),
+        "limitations": [
+            "local_dev_only_127.0.0.1:8010",
+            "read_only_queries_only",
+            "no_productive_write_path",
+            "standard_ci_excludes_local_only",
+            "lr_no_go",
+        ],
+    }
+
+
+def build_live_adapter(
+    *,
+    config_path: Path,
+    secrets_path: Path,
+    hard_mode: bool = False,
+) -> SurrealDBLocalQueryAdapter:
+    config = load_config(config_path)
+    user, password = _load_query_credentials(config, secrets_path)
+    return SurrealDBLocalQueryAdapter(
+        surreal_url=config.surreal_url,
+        namespace=config.namespace,
+        database=config.database,
+        user=user,
+        password=password,
+        timeout=config.timeout,
+        hard_mode=hard_mode,
+        config=config,
+    )
+
+
+def build_adapter_for_mode(
+    mode: TestMode,
+    *,
+    config_path: Path | None = None,
+    secrets_path: Path | None = None,
+    mem_rows: list[dict[str, Any]] | None = None,
+) -> QueryAdapter:
+    if mode == "embedded":
+        from tools.surrealdb.context_query import NoopQueryAdapter
+
+        return NoopQueryAdapter()
+    if mode == "mem":
+        return MemQueryAdapter(mem_rows)
+    if mode == "file":
+        if config_path is None:
+            raise ValueError("file mode requires config_path")
+        config = load_config(config_path)
+        return MemQueryAdapter(
+            [{"config_namespace": config.namespace, "config_database": config.database}],
+            namespace=config.namespace,
+            database=config.database,
+        )
+    if mode == "live":
+        if config_path is None or secrets_path is None:
+            raise ValueError("live mode requires config_path and secrets_path")
+        return build_live_adapter(config_path=config_path, secrets_path=secrets_path)
+    raise ValueError(f"unsupported harness mode: {mode}")
+
+
+def run_readonly_probe(adapter: QueryAdapter, *, query: str = HARNESS_PROBE_QUERY) -> dict[str, Any]:
+    """Execute a read-only probe and return structured harness evidence."""
+
+    classification = adapter.classify(query)
+    if not classification.allowed:
+        raise WriteDeniedError(classification.reason)
+    rows = adapter.execute(query)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "query": query,
+        "classification": classification.to_payload(),
+        "row_count": len(rows),
+        "adapter_status": getattr(adapter, "status", "unknown"),
+        "read_only": True,
+    }
+
+
+def assert_harness_has_no_productive_write_path() -> list[str]:
+    """Static contract: harness module must not import productive write executors."""
+
+    module_path = Path(__file__)
+    source = module_path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    for token in _FORBIDDEN_WRITE_IMPORTS:
+        if f"import {token}" in source or f"from tools.surrealdb.{token}" in source:
+            violations.append(token)
+    return violations
+
+
+def standard_ci_excludes_local_only() -> dict[str, Any]:
+    """Repo-backed evidence that standard CI skips local_only tests."""
+
+    root = repo_root()
+    ci_yaml = (root / ".github" / "workflows" / "ci.yaml").read_text(encoding="utf-8")
+    pytest_ini = (root / "pytest.ini").read_text(encoding="utf-8")
+    marker_present = "local_only:" in pytest_ini
+    ci_excludes = "not local_only" in ci_yaml
+    return {
+        "pytest_marker_registered": marker_present,
+        "ci_excludes_local_only": ci_excludes,
+        "ok": marker_present and ci_excludes,
+    }


### PR DESCRIPTION
## Summary

- Add `tools/surrealdb/context_readonly_query_harness.py` — read-only local integration contract with namespace isolation, `MUTATION_ALLOWED=False` safety flags, fail-closed repo-fallback posture, and adapter modes (`embedded`/`file`/`mem`/`live`).
- Add 16 CI-safe unit contract tests + 3 opt-in `local_only` integration tests (skipped without `CDB_RUN_REAL_SURREALDB_READONLY_QUERY=1` and local DB).
- Document local vs CI test paths in `docs/surrealdb/context-readonly-query-harness.md`; add `make context-readonly-query-harness` for unit contract.

Closes #3776
Refs #3771

## Brain Evidence

- brain_source: repo-only (+ MCP briefing attempted, no DB records)
- brain_status: not-used
- context_tool_status: available; context_trust_level: none; records_found: none
- repo_fallback_reason: insufficient_evidence

## Delivered

| Case | Evidence |
| --- | --- |
| local_only marker | `tests/local/surrealdb/test_context_readonly_query_harness.py` |
| standard CI excludes local_only | `standard_ci_excludes_local_only()` + `.github/workflows/ci.yaml` |
| readonly default | Classifier denies `CREATE`; `MUTATION_ALLOWED=False` |
| unreachable DB fail-closed | `classify_db_evidence_posture()` → repo-only |
| namespace isolation | `cdb_context_local` / `cdb_context_intel` contract |
| no productive write path | static import guard on harness module |
| local run reproducible | docs + `make context-readonly-query-harness` |
| fixture adapter secondary | embedded/file/mem unit tests |

## Test plan

- [x] `pytest -q tests/unit/surrealdb/test_context_readonly_query_harness.py` — 16 passed
- [x] `pytest -q -m local_only tests/local/surrealdb/test_context_readonly_query_harness.py` — 1 passed, 2 skipped (no local DB opt-in)
- [x] `ruff check` on changed Python files
- [x] `git diff --check`

## Non-goals

- No retrieval ranking regression (#3777)
- No stale-doc drift suite (#3779)
- No productive SurrealDB writes or MCP mutation
- No standard CI live-DB requirement

## Safety Boundaries

- LR NO-GO unchanged
- `MUTATION_ALLOWED=False` default
- Harness read-only probes only; no importer/UPSERT path

## Remaining uncertainty

- Live `local_only` integration not executed in this session (local SurrealDB opt-in absent); tests skip cleanly.
