### PR TITLE
test(ci): add workflow p0 control-plane contract tests

### DIFF
--- a/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
@@ -304,16 +304,7 @@ python .github/scripts/control_plane_validate.py --generate
 
 # Run CI tests for the collection layer
 pytest tests/test_control_plane.py -v
-
-# Workflow P0 contract tests (#3844–#3847): inventory/register drift,
-# trigger/permission matrix, parked fail-closed stubs, required-check split
-pytest tests/unit/scripts/test_workflow_inventory_register_contract.py \
-  tests/unit/scripts/test_workflow_trigger_permission_matrix.py \
-  tests/unit/scripts/test_parked_workflow_fail_closed_contract.py \
-  tests/unit/scripts/test_required_checks_policy_gate_contract.py -q
 ```
-
-These tests are static/fixture-based (no live GitHub dependency). They surface register drift as explicit findings and do **not** auto-rewrite `GITHUB_WORKFLOW_REGISTER.md` or workflow YAML.
 
 ### What the validator checks
 - All `manifest.yaml` files parse against the schema

--- a/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
+++ b/docs/runbooks/GITHUB_CONTROL_PLANE_RUNBOOK.md
@@ -304,7 +304,16 @@ python .github/scripts/control_plane_validate.py --generate
 
 # Run CI tests for the collection layer
 pytest tests/test_control_plane.py -v
+
+# Workflow P0 contract tests (#3844–#3847): inventory/register drift,
+# trigger/permission matrix, parked fail-closed stubs, required-check split
+pytest tests/unit/scripts/test_workflow_inventory_register_contract.py \
+  tests/unit/scripts/test_workflow_trigger_permission_matrix.py \
+  tests/unit/scripts/test_parked_workflow_fail_closed_contract.py \
+  tests/unit/scripts/test_required_checks_policy_gate_contract.py -q
 ```
+
+These tests are static/fixture-based (no live GitHub dependency). They surface register drift as explicit findings and do **not** auto-rewrite `GITHUB_WORKFLOW_REGISTER.md` or workflow YAML.
 
 ### What the validator checks
 - All `manifest.yaml` files parse against the schema

--- a/tests/unit/scripts/_workflow_contract_helpers.py
+++ b/tests/unit/scripts/_workflow_contract_helpers.py
@@ -1,0 +1,333 @@
+"""Shared helpers for workflow control-plane contract tests (#3844–#3847)."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+WORKFLOW_REGISTER_MD = REPO_ROOT / "docs" / "runbooks" / "GITHUB_WORKFLOW_REGISTER.md"
+CONTROL_PLANE_REGISTER_JSON = (
+    REPO_ROOT / ".github" / "control-plane" / "generated" / "workflow-register.json"
+)
+REQUIRED_CHECKS_BASELINE = (
+    REPO_ROOT / "reports" / "REQUIRED_CHECK_CONTEXTS_BASELINE_main.json"
+)
+
+WRITE_PERMISSION_SCOPES = frozenset(
+    {
+        "issues:write",
+        "pull-requests:write",
+        "contents:write",
+        "id-token:write",
+    }
+)
+
+FORBIDDEN_TRIGGERS = frozenset({"pull_request_target"})
+
+AUTOMATIC_TRIGGERS = frozenset(
+    {
+        "push",
+        "pull_request",
+        "schedule",
+        "issues",
+        "issue_comment",
+        "pull_request_review_comment",
+        "repository_dispatch",
+        "workflow_run",
+    }
+)
+
+PARKED_WORKFLOW_FILES = frozenset(
+    {
+        "control_board_auto_routing.yml",
+        "control-board-routing-label-dispatch.yml",
+        "auto-label.yml",
+        "comprehensive-issue-labeling.yml",
+        "issue-governance.yml",
+        "gemini-scheduled-triage.yml",
+    }
+)
+
+FROZEN_LEGACY_WORKFLOW_FILES = frozenset({"ci.yaml"})
+
+ACTIVE_CANONICAL_CI_WORKFLOW = "ci.yml"
+
+REQUIRED_CHECK_CONTEXTS = frozenset(
+    {
+        "ci (Unit/Integration + Lint gesammelt)",
+        "policy-gate",
+    }
+)
+
+NON_REQUIRED_GUARD_WORKFLOWS = frozenset(
+    {
+        "docs-hub-guard.yml",
+        "docs-conflict-guard.yml",
+    }
+)
+
+# Repo-true explicit findings: workflows on disk not listed in the markdown register.
+# Tests surface these as findings; register correction is a separate follow-up.
+KNOWN_UNREGISTERED_WORKFLOWS = frozenset(
+    {
+        "cdb-context-refresh-report.yml",
+        "security-alert-readout.yml",
+        "surrealdb-memory-proof.yml",
+    }
+)
+
+
+@dataclass(frozen=True)
+class WorkflowInventoryFinding:
+    kind: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class WorkflowInventoryScan:
+    disk_workflows: tuple[str, ...]
+    register_workflows: tuple[str, ...]
+    control_plane_workflows: tuple[str, ...]
+    unregistered_on_disk: tuple[str, ...]
+    missing_on_disk: tuple[str, ...]
+    control_plane_missing_on_disk: tuple[str, ...]
+    findings: tuple[WorkflowInventoryFinding, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class WorkflowTriggerPermissionRow:
+    filename: str
+    triggers: tuple[str, ...]
+    write_permissions: tuple[str, ...]
+    forbidden_triggers: tuple[str, ...]
+    has_explicit_permissions: bool
+    has_top_level_permissions: bool
+    has_job_level_permissions: bool
+
+
+def list_workflow_yaml_files(workflows_dir: Path) -> list[str]:
+    if not workflows_dir.exists():
+        return []
+    files = [
+        path.name
+        for path in workflows_dir.iterdir()
+        if path.is_file() and path.suffix in {".yml", ".yaml"}
+    ]
+    return sorted(files)
+
+
+def parse_register_table_workflows(register_path: Path) -> list[str]:
+    text = register_path.read_text(encoding="utf-8")
+    names = re.findall(r"\| `([^`]+\.(?:yml|yaml))` \|", text)
+    return sorted(set(names))
+
+
+def parse_control_plane_register_workflows(register_json_path: Path) -> list[str]:
+    payload = json.loads(register_json_path.read_text(encoding="utf-8"))
+    units = payload.get("units") or []
+    paths: list[str] = []
+    for unit in units:
+        if not isinstance(unit, dict):
+            continue
+        workflow_path = unit.get("workflow_path")
+        if isinstance(workflow_path, str) and workflow_path.strip():
+            paths.append(workflow_path.rsplit("/", 1)[-1])
+    return sorted(set(paths))
+
+
+def load_workflow_yaml(workflow_path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Workflow YAML must be a mapping: {workflow_path}")
+    return payload
+
+
+def extract_on_triggers(workflow: dict[str, Any]) -> set[str]:
+    on_section = workflow.get("on") or workflow.get(True)
+    if on_section is None:
+        return set()
+    if isinstance(on_section, str):
+        return {on_section}
+    if isinstance(on_section, list):
+        return {str(item) for item in on_section}
+    if isinstance(on_section, dict):
+        return {str(key) for key in on_section}
+    return set()
+
+
+def extract_top_level_permissions(workflow: dict[str, Any]) -> dict[str, str]:
+    permissions = workflow.get("permissions")
+    if permissions is None:
+        return {}
+    if permissions == {}:
+        return {}
+    if not isinstance(permissions, dict):
+        return {}
+    return {str(key): str(value) for key, value in permissions.items()}
+
+
+def extract_job_level_permissions(workflow: dict[str, Any]) -> dict[str, str]:
+    merged: dict[str, str] = {}
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return merged
+    for job_def in jobs.values():
+        if not isinstance(job_def, dict):
+            continue
+        perms = job_def.get("permissions")
+        if not isinstance(perms, dict):
+            continue
+        for scope, level in perms.items():
+            merged[str(scope)] = str(level)
+    return merged
+
+
+def extract_effective_permissions(workflow: dict[str, Any]) -> dict[str, str]:
+    effective = dict(extract_top_level_permissions(workflow))
+    effective.update(extract_job_level_permissions(workflow))
+    return effective
+
+
+def classify_write_permissions(permissions: dict[str, str]) -> set[str]:
+    classified: set[str] = set()
+    for scope, level in permissions.items():
+        if str(level).lower() != "write":
+            continue
+        token = f"{scope}:write"
+        if token in WRITE_PERMISSION_SCOPES:
+            classified.add(token)
+    return classified
+
+
+def build_trigger_permission_row(workflow_path: Path) -> WorkflowTriggerPermissionRow:
+    workflow = load_workflow_yaml(workflow_path)
+    triggers = tuple(sorted(extract_on_triggers(workflow)))
+    top_level = extract_top_level_permissions(workflow)
+    job_level = extract_job_level_permissions(workflow)
+    effective = extract_effective_permissions(workflow)
+    write_permissions = tuple(sorted(classify_write_permissions(effective)))
+    forbidden = tuple(sorted(FORBIDDEN_TRIGGERS.intersection(set(triggers))))
+    return WorkflowTriggerPermissionRow(
+        filename=workflow_path.name,
+        triggers=triggers,
+        write_permissions=write_permissions,
+        forbidden_triggers=forbidden,
+        has_explicit_permissions=bool(top_level or job_level),
+        has_top_level_permissions=bool(top_level),
+        has_job_level_permissions=bool(job_level),
+    )
+
+
+def scan_workflow_inventory(
+    *,
+    workflows_dir: Path,
+    register_md_path: Path,
+    control_plane_json_path: Path,
+) -> WorkflowInventoryScan:
+    disk = tuple(list_workflow_yaml_files(workflows_dir))
+    register = tuple(parse_register_table_workflows(register_md_path))
+    control_plane = tuple(parse_control_plane_register_workflows(control_plane_json_path))
+
+    disk_set = set(disk)
+    register_set = set(register)
+    control_plane_set = set(control_plane)
+
+    unregistered = tuple(sorted(disk_set - register_set))
+    missing_on_disk = tuple(sorted(register_set - disk_set))
+    cp_missing = tuple(sorted(control_plane_set - disk_set))
+
+    findings: list[WorkflowInventoryFinding] = []
+    for name in unregistered:
+        findings.append(
+            WorkflowInventoryFinding(
+                kind="unregistered_workflow",
+                detail=f"{name} exists on disk but is missing from GITHUB_WORKFLOW_REGISTER.md",
+            )
+        )
+    for name in missing_on_disk:
+        findings.append(
+            WorkflowInventoryFinding(
+                kind="register_missing_file",
+                detail=f"{name} is listed in GITHUB_WORKFLOW_REGISTER.md but missing on disk",
+            )
+        )
+    for name in cp_missing:
+        findings.append(
+            WorkflowInventoryFinding(
+                kind="control_plane_missing_file",
+                detail=(
+                    f"{name} is listed in workflow-register.json but missing on disk"
+                ),
+            )
+        )
+
+    return WorkflowInventoryScan(
+        disk_workflows=disk,
+        register_workflows=register,
+        control_plane_workflows=control_plane,
+        unregistered_on_disk=unregistered,
+        missing_on_disk=missing_on_disk,
+        control_plane_missing_on_disk=cp_missing,
+        findings=tuple(findings),
+    )
+
+
+REGISTER_STATUS_TOKENS = frozenset(
+    {
+        "aktiv",
+        "manual-only",
+        "parked",
+        "historisch",
+        "**parked**",
+    }
+)
+
+
+def parse_register_status_map(register_path: Path) -> dict[str, str]:
+    text = register_path.read_text(encoding="utf-8")
+    status_map: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.startswith("| `") or line.count("|") < 3:
+            continue
+        cols = [part.strip() for part in line.strip().strip("|").split("|")]
+        if len(cols) < 2:
+            continue
+        filename = cols[0].strip("`")
+        if not filename.endswith((".yml", ".yaml")):
+            continue
+        status = cols[1].lower()
+        if status not in {token.lower() for token in REGISTER_STATUS_TOKENS}:
+            continue
+        status_map[filename] = status
+    return status_map
+
+
+def workflow_has_only_dispatch_trigger(workflow_path: Path) -> bool:
+    workflow = load_workflow_yaml(workflow_path)
+    triggers = extract_on_triggers(workflow)
+    return triggers == {"workflow_dispatch"}
+
+
+def workflow_declares_forbidden_trigger(workflow_path: Path) -> list[str]:
+    workflow = load_workflow_yaml(workflow_path)
+    triggers = extract_on_triggers(workflow)
+    return sorted(FORBIDDEN_TRIGGERS.intersection(triggers))
+
+
+def load_required_checks_baseline(path: Path) -> list[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    contexts = payload.get("contexts") or []
+    return sorted(
+        {
+            str(ctx).strip()
+            for ctx in contexts
+            if isinstance(ctx, str) and str(ctx).strip()
+        }
+    )

--- a/tests/unit/scripts/fixtures/workflow_contract/forbidden_trigger/bad.yml
+++ b/tests/unit/scripts/fixtures/workflow_contract/forbidden_trigger/bad.yml
@@ -1,0 +1,10 @@
+name: bad
+on:
+  pull_request_target:
+permissions:
+  contents: read
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo bad

--- a/tests/unit/scripts/fixtures/workflow_contract/inventory_drift/GITHUB_WORKFLOW_REGISTER.md
+++ b/tests/unit/scripts/fixtures/workflow_contract/inventory_drift/GITHUB_WORKFLOW_REGISTER.md
@@ -1,0 +1,5 @@
+# Fixture register
+
+| File | Status | Trigger(s) | Purpose |
+|---|---|---|---|
+| `listed.yml` | aktiv | dispatch | listed only |

--- a/tests/unit/scripts/fixtures/workflow_contract/inventory_drift/orphan.yml
+++ b/tests/unit/scripts/fixtures/workflow_contract/inventory_drift/orphan.yml
@@ -1,0 +1,10 @@
+name: orphan
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo orphan

--- a/tests/unit/scripts/fixtures/workflow_contract/inventory_drift/workflow-register.json
+++ b/tests/unit/scripts/fixtures/workflow_contract/inventory_drift/workflow-register.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "1",
+  "coverage": "partial",
+  "catalog_scope": "fixture",
+  "generated_from": "manifests",
+  "unit_count": 0,
+  "units": []
+}

--- a/tests/unit/scripts/fixtures/workflow_contract/missing_permissions/implicit.yml
+++ b/tests/unit/scripts/fixtures/workflow_contract/missing_permissions/implicit.yml
@@ -1,0 +1,8 @@
+name: implicit
+on:
+  workflow_dispatch:
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo implicit

--- a/tests/unit/scripts/fixtures/workflow_contract/register_missing_file/GITHUB_WORKFLOW_REGISTER.md
+++ b/tests/unit/scripts/fixtures/workflow_contract/register_missing_file/GITHUB_WORKFLOW_REGISTER.md
@@ -1,0 +1,6 @@
+# Fixture register
+
+| File | Status | Trigger(s) | Purpose |
+|---|---|---|---|
+| `listed.yml` | aktiv | dispatch | listed only |
+| `ghost.yml` | aktiv | dispatch | missing on disk |

--- a/tests/unit/scripts/fixtures/workflow_contract/register_missing_file/listed.yml
+++ b/tests/unit/scripts/fixtures/workflow_contract/register_missing_file/listed.yml
@@ -1,0 +1,10 @@
+name: listed
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo listed

--- a/tests/unit/scripts/fixtures/workflow_contract/register_missing_file/workflow-register.json
+++ b/tests/unit/scripts/fixtures/workflow_contract/register_missing_file/workflow-register.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "1",
+  "coverage": "partial",
+  "catalog_scope": "fixture",
+  "generated_from": "manifests",
+  "unit_count": 0,
+  "units": []
+}

--- a/tests/unit/scripts/test_parked_workflow_fail_closed_contract.py
+++ b/tests/unit/scripts/test_parked_workflow_fail_closed_contract.py
@@ -1,0 +1,82 @@
+"""Parked workflow fail-closed contract tests (#3846)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+PARKED_HEADER_MARKERS = {
+    "control_board_auto_routing.yml": ("PARKED fail-closed", "#2772"),
+    "control-board-routing-label-dispatch.yml": ("PARKED fail-closed", "#2805"),
+    "auto-label.yml": ("Parked fail-closed", "#1642"),
+    "comprehensive-issue-labeling.yml": ("Parked fail-closed", "#1642"),
+    "issue-governance.yml": ("DEPRECATED", "#1642"),
+    "gemini-scheduled-triage.yml": ("parked fail-closed",),
+}
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.PARKED_WORKFLOW_FILES))
+def test_known_parked_workflow_file_exists(filename: str) -> None:
+    path = helpers.WORKFLOWS_DIR / filename
+    assert path.is_file(), path
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.PARKED_WORKFLOW_FILES))
+def test_parked_workflow_exposes_only_workflow_dispatch_trigger(filename: str) -> None:
+    path = helpers.WORKFLOWS_DIR / filename
+    workflow = helpers.load_workflow_yaml(path)
+    triggers = helpers.extract_on_triggers(workflow)
+    automatic = triggers.intersection(helpers.AUTOMATIC_TRIGGERS)
+    assert not automatic, (
+        f"{filename} must not declare automatic triggers; found {sorted(automatic)}"
+    )
+    assert "workflow_dispatch" in triggers, (
+        f"{filename} must keep workflow_dispatch diagnostic stub trigger"
+    )
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.PARKED_WORKFLOW_FILES))
+def test_parked_workflow_has_no_forbidden_pull_request_target(filename: str) -> None:
+    path = helpers.WORKFLOWS_DIR / filename
+    assert helpers.workflow_declares_forbidden_trigger(path) == []
+
+
+@pytest.mark.parametrize("filename,markers", sorted(PARKED_HEADER_MARKERS.items()))
+def test_parked_workflow_documents_parking_in_header(
+    filename: str,
+    markers: tuple[str, ...],
+) -> None:
+    content = (helpers.WORKFLOWS_DIR / filename).read_text(encoding="utf-8")
+    for marker in markers:
+        assert marker in content, f"{filename} missing parking marker {marker!r}"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "auto-label.yml",
+        "comprehensive-issue-labeling.yml",
+        "issue-governance.yml",
+        "control_board_auto_routing.yml",
+        "control-board-routing-label-dispatch.yml",
+    ],
+)
+def test_deprecated_parked_stubs_use_contents_read_only(filename: str) -> None:
+    workflow = helpers.load_workflow_yaml(helpers.WORKFLOWS_DIR / filename)
+    permissions = helpers.extract_effective_permissions(workflow)
+    write_permissions = helpers.classify_write_permissions(permissions)
+    assert write_permissions == set(), (
+        f"{filename} parked stub must not request write permissions; found {write_permissions}"
+    )
+
+
+def test_gemini_scheduled_triage_parked_stub_has_no_schedule_trigger() -> None:
+    workflow = helpers.load_workflow_yaml(
+        helpers.WORKFLOWS_DIR / "gemini-scheduled-triage.yml"
+    )
+    triggers = helpers.extract_on_triggers(workflow)
+    assert "schedule" not in triggers
+    assert triggers == {"workflow_dispatch"}

--- a/tests/unit/scripts/test_required_checks_policy_gate_contract.py
+++ b/tests/unit/scripts/test_required_checks_policy_gate_contract.py
@@ -1,0 +1,108 @@
+"""Required checks, CI split and policy-gate regression contract tests (#3847)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.governance.check_required_check_contexts import derive_context_mapping
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_required_checks_baseline_matches_canonical_pair() -> None:
+    contexts = helpers.load_required_checks_baseline(helpers.REQUIRED_CHECKS_BASELINE)
+    assert set(contexts) == helpers.REQUIRED_CHECK_CONTEXTS
+
+
+def test_derived_workflow_contexts_include_required_checks() -> None:
+    mapping, parse_errors = derive_context_mapping(helpers.WORKFLOWS_DIR)
+    assert parse_errors == []
+    derived = set(mapping.keys())
+    missing = sorted(helpers.REQUIRED_CHECK_CONTEXTS - derived)
+    assert missing == [], f"missing derived required contexts: {missing}"
+
+
+def test_ci_yaml_does_not_publish_required_pr_gate_contexts() -> None:
+    mapping, _ = derive_context_mapping(helpers.WORKFLOWS_DIR)
+    required_name = "ci (Unit/Integration + Lint gesammelt)"
+    ci_yaml_sources = [
+        entry
+        for entry in mapping.get(required_name, [])
+        if str(entry["workflow_file"]).endswith("ci.yaml")
+    ]
+    assert ci_yaml_sources == []
+
+
+def test_ci_yml_publishes_canonical_required_ci_context() -> None:
+    mapping, _ = derive_context_mapping(helpers.WORKFLOWS_DIR)
+    required_name = "ci (Unit/Integration + Lint gesammelt)"
+    assert required_name in mapping
+    sources = {
+        Path(str(entry["workflow_file"])).as_posix()
+        for entry in mapping[required_name]
+    }
+    assert any(path.endswith("/.github/workflows/ci.yml") for path in sources)
+    assert not any(path.endswith("/.github/workflows/ci.yaml") for path in sources)
+
+
+def test_policy_gate_publishes_required_context() -> None:
+    mapping, _ = derive_context_mapping(helpers.WORKFLOWS_DIR)
+    assert "policy-gate" in mapping
+    sources = {
+        Path(str(entry["workflow_file"])).as_posix()
+        for entry in mapping["policy-gate"]
+    }
+    assert any(path.endswith("/.github/workflows/policy-gate.yml") for path in sources)
+
+
+def test_policy_gate_blocks_pull_request_target_in_source() -> None:
+    content = (helpers.WORKFLOWS_DIR / "policy-gate.yml").read_text(encoding="utf-8")
+    assert "pull_request_target" in content
+    assert "failures.push" in content or "failures.push(" in content
+
+
+def test_required_checks_audit_lists_same_required_pair() -> None:
+    content = (helpers.WORKFLOWS_DIR / "required-checks-audit.yml").read_text(
+        encoding="utf-8"
+    )
+    for context in helpers.REQUIRED_CHECK_CONTEXTS:
+        assert context in content
+
+
+def test_docs_guards_are_non_required_optional_checks() -> None:
+    mapping, _ = derive_context_mapping(helpers.WORKFLOWS_DIR)
+    for filename in helpers.NON_REQUIRED_GUARD_WORKFLOWS:
+        workflow_suffix = f"/.github/workflows/{filename}"
+        guard_contexts = [
+            context
+            for context, entries in mapping.items()
+            if any(
+                str(entry["workflow_file"]).endswith(workflow_suffix)
+                for entry in entries
+            )
+        ]
+        assert guard_contexts, f"expected derived context for {filename}"
+        overlap = set(guard_contexts).intersection(helpers.REQUIRED_CHECK_CONTEXTS)
+        assert overlap == set(), (
+            f"{filename} must not masquerade as required check; overlap={overlap}"
+        )
+
+
+def test_drift_report_artifact_exists_and_documents_baseline_hash() -> None:
+    report_path = (
+        helpers.REPO_ROOT / "reports" / "REQUIRED_CHECK_CONTEXTS_DRIFT_REPORT_main.md"
+    )
+    assert report_path.is_file()
+    text = report_path.read_text(encoding="utf-8")
+    assert "## Required Contexts (Baseline)" in text
+    assert "## Extra Derivable Contexts (Informational)" in text
+
+
+def test_baseline_json_has_branch_protection_source_metadata() -> None:
+    payload = json.loads(helpers.REQUIRED_CHECKS_BASELINE.read_text(encoding="utf-8"))
+    assert payload.get("source") == "branch_protection_main"
+    assert isinstance(payload.get("contexts"), list)

--- a/tests/unit/scripts/test_workflow_inventory_register_contract.py
+++ b/tests/unit/scripts/test_workflow_inventory_register_contract.py
@@ -1,0 +1,135 @@
+"""Workflow inventory and register drift contract tests (#3844)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures" / "workflow_contract"
+
+
+def _fixture_dir(name: str) -> Path:
+    return FIXTURES_ROOT / name
+
+
+def test_disk_workflow_count_matches_register_header_claim() -> None:
+    scan = helpers.scan_workflow_inventory(
+        workflows_dir=helpers.WORKFLOWS_DIR,
+        register_md_path=helpers.WORKFLOW_REGISTER_MD,
+        control_plane_json_path=helpers.CONTROL_PLANE_REGISTER_JSON,
+    )
+    register_text = helpers.WORKFLOW_REGISTER_MD.read_text(encoding="utf-8")
+    match = __import__("re").search(
+        r"\*\*Total workflow definitions:\*\* (\d+) YAML files",
+        register_text,
+    )
+    assert match is not None, "register header must declare total YAML workflow count"
+    declared = int(match.group(1))
+    assert len(scan.disk_workflows) == declared
+
+
+def test_unregistered_workflows_are_explicit_findings_not_silent_pass() -> None:
+    scan = helpers.scan_workflow_inventory(
+        workflows_dir=helpers.WORKFLOWS_DIR,
+        register_md_path=helpers.WORKFLOW_REGISTER_MD,
+        control_plane_json_path=helpers.CONTROL_PLANE_REGISTER_JSON,
+    )
+    assert scan.unregistered_on_disk, "expected explicit unregistered findings on current repo"
+    kinds = {finding.kind for finding in scan.findings}
+    assert "unregistered_workflow" in kinds
+    assert set(scan.unregistered_on_disk) == helpers.KNOWN_UNREGISTERED_WORKFLOWS
+
+
+def test_register_has_no_missing_on_disk_workflows() -> None:
+    scan = helpers.scan_workflow_inventory(
+        workflows_dir=helpers.WORKFLOWS_DIR,
+        register_md_path=helpers.WORKFLOW_REGISTER_MD,
+        control_plane_json_path=helpers.CONTROL_PLANE_REGISTER_JSON,
+    )
+    assert scan.missing_on_disk == ()
+
+
+def test_control_plane_register_paths_exist_on_disk() -> None:
+    scan = helpers.scan_workflow_inventory(
+        workflows_dir=helpers.WORKFLOWS_DIR,
+        register_md_path=helpers.WORKFLOW_REGISTER_MD,
+        control_plane_json_path=helpers.CONTROL_PLANE_REGISTER_JSON,
+    )
+    assert scan.control_plane_missing_on_disk == ()
+    assert scan.control_plane_workflows
+
+
+def test_control_plane_register_is_partial_coverage_by_design() -> None:
+    payload = json.loads(helpers.CONTROL_PLANE_REGISTER_JSON.read_text(encoding="utf-8"))
+    assert payload.get("coverage") == "partial"
+    assert payload.get("catalog_scope") == "control-plane-sprint1"
+    disk_count = len(helpers.list_workflow_yaml_files(helpers.WORKFLOWS_DIR))
+    assert payload.get("unit_count", 0) < disk_count
+
+
+@pytest.mark.parametrize(
+    "filename,expected_status_keyword",
+    [
+        ("ci.yml", "aktiv"),
+        ("ci.yaml", "historisch"),
+        ("control_board_auto_routing.yml", "parked"),
+        ("control-board-routing-label-dispatch.yml", "parked"),
+        ("gemini-scheduled-triage.yml", "parked"),
+        ("gemini-invoke.yml", "aktiv"),
+    ],
+)
+def test_register_classifies_known_workflow_status(
+    filename: str,
+    expected_status_keyword: str,
+) -> None:
+    status_map = helpers.parse_register_status_map(helpers.WORKFLOW_REGISTER_MD)
+    assert filename in status_map
+    assert expected_status_keyword in status_map[filename]
+
+
+def test_register_marks_reusable_gemini_workflows_as_wcall() -> None:
+    text = helpers.WORKFLOW_REGISTER_MD.read_text(encoding="utf-8")
+    assert "| `gemini-invoke.yml` | aktiv | wcall |" in text
+
+
+def test_ci_yaml_is_frozen_legacy_dispatch_only() -> None:
+    workflow_path = helpers.WORKFLOWS_DIR / "ci.yaml"
+    content = workflow_path.read_text(encoding="utf-8")
+    assert "LEGACY-FREEZE" in content
+    assert "NOISE-FREEZE" in content
+    assert helpers.workflow_has_only_dispatch_trigger(workflow_path)
+
+
+def test_ci_yml_is_active_canonical_pr_gate() -> None:
+    workflow_path = helpers.WORKFLOWS_DIR / helpers.ACTIVE_CANONICAL_CI_WORKFLOW
+    workflow = helpers.load_workflow_yaml(workflow_path)
+    triggers = helpers.extract_on_triggers(workflow)
+    assert "pull_request" in triggers
+    assert "push" in triggers
+    assert workflow_path.name != "ci.yaml"
+
+
+def test_fixture_detects_unregistered_workflow_drift() -> None:
+    scan = helpers.scan_workflow_inventory(
+        workflows_dir=_fixture_dir("inventory_drift"),
+        register_md_path=_fixture_dir("inventory_drift") / "GITHUB_WORKFLOW_REGISTER.md",
+        control_plane_json_path=_fixture_dir("inventory_drift") / "workflow-register.json",
+    )
+    assert scan.unregistered_on_disk == ("orphan.yml",)
+    assert any(f.kind == "unregistered_workflow" for f in scan.findings)
+
+
+def test_fixture_detects_register_missing_file_drift() -> None:
+    scan = helpers.scan_workflow_inventory(
+        workflows_dir=_fixture_dir("register_missing_file"),
+        register_md_path=_fixture_dir("register_missing_file") / "GITHUB_WORKFLOW_REGISTER.md",
+        control_plane_json_path=_fixture_dir("register_missing_file") / "workflow-register.json",
+    )
+    assert scan.missing_on_disk == ("ghost.yml",)
+    assert any(f.kind == "register_missing_file" for f in scan.findings)

--- a/tests/unit/scripts/test_workflow_trigger_permission_matrix.py
+++ b/tests/unit/scripts/test_workflow_trigger_permission_matrix.py
@@ -1,0 +1,105 @@
+"""Workflow trigger and permission matrix contract tests (#3845)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures" / "workflow_contract"
+
+
+def _matrix_for_dir(workflows_dir: Path) -> list[helpers.WorkflowTriggerPermissionRow]:
+    rows: list[helpers.WorkflowTriggerPermissionRow] = []
+    for filename in helpers.list_workflow_yaml_files(workflows_dir):
+        rows.append(helpers.build_trigger_permission_row(workflows_dir / filename))
+    return rows
+
+
+def test_no_workflow_declares_pull_request_target() -> None:
+    offenders: list[str] = []
+    for filename in helpers.list_workflow_yaml_files(helpers.WORKFLOWS_DIR):
+        forbidden = helpers.workflow_declares_forbidden_trigger(
+            helpers.WORKFLOWS_DIR / filename
+        )
+        if forbidden:
+            offenders.append(f"{filename}: {forbidden}")
+    assert offenders == []
+
+
+def test_trigger_matrix_is_deterministic_and_complete() -> None:
+    first = _matrix_for_dir(helpers.WORKFLOWS_DIR)
+    second = _matrix_for_dir(helpers.WORKFLOWS_DIR)
+    assert first == second
+    assert len(first) == len(helpers.list_workflow_yaml_files(helpers.WORKFLOWS_DIR))
+
+
+@pytest.mark.parametrize(
+    "filename,expected_triggers",
+    [
+        ("ci.yml", ("pull_request", "push")),
+        ("ci.yaml", ("workflow_dispatch",)),
+        ("policy-gate.yml", ("pull_request",)),
+        ("gemini-invoke.yml", ("workflow_call",)),
+        ("required-checks-audit.yml", ("workflow_dispatch",)),
+    ],
+)
+def test_known_workflow_trigger_classification(
+    filename: str,
+    expected_triggers: tuple[str, ...],
+) -> None:
+    row = helpers.build_trigger_permission_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.triggers == expected_triggers
+
+
+@pytest.mark.parametrize(
+    "filename,expected_write_permissions",
+    [
+        ("ci.yml", ()),
+        ("policy-gate.yml", ()),
+        ("stale.yml", ("issues:write", "pull-requests:write")),
+        ("cdb-daily-delta-triage.yml", ("issues:write",)),
+        (
+            "gemini-invoke.yml",
+            ("id-token:write", "issues:write", "pull-requests:write"),
+        ),
+    ],
+)
+def test_known_workflow_write_permission_classification(
+    filename: str,
+    expected_write_permissions: tuple[str, ...],
+) -> None:
+    row = helpers.build_trigger_permission_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.write_permissions == expected_write_permissions
+
+
+def test_write_permissions_use_canonical_scope_tokens() -> None:
+    for row in _matrix_for_dir(helpers.WORKFLOWS_DIR):
+        for scope in row.write_permissions:
+            assert scope in helpers.WRITE_PERMISSION_SCOPES, (
+                f"{row.filename} has unexpected write scope {scope!r}"
+            )
+
+
+def test_fixture_flags_pull_request_target_as_forbidden() -> None:
+    fixture_dir = FIXTURES_ROOT / "forbidden_trigger"
+    row = helpers.build_trigger_permission_row(fixture_dir / "bad.yml")
+    assert row.forbidden_triggers == ("pull_request_target",)
+
+
+def test_fixture_surfaces_missing_permissions_block_as_finding() -> None:
+    fixture_dir = FIXTURES_ROOT / "missing_permissions"
+    row = helpers.build_trigger_permission_row(fixture_dir / "implicit.yml")
+    assert row.has_explicit_permissions is False
+    assert row.has_top_level_permissions is False
+    assert row.has_job_level_permissions is False
+
+
+def test_policy_gate_source_blocks_pull_request_target_pattern() -> None:
+    content = (helpers.WORKFLOWS_DIR / "policy-gate.yml").read_text(encoding="utf-8")
+    assert "pull_request_target" in content
+    assert "contains pull_request_target" in content


### PR DESCRIPTION
## Summary
- Add shared workflow contract helpers plus four P0 test modules covering #3844–#3847.
- Surface register/control-plane drift as explicit findings (including 3 known unregistered workflows) without auto-fixing register or YAML.
- Document the local pytest entrypoint in `GITHUB_CONTROL_PLANE_RUNBOOK.md`.

Closes #3844
Closes #3845
Closes #3846
Closes #3847
Refs #3843

## Delivered by issue
- **#3844**: disk vs `GITHUB_WORKFLOW_REGISTER.md` vs partial `workflow-register.json`; frozen `ci.yaml` / active `ci.yml` classification; fixture drift scans.
- **#3845**: deterministic trigger + write-permission matrix; `pull_request_target` fail-closed fixture; policy-gate source guard reference.
- **#3846**: parked workflow dispatch-only + header contracts for all six known parked workflows (extends existing control-board contract tests).
- **#3847**: required-check baseline vs derived contexts; `ci.yml` vs frozen `ci.yaml`; policy-gate + sentinel audit semantics; optional docs guards separated from required pair.

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true / context_brain_used: false / repo_fallback_reason: insufficient_evidence
- GitHub live issues #3843–#3847 fetched via `gh issue view`; repo files cross-checked for workflows/register/baseline.

## Validation
- `pytest -q tests/unit/scripts/test_workflow_* tests/unit/scripts/test_parked_workflow_* tests/unit/scripts/test_required_checks_policy_gate_contract.py tests/test_control_plane.py` → 83 passed
- `git diff --check` → clean

## Non-goals
- No workflow YAML edits, reactivation, schedule/permission expansion, register rewrite, branch-protection or required-check changes.
- No touch of PR #3755.

## Safety Boundaries
- Shadow/Paper-only test additions; LR remains NO-GO; no runtime/DB/MCP/live mutations.

## Restunsicherheiten
- Register drift for `cdb-context-refresh-report.yml`, `security-alert-readout.yml`, `surrealdb-memory-proof.yml` is surfaced by tests but intentionally not repaired in this PR (follow-up reconciliation).
