### PR TITLE
test(infra): add compose and stack lifecycle contracts

### DIFF
--- a/infrastructure/compose/README.md
+++ b/infrastructure/compose/README.md
@@ -118,4 +118,13 @@ Diese Fragmente sind K8s-ready:
 ## Nächste Schritte
 
 - [ ] Sekundaere Workflow-Pfade bei Bedarf spaeter auf die 431B-Baseline ziehen
+
+## Contract Tests (static / fixture)
+
+Issue slices **#3856** / **#3857** (parent **#3855**) add repo-local guards under
+`tests/unit/infra/`. They classify compose layers, protect BLUE/RED canon vs legacy
+topology, and assert stack-lifecycle script fail-closed semantics.
+
+These tests do **not** start Docker or prove runtime health — see
+`tests/unit/infra/README.md`.
 - [ ] K8s-Manifeste aus Fragmenten generieren (via Kompose)

--- a/tests/unit/infra/README.md
+++ b/tests/unit/infra/README.md
@@ -1,0 +1,24 @@
+# Infra / Compose / Stack Lifecycle Contract Tests
+
+Static and fixture-backed guards for issues **#3856** (compose BLUE/RED) and **#3857**
+(stack lifecycle scripts). Parent meta: **#3855**.
+
+## What these tests prove
+
+- Compose layer classification (`canonical_runtime` vs `legacy_ci` / overlays)
+- BLUE/RED service canon, network/volume naming, healthcheck posture
+- Legacy topology references remain visible (e.g. `stack_up.ps1` → `base.yml` + `dev.yml`)
+- Stack lifecycle scripts expose operator gates (`-Force`, `Read-Host`, `-DeepClean`, skip flags)
+- Failure paths fail closed; scripts do not echo secret payloads
+
+## What these tests do **not** prove
+
+- No `docker compose up/down` — not a runtime or stack-start proof
+- No container health at execution time
+- No operator authorization to mutate production stacks
+
+Run targeted checks:
+
+```bash
+pytest -q tests/unit/infra -m contract
+```

--- a/tests/unit/infra/_compose_stack_contract_helpers.py
+++ b/tests/unit/infra/_compose_stack_contract_helpers.py
@@ -1,0 +1,208 @@
+"""Shared helpers for compose / BLUE-RED / stack-lifecycle contract tests (#3856, #3857)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_DIR = REPO_ROOT / "infrastructure" / "compose"
+
+ComposeLayer = Literal["canonical_runtime", "legacy_ci", "legacy_overlay", "optional_overlay"]
+
+COMPOSE_LAYER_FILES: dict[str, ComposeLayer] = {
+    "compose.blue.yml": "canonical_runtime",
+    "compose.red.yml": "canonical_runtime",
+    "base.yml": "legacy_ci",
+    "dev.yml": "legacy_overlay",
+    "test.yml": "legacy_ci",
+    "logging.yml": "optional_overlay",
+    "prod.yml": "legacy_overlay",
+}
+
+CANONICAL_RUNTIME_FILES = (
+    "compose.blue.yml",
+    "compose.red.yml",
+)
+
+LEGACY_CI_FILES = (
+    "base.yml",
+    "dev.yml",
+    "test.yml",
+)
+
+BLUE_CANONICAL_SERVICES: frozenset[str] = frozenset(
+    {
+        "cdb_postgres",
+        "cdb_redis",
+        "cdb_market",
+        "cdb_candles",
+        "cdb_regime",
+        "cdb_allocation",
+        "cdb_risk",
+        "cdb_execution",
+        "cdb_db_writer",
+        "cdb_paper_runner",
+    }
+)
+
+RED_CANONICAL_SERVICES: frozenset[str] = frozenset(
+    {
+        "cdb_ws",
+        "cdb_signal",
+        "cdb_prometheus",
+        "cdb_grafana",
+        "cdb_postgres_exporter",
+        "cdb_redis_exporter",
+        "cdb_cadvisor",
+        "cdb_reports",
+    }
+)
+
+KNOWN_CANONICAL_VOLUMES = frozenset({"kill_switch_state"})
+
+
+def is_known_canonical_volume(name: str) -> bool:
+    return name.endswith("_data") or name.startswith("cdb_") or name in KNOWN_CANONICAL_VOLUMES
+
+
+CANONICAL_NETWORK = "cdb_network"
+TEST_NETWORK = "cdb_test_network"
+
+SECRET_ECHO_FORBIDDEN_LINE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"Write-Host\s+\$value\b", re.IGNORECASE),
+    re.compile(r"Write-Output\s+\$value\b", re.IGNORECASE),
+    re.compile(
+        r"Write-Host\s+.*\$env:(REDIS_PASSWORD|POSTGRES_PASSWORD|GRAFANA_PASSWORD)\b"
+    ),
+)
+
+MUTATING_DOCKER_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"docker\s+compose\s+.*\bup\b", re.IGNORECASE),
+    re.compile(r"docker-compose\s+.*\bup\b", re.IGNORECASE),
+    re.compile(r"docker\s+compose\s+.*\bdown\b", re.IGNORECASE),
+    re.compile(r"docker-compose\s+.*\bdown\b", re.IGNORECASE),
+    re.compile(r"docker\s+rm\b", re.IGNORECASE),
+    re.compile(r"docker\s+stop\b", re.IGNORECASE),
+    re.compile(r"docker\s+network\s+create\b", re.IGNORECASE),
+    re.compile(r"docker\s+network\s+rm\b", re.IGNORECASE),
+    re.compile(r"docker\s+volume\s+rm\b", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class LegacyTopologyFinding:
+    script: str
+    pattern: str
+    detail: str
+
+
+def load_compose_yaml(filename: str) -> dict[str, Any]:
+    path = COMPOSE_DIR / filename
+    if not path.is_file():
+        raise FileNotFoundError(f"Compose file missing: {path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Compose file must parse to mapping: {filename}")
+    return data
+
+
+def service_names(compose: dict[str, Any]) -> list[str]:
+    services = compose.get("services") or {}
+    if not isinstance(services, dict):
+        return []
+    return sorted(name for name in services if name.startswith("cdb_"))
+
+
+def services_missing_healthcheck(compose: dict[str, Any]) -> list[str]:
+    services = compose.get("services") or {}
+    missing: list[str] = []
+    if not isinstance(services, dict):
+        return missing
+    for name, cfg in services.items():
+        if not name.startswith("cdb_"):
+            continue
+        if not isinstance(cfg, dict):
+            missing.append(name)
+            continue
+        if "healthcheck" not in cfg:
+            missing.append(name)
+    return sorted(missing)
+
+
+def container_name_mismatches(compose: dict[str, Any]) -> list[str]:
+    services = compose.get("services") or {}
+    mismatches: list[str] = []
+    if not isinstance(services, dict):
+        return mismatches
+    for name, cfg in services.items():
+        if not name.startswith("cdb_"):
+            continue
+        if not isinstance(cfg, dict):
+            continue
+        container_name = cfg.get("container_name")
+        if container_name and container_name != name:
+            mismatches.append(f"{name} -> {container_name}")
+    return sorted(mismatches)
+
+
+def network_names(compose: dict[str, Any]) -> set[str]:
+    networks = compose.get("networks") or {}
+    if not isinstance(networks, dict):
+        return set()
+    return set(networks.keys())
+
+
+def volume_names(compose: dict[str, Any]) -> set[str]:
+    volumes = compose.get("volumes") or {}
+    if not isinstance(volumes, dict):
+        return set()
+    return set(volumes.keys())
+
+
+def read_script_text(relative_path: str) -> str:
+    path = REPO_ROOT / relative_path
+    if not path.is_file():
+        raise FileNotFoundError(f"Script missing: {relative_path}")
+    return path.read_text(encoding="utf-8")
+
+
+def find_legacy_compose_references(script_text: str, script_name: str) -> list[LegacyTopologyFinding]:
+    findings: list[LegacyTopologyFinding] = []
+    legacy_markers = (
+        ("base.yml", "legacy single-compose base chain"),
+        ("dev.yml", "legacy dev overlay"),
+        ("docker-compose down", "unqualified legacy docker-compose"),
+        ("docker-compose `", "legacy docker-compose hyphen invocation"),
+    )
+    for marker, detail in legacy_markers:
+        if marker in script_text:
+            findings.append(
+                LegacyTopologyFinding(script=script_name, pattern=marker, detail=detail)
+            )
+    return findings
+
+
+def script_has_operator_gate(script_text: str) -> bool:
+    return "Read-Host" in script_text or re.search(r"\[switch\]\$Force", script_text) is not None
+
+
+def script_mutating_paths_gated(script_text: str) -> bool:
+    if not any(pattern.search(script_text) for pattern in MUTATING_DOCKER_PATTERNS):
+        return True
+    return script_has_operator_gate(script_text)
+
+
+def script_secret_echo_violations(script_text: str) -> list[str]:
+    violations: list[str] = []
+    for line in script_text.splitlines():
+        if ".Length" in line:
+            continue
+        for pattern in SECRET_ECHO_FORBIDDEN_LINE_PATTERNS:
+            if pattern.search(line):
+                violations.append(f"{pattern.pattern}: {line.strip()}")
+    return violations

--- a/tests/unit/infra/test_compose_blue_red_stack_contract.py
+++ b/tests/unit/infra/test_compose_blue_red_stack_contract.py
@@ -1,0 +1,140 @@
+"""Compose layer and BLUE/RED stack contract tests (#3856).
+
+Fixture-backed, static YAML contracts — no Docker runtime, no compose mutation.
+Refs #3855, #1445, #2985.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.infra._compose_stack_contract_helpers import (
+    BLUE_CANONICAL_SERVICES,
+    CANONICAL_NETWORK,
+    CANONICAL_RUNTIME_FILES,
+    COMPOSE_DIR,
+    COMPOSE_LAYER_FILES,
+    LEGACY_CI_FILES,
+    RED_CANONICAL_SERVICES,
+    REPO_ROOT,
+    TEST_NETWORK,
+    container_name_mismatches,
+    is_known_canonical_volume,
+    load_compose_yaml,
+    network_names,
+    service_names,
+    services_missing_healthcheck,
+    volume_names,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+@pytest.mark.parametrize("filename,layer", list(COMPOSE_LAYER_FILES.items()))
+def test_compose_layer_classification_is_fixture_backed(
+    filename: str, layer: str
+) -> None:
+    compose = load_compose_yaml(filename)
+    assert compose.get("services"), f"{filename} must declare services"
+    assert layer in {
+        "canonical_runtime",
+        "legacy_ci",
+        "legacy_overlay",
+        "optional_overlay",
+    }
+
+
+def test_canonical_runtime_files_exist_and_are_not_legacy_ci() -> None:
+    for filename in CANONICAL_RUNTIME_FILES:
+        assert COMPOSE_LAYER_FILES[filename] == "canonical_runtime"
+        load_compose_yaml(filename)
+
+
+def test_legacy_ci_files_are_classified_separately_from_canonical_runtime() -> None:
+    for filename in LEGACY_CI_FILES:
+        assert COMPOSE_LAYER_FILES[filename] != "canonical_runtime"
+        load_compose_yaml(filename)
+
+
+def test_blue_red_canon_service_sets_do_not_overlap() -> None:
+    overlap = BLUE_CANONICAL_SERVICES & RED_CANONICAL_SERVICES
+    assert not overlap, f"BLUE/RED service overlap: {sorted(overlap)}"
+
+
+def test_compose_blue_declares_full_blue_canon() -> None:
+    blue = load_compose_yaml("compose.blue.yml")
+    declared = set(service_names(blue))
+    missing = BLUE_CANONICAL_SERVICES - declared
+    assert not missing, f"compose.blue.yml missing BLUE services: {sorted(missing)}"
+    assert declared.issubset(BLUE_CANONICAL_SERVICES)
+
+
+def test_compose_red_declares_full_red_canon() -> None:
+    red = load_compose_yaml("compose.red.yml")
+    declared = set(service_names(red))
+    missing = RED_CANONICAL_SERVICES - declared
+    assert not missing, f"compose.red.yml missing RED services: {sorted(missing)}"
+    assert declared.issubset(RED_CANONICAL_SERVICES)
+
+
+def test_canonical_compose_uses_cdb_network() -> None:
+    for filename in CANONICAL_RUNTIME_FILES:
+        compose = load_compose_yaml(filename)
+        nets = network_names(compose)
+        assert CANONICAL_NETWORK in nets, f"{filename} must declare {CANONICAL_NETWORK}"
+
+
+def test_test_overlay_uses_isolated_test_network() -> None:
+    test_overlay = load_compose_yaml("test.yml")
+    nets = network_names(test_overlay)
+    assert TEST_NETWORK in nets, "test.yml must use isolated cdb_test_network"
+
+
+def test_canonical_service_container_names_match_service_keys() -> None:
+    for filename in CANONICAL_RUNTIME_FILES:
+        compose = load_compose_yaml(filename)
+        mismatches = container_name_mismatches(compose)
+        assert not mismatches, f"{filename} container_name drift: {mismatches}"
+
+
+def test_canonical_volumes_use_cdb_prefix_or_known_data_names() -> None:
+    for filename in CANONICAL_RUNTIME_FILES:
+        compose = load_compose_yaml(filename)
+        for vol in volume_names(compose):
+            assert is_known_canonical_volume(vol), (
+                f"{filename} unexpected volume name: {vol}"
+            )
+
+
+def test_blue_stack_services_have_healthchecks() -> None:
+    blue = load_compose_yaml("compose.blue.yml")
+    missing = services_missing_healthcheck(blue)
+    assert not missing, f"BLUE services without healthcheck: {missing}"
+
+
+def test_red_stack_healthcheck_gaps_are_visible() -> None:
+    """Document known RED gaps (e.g. cdb_cadvisor) without blocking canon drift."""
+    red = load_compose_yaml("compose.red.yml")
+    missing = services_missing_healthcheck(red)
+    assert missing == ["cdb_cadvisor"], (
+        "Update contract if RED healthcheck posture changed; "
+        f"unexpected missing: {missing}"
+    )
+
+
+def test_compose_readme_distinguishes_canonical_from_legacy() -> None:
+    readme = (COMPOSE_DIR / "README.md").read_text(encoding="utf-8")
+    assert "compose.blue.yml" in readme
+    assert "compose.red.yml" in readme
+    assert "Legacy" in readme or "legacy" in readme
+    assert "base.yml" in readme
+
+
+def test_stack_lifecycle_doc_points_at_blue_red_canon() -> None:
+    lifecycle = (REPO_ROOT / "knowledge" / "systems" / "STACK_LIFECYCLE.md").read_text(
+        encoding="utf-8"
+    )
+    assert "compose.blue.yml" in lifecycle
+    assert "compose.red.yml" in lifecycle
+    assert "base.yml" in lifecycle
+    assert "LEGACY" in lifecycle or "legacy" in lifecycle

--- a/tests/unit/infra/test_stack_lifecycle_script_contract.py
+++ b/tests/unit/infra/test_stack_lifecycle_script_contract.py
@@ -1,0 +1,148 @@
+"""Stack lifecycle script fail-closed contract tests (#3857).
+
+Static PowerShell source inspection — no Docker, no container mutation, no rollbacks.
+Refs #3855, #1445, #2985.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from tests.unit.infra._compose_stack_contract_helpers import (
+    find_legacy_compose_references,
+    read_script_text,
+    script_has_operator_gate,
+    script_mutating_paths_gated,
+    script_secret_echo_violations,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+LIFECYCLE_SCRIPTS: dict[str, str] = {
+    "stack_up": "infrastructure/scripts/stack_up.ps1",
+    "stack_verify": "infrastructure/scripts/stack_verify.ps1",
+    "stack_clean": "infrastructure/scripts/stack_clean.ps1",
+    "stack_rollback": "infrastructure/scripts/stack_rollback.ps1",
+    "setup_blue_red": "infrastructure/scripts/setup_blue_red.ps1",
+    "cdb_stack_doctor": "tools/cdb-stack-doctor.ps1",
+}
+
+
+@pytest.mark.parametrize("name,path", list(LIFECYCLE_SCRIPTS.items()))
+def test_lifecycle_script_exists(name: str, path: str) -> None:
+    text = read_script_text(path)
+    assert text.strip(), f"{name} must not be empty"
+
+
+def test_setup_blue_red_uses_canonical_compose_files() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["setup_blue_red"])
+    assert "compose.blue.yml" in text
+    assert "compose.red.yml" in text
+    assert "base.yml" not in text or "LEGACY" in text.upper()
+
+
+def test_cdb_stack_doctor_uses_canonical_compose_files() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["cdb_stack_doctor"])
+    assert "compose.blue.yml" in text
+    assert "compose.red.yml" in text
+
+
+def test_stack_up_legacy_topology_findings_are_visible() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_up"])
+    findings = find_legacy_compose_references(text, "stack_up.ps1")
+    patterns = {f.pattern for f in findings}
+    assert "base.yml" in patterns
+    assert "dev.yml" in patterns
+
+
+def test_stack_rollback_legacy_topology_findings_are_visible() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_rollback"])
+    findings = find_legacy_compose_references(text, "stack_rollback.ps1")
+    patterns = {f.pattern for f in findings}
+    assert "base.yml" in patterns
+
+
+def test_stack_clean_has_deep_clean_and_force_operator_flags() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_clean"])
+    assert re.search(r"\[switch\]\$DeepClean", text)
+    assert re.search(r"\[switch\]\$Force", text)
+    assert "Read-Host" in text
+    assert "GO DEEP CLEAN" in text
+
+
+def test_stack_rollback_has_force_operator_gate() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_rollback"])
+    assert re.search(r"\[switch\]\$Force", text)
+    assert "Read-Host" in text
+
+
+def test_setup_blue_red_has_skip_flags_for_partial_dry_paths() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["setup_blue_red"])
+    assert re.search(r"\[switch\]\$SkipRed", text)
+    assert re.search(r"\[switch\]\$SkipSmokeTest", text)
+
+
+def test_mutating_scripts_require_operator_gate_or_force_bypass() -> None:
+    mutating = ("stack_clean", "stack_rollback")
+    for name in mutating:
+        text = read_script_text(LIFECYCLE_SCRIPTS[name])
+        assert script_has_operator_gate(text), (
+            f"{name} mutates Docker state and must expose Read-Host or -Force gate"
+        )
+
+
+def test_stack_up_fails_closed_on_missing_secrets_directory() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_up"])
+    assert "FATAL: Secrets directory not found" in text
+    assert "exit 1" in text
+    assert "FATAL: Missing required secrets" in text
+
+
+def test_setup_blue_red_fails_closed_on_missing_secrets_path() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["setup_blue_red"])
+    assert "Write-Error" in text
+    assert "Secrets directory not found" in text
+
+
+def test_cdb_stack_doctor_fails_closed_on_missing_compose_or_docker() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["cdb_stack_doctor"])
+    assert "exit 1" in text
+    assert "Docker Desktop is not accessible" in text
+    assert "Configuration issues detected" in text
+
+
+def test_lifecycle_scripts_do_not_echo_secret_values() -> None:
+    for name, path in LIFECYCLE_SCRIPTS.items():
+        violations = script_secret_echo_violations(read_script_text(path))
+        assert not violations, f"{name} secret echo risk patterns: {violations}"
+
+
+def test_stack_up_load_secrets_only_prints_secret_names_not_values() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_up"])
+    assert 'Write-Host "  [OK] $secret"' in text
+    assert "Write-Host $value" not in text
+
+
+def test_runtime_env_loader_reports_length_not_secret_payload() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_up"])
+    assert "length: $($value.Length)" in text
+    assert "Write-Host $value" not in text
+
+
+@pytest.mark.parametrize("name,path", list(LIFECYCLE_SCRIPTS.items()))
+def test_scripts_do_not_implement_dry_run_switch(name: str, path: str) -> None:
+    """Document posture: lifecycle scripts are operator tools, not dry-run CLIs."""
+    text = read_script_text(path)
+    assert "DryRun" not in text and "-WhatIf" not in text, (
+        f"{name}: if dry-run is added, extend contract tests explicitly"
+    )
+
+
+def test_stack_verify_is_read_only_docker_inspection() -> None:
+    text = read_script_text(LIFECYCLE_SCRIPTS["stack_verify"])
+    assert "docker ps" in text
+    assert "docker inspect" in text
+    assert "docker compose up" not in text
+    assert "docker rm" not in text


### PR DESCRIPTION
## Summary

Closes #3856
Closes #3857
Refs #3855
Refs #1445
Refs #2985

Adds static/fixture-backed contract tests for compose BLUE/RED layers and stack lifecycle PowerShell scripts. No Docker runtime, no compose mutation, no secrets access.

## Brain Evidence

- `brain_source`: repo-only
- `brain_status`: not-used
- `context_brain_attempted`: true
- `context_brain_used`: false
- `context_available`: false
- `repo_fallback_used`: true
- `repo_fallback_reason`: insufficient_evidence
- `context_tool_status`: available
- `context_trust_level`: none
- `records_found`: none
- MCP `cdb_context_briefing` attempted (task_id `cdb-briefing-3856-compose-stack`); no DB-backed records

## Bootloader / Read-Order Evidence

- Root pointer `AGENTS.md` → `agents/AGENTS.md` read
- Read Order from `agents/AGENTS.md` resolved (governance chain)
- Live GitHub: #3855/#3856/#3857 OPEN; no duplicate PR for this slice

## Delivered

- `tests/unit/infra/_compose_stack_contract_helpers.py` — shared YAML/script parsers
- `tests/unit/infra/test_compose_blue_red_stack_contract.py` — compose layer + BLUE/RED canon (#3856)
- `tests/unit/infra/test_stack_lifecycle_script_contract.py` — lifecycle script fail-closed contracts (#3857)
- `tests/unit/infra/README.md` + short note in `infrastructure/compose/README.md`

## Validation

- `git diff --check` — pass
- `ruff check tests/unit/infra/` — pass
- `pytest -q tests/unit/infra -m contract` — 47 passed
- `pytest -q tests/unit -k "compose or blue or red or stack or lifecycle or script or docker or healthcheck"` — 1012 passed

## Non-goals

- No `docker compose up/down`
- No stack start/stop or real rollbacks
- No compose file functional changes
- No #3858/#3859 backup/secrets slices
- No CURRENT_STATUS / ledger update (per #3855 meta policy)

## Safety Boundaries

- LR remains NO-GO
- Compose contract tests are not runtime proof
- Stack lifecycle contract tests are not operator-GO for mutation

## Ledger Policy

No `CURRENT_STATUS.md` or session-ledger update in this slice. PR body + issue comments are the work evidence until #3855 meta completes.

## Test plan

- [x] Compose layer classification fixtures
- [x] BLUE/RED service canon + healthcheck posture
- [x] Legacy topology findings visible (`stack_up.ps1` → base+dev)
- [x] Operator gates on mutating scripts (`-Force`, `Read-Host`, `-DeepClean`)
- [x] No secret value echo patterns in lifecycle scripts
