### PR TITLE
test(infra): add secrets and backup restore contracts

### DIFF
--- a/tests/unit/infra/README.md
+++ b/tests/unit/infra/README.md
@@ -1,19 +1,31 @@
-# Infra / Compose / Stack Lifecycle Contract Tests
+# Infra / Compose / Stack / Secrets / Backup Contract Tests
 
-Static and fixture-backed guards for issues **#3856** (compose BLUE/RED) and **#3857**
-(stack lifecycle scripts). Parent meta: **#3855**.
+Static and fixture-backed guards for infra ops contracts. Parent meta: **#3855**.
+
+| Slice | Issues | Focus |
+|-------|--------|--------|
+| Compose BLUE/RED | #3856 | Layer classification, service canon |
+| Stack lifecycle | #3857 | Operator gates, fail-closed secrets dir |
+| Secrets SSOT | #3858 | `SECRETS_PATH`, canonical path, no secret echo |
+| Backup / Restore / DR | #3859 | Manifest drift, destructive gates, artifacts |
 
 ## What these tests prove
 
 - Compose layer classification (`canonical_runtime` vs `legacy_ci` / overlays)
 - BLUE/RED service canon, network/volume naming, healthcheck posture
-- Legacy topology references remain visible (e.g. `stack_up.ps1` → `base.yml` + `dev.yml`)
-- Stack lifecycle scripts expose operator gates (`-Force`, `Read-Host`, `-DeepClean`, skip flags)
-- Failure paths fail closed; scripts do not echo secret payloads
+- Canonical secrets path `~/Documents/.secrets/.cdb` / `SECRETS_PATH` (not legacy `.cdb_local/.secrets`)
+- Docker secrets + env fallback contracts in `core/secrets.py`
+- `.env.runtime` export boundary (gitignored, optional — not required for BLUE+RED)
+- Backup manifest reconciliation for Postgres / Redis / SurrealDB artifacts
+- Restore destructive paths gated (`-Force`, `Read-Host`, explicit `yes`)
+- `restore_all.ps1 -ListAvailable` list semantics documented in source
+- Scripts do not echo secret payloads
 
 ## What these tests do **not** prove
 
+- No real secrets read, rotated, or written
 - No `docker compose up/down` — not a runtime or stack-start proof
+- No backup or restore execution, no DB writes, no volume deletion
 - No container health at execution time
 - No operator authorization to mutate production stacks
 
@@ -21,4 +33,6 @@ Run targeted checks:
 
 ```bash
 pytest -q tests/unit/infra -m contract
+pytest -q tests/unit/scripts -k "backup_manifest"
+pytest -q tests/unit -k "secret or secrets or SECRETS_PATH or backup or restore or manifest or dr_"
 ```

--- a/tests/unit/infra/_secrets_backup_contract_helpers.py
+++ b/tests/unit/infra/_secrets_backup_contract_helpers.py
@@ -1,0 +1,92 @@
+"""Shared helpers for secrets SSOT and backup/restore/DR contract tests (#3858, #3859)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CANONICAL_SECRETS_DIR_MARKERS: tuple[str, ...] = (
+    r"Documents\.secrets\.cdb",
+    r"Documents/\.secrets/\.cdb",
+)
+
+LEGACY_SECRETS_QUARANTINE_MARKERS: tuple[str, ...] = (
+    r"\.cdb_local[\\/]\.secrets",
+    r"\.cdb_local\.secrets",
+)
+
+ACTIVE_SECRETS_SCRIPTS: dict[str, str] = {
+    "init_secrets": "infrastructure/scripts/init-secrets.ps1",
+    "manage_secrets": "infrastructure/scripts/manage_secrets.ps1",
+    "rotate_secrets": "tools/secrets/Rotate-Secrets.ps1",
+    "setup_blue_red": "infrastructure/scripts/setup_blue_red.ps1",
+}
+
+BACKUP_RESTORE_DR_SCRIPTS: dict[str, str] = {
+    "backup_all": "infrastructure/scripts/backup_all.ps1",
+    "restore_all": "infrastructure/scripts/restore_all.ps1",
+    "backup_manifest_helpers": "infrastructure/scripts/backup_manifest_helpers.ps1",
+    "backup_health_check": "infrastructure/scripts/backup_health_check.ps1",
+    "dr_backup": "infrastructure/scripts/dr_backup.ps1",
+    "dr_restore": "infrastructure/scripts/dr_restore.ps1",
+}
+
+CANONICAL_COMPOSE_RUNTIME = (
+    "infrastructure/compose/compose.blue.yml",
+    "infrastructure/compose/compose.red.yml",
+)
+
+BACKUP_COMPONENT_ARTIFACTS: dict[str, str] = {
+    "Postgres": "postgres_dump.sql",
+    "Redis": "redis_dump.rdb",
+    "SurrealDB": "surrealdb_data",
+}
+
+SECRET_ECHO_FORBIDDEN_LINE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"Write-Host\s+\$content\b", re.IGNORECASE),
+    re.compile(r"Write-Host\s+\$password\b", re.IGNORECASE),
+    re.compile(r"Write-Host\s+\$pass\b", re.IGNORECASE),
+    re.compile(r"Write-Output\s+\$content\b", re.IGNORECASE),
+    re.compile(r"Write-Host\s+\$value\b", re.IGNORECASE),
+    re.compile(
+        r"Write-Host\s+.*\$env:(REDIS_PASSWORD|POSTGRES_PASSWORD|GRAFANA_PASSWORD)\b"
+    ),
+)
+
+
+def read_repo_text(relative_path: str) -> str:
+    path = REPO_ROOT / relative_path
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing repo file: {relative_path}")
+    return path.read_text(encoding="utf-8")
+
+
+def script_uses_canonical_secrets_path(script_text: str) -> bool:
+    if "SECRETS_PATH" in script_text:
+        return True
+    return any(re.search(marker, script_text) for marker in CANONICAL_SECRETS_DIR_MARKERS)
+
+
+def script_promotes_legacy_secrets_path(script_text: str) -> bool:
+    return any(re.search(marker, script_text) for marker in LEGACY_SECRETS_QUARANTINE_MARKERS)
+
+
+def script_secret_echo_violations(script_text: str) -> list[str]:
+    violations: list[str] = []
+    for line in script_text.splitlines():
+        if ".Length" in line or "chars)" in line:
+            continue
+        for pattern in SECRET_ECHO_FORBIDDEN_LINE_PATTERNS:
+            if pattern.search(line):
+                violations.append(f"{pattern.pattern}: {line.strip()}")
+    return violations
+
+
+def script_has_operator_gate(script_text: str) -> bool:
+    return "Read-Host" in script_text or re.search(r"\[switch\]\$Force", script_text) is not None
+
+
+def compose_requires_secrets_path(compose_text: str) -> bool:
+    return "SECRETS_PATH:?SECRETS_PATH must be set" in compose_text

--- a/tests/unit/infra/test_backup_restore_dr_contract.py
+++ b/tests/unit/infra/test_backup_restore_dr_contract.py
@@ -1,0 +1,152 @@
+"""Backup, restore and DR manifest regression contract tests (#3859).
+
+Static script inspection and fixture reconciliation — no backup/restore execution.
+Refs #3855, #1445, #2985.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from tests.unit.infra._compose_stack_contract_helpers import read_script_text
+from tests.unit.infra._secrets_backup_contract_helpers import (
+    BACKUP_COMPONENT_ARTIFACTS,
+    BACKUP_RESTORE_DR_SCRIPTS,
+    script_has_operator_gate,
+    script_secret_echo_violations,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+@pytest.mark.parametrize("name,path", list(BACKUP_RESTORE_DR_SCRIPTS.items()))
+def test_backup_restore_dr_scripts_exist(name: str, path: str) -> None:
+    text = read_script_text(path)
+    assert text.strip(), f"{name} must not be empty"
+
+
+def test_backup_all_dot_sources_manifest_helpers() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["backup_all"])
+    assert "backup_manifest_helpers.ps1" in text
+    assert "Sync-BackupComponentManifest" in text
+
+
+def test_restore_all_dot_sources_manifest_helpers() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["restore_all"])
+    assert "backup_manifest_helpers.ps1" in text
+    assert "Resolve-BackupComponentInclusion" in text
+
+
+def test_backup_manifest_helpers_declares_component_artifacts() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["backup_manifest_helpers"])
+    for artifact in BACKUP_COMPONENT_ARTIFACTS.values():
+        assert artifact in text
+
+
+def test_backup_manifest_helpers_treats_empty_artifacts_as_absent() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["backup_manifest_helpers"])
+    assert "Test-BackupArtifactPresent" in text
+    assert ".Length -gt 0" in text
+
+
+def test_backup_manifest_helpers_surfaces_manifest_drift() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["backup_manifest_helpers"])
+    assert "Manifest drift" in text
+    assert "DriftCorrected" in text
+
+
+def test_restore_all_exposes_list_available_semantics() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["restore_all"])
+    assert re.search(r"\[switch\]\$ListAvailable", text)
+    assert "Available backups" in text
+    assert "No backup archives found" in text
+
+
+def test_restore_all_destructive_path_requires_explicit_yes_confirmation() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["restore_all"])
+    assert re.search(r"\[switch\]\$Force", text)
+    assert "DESTRUCTIVELY REPLACE" in text
+    assert "Read-Host" in text
+    assert "$confirmation -ne 'yes'" in text
+    assert "Restore cancelled" in text
+
+
+def test_restore_all_fails_when_no_restorable_components() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["restore_all"])
+    assert "does not contain any restorable components" in text
+
+
+def test_restore_all_missing_postgres_artifact_is_visible() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["restore_all"])
+    assert "postgres_dump.sql not found" in text
+
+
+def test_dr_restore_has_force_operator_gate() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["dr_restore"])
+    assert script_has_operator_gate(text)
+    assert "REPLACE all current data" in text
+
+
+def test_dr_restore_lists_available_archives_on_missing_backup() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["dr_restore"])
+    assert "Available backups" in text
+
+
+def test_backup_health_check_documents_exit_codes() -> None:
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["backup_health_check"])
+    assert "Exit codes" in text
+    assert "exit 0" in text
+    assert "exit 1" in text
+    assert "cdb_backup_*.zip" in text
+
+
+def test_dr_backup_legacy_topology_is_visible_not_canonical() -> None:
+    """dr_backup.ps1 still references legacy base.yml — contract documents quarantine."""
+    text = read_script_text(BACKUP_RESTORE_DR_SCRIPTS["dr_backup"])
+    assert "base.yml" in text
+    assert "docker-compose" in text
+
+
+@pytest.mark.parametrize("name,path", list(BACKUP_RESTORE_DR_SCRIPTS.items()))
+def test_backup_restore_scripts_do_not_echo_secret_values(name: str, path: str) -> None:
+    violations = script_secret_echo_violations(read_script_text(path))
+    assert not violations, f"{name} secret echo risk: {violations}"
+
+
+def test_manifest_reconciliation_fixture_postgres_redis_surrealdb() -> None:
+    """Fixture: all three component artifacts reconcile to included."""
+    manifest = {
+        "Components": {"Postgres": True, "Redis": True, "SurrealDB": True},
+        "Evidence": {
+            "Postgres": {"Artifact": "postgres_dump.sql", "SizeBytes": 100},
+            "Redis": {"Artifact": "redis_dump.rdb", "SizeBytes": 50},
+            "SurrealDB": {"Artifact": "surrealdb_data", "FileCount": 3, "TotalBytes": 200},
+        },
+    }
+    artifacts = {
+        "postgres_dump.sql": 100,
+        "redis_dump.rdb": 50,
+        "surrealdb_data": 200,
+    }
+    for component, filename in BACKUP_COMPONENT_ARTIFACTS.items():
+        assert manifest["Components"][component] is True
+        assert artifacts.get(filename, 0) > 0 or component == "SurrealDB"
+
+    payload = json.dumps(manifest)
+    assert '"Postgres":true' in payload.replace(" ", "")
+
+
+def test_missing_artifact_fixture_makes_component_not_included() -> None:
+    """Regression: missing Redis RDB must not be silently treated as backed up."""
+    manifest = {
+        "Components": {"Postgres": True, "Redis": False, "SurrealDB": False},
+        "Evidence": {"Postgres": {"Artifact": "postgres_dump.sql"}, "Redis": {}},
+    }
+    artifacts = {"postgres_dump.sql": 1024}
+
+    redis_present = "redis_dump.rdb" in artifacts and artifacts["redis_dump.rdb"] > 0
+    assert manifest["Components"]["Redis"] is False
+    assert redis_present is False

--- a/tests/unit/infra/test_secrets_ssot_contract.py
+++ b/tests/unit/infra/test_secrets_ssot_contract.py
@@ -1,0 +1,150 @@
+"""Secrets SSOT / SECRETS_PATH contract tests (#3858).
+
+Static and fixture-backed guards — no real secrets read, no secret writes.
+Refs #3855, #1445, #2985.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.unit.infra._secrets_backup_contract_helpers import (
+    ACTIVE_SECRETS_SCRIPTS,
+    CANONICAL_COMPOSE_RUNTIME,
+    compose_requires_secrets_path,
+    read_repo_text,
+    script_promotes_legacy_secrets_path,
+    script_secret_echo_violations,
+    script_uses_canonical_secrets_path,
+)
+from tests.unit.infra._compose_stack_contract_helpers import read_script_text
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+@pytest.mark.parametrize("name,path", list(ACTIVE_SECRETS_SCRIPTS.items()))
+def test_active_secrets_scripts_exist(name: str, path: str) -> None:
+    text = read_script_text(path)
+    assert text.strip(), f"{name} must not be empty"
+
+
+@pytest.mark.parametrize("name,path", list(ACTIVE_SECRETS_SCRIPTS.items()))
+def test_active_secrets_scripts_use_canonical_documents_path(name: str, path: str) -> None:
+    text = read_script_text(path)
+    assert script_uses_canonical_secrets_path(text), (
+        f"{name} must reference ~/Documents/.secrets/.cdb (or SECRETS_PATH)"
+    )
+
+
+@pytest.mark.parametrize("name,path", list(ACTIVE_SECRETS_SCRIPTS.items()))
+def test_active_secrets_scripts_do_not_promote_legacy_cdb_local(name: str, path: str) -> None:
+    text = read_script_text(path)
+    assert not script_promotes_legacy_secrets_path(text), (
+        f"{name} must not use legacy .cdb_local/.secrets as current canon"
+    )
+
+
+@pytest.mark.parametrize("compose_path", CANONICAL_COMPOSE_RUNTIME)
+def test_canonical_compose_fail_closed_on_missing_secrets_path(compose_path: str) -> None:
+    text = read_repo_text(compose_path)
+    assert compose_requires_secrets_path(text), (
+        f"{compose_path} must require SECRETS_PATH via :?SECRETS_PATH must be set"
+    )
+
+
+def test_gitignore_quarantines_env_runtime_exports() -> None:
+    gitignore = read_repo_text(".gitignore")
+    assert "*.env.runtime" in gitignore
+
+
+def test_rotate_secrets_documents_env_runtime_as_optional_export() -> None:
+    text = read_script_text(ACTIVE_SECRETS_SCRIPTS["rotate_secrets"])
+    assert ".env.runtime" in text
+    readme = read_repo_text("tools/secrets/README.md")
+    assert "No `.env.runtime` required for normal operation" in readme
+
+
+def test_tools_secrets_readme_marks_legacy_paths_as_deprecated() -> None:
+    readme = read_repo_text("tools/secrets/README.md")
+    assert "LEGACY" in readme
+    assert ".cdb_local" in readme
+    assert "nicht mehr kanonisch" in readme or "NICHT VERWENDEN" in readme
+
+
+def test_manage_secrets_validate_reports_length_not_payload() -> None:
+    text = read_script_text(ACTIVE_SECRETS_SCRIPTS["manage_secrets"])
+    assert "$length = $content.Trim().Length" in text
+    assert "SET ($length chars)" in text
+    assert "Write-Host $content" not in text
+
+
+@pytest.mark.parametrize("name,path", list(ACTIVE_SECRETS_SCRIPTS.items()))
+def test_secrets_scripts_do_not_echo_secret_values(name: str, path: str) -> None:
+    violations = script_secret_echo_violations(read_script_text(path))
+    assert not violations, f"{name} secret echo risk: {violations}"
+
+
+def test_core_secrets_module_uses_docker_secrets_and_env_fallback() -> None:
+    text = read_repo_text("core/secrets.py")
+    assert "/run/secrets/" in text
+    assert "os.getenv" in text
+    assert "Never logs secret values" in text
+
+
+def test_core_domain_secrets_module_uses_docker_then_env() -> None:
+    text = read_repo_text("core/domain/secrets.py")
+    assert "/run/secrets/" in text
+    assert "os.getenv" in text
+
+
+def test_secrets_ssot_runbook_points_to_external_store_only() -> None:
+    runbook = read_repo_text("docs/runbooks/cdb_secrets_ssot.md")
+    assert ".secrets" in runbook
+    assert "Never store secret values in repository" in runbook
+    assert "never values" in runbook.lower() or "never values" in runbook
+
+
+def test_candidate_secrets_paths_prefers_env_over_default(tmp_path: Path, monkeypatch) -> None:
+    from tools.surrealdb.memory_db_proof_local_dev import (
+        candidate_secrets_paths,
+        resolve_secrets_path,
+    )
+
+    synthetic = tmp_path / "synthetic-secrets"
+    synthetic.mkdir()
+    (synthetic / "SURREALDB_ENV").write_text("SURREAL_USER=test\n", encoding="utf-8")
+
+    monkeypatch.setenv("SECRETS_PATH", str(synthetic))
+    paths = candidate_secrets_paths()
+    assert paths[0] == synthetic
+
+    resolved = resolve_secrets_path()
+    assert resolved == synthetic
+
+
+def test_resolve_secrets_path_returns_none_when_no_synthetic_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.surrealdb.memory_db_proof_local_dev import resolve_secrets_path
+
+    monkeypatch.delenv("SECRETS_PATH", raising=False)
+    monkeypatch.delenv("CDB_CONTEXT_SECRETS_PATH", raising=False)
+    missing = Path(os.devnull) / "no-such-secrets-dir"
+    monkeypatch.setattr(
+        "tools.surrealdb.memory_db_proof_local_dev.candidate_secrets_paths",
+        lambda: [missing],
+    )
+    assert resolve_secrets_path() is None
+
+
+def test_audit_trail_resolve_secrets_path_uses_documents_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tools.surrealdb.audit_trail_t3_common import resolve_secrets_path
+
+    monkeypatch.delenv("SECRETS_PATH", raising=False)
+    default = resolve_secrets_path()
+    assert default == Path.home() / "Documents" / ".secrets" / ".cdb"

--- a/tests/unit/scripts/test_backup_manifest_contract.py
+++ b/tests/unit/scripts/test_backup_manifest_contract.py
@@ -32,3 +32,54 @@ def test_manifest_drift_fixture_documents_redis_false_with_artifact() -> None:
 
     payload = json.dumps(manifest)
     assert '"Redis":  false' in payload or '"Redis": false' in payload
+
+
+@pytest.mark.unit
+def test_manifest_reconciliation_fixture_surrealdb_artifact_present() -> None:
+    """Regression fixture: SurrealDB directory evidence reconciles to included."""
+    manifest = {
+        "Components": {"Postgres": False, "Redis": False, "SurrealDB": False},
+        "Evidence": {"SurrealDB": {}},
+    }
+    artifacts = {
+        "surrealdb_data": {
+            "file_count": 4,
+            "total_bytes": 8192,
+        }
+    }
+
+    surreal_present = (
+        artifacts["surrealdb_data"]["file_count"] > 0
+        and artifacts["surrealdb_data"]["total_bytes"] > 0
+    )
+    reconciled = surreal_present
+    assert reconciled is True
+
+    manifest["Components"]["SurrealDB"] = reconciled
+    manifest["Evidence"]["SurrealDB"] = {
+        "Artifact": "surrealdb_data",
+        "FileCount": artifacts["surrealdb_data"]["file_count"],
+        "TotalBytes": artifacts["surrealdb_data"]["total_bytes"],
+    }
+    assert manifest["Components"]["SurrealDB"] is True
+
+
+@pytest.mark.unit
+def test_missing_artifacts_fixture_all_components_absent() -> None:
+    """Missing artifacts must remain visible as not included."""
+    manifest = {
+        "Components": {"Postgres": False, "Redis": False, "SurrealDB": False},
+        "Evidence": {
+            "Postgres": {},
+            "Redis": {},
+            "SurrealDB": {},
+        },
+    }
+    artifacts: dict[str, int] = {}
+
+    missing = [
+        name
+        for name, flag in manifest["Components"].items()
+        if not flag and not artifacts
+    ]
+    assert missing == ["Postgres", "Redis", "SurrealDB"]


### PR DESCRIPTION
## Summary

Closes #3858
Closes #3859
Refs #3855
Refs #1445
Refs #2985

Adds static and fixture-backed contract tests for Secrets SSOT / `SECRETS_PATH` and backup/restore/DR manifest behavior. No real secrets, no backup/restore execution, no DB writes.

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: tool_blocked (`context_briefing` → `unknown_tool` on active MCP surface)
- context_tool_status: partial
- context_trust_level: none
- records_found: none

## Bootloader / Read-Order Evidence

- Root pointer `AGENTS.md` → `agents/AGENTS.md` Read Order resolved
- Live GitHub: #3858/#3859 OPEN; no duplicate open PR; #3856/#3857 delivered via merged #3890
- Branch from current `origin/main` (`7c7c1a31`)

## Delivered

**#3858 Secrets SSOT**
- `tests/unit/infra/test_secrets_ssot_contract.py` — canonical `Documents/.secrets/.cdb` / `SECRETS_PATH`, compose fail-closed, legacy `.cdb_local` quarantine, `.env.runtime` boundary, no secret echo, Python path resolution with synthetic fixtures
- Shared helpers in `tests/unit/infra/_secrets_backup_contract_helpers.py`

**#3859 Backup / Restore / DR**
- `tests/unit/infra/test_backup_restore_dr_contract.py` — manifest helpers, drift, artifact presence, `restore_all` list/destructive gates, `dr_restore` gates, health-check exit codes
- Extended `tests/unit/scripts/test_backup_manifest_contract.py` with SurrealDB + missing-artifact fixtures
- `tests/unit/infra/README.md` documents scope for #3858/#3859

## Validation

- `git diff --check` — pass
- `ruff check` on touched test files — pass
- `pytest -q tests/unit/infra/test_secrets_ssot_contract.py tests/unit/infra/test_backup_restore_dr_contract.py tests/unit/scripts/test_backup_manifest_contract.py -m contract` — 55 passed
- `pytest -q tests/unit -k "secret or secrets or SECRETS_PATH or backup or restore or manifest or dr_ or disaster"` — 287 passed

## Non-goals

- No real secrets read/rotate/write
- No backup or restore execution, no volume deletion, no Docker stack start
- #3860–#3863 monitoring/TLS/legacy slices out of scope
- No `CURRENT_STATUS.md` / ledger update (per #3855 meta policy)

## Safety Boundaries

- LR remains NO-GO; contract tests are not live/echtgeld authorization
- Secret-contract tests use synthetic paths only
- Backup-manifest tests are fixture/static source inspection only

## Ledger Policy

No `CURRENT_STATUS.md` or session-ledger update in this slice. PR body + issue comments are the work evidence until #3855 meta closes.
