### PR TITLE
test(agent-os): add onboarding and role consistency contracts

### DIFF
--- a/knowledge/testing/AGENT_OS_CONTRACT_TESTS.md
+++ b/knowledge/testing/AGENT_OS_CONTRACT_TESTS.md
@@ -16,6 +16,10 @@ and emit honest Brain Evidence without inventing DB-backed claims?
 | #3866 | `tests/unit/tools/test_validate_skill_surface_mirror.py` | Drift guard implementation (#3643) |
 | #3867 | `tests/unit/agents/test_brain_evidence_agent_os_regression_contract.py` | Brain Evidence block + final report shape |
 | #3867 | `tests/unit/agents/test_brain_evidence_block_contract.py` | MCP briefing Brain Evidence gate (#3774) |
+| #3868 | `tests/unit/agents/test_onboarding_fresh_agent_contract.py` | Fresh-agent read-only default, setup GO gate, simulation modes |
+| #3868 | `tests/smoke/test_onboarding_orchestrator.py` | Orchestrator CLI smoke (no mutations) |
+| #3868 | `tests/smoke/test_onboarding_cross_agent_surfaces.py` | Cross-surface onboarding routing |
+| #3869 | `tests/unit/agents/test_agent_role_consistency_contract.py` | Agent role LR/Live/MCP/write/onboarding consistency |
 
 Shared helpers: `tests/unit/agents/_bootloader_read_order_helpers.py`,
 `tests/unit/agents/_agent_os_contract_helpers.py`.
@@ -32,8 +36,11 @@ Shared helpers: `tests/unit/agents/_bootloader_read_order_helpers.py`,
 ```bash
 pytest -q tests/unit/agents/test_skill_surface_adapter_drift_contract.py
 pytest -q tests/unit/agents/test_brain_evidence_agent_os_regression_contract.py
+pytest -q tests/unit/agents/test_onboarding_fresh_agent_contract.py
+pytest -q tests/unit/agents/test_agent_role_consistency_contract.py
 pytest -q tests/unit/tools/test_validate_skill_surface_mirror.py
-pytest -q tests/unit -k "skill or surface or mirror or brain_evidence or bootloader"
+pytest -q tests/unit -k "onboarding or agent or role or guardrail or brain_evidence"
+pytest -q tests/smoke -k "onboarding"
 python tools/validate_skill_surface_mirror.py
 ```
 

--- a/tests/unit/agents/_agent_os_contract_helpers.py
+++ b/tests/unit/agents/_agent_os_contract_helpers.py
@@ -47,6 +47,77 @@ REGISTRY_SURFACE_PATHS: dict[str, str] = {
 
 SECTION_16_ONBOARDING_SURFACES: frozenset[str] = frozenset({"opencode", "cursor", "claude"})
 
+# Canonical agent role files (#3869).
+CANONICAL_AGENT_ROLE_PATHS: dict[str, str] = {
+    "codex": "agents/roles/CODEX.md",
+    "claude": "agents/roles/CLAUDE.md",
+    "gemini": "agents/roles/GEMINI.md",
+    "copilot": "agents/roles/COPILOT.md",
+    "opencode": "agents/roles/OPENCODE.md",
+}
+
+SHARED_ROLE_GUARDRAIL_ANCHORS: tuple[str, ...] = (
+    "Brain Evidence Gate",
+    "agents/AGENTS.md",
+    "LR-AUDIT-STATUS",
+    "read-only",
+)
+
+LR_STAGE_SEPARATION_ANCHORS: tuple[str, ...] = (
+    "trade-capable",
+    "NO-GO",
+)
+
+FORBIDDEN_ROLE_LIVE_GO_PHRASES: tuple[str, ...] = (
+    "Live-Go approved",
+    "Echtgeld-Go erteilt",
+    "trade-capable erlaubt Live",
+    "trade-capable ist Live-Go",
+    "autorisiert Live-Kapital",
+)
+
+# Negated LR-GO phrases are allowed (e.g. "kein LR-GO").
+FORBIDDEN_ROLE_LIVE_GO_STANDALONE: tuple[str, ...] = (
+    "LR GO",
+    "LR-GO",
+)
+
+ROLE_SPECIFIC_GUARDRAIL_ANCHORS: dict[str, tuple[str, ...]] = {
+    "codex": SHARED_ROLE_GUARDRAIL_ANCHORS + LR_STAGE_SEPARATION_ANCHORS,
+    "claude": SHARED_ROLE_GUARDRAIL_ANCHORS
+    + (
+        "LR-Go/No-Go",
+        "CONTROL_REGISTER",
+        "docs/live-readiness",
+    ),
+    "gemini": SHARED_ROLE_GUARDRAIL_ANCHORS
+    + (
+        "trade-capable",
+        "kein LR-GO",
+        "LR-AUDIT-STATUS",
+    ),
+    "copilot": SHARED_ROLE_GUARDRAIL_ANCHORS + LR_STAGE_SEPARATION_ANCHORS,
+    "opencode": (
+        "Brain Evidence Gate",
+        "agents/AGENTS.md",
+        "read-only",
+        "Canon-Governance ist read-only",
+    ),
+}
+
+ONBOARDING_PRIMARY_ROUTE = "python -m tools.onboarding_orchestrator"
+ONBOARDING_ROUTING_ROLE_PATHS: tuple[str, ...] = (
+    "agents/roles/CODEX.md",
+    "GEMINI.md",
+    "AGENTS.md",
+)
+
+MCP_CAPABILITY_REFERENCE_ANCHORS: tuple[str, ...] = (
+    "MCP Capability",
+    "surrealdb_context_mcp_access.md",
+    "Repo-Präsenz ist nicht gleich MCP-Verfügbarkeit",
+)
+
 
 def parse_registry_excluded_onboarding_surfaces(registry_text: str) -> frozenset[str]:
     """Return surfaces documented as excluded for cdb-onboarding in Registry §16."""

--- a/tests/unit/agents/test_agent_role_consistency_contract.py
+++ b/tests/unit/agents/test_agent_role_consistency_contract.py
@@ -1,0 +1,154 @@
+"""Agent role consistency contract tests (#3869).
+
+Static checks that Codex, Claude, Gemini, Copilot, and OpenCode role surfaces
+do not contradict each other on LR, Live-Go, MCP, writes, Brain Evidence,
+or onboarding routing references.
+
+MCP capability resolution depth remains #3870; here we only guard shared
+role references and forbidden live-go phrasing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.agents._agent_os_contract_helpers import (
+    CANONICAL_AGENT_ROLE_PATHS,
+    FORBIDDEN_ROLE_LIVE_GO_PHRASES,
+    FORBIDDEN_ROLE_LIVE_GO_STANDALONE,
+    MCP_CAPABILITY_REFERENCE_ANCHORS,
+    ONBOARDING_PRIMARY_ROUTE,
+    ONBOARDING_ROUTING_ROLE_PATHS,
+    ROLE_SPECIFIC_GUARDRAIL_ANCHORS,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+OPEN_CODE_AGENTS = REPO_ROOT / "agents" / "OPEN_CODE_AGENTS.md"
+AGENTS_REGISTRY = REPO_ROOT / "agents" / "AGENTS.md"
+
+
+def _read_repo(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Role file presence + shared guardrails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("relative_path", list(CANONICAL_AGENT_ROLE_PATHS.values()))
+def test_canonical_agent_role_files_exist(relative_path: str) -> None:
+    assert (REPO_ROOT / relative_path).is_file(), f"missing role file: {relative_path}"
+
+
+@pytest.mark.parametrize(
+    ("role_name", "relative_path"),
+    list(CANONICAL_AGENT_ROLE_PATHS.items()),
+)
+def test_roles_share_brain_evidence_and_status_guardrails(
+    role_name: str, relative_path: str
+) -> None:
+    text = _read_repo(relative_path)
+    anchors = ROLE_SPECIFIC_GUARDRAIL_ANCHORS[role_name]
+    for anchor in anchors:
+        assert anchor in text, f"{role_name}: missing guardrail {anchor!r}"
+
+
+@pytest.mark.parametrize(
+    ("role_name", "relative_path"),
+    list(CANONICAL_AGENT_ROLE_PATHS.items()),
+)
+def test_roles_do_not_authorize_live_go_phrases(
+    role_name: str, relative_path: str
+) -> None:
+    text = _read_repo(relative_path)
+    for phrase in FORBIDDEN_ROLE_LIVE_GO_PHRASES:
+        assert phrase not in text, f"{role_name}: forbidden live-go phrase {phrase!r}"
+    for phrase in FORBIDDEN_ROLE_LIVE_GO_STANDALONE:
+        if phrase not in text:
+            continue
+        for line in text.splitlines():
+            if phrase not in line:
+                continue
+            lowered = line.lower()
+            if any(neg in lowered for neg in ("kein ", "nicht ", "no ", "never ", "nie ")):
+                continue
+            pytest.fail(
+                f"{role_name}: affirmative live-go phrase {phrase!r} in line: {line.strip()}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Onboarding routing consistency (#3869)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("relative_path", ONBOARDING_ROUTING_ROLE_PATHS)
+def test_onboarding_entry_surfaces_route_to_orchestrator(relative_path: str) -> None:
+    text = _read_repo(relative_path)
+    assert ONBOARDING_PRIMARY_ROUTE in text, (
+        f"{relative_path}: missing onboarding orchestrator route"
+    )
+
+
+def test_agents_registry_documents_onboarding_intent_router() -> None:
+    text = _read_repo("AGENTS.md")
+    assert "Quick Intent Router" in text or "onboarding" in text.lower()
+    assert ONBOARDING_PRIMARY_ROUTE in text
+
+
+def test_codex_role_defers_onboarding_from_session_start() -> None:
+    text = _read_repo("agents/roles/CODEX.md")
+    assert "Do not start `cdb-session-start` or `onboarding_doctor`" in text
+    assert "Default output is the CDB Onboarding status card." in text
+
+
+# ---------------------------------------------------------------------------
+# Brain Evidence + MCP capability references (#3869, not full #3870)
+# ---------------------------------------------------------------------------
+
+
+def test_open_code_agents_requires_brain_evidence_before_planning() -> None:
+    text = OPEN_CODE_AGENTS.read_text(encoding="utf-8")
+    assert "Brain Evidence Gate" in text
+    assert "brain_source" in text
+    assert "context_brain_attempted" in text
+    assert "vor jeder Planung" in text
+
+
+def test_open_code_agents_references_mcp_capability_resolution() -> None:
+    text = OPEN_CODE_AGENTS.read_text(encoding="utf-8")
+    for anchor in MCP_CAPABILITY_REFERENCE_ANCHORS:
+        assert anchor in text, f"OPEN_CODE_AGENTS missing MCP anchor: {anchor!r}"
+
+
+def test_open_code_agents_blocks_writes_without_human_go() -> None:
+    text = OPEN_CODE_AGENTS.read_text(encoding="utf-8")
+    assert "Keine Writes ohne Human-GO" in text
+    assert "MUTATION_ALLOWED=False" in text
+    assert "PERSIST_ALLOWED=False" in text
+
+
+def test_agents_registry_brain_evidence_matches_open_code_contract() -> None:
+    registry = AGENTS_REGISTRY.read_text(encoding="utf-8")
+    opencode = OPEN_CODE_AGENTS.read_text(encoding="utf-8")
+    for field in ("context_brain_attempted", "repo_fallback_reason", "brain_source"):
+        assert field in registry, f"agents/AGENTS.md missing {field!r}"
+        assert field in opencode, f"OPEN_CODE_AGENTS missing {field!r}"
+
+
+def test_gemini_role_declares_trade_capable_not_lr_go() -> None:
+    text = _read_repo("agents/roles/GEMINI.md")
+    assert "trade-capable` ist kein LR-GO" in text or "kein LR-GO" in text
+    assert "kein Live-Kapital" in text or "Live-Kapital" in text
+
+
+def test_copilot_role_preserves_lr_no_go_with_trade_capable_stage() -> None:
+    text = _read_repo("agents/roles/COPILOT.md")
+    assert "trade-capable" in text
+    assert "LR-050 NO-GO" in text or "NO-GO" in text

--- a/tests/unit/agents/test_onboarding_fresh_agent_contract.py
+++ b/tests/unit/agents/test_onboarding_fresh_agent_contract.py
@@ -1,0 +1,191 @@
+"""Onboarding fresh-agent and simulation contract tests (#3868).
+
+Contract-Test: read-only default, explicit setup GO, first-issue dry-run,
+guided-rehearsal routing, and orchestrator state machine boundaries.
+
+Complements smoke tests under tests/smoke/test_onboarding_* and
+tests/unit/tools/test_onboarding_simulation.py.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.onboarding_orchestrator import (
+    ACTION_ABORT,
+    ACTION_APPROVE_SETUP,
+    ACTION_REQUEST_SETUP_GO,
+    ACTION_STATUS_ONLY,
+    SETUP_ABORTED,
+    SETUP_APPROVED,
+    SETUP_CONFIRMATION_PENDING,
+    SETUP_REQUIRED,
+    OrchestratorOutput,
+    build_verdict,
+    format_output,
+    get_setup_prompt_text,
+    normalize_setup_prompt_input,
+)
+from tools.onboarding_simulation import render_simulation
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+ONBOARDING_MODULE = REPO_ROOT / "tools" / "onboarding_orchestrator.py"
+AGENTS_ROOT = REPO_ROOT / "AGENTS.md"
+
+
+# ---------------------------------------------------------------------------
+# Read-only default (#3868)
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_module_declares_read_only_default() -> None:
+    doc = inspect.getdoc(__import__("tools.onboarding_orchestrator", fromlist=["x"]))
+    assert doc is not None
+    lowered = doc.lower()
+    assert "read-only by default" in lowered
+    assert "no file writes" in lowered
+    assert "no setup mutation" in lowered
+
+
+def test_orchestrator_source_has_two_option_setup_prompt_only() -> None:
+    text = ONBOARDING_MODULE.read_text(encoding="utf-8")
+    assert "1. Ja" in text
+    assert "2. Abbruch" in text
+    assert "SETUP_CONFIRMATION_PENDING" in text
+
+
+def test_format_output_always_declares_no_changes_and_lr_no_go() -> None:
+    report = OrchestratorOutput(status="PASS", state="STATUS_ONLY")
+    output = format_output(report, "text")
+    assert "No changes made." in output
+    assert "LR remains NO-GO." in output
+    assert "trade-capable is not Live-Go." in output
+
+
+def test_simulation_default_disables_writes() -> None:
+    output = render_simulation()
+    assert "writes: disabled" in output
+    assert "github_writes: disabled" in output
+    assert "lr: NO-GO" in output
+
+
+# ---------------------------------------------------------------------------
+# Setup mutation requires explicit selection (#3868)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1", SETUP_APPROVED),
+        ("ja", SETUP_APPROVED),
+        ("yes", SETUP_APPROVED),
+        ("2", SETUP_ABORTED),
+        ("nein", SETUP_ABORTED),
+        ("abbruch", SETUP_ABORTED),
+        ("maybe", None),
+        ("", None),
+    ],
+)
+def test_normalize_setup_prompt_input_gate(raw: str, expected: str | None) -> None:
+    assert normalize_setup_prompt_input(raw) == expected
+
+
+def test_setup_prompt_has_exactly_two_options() -> None:
+    prompt = get_setup_prompt_text()
+    assert prompt.count("1. Ja") == 1
+    assert prompt.count("2. Abbruch") == 1
+
+
+def test_build_verdict_setup_warn_requires_explicit_go_in_default_mode() -> None:
+    report = build_verdict(REPO_ROOT, mode="default")
+    if report.status == "SETUP_WARN":
+        assert report.requires_explicit_setup_go is True
+        assert report.state == SETUP_CONFIRMATION_PENDING
+        assert report.setup_prompt_visible is True
+        assert ACTION_APPROVE_SETUP in report.allowed_next_actions
+        assert ACTION_ABORT in report.allowed_next_actions
+
+
+def test_build_verdict_check_only_never_shows_setup_prompt() -> None:
+    report = build_verdict(REPO_ROOT, mode="check-only")
+    assert report.setup_prompt_visible is False
+    assert report.state in {SETUP_REQUIRED, "DRY_RUN_COMPLETE", "BLOCKED", "STATUS_ONLY"}
+    if report.status == "SETUP_WARN":
+        assert ACTION_REQUEST_SETUP_GO in report.allowed_next_actions
+        assert ACTION_APPROVE_SETUP not in report.allowed_next_actions
+
+
+def test_format_output_check_only_forbids_setup_mutation() -> None:
+    report = OrchestratorOutput(mode="check-only", status="SETUP_WARN", state=SETUP_REQUIRED)
+    report.requires_explicit_setup_go = True
+    output = format_output(report, "text")
+    assert "check-only mode is dry-run only." in output
+    assert "No setup mutation is allowed from this run." in output
+
+
+# ---------------------------------------------------------------------------
+# First-issue dry-run without side effects (#3868)
+# ---------------------------------------------------------------------------
+
+
+def test_first_issue_dry_run_simulation_is_read_only() -> None:
+    output = render_simulation(mode="first-issue-dry-run")
+    assert "mode: first-issue-dry-run" in output
+    assert "writes: disabled" in output
+    assert "github_writes: disabled" in output
+    assert "READY_FOR_REAL_FIRST_ISSUE" in output
+    assert "First-Issue Dry Run:" in output
+
+
+def test_first_issue_dry_run_json_has_no_mutation_flags() -> None:
+    from tools.onboarding_simulation import render_simulation_json
+
+    data = __import__("json").loads(render_simulation_json(mode="first-issue-dry-run"))
+    assert data["mode"] == "first-issue-dry-run"
+    assert data["verdict"] == "READY_FOR_REAL_FIRST_ISSUE"
+
+
+# ---------------------------------------------------------------------------
+# Guided rehearsal / onboarding routing (#3868)
+# ---------------------------------------------------------------------------
+
+
+def test_agents_root_routes_onboarding_to_orchestrator() -> None:
+    text = AGENTS_ROOT.read_text(encoding="utf-8")
+    assert "python -m tools.onboarding_orchestrator" in text
+    assert "fresh agent onboarding" in text
+    assert "onboarding_simulation --mode guided-rehearsal" in text
+
+
+def test_guided_rehearsal_simulation_is_non_mutating() -> None:
+    output = render_simulation(mode="guided-rehearsal")
+    assert "mode: guided-rehearsal" in output
+    assert "writes: disabled" in output
+    assert "GUIDED_REHEARSAL_DONE" in output
+    assert "simuliert" in output.lower()
+
+
+def test_build_verdict_with_mocked_doctor_runners_stays_deterministic() -> None:
+    ok_proc = MagicMock(returncode=0, stdout="ok", stderr="")
+
+    def _runner(*_args, **_kwargs):
+        return ok_proc
+
+    report = build_verdict(
+        REPO_ROOT,
+        mode="check-only",
+        doctor_runner=_runner,
+        context_doctor_runner=_runner,
+    )
+    assert report.mode == "check-only"
+    assert report.check_scope == "onboarding_status_check_only"
+    if not report.blockers:
+        assert ACTION_STATUS_ONLY in report.allowed_next_actions or ACTION_ABORT in report.allowed_next_actions


### PR DESCRIPTION
## Summary

Closes #3868
Closes #3869
Refs #3864
Refs #1445

Adds Agent OS contract tests for fresh-agent onboarding (read-only default, explicit setup GO, simulation modes) and cross-role guardrail consistency (Codex, Claude, Gemini, Copilot, OpenCode).

## Brain Evidence

- `brain_source`: repo-only
- `brain_status`: not-used
- `context_brain_attempted`: true
- `context_brain_used`: false
- `context_available`: false
- `repo_fallback_used`: true
- `repo_fallback_reason`: insufficient_evidence
- `context_tool_status`: available
- `context_trust_level`: none
- `records_found`: none
- MCP `cdb_context_briefing` returned LOW trust, no enrichment records; GitHub/repo used for delivery truth.

## Bootloader-/Read-Order-Evidence

- Root pointer `AGENTS.md` → `agents/AGENTS.md` Read Order resolved
- Governance chain read: `CDB_CONSTITUTION`, `CDB_AGENT_POLICY`, `CONTROL_REGISTER`, `LR-AUDIT-STATUS`
- No duplicate open PR for #3868/#3869

## Delivered

- `tests/unit/agents/test_onboarding_fresh_agent_contract.py` (#3868)
- `tests/unit/agents/test_agent_role_consistency_contract.py` (#3869)
- Shared helpers extended in `_agent_os_contract_helpers.py`
- `knowledge/testing/AGENT_OS_CONTRACT_TESTS.md` updated

## Validation

- `git diff --check` — pass
- `ruff check` on changed tests — pass
- `pytest -q tests/unit/agents/test_onboarding_fresh_agent_contract.py tests/unit/agents/test_agent_role_consistency_contract.py` — 47 passed
- `pytest -q tests/smoke -k onboarding` — 88 passed
- Keyword filter `tests/unit -k "onboarding or agent or role or guardrail or brain_evidence"` — 593 passed (1 pre-existing unrelated `test_clock` failure in full filter)

## Non-goals

- No new agent roles or Agent Policy
- No onboarding system redesign
- No MCP capability resolution depth (#3870)
- No knowledge/skill-map tests (#3871)
- No runtime/Docker/BLUE/RED changes
- No CURRENT_STATUS or ledger update (per #3864 slice policy)

## Safety Boundaries

- LR remains NO-GO
- No MCP/DB mutations
- No secrets in diff
- Test-only / contract guards

## Ledger Policy

No `CURRENT_STATUS.md` or session-ledger update until parent #3864 is fully complete.

## Test plan

- [x] Fresh-agent orchestrator read-only contract
- [x] Setup mutation explicit GO gate
- [x] First-issue dry-run + guided-rehearsal simulation contracts
- [x] Agent role LR/Live/MCP/write/onboarding consistency
- [x] CI required checks (pending)
