### PR TITLE
test(test-pack): add P1 mockexchange chaos and metrics contracts

### DIFF
--- a/knowledge/testing/TEST_PACK_CONTRACT_TESTS.md
+++ b/knowledge/testing/TEST_PACK_CONTRACT_TESTS.md
@@ -1,20 +1,26 @@
 # Test Pack Contract Tests
 
-Status: active (Issue #3872 child slice — P0)
-Scope: Test Pack manifest, operator drill evidence, kill-switch simulation — test-only
+Status: active (Issue #3872 child slices — P0 + P1)
+Scope: Test Pack manifest, operator drill evidence, kill-switch simulation,
+MockExchange boundary, chaos assertions, metrics smoke — test-only
 
 ## Purpose
 
 Contract tests distinguish **frozen Test Pack artifacts** from live runtime proof.
-They guard manifest/catalog integrity, operator evidence pack shape, and
-kill-switch drill simulation semantics without Docker, alerts, or real kill-switch
-activation. LR remains NO-GO; simulation and drill evidence are not Live-Go.
+They guard manifest/catalog integrity, operator evidence pack shape,
+kill-switch drill simulation semantics, MockExchange adapter boundaries,
+deterministic chaos assertion evaluation, and metrics-smoke PASS/WARN/FAIL
+semantics without Docker, alerts, live exchange, or real monitoring instances.
+LR remains NO-GO; simulation and drill evidence are not Live-Go.
 
 | Issue | Test module | Rule protected |
 |---|---|---|
 | #3873 | `tests/unit/test_pack/test_test_pack_manifest_catalog_contract.py` | Manifest/catalog parseability, scenario IDs, artifact links, no live defaults |
 | #3874 | `tests/unit/test_pack/test_operator_drill_evidence_pack_contract.py` | Evidence pack template, timestamps, operator fields, PASS/WARN/FAIL, no credentials in evidence |
 | #3875 | `tests/unit/test_pack/test_kill_switch_drill_simulation_contract.py` | Simulated drill states (active/inactive/unknown), fail-closed unknown |
+| #3876 | `tests/unit/test_pack/test_mock_exchange_cdb_integration_contract.py` | MockExchange shim boundary, order lifecycle, Valkey/cdb_redis separation |
+| #3877 | `tests/unit/test_pack/test_chaos_scenario_assertion_contract.py` | Deterministic scenario generation, assertion PASS/FAIL, operator-only drill paths |
+| #3878 | `tests/unit/test_pack/test_metrics_smoke_contract.py` | Metrics snapshot evaluation, no-data detection, PASS/WARN/FAIL semantics |
 
 Shared helpers: `tests/unit/test_pack/_test_pack_contract_helpers.py`  
 Fixtures: `tests/fixtures/test_pack/`
@@ -22,15 +28,16 @@ Fixtures: `tests/fixtures/test_pack/`
 ## Why contract / fixture / simulation tests
 
 - **Testart:** Contract-Test + Simulation (see `knowledge/testing/README.md`).
-- **Fail-closed:** Missing artifacts, unknown kill-switch state, or credential-like
-  evidence content fails CI before operators treat partial packs as PASS.
-- **No runtime:** No BLUE/RED, no HTTP to risk service, no kill-switch file writes.
+- **Fail-closed:** Missing artifacts, unknown kill-switch state, no-data metrics,
+  or credential-like evidence content fails CI before operators treat partial packs as PASS.
+- **No runtime:** No BLUE/RED, no HTTP to risk service, no kill-switch file writes,
+  no live Prometheus/Grafana, no dockerized chaos drills in standard CI.
 
 ## Validation commands
 
 ```bash
 pytest -q tests/unit/test_pack/
-pytest -q tests/unit -k "test_pack or manifest or scenario or operator or drill or kill_switch or evidence"
+pytest -q tests/unit -k "mock_exchange or mockexchange or chaos or assertion or metrics or smoke or snapshot or no_data or test_pack"
 ruff check tests/unit/test_pack/
 ```
 
@@ -38,4 +45,5 @@ ruff check tests/unit/test_pack/
 
 - New scenarios or MockExchange architecture.
 - Productive operator drills or Alertmanager/Grafana mutations.
+- Runtime-mutating LR-041/LR-042 drill execution in standard CI.
 - `CURRENT_STATUS.md` / ledger updates while #3872 remains open.

--- a/tests/fixtures/test_pack/metrics_smoke_fail.json
+++ b/tests/fixtures/test_pack/metrics_smoke_fail.json
@@ -1,0 +1,10 @@
+{
+  "ts": "2026-07-06T12:00:00+00:00",
+  "prometheus": {
+    "error": "connection refused"
+  },
+  "grafana": {
+    "error": "connection refused"
+  },
+  "notes": []
+}

--- a/tests/fixtures/test_pack/metrics_smoke_no_data.json
+++ b/tests/fixtures/test_pack/metrics_smoke_no_data.json
@@ -1,0 +1,13 @@
+{
+  "ts": "2026-07-06T12:00:00+00:00",
+  "prometheus": {
+    "targets_active": 0,
+    "targets_dropped": 0,
+    "query_no_data": true
+  },
+  "grafana": {
+    "database": "ok",
+    "version": "10.0.0"
+  },
+  "notes": ["no-data detected on prometheus targets"]
+}

--- a/tests/fixtures/test_pack/metrics_smoke_pass.json
+++ b/tests/fixtures/test_pack/metrics_smoke_pass.json
@@ -1,0 +1,12 @@
+{
+  "ts": "2026-07-06T12:00:00+00:00",
+  "prometheus": {
+    "targets_active": 12,
+    "targets_dropped": 0
+  },
+  "grafana": {
+    "database": "ok",
+    "version": "10.0.0"
+  },
+  "notes": []
+}

--- a/tests/fixtures/test_pack/metrics_snapshot_no_data.json
+++ b/tests/fixtures/test_pack/metrics_snapshot_no_data.json
@@ -1,0 +1,38 @@
+{
+  "ts": "2026-07-06T12:00:00+00:00",
+  "prom_url": "http://127.0.0.1:19090",
+  "queries": {
+    "up_cdb": {
+      "query": "up{job=~\"cdb_.*\"}",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {"result": []}
+      }
+    },
+    "circuit_breaker_active": {
+      "query": "circuit_breaker_active",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {"result": []}
+      }
+    },
+    "orders_approved_total": {
+      "query": "orders_approved_total",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {"result": []}
+      }
+    },
+    "orders_blocked_total": {
+      "query": "orders_blocked_total",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {"result": []}
+      }
+    }
+  }
+}

--- a/tests/fixtures/test_pack/metrics_snapshot_pass.json
+++ b/tests/fixtures/test_pack/metrics_snapshot_pass.json
@@ -1,0 +1,47 @@
+{
+  "ts": "2026-07-06T12:00:00+00:00",
+  "prom_url": "http://127.0.0.1:19090",
+  "queries": {
+    "up_cdb": {
+      "query": "up{job=~\"cdb_.*\"}",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {
+          "result": [
+            {"metric": {"job": "cdb_risk"}, "value": [1710000000, "1"]},
+            {"metric": {"job": "cdb_execution"}, "value": [1710000000, "1"]}
+          ]
+        }
+      }
+    },
+    "circuit_breaker_active": {
+      "query": "circuit_breaker_active",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {
+          "result": [{"metric": {}, "value": [1710000000, "0"]}]
+        }
+      }
+    },
+    "orders_approved_total": {
+      "query": "orders_approved_total",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {
+          "result": [{"metric": {}, "value": [1710000000, "3"]}]
+        }
+      }
+    },
+    "orders_blocked_total": {
+      "query": "orders_blocked_total",
+      "status": "success",
+      "data": {
+        "status": "success",
+        "data": {"result": []}
+      }
+    }
+  }
+}

--- a/tests/unit/test_pack/_test_pack_contract_helpers.py
+++ b/tests/unit/test_pack/_test_pack_contract_helpers.py
@@ -1,4 +1,4 @@
-"""Shared helpers for Test Pack contract tests (#3873, #3874, #3875)."""
+"""Shared helpers for Test Pack contract tests (#3873–#3878)."""
 
 from __future__ import annotations
 
@@ -20,6 +20,22 @@ SCENARIO_CATALOG = TEST_PACK_ROOT / "scenarios" / "catalog.yaml"
 EVIDENCE_README_TEMPLATE = TEST_PACK_ROOT / "templates" / "evidence_pack_README.md"
 OPERATOR_DRILL_SCRIPT = TEST_PACK_ROOT / "tools" / "drills" / "trigger-operator-drill.ps1"
 KILL_SWITCH_CHECKLIST_REPO = REPO_ROOT / "docs" / "operations" / "KILL_SWITCH_OPERATOR_CHECKLIST.md"
+MOCK_EXCHANGE_SHIM = TEST_PACK_ROOT / "tools" / "mock_exchange" / "mock_exchange.py"
+CHAOS_GENERATE_SCENARIO = TEST_PACK_ROOT / "tools" / "chaos" / "generate_scenario.py"
+EVALUATE_ASSERTIONS_SCRIPT = TEST_PACK_ROOT / "tools" / "assertions" / "evaluate_assertions.py"
+METRICS_SNAPSHOT_SCRIPT = TEST_PACK_ROOT / "tools" / "metrics" / "metrics_snapshot.py"
+METRICS_SMOKE_PS1 = TEST_PACK_ROOT / "tools" / "metrics" / "metrics-smoke.ps1"
+METRICS_MATRIX_DOC = REPO_ROOT / "infrastructure" / "monitoring" / "METRICS_MATRIX.md"
+LR041_RUNNER = REPO_ROOT / "scripts" / "drills" / "lr041_redis_postgres_failure_runner.py"
+LR042_RUNNER = REPO_ROOT / "scripts" / "drills" / "lr042_network_latency_packet_loss_runner.py"
+MOCKEXCHANGE_TEST_MAP = REPO_ROOT / "knowledge" / "testing" / "MOCKEXCHANGE_CDB_TEST_MAP.md"
+
+CANONICAL_REDIS_CONTAINER = "cdb_redis"
+VALKEY_DRIFT_PATTERNS = (
+    re.compile(r"mockx-valkey"),
+    re.compile(r"\bVALKEY_HOST\b"),
+    re.compile(r"\bvalkey\b", re.I),
+)
 
 VERDICT_VALUES = frozenset({"PASS", "WARN", "FAIL"})
 KILL_SWITCH_STATES = frozenset({"active", "inactive", "unknown"})
@@ -268,3 +284,175 @@ def simulate_kill_switch_drill(
         fail_reasons=tuple(fail_reasons),
         evidence_artifacts=artifacts,
     )
+
+
+@dataclass(frozen=True)
+class MockExchangeOrderSimulation:
+    http_status: int
+    order_status: str | None
+    error: str | None = None
+    filled_qty: float | None = None
+
+
+def simulate_mock_exchange_order(
+    *,
+    symbol: str,
+    side: str,
+    qty: float,
+    price: float | None = None,
+    partial_fill_ratio: float = 1.0,
+) -> MockExchangeOrderSimulation:
+    """Contract simulation of Test Pack mock_exchange shim — no HTTP, no live exchange."""
+    try:
+        normalized_side = str(side).upper()
+        normalized_qty = float(qty)
+        if normalized_side not in {"BUY", "SELL"} or normalized_qty <= 0:
+            raise ValueError("bad_order")
+        if not str(symbol).strip():
+            raise ValueError("bad_symbol")
+    except (TypeError, ValueError):
+        return MockExchangeOrderSimulation(400, None, error="bad_order_payload")
+
+    if price is None:
+        return MockExchangeOrderSimulation(200, "NEW")
+
+    if partial_fill_ratio < 1.0:
+        if partial_fill_ratio <= 0:
+            return MockExchangeOrderSimulation(200, "REJECTED", filled_qty=0.0)
+        filled = round(normalized_qty * partial_fill_ratio, 8)
+        return MockExchangeOrderSimulation(200, "PARTIAL", filled_qty=filled)
+
+    return MockExchangeOrderSimulation(200, "FILLED", filled_qty=normalized_qty)
+
+
+def simulate_mock_exchange_cancel(
+    *,
+    order_status: str,
+) -> MockExchangeOrderSimulation:
+    if order_status in {"FILLED", "CANCELED"}:
+        return MockExchangeOrderSimulation(200, order_status)
+    if order_status == "NEW":
+        return MockExchangeOrderSimulation(200, "CANCELED")
+    return MockExchangeOrderSimulation(404, None, error="unknown_order")
+
+
+def scan_text_for_valkey_drift(text: str, *, label: str) -> list[str]:
+    violations: list[str] = []
+    for pattern in VALKEY_DRIFT_PATTERNS:
+        if pattern.search(text):
+            violations.append(f"{label}: valkey drift pattern {pattern.pattern!r}")
+    return violations
+
+
+def extract_prometheus_values(result_payload: dict[str, Any]) -> list[float]:
+    data = result_payload.get("data", {}) if isinstance(result_payload, dict) else {}
+    items = data.get("data", {}).get("result", []) if isinstance(data, dict) else []
+    values: list[float] = []
+    for item in items:
+        value = item.get("value")
+        if isinstance(value, list) and len(value) == 2:
+            try:
+                values.append(float(value[1]))
+            except ValueError:
+                continue
+    return values
+
+
+@dataclass(frozen=True)
+class ChaosAssertionEvaluation:
+    overall_pass: bool
+    failed_ids: tuple[str, ...]
+    assertion_count: int
+
+
+def evaluate_chaos_assertions_from_snapshot(snapshot: dict[str, Any]) -> ChaosAssertionEvaluation:
+    """Mirror evaluate_assertions.py semantics for fixture-based contract tests."""
+    assertions: list[dict[str, Any]] = []
+    queries = snapshot.get("queries", {}) if isinstance(snapshot, dict) else {}
+
+    up_vals = extract_prometheus_values(queries.get("up_cdb", {}))
+    up_pass = bool(up_vals) and all(v >= 1 for v in up_vals)
+    assertions.append({"id": "up_cdb", "pass": up_pass})
+
+    cb_vals = extract_prometheus_values(queries.get("circuit_breaker_active", {}))
+    assertions.append({"id": "circuit_breaker_metric", "pass": bool(cb_vals)})
+
+    approved = extract_prometheus_values(queries.get("orders_approved_total", {}))
+    blocked = extract_prometheus_values(queries.get("orders_blocked_total", {}))
+    assertions.append(
+        {"id": "orders_metrics_present", "pass": bool(approved) or bool(blocked)}
+    )
+
+    failed = tuple(a["id"] for a in assertions if not a["pass"])
+    return ChaosAssertionEvaluation(
+        overall_pass=not failed,
+        failed_ids=failed,
+        assertion_count=len(assertions),
+    )
+
+
+@dataclass(frozen=True)
+class MetricsSmokeScore:
+    verdict: Literal["PASS", "WARN", "FAIL"]
+    reasons: tuple[str, ...]
+    no_data_detected: bool
+    prometheus_reachable: bool
+    grafana_reachable: bool
+
+
+def score_metrics_smoke_report(report: dict[str, Any]) -> MetricsSmokeScore:
+    """Fixture-based metrics smoke scoring — not live Prometheus/Grafana proof."""
+    reasons: list[str] = []
+    prom = report.get("prometheus", {}) if isinstance(report, dict) else {}
+    grafana = report.get("grafana", {}) if isinstance(report, dict) else {}
+
+    prom_error = prom.get("error")
+    grafana_error = grafana.get("error") if isinstance(grafana, dict) else None
+
+    prom_reachable = prom_error is None
+    grafana_reachable = grafana_error is None
+
+    active_targets = prom.get("targets_active")
+    if prom_reachable and active_targets is None:
+        active_targets = prom.get("active_targets")
+
+    no_data = False
+    if prom_reachable:
+        if active_targets == 0:
+            no_data = True
+            reasons.append("prometheus has zero active targets")
+        elif active_targets is None and prom.get("query_no_data"):
+            no_data = True
+            reasons.append("prometheus query returned no data")
+
+    if not prom_reachable:
+        reasons.append(f"prometheus unreachable: {prom_error}")
+    if not grafana_reachable:
+        reasons.append(f"grafana unreachable: {grafana_error}")
+
+    if not prom_reachable and not grafana_reachable:
+        return MetricsSmokeScore("FAIL", tuple(reasons), no_data, False, False)
+
+    if no_data or (prom_reachable and not grafana_reachable):
+        return MetricsSmokeScore(
+            "WARN",
+            tuple(reasons or ("partial monitoring visibility",)),
+            no_data,
+            prom_reachable,
+            grafana_reachable,
+        )
+
+    if prom_reachable and grafana_reachable:
+        return MetricsSmokeScore("PASS", tuple(reasons), False, True, True)
+
+    return MetricsSmokeScore("FAIL", tuple(reasons or ("metrics smoke incomplete",)), no_data, prom_reachable, grafana_reachable)
+
+
+def runtime_drill_operator_markers(script_text: str) -> dict[str, bool]:
+    lowered = script_text.lower()
+    return {
+        "uses_docker_subprocess": "subprocess" in lowered and "docker" in lowered,
+        "mentions_container_restart": "restart" in lowered and "cdb_" in script_text,
+        "mentions_netem": "netem" in lowered,
+        "requires_cdb_redis": CANONICAL_REDIS_CONTAINER in script_text,
+    }

--- a/tests/unit/test_pack/test_chaos_scenario_assertion_contract.py
+++ b/tests/unit/test_pack/test_chaos_scenario_assertion_contract.py
@@ -1,0 +1,157 @@
+"""Chaos scenario assertion contract tests (#3877).
+
+Parent #3872. Deterministic fixtures and repo reads — no runtime mutation in CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_pack._test_pack_contract_helpers import (
+    CANONICAL_REDIS_CONTAINER,
+    CHAOS_GENERATE_SCENARIO,
+    EVALUATE_ASSERTIONS_SCRIPT,
+    FIXTURES_ROOT,
+    LR041_RUNNER,
+    LR042_RUNNER,
+    TEST_PACK_ROOT,
+    evaluate_chaos_assertions_from_snapshot,
+    runtime_drill_operator_markers,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def _load_gen_regime():
+    module = _load_module_from_path(
+        "cdb_test_pack_generate_scenario", CHAOS_GENERATE_SCENARIO
+    )
+    return module.gen_regime
+
+
+def _load_module_from_path(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_lr041_catalog():
+    module = _load_module_from_path("cdb_lr041_runner_contract", LR041_RUNNER)
+    return module._scenario_catalog()
+
+
+def _load_lr042_catalog():
+    module = _load_module_from_path("cdb_lr042_runner_contract", LR042_RUNNER)
+    return module._scenario_catalog()
+
+
+@pytest.mark.parametrize(
+    ("mode", "step", "expected"),
+    [
+        ("flipflop", 0, "TREND"),
+        ("flipflop", 1, "RANGE"),
+        ("highvol_noise", 3, "NOISE"),
+        ("whipsaw", 5, "TREND"),
+        ("whipsaw", 15, "RANGE"),
+    ],
+)
+def test_gen_regime_is_deterministic(mode: str, step: int, expected: str) -> None:
+    gen_regime = _load_gen_regime()
+    assert gen_regime(mode, step) == expected
+
+
+def test_generate_scenario_output_is_byte_stable(tmp_path: Path) -> None:
+    out_a = tmp_path / "a.jsonl"
+    out_b = tmp_path / "b.jsonl"
+    base_cmd = [
+        sys.executable,
+        str(CHAOS_GENERATE_SCENARIO),
+        "--mode",
+        "flipflop",
+        "--minutes",
+        "12",
+        "--seed",
+        "1337",
+        "--start-utc",
+        "2026-01-03T12:00:00Z",
+    ]
+    subprocess.run([*base_cmd, "--out", str(out_a)], check=True)
+    subprocess.run([*base_cmd, "--out", str(out_b)], check=True)
+    assert out_a.read_bytes() == out_b.read_bytes()
+    lines = out_a.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 12
+    first = json.loads(lines[0])
+    assert {"ts", "price", "regime_hint", "seed", "step"} <= set(first.keys())
+
+
+def test_chaos_assertions_pass_on_complete_snapshot_fixture() -> None:
+    snapshot = json.loads(
+        (FIXTURES_ROOT / "metrics_snapshot_pass.json").read_text(encoding="utf-8")
+    )
+    result = evaluate_chaos_assertions_from_snapshot(snapshot)
+    assert result.overall_pass is True
+    assert result.assertion_count == 3
+    assert result.failed_ids == ()
+
+
+def test_chaos_assertions_fail_on_no_data_snapshot_fixture() -> None:
+    snapshot = json.loads(
+        (FIXTURES_ROOT / "metrics_snapshot_no_data.json").read_text(encoding="utf-8")
+    )
+    result = evaluate_chaos_assertions_from_snapshot(snapshot)
+    assert result.overall_pass is False
+    assert "up_cdb" in result.failed_ids
+    assert "circuit_breaker_metric" in result.failed_ids
+    assert "orders_metrics_present" in result.failed_ids
+
+
+def test_evaluate_assertions_script_is_stdlib_fixture_evaluator() -> None:
+    text = EVALUATE_ASSERTIONS_SCRIPT.read_text(encoding="utf-8")
+    assert "overall_pass" in text
+    assert "snapshot_exists" in text
+    assert "urlopen" not in text
+
+
+def test_lr041_drill_contract_targets_cdb_redis_not_valkey() -> None:
+    catalog = _load_lr041_catalog()
+    assert "redis_restart" in catalog
+    assert catalog["redis_restart"].target_container == CANONICAL_REDIS_CONTAINER
+    markers = runtime_drill_operator_markers(LR041_RUNNER.read_text(encoding="utf-8"))
+    assert markers["uses_docker_subprocess"]
+    assert markers["mentions_container_restart"]
+    assert markers["requires_cdb_redis"]
+
+
+def test_lr042_drill_contract_is_operator_netem_path() -> None:
+    catalog = _load_lr042_catalog()
+    assert "latency_only" in catalog
+    assert "packet_loss_only" in catalog
+    markers = runtime_drill_operator_markers(LR042_RUNNER.read_text(encoding="utf-8"))
+    assert markers["uses_docker_subprocess"]
+    assert markers["mentions_netem"]
+    assert markers["requires_cdb_redis"]
+
+
+def test_chaos_template_declares_pass_fail_output_shape() -> None:
+    template = (TEST_PACK_ROOT / "templates" / "assertions_chaos.md").read_text(
+        encoding="utf-8"
+    )
+    assert "overall_pass" in template
+    assert "assertions_result.json" in template
+    assert "Pass/Fail" in template or "pass" in template.lower()
+
+
+def test_contract_tests_use_unit_markers_not_runtime_chaos() -> None:
+    markers = {mark.name for mark in pytestmark}
+    assert markers == {"unit", "contract"}
+    assert "chaos" not in markers
+    assert "local_only" not in markers

--- a/tests/unit/test_pack/test_metrics_smoke_contract.py
+++ b/tests/unit/test_pack/test_metrics_smoke_contract.py
@@ -1,0 +1,98 @@
+"""Metrics-smoke PASS/WARN/FAIL contract tests (#3878).
+
+Parent #3872. Fixture-based evaluation — no live Prometheus/Grafana in CI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.unit.test_pack._test_pack_contract_helpers import (
+    FIXTURES_ROOT,
+    METRICS_MATRIX_DOC,
+    METRICS_SMOKE_PS1,
+    METRICS_SNAPSHOT_SCRIPT,
+    VERDICT_VALUES,
+    evaluate_chaos_assertions_from_snapshot,
+    score_metrics_smoke_report,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+def test_metrics_snapshot_script_declares_experimental_helper_status() -> None:
+    text = METRICS_SNAPSHOT_SCRIPT.read_text(encoding="utf-8")
+    assert "experimental" in text.lower()
+    assert "DEFAULT_QUERIES" in text
+    assert "up_cdb" in text
+
+
+def test_metrics_smoke_ps1_declares_experimental_and_todo_tracking() -> None:
+    text = METRICS_SMOKE_PS1.read_text(encoding="utf-8")
+    assert "experimental" in text.lower()
+    assert "no-data" in text.lower() or "no data" in text.lower()
+    assert "targets_active" in text or "activeTargets" in text
+
+
+def test_metrics_matrix_doc_exists_for_cross_reference() -> None:
+    assert METRICS_MATRIX_DOC.is_file()
+    text = METRICS_MATRIX_DOC.read_text(encoding="utf-8")
+    assert "prometheus" in text.lower() or "metric" in text.lower()
+
+
+def test_metrics_smoke_pass_fixture_scores_pass() -> None:
+    report = _load_fixture("metrics_smoke_pass.json")
+    score = score_metrics_smoke_report(report)
+    assert score.verdict == "PASS"
+    assert score.prometheus_reachable is True
+    assert score.grafana_reachable is True
+    assert score.no_data_detected is False
+
+
+def test_metrics_smoke_no_data_fixture_scores_warn() -> None:
+    report = _load_fixture("metrics_smoke_no_data.json")
+    score = score_metrics_smoke_report(report)
+    assert score.verdict == "WARN"
+    assert score.no_data_detected is True
+    assert any("no data" in r.lower() or "zero active" in r.lower() for r in score.reasons)
+
+
+def test_metrics_smoke_fail_fixture_scores_fail() -> None:
+    report = _load_fixture("metrics_smoke_fail.json")
+    score = score_metrics_smoke_report(report)
+    assert score.verdict == "FAIL"
+    assert score.prometheus_reachable is False
+    assert score.grafana_reachable is False
+
+
+def test_snapshot_pass_fixture_yields_evaluable_assertions_not_collection_only() -> None:
+    snapshot = _load_fixture("metrics_snapshot_pass.json")
+    evaluation = evaluate_chaos_assertions_from_snapshot(snapshot)
+    assert evaluation.overall_pass is True
+    assert evaluation.assertion_count >= 3
+
+
+def test_snapshot_no_data_fixture_detects_missing_series() -> None:
+    snapshot = _load_fixture("metrics_snapshot_no_data.json")
+    evaluation = evaluate_chaos_assertions_from_snapshot(snapshot)
+    assert evaluation.overall_pass is False
+    assert len(evaluation.failed_ids) >= 1
+
+
+@pytest.mark.parametrize("verdict", sorted(VERDICT_VALUES))
+def test_metrics_smoke_verdict_domain_matches_operator_evidence_pack(verdict: str) -> None:
+    assert verdict in {"PASS", "WARN", "FAIL"}
+
+
+def test_contract_module_uses_unit_markers_not_live_monitoring() -> None:
+    markers = {mark.name for mark in pytestmark}
+    assert markers == {"unit", "contract"}
+    assert "e2e" not in markers
+    assert "local_only" not in markers

--- a/tests/unit/test_pack/test_mock_exchange_cdb_integration_contract.py
+++ b/tests/unit/test_pack/test_mock_exchange_cdb_integration_contract.py
@@ -1,0 +1,122 @@
+"""MockExchange CDB integration contract tests (#3876).
+
+Parent #3872. Simulation and repo reads only — no live exchange, no cdb_redis replacement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.test_pack._test_pack_contract_helpers import (
+    CANONICAL_REDIS_CONTAINER,
+    MOCKEXCHANGE_TEST_MAP,
+    MOCK_EXCHANGE_SHIM,
+    TEST_PACK_ROOT,
+    load_scenario_catalog,
+    scan_text_for_valkey_drift,
+    simulate_mock_exchange_cancel,
+    simulate_mock_exchange_order,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_mock_exchange_shim_exists_as_pack_scenario_server() -> None:
+    catalog = load_scenario_catalog()
+    mock_scenario = next(s for s in catalog["scenarios"] if s["id"] == "S-MOCK-001")
+    assert mock_scenario["server"] == "tools/mock_exchange/mock_exchange.py"
+    assert MOCK_EXCHANGE_SHIM.is_file()
+
+
+def test_mock_exchange_shim_documents_cdb_adapter_boundary() -> None:
+    text = MOCK_EXCHANGE_SHIM.read_text(encoding="utf-8")
+    assert "cdb_execution" in text
+    assert "no real market access" in text.lower() or "without the real exchange" in text
+    assert "generate_uuid" in text
+    assert "redis" not in text.lower() or "cdb_redis" not in text.lower()
+
+
+def test_mock_exchange_shim_has_no_valkey_drift() -> None:
+    text = MOCK_EXCHANGE_SHIM.read_text(encoding="utf-8")
+    assert scan_text_for_valkey_drift(text, label="mock_exchange_shim") == []
+
+
+def test_mockexchange_test_map_preserves_cdb_redis_canonical_boundary() -> None:
+    text = MOCKEXCHANGE_TEST_MAP.read_text(encoding="utf-8")
+    assert CANONICAL_REDIS_CONTAINER in text
+    assert "must not be staged" in text or "gitignored" in text
+    assert "no Live-Go" in text or "No Live-Go" in text
+
+
+def test_filled_order_when_price_provided() -> None:
+    result = simulate_mock_exchange_order(
+        symbol="BTCUSDT",
+        side="BUY",
+        qty=1.0,
+        price=100.0,
+    )
+    assert result.http_status == 200
+    assert result.order_status == "FILLED"
+    assert result.filled_qty == 1.0
+
+
+def test_new_order_when_price_missing() -> None:
+    result = simulate_mock_exchange_order(
+        symbol="BTCUSDT",
+        side="SELL",
+        qty=2.5,
+        price=None,
+    )
+    assert result.http_status == 200
+    assert result.order_status == "NEW"
+    assert result.filled_qty is None
+
+
+def test_rejected_order_on_bad_payload() -> None:
+    result = simulate_mock_exchange_order(
+        symbol="BTCUSDT",
+        side="HOLD",
+        qty=1.0,
+        price=10.0,
+    )
+    assert result.http_status == 400
+    assert result.order_status is None
+    assert result.error == "bad_order_payload"
+
+
+@pytest.mark.parametrize(
+    ("ratio", "expected_status"),
+    [
+        (0.5, "PARTIAL"),
+        (1.0, "FILLED"),
+        (0.0, "REJECTED"),
+    ],
+)
+def test_partial_and_terminal_fill_semantics(ratio: float, expected_status: str) -> None:
+    result = simulate_mock_exchange_order(
+        symbol="ETHUSDT",
+        side="BUY",
+        qty=10.0,
+        price=50.0,
+        partial_fill_ratio=ratio,
+    )
+    assert result.order_status == expected_status
+
+
+def test_cancel_open_order_transitions_to_canceled() -> None:
+    result = simulate_mock_exchange_cancel(order_status="NEW")
+    assert result.http_status == 200
+    assert result.order_status == "CANCELED"
+
+
+def test_cancel_terminal_order_is_idempotent() -> None:
+    for status in ("FILLED", "CANCELED"):
+        result = simulate_mock_exchange_cancel(order_status=status)
+        assert result.http_status == 200
+        assert result.order_status == status
+
+
+def test_test_pack_readme_documents_valkey_boundary_without_replacing_cdb_redis() -> None:
+    readme = (TEST_PACK_ROOT / "README.md").read_text(encoding="utf-8")
+    assert CANONICAL_REDIS_CONTAINER in readme
+    assert "must never replace" in readme.lower() or "not CDB-canonical Redis" in readme

--- a/tools/test_pack/tools/metrics/metrics-smoke.ps1
+++ b/tools/test_pack/tools/metrics/metrics-smoke.ps1
@@ -1,4 +1,4 @@
-# tools/metrics/metrics-smoke.ps1
+# tools/test_pack/tools/metrics/metrics-smoke.ps1
 <#
 Status:
   Experimental helper under tools/test_pack; not the canonical repo-wide 431C drill source of truth.
@@ -7,7 +7,8 @@ Purpose:
   Quick "are we blind?" check before running longer drills.
   - Prometheus targets reachable?
   - Grafana health ok?
-  - Optional: detect "No data" by running a minimal query (TODO hook)
+  - No-data detection: zero active targets sets query_no_data on the report
+    (PASS/WARN/FAIL scoring lives in tests/unit/test_pack/test_metrics_smoke_contract.py)
 
 This is a lightweight helper, not a full monitoring test suite.
 #>
@@ -36,8 +37,13 @@ $report = [ordered]@{
 
 try {
   $targets = Invoke-RestMethod -Uri "$PromUrl/api/v1/targets" -Method GET -TimeoutSec 10
-  $report.prometheus.targets_active = @($targets.data.activeTargets).Count
+  $activeCount = @($targets.data.activeTargets).Count
+  $report.prometheus.targets_active = $activeCount
   $report.prometheus.targets_dropped = @($targets.data.droppedTargets).Count
+  if ($activeCount -eq 0) {
+    $report.prometheus.query_no_data = $true
+    $report.notes += "no-data: prometheus has zero active targets"
+  }
   Write-Json (Join-Path $OutDir "prometheus_targets.json") $targets
 } catch {
   $report.prometheus.error = $_.Exception.Message


### PR DESCRIPTION
## Summary
Closes #3876
Closes #3877
Closes #3878
Refs #3872
Refs #1445
Refs #1784
Refs #2985

P1 Test-Pack slice: fixture/contract tests for MockExchange CDB boundary, deterministic chaos assertion evaluation, and metrics-smoke PASS/WARN/FAIL semantics.

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: none
- records_found: none
- tools_or_queries: context.briefing (MCP), gh issue view, repo reads
- limitations: no DB-backed brain records; GitHub live state authoritative for merge

## Bootloader-/Read-Order-Evidence
- AGENTS.md -> agents/AGENTS.md Read Order resolved
- P0 helpers reused from #3886 (`tests/unit/test_pack/_test_pack_contract_helpers.py`)
- LR remains NO-GO; board stage trade-capable is not live-go

## Delivered
- #3876: `test_mock_exchange_cdb_integration_contract.py` — order lifecycle (NEW/FILLED/PARTIAL/REJECTED/CANCELED), shim boundary, cdb_redis vs Valkey separation
- #3877: `test_chaos_scenario_assertion_contract.py` — deterministic scenario generation, assertion PASS/FAIL fixtures, LR-041/LR-042 operator-only drill markers
- #3878: `test_metrics_smoke_contract.py` + fixtures — snapshot evaluation, no-data detection, PASS/WARN/FAIL scoring
- Extended shared helpers + metrics-smoke.ps1 no-data hook
- `knowledge/testing/TEST_PACK_CONTRACT_TESTS.md` updated for P1

## Validation
- `git diff --check` — pass
- `ruff check tests/unit/test_pack/` — pass
- `pytest -q tests/unit/test_pack/` — 73 passed
- `pytest -q tests/unit -k "mock_exchange or chaos or assertion or metrics or smoke or snapshot or no_data"` — 241 passed, 1 skipped

## Non-goals
- Live exchange, real orders, runtime drills, Docker in standard CI
- #3879 docs/drift slice
- CURRENT_STATUS.md / ledger update (#3872 still open)

## Safety Boundaries
- Simulation/fixture/contract only — no BLUE/RED, no MCP/DB mutation, no kill-switch activation
- MockExchange shim is not live exchange; chaos assertions are not productive drills; metrics fixtures are not live monitoring proof
- LR NO-GO unchanged

## Ledger Policy
- No CURRENT_STATUS.md update per #3872 slice rule; PR body + issue comments are sufficient work evidence

## Test plan
- [x] Unit contract tests for all three P1 issues
- [x] Local pytest + ruff validation
- [ ] CI required checks green

Made with [Cursor](https://cursor.com)