### PR TITLE
test(ci): add workflow p1 control-plane contract tests

### DIFF
--- a/tests/unit/scripts/_workflow_contract_helpers.py
+++ b/tests/unit/scripts/_workflow_contract_helpers.py
@@ -1,4 +1,4 @@
-"""Shared helpers for workflow control-plane contract tests (#3844–#3847)."""
+"""Shared helpers for workflow control-plane contract tests (#3844–#3852)."""
 
 from __future__ import annotations
 
@@ -331,3 +331,334 @@ def load_required_checks_baseline(path: Path) -> list[str]:
             if isinstance(ctx, str) and str(ctx).strip()
         }
     )
+
+
+# --- P1 scope (#3848–#3852) -------------------------------------------------
+
+LABEL_CASCADE_WORKFLOW_FILES = frozenset(
+    {
+        "auto-milestone.yml",
+        "auto-milestone-label-dispatch.yml",
+        "project_status_sync.yml",
+        "project_status_label_map.yml",
+        "triage_guard.yml",
+        "add_to_project.yml",
+        "sync-labels.yml",
+    }
+)
+
+ISSUES_LABELED_CASCADE_FILES = frozenset(
+    {
+        "auto-milestone-label-dispatch.yml",
+        "project_status_label_map.yml",
+    }
+)
+
+MILESTONE_DISPATCH_CASCADE = (
+    ("auto-milestone-label-dispatch.yml", "auto_milestone_issue_label", "auto-milestone.yml"),
+)
+
+PROJECT_API_MARKERS = (
+    "gh api graphql",
+    "projectV2",
+    "addProjectV2ItemById",
+    "updateProjectV2ItemFieldValue",
+    "ensure_project_membership.py",
+)
+
+REUSABLE_GEMINI_WORKFLOW_FILES = frozenset(
+    {
+        "gemini-invoke.yml",
+        "gemini-review.yml",
+        "gemini-triage.yml",
+    }
+)
+
+REACHABLE_AGENT_AI_WORKFLOW_FILES = frozenset(
+    {
+        "gemini-dispatch.yml",
+        "opencode.yml",
+        "copilot-setup-steps.yml",
+        "copilot-housekeeping.yml",
+        "ai-review-router.yml",
+    }
+)
+
+GEMINI_DISPATCH_PLACEHOLDER_MARKERS = (
+    "gemini-dispatch placeholder",
+    'echo "gemini-dispatch placeholder"',
+)
+
+SECURITY_WORKFLOW_FILES = frozenset(
+    {
+        "trivy.yml",
+        "gitleaks.yml",
+        "codeql-python.yml",
+        "security-scan.yml",
+        "security-alert-readout.yml",
+    }
+)
+
+P1_SCHEDULED_WORKFLOW_FILES = frozenset(
+    {
+        "weekly_digest.yml",
+        "weekly_digest_failure_alert.yml",
+        "cdb-daily-delta-triage.yml",
+        "cdb-weekly-control-hygiene-classifier.yml",
+        "cdb-context-refresh-report.yml",
+        "stale.yml",
+        "python-compat.yml",
+        "e2e.yml",
+        "e2e-tests.yml",
+        "e2e-happy-path.yaml",
+    }
+)
+
+CONTROL_PLANE_COLLECTION_DIR = REPO_ROOT / ".github" / "control-plane" / "src"
+CONTROL_PLANE_VALIDATOR = REPO_ROOT / ".github" / "scripts" / "control_plane_validate.py"
+
+MANIFEST_STATUS_VALUES = frozenset(
+    {
+        "active",
+        "manual_only",
+        "parked",
+        "historical_unclear",
+    }
+)
+
+FORBIDDEN_SECRET_PERSISTENCE_MARKERS = (
+    "upload-artifact",
+    "actions/cache/save",
+    "persist_secret",
+    "secrets.json",
+)
+
+
+@dataclass(frozen=True)
+class LabelCascadeRow:
+    filename: str
+    triggers: tuple[str, ...]
+    issues_types: tuple[str, ...]
+    write_permissions: tuple[str, ...]
+    uses_project_api: bool
+    uses_repository_dispatch: bool
+    has_noise_guard: bool
+
+
+@dataclass(frozen=True)
+class ScheduleEntry:
+    filename: str
+    crons: tuple[str, ...]
+    has_workflow_dispatch: bool
+    has_schedule: bool
+    has_workflow_run: bool
+
+
+@dataclass(frozen=True)
+class SecurityWorkflowBoundary:
+    filename: str
+    triggers: tuple[str, ...]
+    has_workflow_dispatch: bool
+    has_schedule: bool
+    write_permissions: tuple[str, ...]
+    forbids_secret_artifact_upload: bool
+
+
+def extract_issues_event_types(workflow: dict[str, Any]) -> tuple[str, ...]:
+    on_section = workflow.get("on") or workflow.get(True)
+    if not isinstance(on_section, dict):
+        return ()
+    issues_block = on_section.get("issues")
+    if issues_block is None:
+        return ()
+    if isinstance(issues_block, dict):
+        types = issues_block.get("types") or []
+        return tuple(sorted(str(item) for item in types))
+    if isinstance(issues_block, list):
+        return tuple(sorted(str(item) for item in issues_block))
+    return ()
+
+
+def workflow_content_markers(path: Path, markers: tuple[str, ...]) -> bool:
+    content = path.read_text(encoding="utf-8")
+    return any(marker in content for marker in markers)
+
+
+def workflow_uses_project_api(path: Path) -> bool:
+    return workflow_content_markers(path, PROJECT_API_MARKERS)
+
+
+def workflow_uses_repository_dispatch(path: Path) -> bool:
+    content = path.read_text(encoding="utf-8")
+    return "createDispatchEvent" in content or "repository_dispatch" in content
+
+
+def workflow_has_noise_guard(path: Path) -> bool:
+    content = path.read_text(encoding="utf-8").lower()
+    guard_tokens = (
+        "concurrency:",
+        "cancel-in-progress",
+        "no-op",
+        "skipping",
+        "idempotent",
+        "prune: false",
+        "ambiguous",
+        "if:",
+        "startsWith(",
+        "--retries",
+    )
+    return any(token in content for token in guard_tokens)
+
+
+def build_label_cascade_row(workflow_path: Path) -> LabelCascadeRow:
+    workflow = load_workflow_yaml(workflow_path)
+    row = build_trigger_permission_row(workflow_path)
+    return LabelCascadeRow(
+        filename=workflow_path.name,
+        triggers=row.triggers,
+        issues_types=extract_issues_event_types(workflow),
+        write_permissions=row.write_permissions,
+        uses_project_api=workflow_uses_project_api(workflow_path),
+        uses_repository_dispatch=workflow_uses_repository_dispatch(workflow_path),
+        has_noise_guard=workflow_has_noise_guard(workflow_path),
+    )
+
+
+def build_label_cascade_map() -> dict[str, LabelCascadeRow]:
+    return {
+        filename: build_label_cascade_row(WORKFLOWS_DIR / filename)
+        for filename in sorted(LABEL_CASCADE_WORKFLOW_FILES)
+        if (WORKFLOWS_DIR / filename).is_file()
+    }
+
+
+def reusable_workflow_is_workflow_call_only(workflow_path: Path) -> bool:
+    workflow = load_workflow_yaml(workflow_path)
+    triggers = extract_on_triggers(workflow)
+    automatic = triggers.intersection(AUTOMATIC_TRIGGERS)
+    return triggers == {"workflow_call"} and not automatic
+
+
+def extract_schedule_crons(workflow: dict[str, Any]) -> tuple[str, ...]:
+    on_section = workflow.get("on") or workflow.get(True)
+    if not isinstance(on_section, dict):
+        return ()
+    schedule_block = on_section.get("schedule")
+    if schedule_block is None:
+        return ()
+    if not isinstance(schedule_block, list):
+        return ()
+    crons: list[str] = []
+    for entry in schedule_block:
+        if isinstance(entry, dict) and entry.get("cron"):
+            crons.append(str(entry["cron"]).strip())
+    return tuple(sorted(crons))
+
+
+def build_schedule_entry(workflow_path: Path) -> ScheduleEntry:
+    workflow = load_workflow_yaml(workflow_path)
+    triggers = extract_on_triggers(workflow)
+    return ScheduleEntry(
+        filename=workflow_path.name,
+        crons=extract_schedule_crons(workflow),
+        has_workflow_dispatch="workflow_dispatch" in triggers,
+        has_schedule="schedule" in triggers,
+        has_workflow_run="workflow_run" in triggers,
+    )
+
+
+def build_p1_schedule_map() -> dict[str, ScheduleEntry]:
+    entries: dict[str, ScheduleEntry] = {}
+    for filename in sorted(P1_SCHEDULED_WORKFLOW_FILES):
+        path = WORKFLOWS_DIR / filename
+        if path.is_file():
+            entries[filename] = build_schedule_entry(path)
+    return entries
+
+
+def find_cron_collisions(schedule_map: dict[str, ScheduleEntry]) -> dict[str, tuple[str, ...]]:
+    collisions: dict[str, list[str]] = {}
+    for filename, entry in schedule_map.items():
+        for cron in entry.crons:
+            collisions.setdefault(cron, []).append(filename)
+    return {
+        cron: tuple(sorted(files))
+        for cron, files in collisions.items()
+        if len(files) > 1
+    }
+
+
+def build_security_boundary_row(workflow_path: Path) -> SecurityWorkflowBoundary:
+    workflow = load_workflow_yaml(workflow_path)
+    triggers = tuple(sorted(extract_on_triggers(workflow)))
+    content = workflow_path.read_text(encoding="utf-8").lower()
+    row = build_trigger_permission_row(workflow_path)
+    forbids_upload = not any(
+        marker in content for marker in FORBIDDEN_SECRET_PERSISTENCE_MARKERS
+    )
+    if workflow_path.name == "gitleaks.yml":
+        forbids_upload = "upload-artifact" not in content
+    if workflow_path.name == "security-scan.yml":
+        forbids_upload = False
+    return SecurityWorkflowBoundary(
+        filename=workflow_path.name,
+        triggers=triggers,
+        has_workflow_dispatch="workflow_dispatch" in triggers,
+        has_schedule="schedule" in triggers,
+        write_permissions=row.write_permissions,
+        forbids_secret_artifact_upload=forbids_upload,
+    )
+
+
+def list_manifest_unit_dirs(collection_dir: Path = CONTROL_PLANE_COLLECTION_DIR) -> list[Path]:
+    if not collection_dir.exists():
+        return []
+    return sorted(
+        path
+        for path in collection_dir.iterdir()
+        if path.is_dir() and (path / "manifest.yaml").is_file()
+    )
+
+
+def load_manifest_yaml(manifest_path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"manifest must be a mapping: {manifest_path}")
+    return payload
+
+
+def manifest_triggers_match_yaml(manifest: dict[str, Any], workflow_path: Path) -> bool:
+    declared = {
+        str(item).split(":")[0].strip()
+        for item in (manifest.get("workflow") or {}).get("triggers") or []
+    }
+    workflow = load_workflow_yaml(workflow_path)
+    actual = extract_on_triggers(workflow)
+    return declared == actual
+
+
+def manifest_permissions_match_yaml(manifest: dict[str, Any], workflow_path: Path) -> bool:
+    declared = (manifest.get("workflow") or {}).get("permissions") or {}
+    if not isinstance(declared, dict):
+        return False
+    workflow = load_workflow_yaml(workflow_path)
+    actual = extract_top_level_permissions(workflow)
+    normalized_declared = {str(k): str(v) for k, v in declared.items()}
+    return normalized_declared == actual
+
+
+def control_plane_missing_unit_findings() -> tuple[str, ...]:
+    cataloged: set[str] = set()
+    for unit_dir in list_manifest_unit_dirs():
+        manifest = load_manifest_yaml(unit_dir / "manifest.yaml")
+        workflow_path = (manifest.get("workflow") or {}).get("path", "")
+        if isinstance(workflow_path, str) and workflow_path.strip():
+            cataloged.add(workflow_path.rsplit("/", 1)[-1])
+    disk = set(list_workflow_yaml_files(WORKFLOWS_DIR))
+    expected_catalog = {
+        "cdb-control-followup-classifier.yml",
+        "cdb-daily-delta-triage.yml",
+        "cdb-post-merge-followup-scanner.yml",
+    }
+    missing = sorted(name for name in expected_catalog if name in disk and name not in cataloged)
+    return tuple(missing)

--- a/tests/unit/scripts/test_agent_ai_workflow_reachability_contract.py
+++ b/tests/unit/scripts/test_agent_ai_workflow_reachability_contract.py
@@ -1,0 +1,95 @@
+"""Agent and AI workflow reachability/safety contract tests (#3849)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_reusable_gemini_workflow_files_exist() -> None:
+    missing = sorted(
+        name
+        for name in helpers.REUSABLE_GEMINI_WORKFLOW_FILES
+        if not (helpers.WORKFLOWS_DIR / name).is_file()
+    )
+    assert missing == []
+
+
+def test_reachable_agent_ai_workflow_files_exist() -> None:
+    missing = sorted(
+        name
+        for name in helpers.REACHABLE_AGENT_AI_WORKFLOW_FILES
+        if not (helpers.WORKFLOWS_DIR / name).is_file()
+    )
+    assert missing == []
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.REUSABLE_GEMINI_WORKFLOW_FILES))
+def test_reusable_gemini_workflows_are_workflow_call_only(filename: str) -> None:
+    path = helpers.WORKFLOWS_DIR / filename
+    assert helpers.reusable_workflow_is_workflow_call_only(path)
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.REUSABLE_GEMINI_WORKFLOW_FILES))
+def test_reusable_gemini_workflows_have_no_hidden_standalone_triggers(filename: str) -> None:
+    workflow = helpers.load_workflow_yaml(helpers.WORKFLOWS_DIR / filename)
+    triggers = helpers.extract_on_triggers(workflow)
+    automatic = triggers.intersection(helpers.AUTOMATIC_TRIGGERS)
+    assert automatic == set()
+
+
+def test_gemini_dispatch_is_explicit_placeholder() -> None:
+    content = (helpers.WORKFLOWS_DIR / "gemini-dispatch.yml").read_text(encoding="utf-8")
+    assert any(marker in content for marker in helpers.GEMINI_DISPATCH_PLACEHOLDER_MARKERS)
+    workflow = helpers.load_workflow_yaml(helpers.WORKFLOWS_DIR / "gemini-dispatch.yml")
+    triggers = helpers.extract_on_triggers(workflow)
+    assert triggers == {"workflow_dispatch"}
+    permissions = helpers.extract_effective_permissions(workflow)
+    assert helpers.classify_write_permissions(permissions) == set()
+
+
+@pytest.mark.parametrize(
+    "filename,expected_triggers",
+    [
+        ("gemini-invoke.yml", ("workflow_call",)),
+        ("gemini-review.yml", ("workflow_call",)),
+        ("gemini-triage.yml", ("workflow_call",)),
+        ("gemini-dispatch.yml", ("workflow_dispatch",)),
+        ("opencode.yml", ("issue_comment", "pull_request_review_comment")),
+        ("copilot-setup-steps.yml", ("push", "workflow_dispatch")),
+        ("copilot-housekeeping.yml", ("schedule", "workflow_dispatch")),
+        ("ai-review-router.yml", ("schedule", "workflow_dispatch")),
+    ],
+)
+def test_agent_ai_trigger_classification(
+    filename: str,
+    expected_triggers: tuple[str, ...],
+) -> None:
+    row = helpers.build_trigger_permission_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.triggers == expected_triggers
+
+
+def test_opencode_declares_id_token_write_permission() -> None:
+    row = helpers.build_trigger_permission_row(helpers.WORKFLOWS_DIR / "opencode.yml")
+    assert "id-token:write" in row.write_permissions
+
+
+def test_gemini_invoke_declares_expected_write_permissions() -> None:
+    row = helpers.build_trigger_permission_row(helpers.WORKFLOWS_DIR / "gemini-invoke.yml")
+    assert row.write_permissions == (
+        "id-token:write",
+        "issues:write",
+        "pull-requests:write",
+    )
+
+
+def test_gemini_scheduled_triage_remains_parked_not_reachable() -> None:
+    workflow = helpers.load_workflow_yaml(
+        helpers.WORKFLOWS_DIR / "gemini-scheduled-triage.yml"
+    )
+    triggers = helpers.extract_on_triggers(workflow)
+    assert triggers == {"workflow_dispatch"}
+    assert "schedule" not in triggers

--- a/tests/unit/scripts/test_control_plane_manifest_register_contract.py
+++ b/tests/unit/scripts/test_control_plane_manifest_register_contract.py
@@ -1,0 +1,113 @@
+"""Control-plane manifest and generated register contract tests (#3852)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+COLLECTION_DIR = helpers.CONTROL_PLANE_COLLECTION_DIR
+GENERATED_REGISTER = helpers.CONTROL_PLANE_REGISTER_JSON
+VALIDATOR = helpers.CONTROL_PLANE_VALIDATOR
+
+
+def _run_validator(*extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), "--repo-root", str(helpers.REPO_ROOT)]
+        + list(extra_args),
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("unit_dir", helpers.list_manifest_unit_dirs(), ids=lambda p: p.name)
+def test_manifest_status_uses_canonical_enum(unit_dir: Path) -> None:
+    manifest = helpers.load_manifest_yaml(unit_dir / "manifest.yaml")
+    assert manifest.get("status") in helpers.MANIFEST_STATUS_VALUES
+
+
+@pytest.mark.parametrize("unit_dir", helpers.list_manifest_unit_dirs(), ids=lambda p: p.name)
+def test_manifest_required_top_level_fields(unit_dir: Path) -> None:
+    manifest = helpers.load_manifest_yaml(unit_dir / "manifest.yaml")
+    required = {
+        "id",
+        "kind",
+        "status",
+        "owner_surface",
+        "workflow",
+        "purpose",
+        "control",
+        "discovery",
+        "tests",
+    }
+    missing = required - set(manifest)
+    assert not missing, f"{unit_dir.name} missing fields: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("unit_dir", helpers.list_manifest_unit_dirs(), ids=lambda p: p.name)
+def test_manifest_triggers_match_real_workflow_yaml(unit_dir: Path) -> None:
+    manifest = helpers.load_manifest_yaml(unit_dir / "manifest.yaml")
+    workflow_rel = (manifest.get("workflow") or {}).get("path")
+    assert isinstance(workflow_rel, str)
+    workflow_path = helpers.REPO_ROOT / workflow_rel
+    assert workflow_path.is_file()
+    assert helpers.manifest_triggers_match_yaml(manifest, workflow_path)
+
+
+@pytest.mark.parametrize("unit_dir", helpers.list_manifest_unit_dirs(), ids=lambda p: p.name)
+def test_manifest_permissions_match_real_workflow_yaml(unit_dir: Path) -> None:
+    manifest = helpers.load_manifest_yaml(unit_dir / "manifest.yaml")
+    workflow_rel = (manifest.get("workflow") or {}).get("path")
+    assert isinstance(workflow_rel, str)
+    workflow_path = helpers.REPO_ROOT / workflow_rel
+    assert helpers.manifest_permissions_match_yaml(manifest, workflow_path)
+
+
+def test_generated_register_has_no_duplicate_ids() -> None:
+    payload = json.loads(GENERATED_REGISTER.read_text(encoding="utf-8"))
+    ids = [unit["id"] for unit in payload.get("units") or []]
+    assert len(ids) == len(set(ids))
+
+
+def test_generated_register_matches_validator_output(tmp_path: Path) -> None:
+    output = tmp_path / "workflow-register.json"
+    result = _run_validator("--generate", "--output", str(output))
+    assert result.returncode == 0, result.stderr
+    generated = json.loads(output.read_text(encoding="utf-8"))
+    committed = json.loads(GENERATED_REGISTER.read_text(encoding="utf-8"))
+    assert generated == committed
+
+
+def test_generated_register_units_sorted_by_id() -> None:
+    payload = json.loads(GENERATED_REGISTER.read_text(encoding="utf-8"))
+    ids = [unit["id"] for unit in payload.get("units") or []]
+    assert ids == sorted(ids)
+
+
+def test_control_plane_partial_coverage_surfaces_missing_units() -> None:
+    disk_count = len(helpers.list_workflow_yaml_files(helpers.WORKFLOWS_DIR))
+    manifest_count = len(helpers.list_manifest_unit_dirs())
+    assert manifest_count < disk_count
+    assert helpers.control_plane_missing_unit_findings() == ()
+
+
+def test_all_manifest_units_pass_validator() -> None:
+    result = _run_validator()
+    assert result.returncode == 0, (
+        f"control_plane_validate failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+
+def test_manifest_schema_documents_status_enum_values() -> None:
+    schema_path = helpers.REPO_ROOT / ".github" / "control-plane" / "schema" / "manifest.schema.yaml"
+    schema = yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+    status_values = set(schema["fields"]["status"]["values"])
+    assert status_values == helpers.MANIFEST_STATUS_VALUES

--- a/tests/unit/scripts/test_label_project_cascade_contract.py
+++ b/tests/unit/scripts/test_label_project_cascade_contract.py
@@ -1,0 +1,113 @@
+"""Label, milestone and project cascade contract tests (#3848)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_label_cascade_workflow_files_exist() -> None:
+    missing = sorted(
+        name
+        for name in helpers.LABEL_CASCADE_WORKFLOW_FILES
+        if not (helpers.WORKFLOWS_DIR / name).is_file()
+    )
+    assert missing == []
+
+
+def test_label_cascade_map_is_fixture_visible_and_deterministic() -> None:
+    first = helpers.build_label_cascade_map()
+    second = helpers.build_label_cascade_map()
+    assert first == second
+    assert set(first) == helpers.LABEL_CASCADE_WORKFLOW_FILES
+
+
+@pytest.mark.parametrize(
+    "filename,expected_issues_types",
+    [
+        ("auto-milestone.yml", ("opened", "reopened")),
+        ("auto-milestone-label-dispatch.yml", ("labeled",)),
+        ("project_status_sync.yml", ("opened", "reopened", "transferred")),
+        ("project_status_label_map.yml", ("closed", "labeled", "reopened", "unlabeled")),
+        ("triage_guard.yml", ("demilestoned", "edited", "milestoned", "opened", "reopened", "transferred")),
+        ("add_to_project.yml", ("opened", "reopened", "transferred")),
+    ],
+)
+def test_issues_trigger_types_are_classified(
+    filename: str,
+    expected_issues_types: tuple[str, ...],
+) -> None:
+    row = helpers.build_label_cascade_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.issues_types == expected_issues_types
+
+
+@pytest.mark.parametrize(
+    "filename,expected_write_permissions",
+    [
+        ("auto-milestone.yml", ("issues:write",)),
+        ("auto-milestone-label-dispatch.yml", ("contents:write",)),
+        ("sync-labels.yml", ("issues:write",)),
+    ],
+)
+def test_label_cascade_write_permissions_are_classified(
+    filename: str,
+    expected_write_permissions: tuple[str, ...],
+) -> None:
+    row = helpers.build_label_cascade_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.write_permissions == expected_write_permissions
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "project_status_sync.yml",
+        "project_status_label_map.yml",
+        "triage_guard.yml",
+        "add_to_project.yml",
+    ],
+)
+def test_project_board_workflows_use_graphql_not_issues_write(filename: str) -> None:
+    row = helpers.build_label_cascade_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.uses_project_api is True
+    assert "issues:write" not in row.write_permissions
+
+
+def test_issues_labeled_cascade_is_explicit_subset() -> None:
+    cascade = helpers.build_label_cascade_map()
+    labeled_files = {
+        name for name, row in cascade.items() if "labeled" in row.issues_types
+    }
+    assert labeled_files == helpers.ISSUES_LABELED_CASCADE_FILES
+
+
+def test_milestone_label_dispatch_repository_dispatch_cascade() -> None:
+    for source, event_type, target in helpers.MILESTONE_DISPATCH_CASCADE:
+        source_content = (helpers.WORKFLOWS_DIR / source).read_text(encoding="utf-8")
+        target_workflow = helpers.load_workflow_yaml(helpers.WORKFLOWS_DIR / target)
+        target_triggers = helpers.extract_on_triggers(target_workflow)
+        assert event_type in source_content
+        assert "repository_dispatch" in target_triggers
+
+
+def test_sync_labels_is_push_triggered_not_issue_cascade() -> None:
+    row = helpers.build_label_cascade_row(helpers.WORKFLOWS_DIR / "sync-labels.yml")
+    assert row.issues_types == ()
+    assert "push" in row.triggers
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.LABEL_CASCADE_WORKFLOW_FILES))
+def test_label_cascade_workflows_document_noise_guards(filename: str) -> None:
+    row = helpers.build_label_cascade_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.has_noise_guard is True
+
+
+def test_no_label_cascade_test_calls_live_project_api() -> None:
+    this_file = Path(__file__)
+    content = this_file.read_text(encoding="utf-8")
+    for marker in helpers.PROJECT_API_MARKERS:
+        assert marker not in content

--- a/tests/unit/scripts/test_scheduled_workflow_cadence_contract.py
+++ b/tests/unit/scripts/test_scheduled_workflow_cadence_contract.py
@@ -1,0 +1,88 @@
+"""Scheduled workflow cadence, noise and collision contract tests (#3851)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+KNOWN_CRON_COLLISIONS = {
+    "0 8 * * 1": ("weekly_digest.yml", "cdb-context-refresh-report.yml"),
+}
+
+
+def test_p1_scheduled_workflow_files_exist() -> None:
+    missing = sorted(
+        name
+        for name in helpers.P1_SCHEDULED_WORKFLOW_FILES
+        if not (helpers.WORKFLOWS_DIR / name).is_file()
+    )
+    assert missing == []
+
+
+def test_schedule_map_is_deterministic_and_visible() -> None:
+    first = helpers.build_p1_schedule_map()
+    second = helpers.build_p1_schedule_map()
+    assert first == second
+    assert set(first) == helpers.P1_SCHEDULED_WORKFLOW_FILES
+
+
+@pytest.mark.parametrize(
+    "filename,expected_crons",
+    [
+        ("weekly_digest.yml", ("0 8 * * 1",)),
+        ("cdb-daily-delta-triage.yml", ("20 6 * * 0", "20 6 * * 2", "20 6 * * 3", "20 6 * * 5")),
+        ("cdb-weekly-control-hygiene-classifier.yml", ("30 7 * * 1", "30 7 * * 4", "30 7 * * 5")),
+        ("cdb-context-refresh-report.yml", ("0 8 * * 1", "0 8 * * 4")),
+        ("stale.yml", ("0 0 * * *",)),
+        ("python-compat.yml", ("0 0 * * 0",)),
+        ("e2e.yml", ("30 6 * * 0",)),
+        ("e2e-tests.yml", ("0 6 * * 0",)),
+        ("e2e-happy-path.yaml", ("30 5 * * 0",)),
+    ],
+)
+def test_known_schedule_cron_classification(
+    filename: str,
+    expected_crons: tuple[str, ...],
+) -> None:
+    entry = helpers.build_schedule_entry(helpers.WORKFLOWS_DIR / filename)
+    assert entry.crons == expected_crons
+
+
+def test_weekly_digest_failure_alert_uses_workflow_run_not_schedule() -> None:
+    entry = helpers.build_schedule_entry(
+        helpers.WORKFLOWS_DIR / "weekly_digest_failure_alert.yml"
+    )
+    assert entry.has_schedule is False
+    assert entry.has_workflow_run is True
+    assert entry.has_workflow_dispatch is True
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.P1_SCHEDULED_WORKFLOW_FILES))
+def test_scheduled_scope_workflows_keep_manual_dispatch_override(filename: str) -> None:
+    entry = helpers.build_schedule_entry(helpers.WORKFLOWS_DIR / filename)
+    if filename == "weekly_digest_failure_alert.yml":
+        assert entry.has_workflow_dispatch is True
+        return
+    if entry.has_schedule:
+        assert entry.has_workflow_dispatch is True
+
+
+def test_cron_collisions_are_surfaced_as_explicit_findings() -> None:
+    schedule_map = helpers.build_p1_schedule_map()
+    collisions = helpers.find_cron_collisions(schedule_map)
+    assert collisions
+    for cron, expected_files in KNOWN_CRON_COLLISIONS.items():
+        assert cron in collisions
+        for filename in expected_files:
+            assert filename in collisions[cron]
+
+
+def test_weekly_digest_and_context_refresh_share_monday_08_utc_collision() -> None:
+    schedule_map = helpers.build_p1_schedule_map()
+    collisions = helpers.find_cron_collisions(schedule_map)
+    assert "0 8 * * 1" in collisions
+    assert "weekly_digest.yml" in collisions["0 8 * * 1"]
+    assert "cdb-context-refresh-report.yml" in collisions["0 8 * * 1"]

--- a/tests/unit/scripts/test_security_workflow_boundary_contract.py
+++ b/tests/unit/scripts/test_security_workflow_boundary_contract.py
@@ -1,0 +1,93 @@
+"""Security workflow dry-run/live boundary contract tests (#3850)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.scripts import _workflow_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_security_workflow_files_exist() -> None:
+    missing = sorted(
+        name
+        for name in helpers.SECURITY_WORKFLOW_FILES
+        if not (helpers.WORKFLOWS_DIR / name).is_file()
+    )
+    assert missing == []
+
+
+@pytest.mark.parametrize("filename", sorted(helpers.SECURITY_WORKFLOW_FILES))
+def test_security_workflows_expose_manual_dispatch(filename: str) -> None:
+    row = helpers.build_security_boundary_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.has_workflow_dispatch is True
+
+
+@pytest.mark.parametrize(
+    "filename,expected_schedule",
+    [
+        ("trivy.yml", True),
+        ("gitleaks.yml", True),
+        ("codeql-python.yml", True),
+        ("security-scan.yml", True),
+        ("security-alert-readout.yml", True),
+    ],
+)
+def test_security_workflows_declare_schedule_trigger(
+    filename: str,
+    expected_schedule: bool,
+) -> None:
+    row = helpers.build_security_boundary_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.has_schedule is expected_schedule
+
+
+@pytest.mark.parametrize(
+    "filename,expected_write_permissions",
+    [
+        ("trivy.yml", ()),
+        ("gitleaks.yml", ()),
+        ("codeql-python.yml", ()),
+        ("security-scan.yml", ()),
+        ("security-alert-readout.yml", ("issues:write", "pull-requests:write")),
+    ],
+)
+def test_security_workflow_write_permissions_are_classified(
+    filename: str,
+    expected_write_permissions: tuple[str, ...],
+) -> None:
+    row = helpers.build_security_boundary_row(helpers.WORKFLOWS_DIR / filename)
+    assert row.write_permissions == expected_write_permissions
+
+
+def test_security_alert_readout_manual_publish_defaults_to_dry_run() -> None:
+    workflow = helpers.load_workflow_yaml(
+        helpers.WORKFLOWS_DIR / "security-alert-readout.yml"
+    )
+    on_triggers = workflow.get("on") or workflow.get(True) or {}
+    inputs = (on_triggers.get("workflow_dispatch") or {}).get("inputs") or {}
+    publish_mode = inputs.get("publish_mode") or {}
+    issue_live = inputs.get("issue_automation_live") or {}
+    assert str(publish_mode.get("default")).lower() == "dry_run"
+    assert str(issue_live.get("default")).lower() == "false"
+
+
+def test_gitleaks_does_not_upload_raw_secret_scan_artifacts() -> None:
+    row = helpers.build_security_boundary_row(helpers.WORKFLOWS_DIR / "gitleaks.yml")
+    assert row.forbids_secret_artifact_upload is True
+    content = (helpers.WORKFLOWS_DIR / "gitleaks.yml").read_text(encoding="utf-8")
+    assert "upload-sarif" in content.lower() or "upload sarif" in content.lower()
+
+
+def test_security_scan_uses_summary_artifacts_not_secret_payloads() -> None:
+    content = (helpers.WORKFLOWS_DIR / "security-scan.yml").read_text(encoding="utf-8")
+    assert "TRIVY_SUMMARY_MAX" in content
+    assert "secrets.json" not in content
+
+
+def test_security_alert_readout_scheduled_vs_manual_boundary_is_documented() -> None:
+    content = (
+        helpers.WORKFLOWS_DIR / "security-alert-readout.yml"
+    ).read_text(encoding="utf-8")
+    assert 'LIVE_MODE="true"' in content
+    assert 'if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then' in content


### PR DESCRIPTION
## Summary
Closes #3848, #3849, #3850, #3851, #3852. Refs #3843.

Batch PR for P1 workflow control-plane contract tests, extending the P0 helper pattern from PR #3895.

## Delivered by issue

### #3848 Label/milestone/project cascade
- `test_label_project_cascade_contract.py` — issues trigger types, write-permission classification, labeled cascade subset, milestone dispatch chain, project API markers, noise guards
- No live Project API in standard CI

### #3849 Agent/AI reachability
- `test_agent_ai_workflow_reachability_contract.py` — reusable Gemini `workflow_call` only, dispatch placeholder, OpenCode id-token, trigger matrix for agent workflows

### #3850 Security dry-run/live boundaries
- `test_security_workflow_boundary_contract.py` — schedule/dispatch classification, security-alert-readout dry_run defaults, gitleaks SARIF-only posture, job-level write scope

### #3851 Scheduled cadence/noise/collisions
- `test_scheduled_workflow_cadence_contract.py` — cron map for P1 scope, workflow_run vs schedule separation, explicit Monday 08:00 UTC collision finding

### #3852 Control-plane manifest/register
- `test_control_plane_manifest_register_contract.py` — manifest status enum, required fields, trigger/permission YAML cross-check, generated register determinism, partial-coverage finding

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_tool_status: blocked (context_briefing unknown_tool)
- repo_fallback_used: true
- repo_fallback_reason: tool_blocked
- records_found: none
- Live GitHub issues #3843/#3848–#3852 verified via `gh issue view`

## Validation
- `pytest -q tests/unit/scripts/` — 651 passed
- `pytest -q tests/test_control_plane.py` — included above
- `ruff check` on touched files — pass
- `git diff --check` — pass

## Non-goals
- No workflow YAML changes
- No register reconciliation or generator architecture changes
- No permission expansion or workflow reactivation
- Register drift (#3853) remains follow-up

## Safety Boundaries
- LR remains NO-GO
- No runtime/DB/MCP/live trading scope
- Tests are fixture/YAML/static inspection only

## Restunsicherheiten
- Cron collision findings are surfaced, not repaired (by design)
- Control-plane catalog remains partial (3 units vs full workflow disk inventory)
