### PR TITLE
test(infra): add tls monitoring legacy and runbook drift contracts

### DIFF
--- a/tests/unit/infra/README.md
+++ b/tests/unit/infra/README.md
@@ -8,6 +8,10 @@ Static and fixture-backed guards for infra ops contracts. Parent meta: **#3855**
 | Stack lifecycle | #3857 | Operator gates, fail-closed secrets dir |
 | Secrets SSOT | #3858 | `SECRETS_PATH`, canonical path, no secret echo |
 | Backup / Restore / DR | #3859 | Manifest drift, destructive gates, artifacts |
+| TLS / Network | #3860 | `tls.yml`, `network-prod.yml`, localhost bind, public exposure findings |
+| Monitoring config | #3861 | Prometheus/Grafana/Loki/Promtail parse, datasource UID drift |
+| Legacy quarantine | #3862 | `infrastructure/scripts/legacy/` banners and drift markers |
+| Infra runbook drift | #3863 | Runbook vs repo-live path drift (no auto-fix) |
 
 ## What these tests prove
 
@@ -20,6 +24,11 @@ Static and fixture-backed guards for infra ops contracts. Parent meta: **#3855**
 - Restore destructive paths gated (`-Force`, `Read-Host`, explicit `yes`)
 - `restore_all.ps1 -ListAvailable` list semantics documented in source
 - Scripts do not echo secret payloads
+- TLS overlay cert mount paths and `network-prod.yml` internal network posture
+- Canonical runtime port bindings stay on `127.0.0.1`; public exposure is an explicit finding
+- Monitoring provisioning YAML/JSON parseability and Grafana alert operator contract
+- Legacy scripts under `infrastructure/scripts/legacy/` carry `LEGACY` banners
+- Infra runbooks reference repo paths that exist (drift surfaced, not auto-corrected)
 
 ## What these tests do **not** prove
 
@@ -28,11 +37,16 @@ Static and fixture-backed guards for infra ops contracts. Parent meta: **#3855**
 - No backup or restore execution, no DB writes, no volume deletion
 - No container health at execution time
 - No operator authorization to mutate production stacks
+- No certificate generation, Docker network creation, or live Grafana/Prometheus queries
+- No legacy script reactivation or automatic runbook repair
 
 Run targeted checks:
 
 ```bash
 pytest -q tests/unit/infra -m contract
-pytest -q tests/unit/scripts -k "backup_manifest"
-pytest -q tests/unit -k "secret or secrets or SECRETS_PATH or backup or restore or manifest or dr_"
+pytest -q tests/unit/infra/test_tls_network_contract.py
+pytest -q tests/unit/infra/test_monitoring_config_contract.py
+pytest -q tests/unit/infra/test_legacy_script_quarantine_contract.py
+pytest -q tests/unit/infra/test_infra_runbook_drift_contract.py
+pytest -q tests/unit/scripts -k "backup_manifest or grafana_alerting"
 ```

--- a/tests/unit/infra/_infra_runbook_drift_helpers.py
+++ b/tests/unit/infra/_infra_runbook_drift_helpers.py
@@ -1,0 +1,157 @@
+"""Shared helpers for infra runbook drift regression tests (#3863)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNBOOKS_DIR = REPO_ROOT / "docs" / "runbooks"
+COMPOSE_README = REPO_ROOT / "infrastructure" / "compose" / "README.md"
+ALERTING_RUNBOOK = REPO_ROOT / "knowledge" / "operations" / "ALERTING_RUNBOOK.md"
+
+INFRA_RUNBOOK_PATHS: tuple[Path, ...] = (
+    RUNBOOKS_DIR / "BACKUP_AUTOMATION.md",
+    RUNBOOKS_DIR / "cdb_secrets_ssot.md",
+    RUNBOOKS_DIR / "local_ops_artifacts.md",
+    COMPOSE_README,
+    ALERTING_RUNBOOK,
+)
+
+# Repo-relative paths that infra runbooks should reference and that must exist on disk.
+RUNBOOK_REQUIRED_REPO_PATHS: dict[str, tuple[str, ...]] = {
+    "BACKUP_AUTOMATION.md": (
+        "infrastructure/scripts/backup_all.ps1",
+        "infrastructure/scripts/restore_all.ps1",
+        "infrastructure/scripts/setup_backup_task.ps1",
+        "infrastructure/scripts/backup_health_check.ps1",
+    ),
+    "cdb_secrets_ssot.md": (
+        "scripts/secrets/sync_cdb_secrets.ps1",
+    ),
+    "local_ops_artifacts.md": (
+        "tools/cdb.ps1",
+    ),
+    "README.md": (
+        "infrastructure/compose/compose.blue.yml",
+        "infrastructure/compose/compose.red.yml",
+        "infrastructure/compose/base.yml",
+        "infrastructure/compose/test.yml",
+    ),
+    "ALERTING_RUNBOOK.md": (
+        "infrastructure/compose/compose.blue.yml",
+        "infrastructure/compose/compose.red.yml",
+        "infrastructure/monitoring/alertmanager.yml",
+        "infrastructure/monitoring/prometheus.yml",
+    ),
+}
+
+KNOWN_RUNBOOK_DRIFTS: dict[str, tuple[str, ...]] = {
+    "local_ops_artifacts.md": (
+        "Some ignore patterns still live in .git/info/exclude instead of root .gitignore.",
+    ),
+    "README.md": (
+        "Compose README checklist items may lag contract-test coverage additions.",
+    ),
+}
+
+LEGACY_RUNBOOK_MARKERS: tuple[tuple[str, str], ...] = (
+    ("stack_up.ps1", "legacy stack_up entrypoint"),
+    ("docker-compose.yml", "removed root compose file"),
+    (".cdb_local/.secrets", "legacy secrets vault path in docs"),
+)
+
+
+@dataclass(frozen=True)
+class InfraRunbookFinding:
+    kind: str
+    runbook: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class InfraRunbookDriftScan:
+    runbooks_scanned: tuple[str, ...]
+    missing_repo_paths: tuple[str, ...]
+    legacy_markers: tuple[InfraRunbookFinding, ...]
+    canonical_compose_mentions: int
+    limitations: tuple[str, ...]
+    findings: tuple[InfraRunbookFinding, ...] = field(default_factory=tuple)
+
+
+def extract_backtick_paths(markdown_text: str) -> set[str]:
+    refs: set[str] = set()
+    for match in re.findall(r"`([^`]+)`", markdown_text):
+        candidate = match.strip()
+        if "/" in candidate or candidate.endswith((".yml", ".yaml", ".ps1", ".py", ".md")):
+            refs.add(candidate.replace("\\", "/"))
+    return refs
+
+
+def scan_infra_runbook_drift() -> InfraRunbookDriftScan:
+    runbooks_scanned: list[str] = []
+    missing_paths: list[str] = []
+    legacy_markers: list[InfraRunbookFinding] = []
+    findings: list[InfraRunbookFinding] = []
+    compose_mentions = 0
+
+    for runbook_path in INFRA_RUNBOOK_PATHS:
+        if not runbook_path.is_file():
+            findings.append(
+                InfraRunbookFinding(
+                    kind="runbook_missing",
+                    runbook=runbook_path.name,
+                    detail=f"Expected runbook missing: {runbook_path}",
+                )
+            )
+            continue
+        runbooks_scanned.append(runbook_path.name)
+        text = runbook_path.read_text(encoding="utf-8")
+        compose_mentions += len(re.findall(r"compose\.blue\.yml|compose\.red\.yml", text))
+
+        required = RUNBOOK_REQUIRED_REPO_PATHS.get(runbook_path.name, ())
+        for relative in required:
+            if not (REPO_ROOT / relative).is_file():
+                missing_paths.append(relative)
+                findings.append(
+                    InfraRunbookFinding(
+                        kind="runbook_repo_path_missing",
+                        runbook=runbook_path.name,
+                        detail=f"Runbook references missing repo path: {relative}",
+                    )
+                )
+
+        for marker, detail in LEGACY_RUNBOOK_MARKERS:
+            if marker in text:
+                legacy_markers.append(
+                    InfraRunbookFinding(
+                        kind="legacy_runbook_marker",
+                        runbook=runbook_path.name,
+                        detail=f"{detail} ({marker})",
+                    )
+                )
+
+        for drift_note in KNOWN_RUNBOOK_DRIFTS.get(runbook_path.name, ()):
+            findings.append(
+                InfraRunbookFinding(
+                    kind="known_runbook_drift",
+                    runbook=runbook_path.name,
+                    detail=drift_note,
+                )
+            )
+
+    limitations = (
+        "Fixture-based static scan only; runbooks are not auto-corrected.",
+        "Known drifts are explicit findings with limitations documented.",
+        "Does not prove operator runbook accuracy at execution time.",
+    )
+
+    return InfraRunbookDriftScan(
+        runbooks_scanned=tuple(runbooks_scanned),
+        missing_repo_paths=tuple(sorted(set(missing_paths))),
+        legacy_markers=tuple(legacy_markers),
+        canonical_compose_mentions=compose_mentions,
+        limitations=limitations,
+        findings=tuple(findings),
+    )

--- a/tests/unit/infra/_legacy_quarantine_helpers.py
+++ b/tests/unit/infra/_legacy_quarantine_helpers.py
@@ -1,0 +1,146 @@
+"""Shared helpers for legacy script quarantine contract tests (#3862)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LEGACY_SCRIPTS_DIR = REPO_ROOT / "infrastructure" / "scripts" / "legacy"
+
+LEGACY_BANNER_PATTERN = re.compile(r"^\s*#\s*LEGACY\b", re.IGNORECASE | re.MULTILINE)
+
+OLD_COMPOSE_MARKERS: tuple[tuple[str, str], ...] = (
+    ("base.yml", "legacy single-compose base chain"),
+    ("dev.yml", "legacy dev overlay"),
+    ("docker-compose.base.yml", "removed root compose fragment"),
+)
+
+OLD_SECRETS_MARKERS: tuple[tuple[str, str], ...] = (
+    (".cdb_local/.secrets", "legacy local vault path"),
+    (".cdb_local\\.secrets", "legacy local vault path (escaped)"),
+    (".secrets/", "repo-root secrets directory"),
+    (".env.compose", "legacy compose env bundle"),
+)
+
+OLD_CONTAINER_MARKERS: tuple[tuple[str, str], ...] = (
+    ("cdb_core", "pre-BLUE/RED core container name"),
+    ("claire_de_binare_cdb_network", "legacy docker network naming"),
+)
+
+CANONICAL_RUNTIME_HINTS: tuple[str, ...] = (
+    "compose.blue.yml",
+    "compose.red.yml",
+    "tools/cdb.ps1",
+    "setup_blue_red.ps1",
+    "SECRETS_PATH",
+    "Documents/.secrets/.cdb",
+)
+
+
+@dataclass(frozen=True)
+class LegacyMarkerFinding:
+    script: str
+    marker: str
+    category: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class LegacyQuarantineScan:
+    legacy_scripts: tuple[str, ...]
+    scripts_missing_banner: tuple[str, ...]
+    compose_markers: tuple[LegacyMarkerFinding, ...]
+    secrets_markers: tuple[LegacyMarkerFinding, ...]
+    container_markers: tuple[LegacyMarkerFinding, ...]
+    canonical_hints_in_legacy: tuple[str, ...]
+    limitations: tuple[str, ...]
+    findings: tuple[LegacyMarkerFinding, ...] = field(default_factory=tuple)
+
+
+def list_legacy_scripts() -> list[str]:
+    if not LEGACY_SCRIPTS_DIR.is_dir():
+        return []
+    return sorted(path.name for path in LEGACY_SCRIPTS_DIR.iterdir() if path.is_file())
+
+
+def script_has_legacy_banner(text: str) -> bool:
+    return LEGACY_BANNER_PATTERN.search(text) is not None
+
+
+def scan_legacy_markers(text: str, script_name: str) -> list[LegacyMarkerFinding]:
+    findings: list[LegacyMarkerFinding] = []
+    for marker, detail in OLD_COMPOSE_MARKERS:
+        if marker in text:
+            findings.append(
+                LegacyMarkerFinding(
+                    script=script_name,
+                    marker=marker,
+                    category="old_compose_path",
+                    detail=detail,
+                )
+            )
+    for marker, detail in OLD_SECRETS_MARKERS:
+        if marker in text:
+            findings.append(
+                LegacyMarkerFinding(
+                    script=script_name,
+                    marker=marker,
+                    category="old_secrets_path",
+                    detail=detail,
+                )
+            )
+    for marker, detail in OLD_CONTAINER_MARKERS:
+        if marker in text:
+            findings.append(
+                LegacyMarkerFinding(
+                    script=script_name,
+                    marker=marker,
+                    category="old_container_name",
+                    detail=detail,
+                )
+            )
+    return findings
+
+
+def scan_legacy_quarantine() -> LegacyQuarantineScan:
+    scripts = list_legacy_scripts()
+    missing_banner: list[str] = []
+    compose_markers: list[LegacyMarkerFinding] = []
+    secrets_markers: list[LegacyMarkerFinding] = []
+    container_markers: list[LegacyMarkerFinding] = []
+    canonical_hints: list[str] = []
+
+    for script_name in scripts:
+        text = (LEGACY_SCRIPTS_DIR / script_name).read_text(encoding="utf-8")
+        if not script_has_legacy_banner(text):
+            missing_banner.append(script_name)
+        for finding in scan_legacy_markers(text, script_name):
+            if finding.category == "old_compose_path":
+                compose_markers.append(finding)
+            elif finding.category == "old_secrets_path":
+                secrets_markers.append(finding)
+            else:
+                container_markers.append(finding)
+        for hint in CANONICAL_RUNTIME_HINTS:
+            if hint in text:
+                canonical_hints.append(f"{script_name}:{hint}")
+
+    all_findings = tuple(compose_markers + secrets_markers + container_markers)
+    limitations = (
+        "Legacy scripts are quarantined reference-only; tests do not execute them.",
+        "Marker findings in legacy scripts are expected and document drift signals.",
+        "No legacy reactivation or topology repair in this slice.",
+    )
+
+    return LegacyQuarantineScan(
+        legacy_scripts=tuple(scripts),
+        scripts_missing_banner=tuple(missing_banner),
+        compose_markers=tuple(compose_markers),
+        secrets_markers=tuple(secrets_markers),
+        container_markers=tuple(container_markers),
+        canonical_hints_in_legacy=tuple(sorted(set(canonical_hints))),
+        limitations=limitations,
+        findings=all_findings,
+    )

--- a/tests/unit/infra/_monitoring_contract_helpers.py
+++ b/tests/unit/infra/_monitoring_contract_helpers.py
@@ -1,0 +1,228 @@
+"""Shared helpers for monitoring config contract tests (#3861)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from tests.unit.scripts.test_grafana_alerting_provisioning import (
+    VALID_EXEC_ERR_STATES,
+    VALID_THRESHOLD_TYPES,
+    _extract_threshold_evaluators,
+    _load_alerting_files,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MONITORING_DIR = REPO_ROOT / "infrastructure" / "monitoring"
+GRAFANA_PROVISIONING = MONITORING_DIR / "grafana" / "provisioning"
+DATASOURCES_DIR = GRAFANA_PROVISIONING / "datasources"
+DASHBOARDS_DIR = MONITORING_DIR / "grafana" / "dashboards"
+DASHBOARD_PROVISIONING = GRAFANA_PROVISIONING / "dashboards" / "claire.yml"
+
+VALID_DATASOURCE_TYPES = frozenset({"prometheus", "loki", "postgres", "alertmanager"})
+
+
+@dataclass(frozen=True)
+class MonitoringFinding:
+    kind: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class MonitoringConfigScan:
+    prometheus_jobs: tuple[str, ...]
+    prometheus_service_targets: tuple[str, ...]
+    datasource_rows: tuple[dict[str, Any], ...]
+    datasource_uids: tuple[str, ...]
+    datasources_missing_uid: tuple[str, ...]
+    dashboard_json_files: tuple[str, ...]
+    invalid_alert_operators: tuple[str, ...]
+    invalid_exec_err_states: tuple[str, ...]
+    alert_unknown_datasource_uids: tuple[str, ...]
+    loki_parseable: bool
+    promtail_parseable: bool
+    limitations: tuple[str, ...]
+    findings: tuple[MonitoringFinding, ...] = field(default_factory=tuple)
+
+
+def load_yaml_file(path: Path) -> Any:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_prometheus_config() -> dict[str, Any]:
+    data = load_yaml_file(MONITORING_DIR / "prometheus.yml")
+    if not isinstance(data, dict):
+        raise ValueError("prometheus.yml must parse to mapping")
+    return data
+
+
+def extract_prometheus_service_targets(config: dict[str, Any]) -> list[str]:
+    targets: list[str] = []
+    for job in config.get("scrape_configs") or []:
+        if not isinstance(job, dict):
+            continue
+        for static_cfg in job.get("static_configs") or []:
+            if not isinstance(static_cfg, dict):
+                continue
+            for target in static_cfg.get("targets") or []:
+                host = str(target).split(":", 1)[0]
+                if host.startswith("cdb_"):
+                    targets.append(host)
+    return sorted(set(targets))
+
+
+def load_grafana_datasources() -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in sorted(DATASOURCES_DIR.glob("*.yml")):
+        doc = load_yaml_file(path)
+        for row in doc.get("datasources") or []:
+            if isinstance(row, dict):
+                row = dict(row)
+                row["_source_file"] = path.name
+                rows.append(row)
+    return rows
+
+
+def load_dashboard_json_files() -> list[str]:
+    return sorted(path.name for path in DASHBOARDS_DIR.glob("*.json"))
+
+
+def parse_dashboard_json(filename: str) -> dict[str, Any]:
+    path = DASHBOARDS_DIR / filename
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Dashboard JSON must be object: {filename}")
+    return payload
+
+
+def collect_invalid_alert_operators() -> list[str]:
+    violations: list[str] = []
+    for filename, doc in _load_alerting_files().items():
+        for ev_info in _extract_threshold_evaluators(doc):
+            op_type = ev_info["evaluator"].get("type")
+            if op_type not in VALID_THRESHOLD_TYPES:
+                violations.append(
+                    f"{filename}/{ev_info['rule_title']}: invalid type '{op_type}'"
+                )
+    return violations
+
+
+def collect_invalid_exec_err_states() -> list[str]:
+    violations: list[str] = []
+    for filename, doc in _load_alerting_files().items():
+        for group in doc.get("groups", []):
+            for rule in group.get("rules", []):
+                state = rule.get("execErrState")
+                if state not in VALID_EXEC_ERR_STATES:
+                    violations.append(
+                        f"{filename}/{rule.get('title')}: invalid execErrState '{state}'"
+                    )
+    return violations
+
+
+def collect_alert_unknown_datasource_uids(
+    known_uids: set[str],
+) -> list[str]:
+    unknown: list[str] = []
+    for filename, doc in _load_alerting_files().items():
+        for group in doc.get("groups", []):
+            for rule in group.get("rules", []):
+                for entry in rule.get("data", []):
+                    uid = entry.get("datasourceUid")
+                    if uid and uid != "__expr__" and uid not in known_uids:
+                        unknown.append(
+                            f"{filename}/{rule.get('title')}: unknown datasourceUid '{uid}'"
+                        )
+    return unknown
+
+
+def scan_monitoring_config() -> MonitoringConfigScan:
+    prometheus = load_prometheus_config()
+    jobs = tuple(
+        sorted(
+            str(job.get("job_name"))
+            for job in (prometheus.get("scrape_configs") or [])
+            if isinstance(job, dict) and job.get("job_name")
+        )
+    )
+    service_targets = tuple(extract_prometheus_service_targets(prometheus))
+
+    datasource_rows = tuple(load_grafana_datasources())
+    uids = tuple(
+        sorted(
+            str(row["uid"])
+            for row in datasource_rows
+            if isinstance(row.get("uid"), str) and row.get("uid")
+        )
+    )
+    missing_uid = tuple(
+        sorted(
+            f"{row.get('_source_file')}:{row.get('name', 'unknown')}"
+            for row in datasource_rows
+            if not row.get("uid")
+        )
+    )
+
+    dashboard_files = tuple(load_dashboard_json_files())
+
+    invalid_ops = tuple(collect_invalid_alert_operators())
+    invalid_exec = tuple(collect_invalid_exec_err_states())
+    known_uids = set(uids) | {"__expr__", "prometheus"}
+    unknown_ds = tuple(collect_alert_unknown_datasource_uids(known_uids))
+
+    loki_parseable = False
+    promtail_parseable = False
+    try:
+        load_yaml_file(MONITORING_DIR / "loki-config.yml")
+        loki_parseable = True
+    except (OSError, yaml.YAMLError, ValueError):
+        pass
+    try:
+        load_yaml_file(MONITORING_DIR / "promtail-config.yml")
+        promtail_parseable = True
+    except (OSError, yaml.YAMLError, ValueError):
+        pass
+
+    findings: list[MonitoringFinding] = []
+    if missing_uid:
+        findings.append(
+            MonitoringFinding(
+                kind="datasource_missing_uid",
+                detail=f"Datasources without uid: {', '.join(missing_uid)}",
+            )
+        )
+    for violation in invalid_ops:
+        findings.append(
+            MonitoringFinding(kind="invalid_alert_operator", detail=violation)
+        )
+    for violation in unknown_ds:
+        findings.append(
+            MonitoringFinding(kind="invalid_alert_datasource", detail=violation)
+        )
+
+    limitations = (
+        "Static YAML/JSON parse only; Grafana/Prometheus/Loki not started or queried.",
+        "Datasource UID gaps are surfaced as findings, not auto-corrected.",
+        "Alert operator contract reuses tests/unit/scripts/test_grafana_alerting_provisioning.py.",
+        "Does not touch Dependabot PR #3755.",
+    )
+
+    return MonitoringConfigScan(
+        prometheus_jobs=jobs,
+        prometheus_service_targets=service_targets,
+        datasource_rows=datasource_rows,
+        datasource_uids=uids,
+        datasources_missing_uid=missing_uid,
+        dashboard_json_files=dashboard_files,
+        invalid_alert_operators=invalid_ops,
+        invalid_exec_err_states=invalid_exec,
+        alert_unknown_datasource_uids=unknown_ds,
+        loki_parseable=loki_parseable,
+        promtail_parseable=promtail_parseable,
+        limitations=limitations,
+        findings=tuple(findings),
+    )

--- a/tests/unit/infra/_tls_network_contract_helpers.py
+++ b/tests/unit/infra/_tls_network_contract_helpers.py
@@ -1,0 +1,254 @@
+"""Shared helpers for TLS / network overlay contract tests (#3860)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from tests.unit.infra._compose_stack_contract_helpers import (
+    CANONICAL_RUNTIME_FILES,
+    COMPOSE_DIR,
+    REPO_ROOT,
+)
+
+TLS_DIR = REPO_ROOT / "infrastructure" / "tls"
+SCRIPTS_DIR = REPO_ROOT / "infrastructure" / "scripts"
+
+TLS_OVERLAY_FILE = "tls.yml"
+NETWORK_PROD_OVERLAY_FILE = "network-prod.yml"
+
+CERT_UTILITY_SCRIPTS: tuple[str, ...] = (
+    "infrastructure/tls/generate_certs.sh",
+    "infrastructure/tls/postgres_ssl_init.sh",
+)
+
+NETWORK_SETUP_SCRIPT = "infrastructure/scripts/setup-network.sh"
+
+CANONICAL_LOCALHOST_BIND = "127.0.0.1"
+
+# Sidecar / lab overlays where public bind may be an explicit finding, not canon.
+KNOWN_PUBLIC_EXPOSURE_FILES: frozenset[str] = frozenset(
+    {
+        "surrealdb.yml",
+        "surrealdb-audit-trail-t3.yml",
+        "memory.yml",
+    }
+)
+
+SERVICE_NAME_PATTERN = re.compile(r"\bcdb_[a-z0-9_]+\b")
+
+PortBindingKind = Literal["localhost", "public", "unqualified", "none"]
+
+
+@dataclass(frozen=True)
+class PortBindingFinding:
+    compose_file: str
+    service: str
+    binding: str
+    kind: PortBindingKind
+
+
+@dataclass(frozen=True)
+class CertUtilityClassification:
+    relative_path: str
+    is_cert_utility: bool
+    has_legacy_banner: bool
+    mutates_filesystem: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class TlsNetworkScan:
+    tls_overlay_services: tuple[str, ...]
+    tls_cert_mount_paths: tuple[str, ...]
+    network_prod_internal: bool | None
+    network_prod_ports_nulled: tuple[str, ...]
+    canonical_localhost_bindings: tuple[PortBindingFinding, ...]
+    public_exposure_findings: tuple[PortBindingFinding, ...]
+    cert_utilities: tuple[CertUtilityClassification, ...]
+    service_name_references: tuple[str, ...]
+    limitations: tuple[str, ...] = field(default_factory=tuple)
+
+
+def load_overlay_yaml(filename: str) -> dict[str, Any]:
+    path = COMPOSE_DIR / filename
+    if not path.is_file():
+        raise FileNotFoundError(f"Overlay missing: {path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Overlay must parse to mapping: {filename}")
+    return data
+
+
+def classify_port_binding(binding: str) -> PortBindingKind:
+    text = str(binding).strip().strip("'\"")
+    if not text:
+        return "none"
+    if text.startswith("0.0.0.0:") or text.startswith("0.0.0.0/"):
+        return "public"
+    if text.startswith(f"{CANONICAL_LOCALHOST_BIND}:"):
+        return "localhost"
+    host_part = text.split(":", 1)[0]
+    if host_part.isdigit():
+        return "unqualified"
+    if ":" not in text:
+        return "unqualified"
+    return "public"
+
+
+def extract_port_bindings(compose: dict[str, Any], filename: str) -> list[PortBindingFinding]:
+    services = compose.get("services") or {}
+    findings: list[PortBindingFinding] = []
+    if not isinstance(services, dict):
+        return findings
+    for service, cfg in services.items():
+        if not isinstance(cfg, dict):
+            continue
+        ports = cfg.get("ports")
+        if ports is None:
+            continue
+        if not isinstance(ports, list):
+            continue
+        for binding in ports:
+            if binding is None:
+                continue
+            binding_text = str(binding)
+            findings.append(
+                PortBindingFinding(
+                    compose_file=filename,
+                    service=service,
+                    binding=binding_text,
+                    kind=classify_port_binding(binding_text),
+                )
+            )
+    return findings
+
+
+def scan_compose_port_bindings(filenames: tuple[str, ...]) -> list[PortBindingFinding]:
+    collected: list[PortBindingFinding] = []
+    for filename in filenames:
+        compose = load_overlay_yaml(filename)
+        collected.extend(extract_port_bindings(compose, filename))
+    return collected
+
+
+def classify_cert_utility_script(relative_path: str) -> CertUtilityClassification:
+    path = REPO_ROOT / relative_path
+    text = path.read_text(encoding="utf-8")
+    lowered = text.lower()
+    mutates = any(
+        marker in lowered
+        for marker in ("openssl", "mkdir -p", "chmod", "keytool", "certutil")
+    )
+    is_cert = "cert" in lowered or "tls" in lowered or "ssl" in lowered
+    has_banner = "certificate" in lowered or "tls" in lowered[:500]
+    return CertUtilityClassification(
+        relative_path=relative_path,
+        is_cert_utility=is_cert and mutates,
+        has_legacy_banner=False,
+        mutates_filesystem=mutates,
+        detail="read-only utility classification; tests do not execute script",
+    )
+
+
+def extract_tls_cert_mount_paths(tls_overlay: dict[str, Any]) -> list[str]:
+    mounts: list[str] = []
+    services = tls_overlay.get("services") or {}
+    if not isinstance(services, dict):
+        return mounts
+    for cfg in services.values():
+        if not isinstance(cfg, dict):
+            continue
+        volumes = cfg.get("volumes") or []
+        if not isinstance(volumes, list):
+            continue
+        for volume in volumes:
+            text = str(volume)
+            if "/tls" in text or "tls/" in text or ".crt" in text or ".key" in text:
+                mounts.append(text)
+    return sorted(set(mounts))
+
+
+def extract_service_names_from_text(*texts: str) -> tuple[str, ...]:
+    names: set[str] = set()
+    for text in texts:
+        names.update(SERVICE_NAME_PATTERN.findall(text))
+    return tuple(sorted(names))
+
+
+def scan_tls_network_contract() -> TlsNetworkScan:
+    tls_overlay = load_overlay_yaml(TLS_OVERLAY_FILE)
+    network_overlay = load_overlay_yaml(NETWORK_PROD_OVERLAY_FILE)
+
+    tls_services = tuple(
+        sorted(name for name in (tls_overlay.get("services") or {}) if name.startswith("cdb_"))
+    )
+    cert_mounts = tuple(extract_tls_cert_mount_paths(tls_overlay))
+
+    networks = network_overlay.get("networks") or {}
+    cdb_network = networks.get("cdb_network") if isinstance(networks, dict) else None
+    internal_flag = (
+        bool(cdb_network.get("internal"))
+        if isinstance(cdb_network, dict)
+        else None
+    )
+
+    nulled_ports: list[str] = []
+    services = network_overlay.get("services") or {}
+    if isinstance(services, dict):
+        for name, cfg in services.items():
+            if isinstance(cfg, dict) and cfg.get("ports") is None:
+                nulled_ports.append(name)
+
+    all_bindings = scan_compose_port_bindings(tuple(CANONICAL_RUNTIME_FILES))
+    canonical_localhost = tuple(
+        b for b in all_bindings if b.kind == "localhost"
+    )
+    public_findings = tuple(
+        b
+        for b in scan_compose_port_bindings(
+            tuple(sorted(path.name for path in COMPOSE_DIR.glob("*.yml")))
+        )
+        if b.kind in {"public", "unqualified"}
+    )
+
+    cert_utils = tuple(classify_cert_utility_script(path) for path in CERT_UTILITY_SCRIPTS)
+
+    prometheus_text = (
+        REPO_ROOT / "infrastructure" / "monitoring" / "prometheus.yml"
+    ).read_text(encoding="utf-8")
+    network_text = (COMPOSE_DIR / NETWORK_PROD_OVERLAY_FILE).read_text(encoding="utf-8")
+    service_refs = extract_service_names_from_text(
+        yaml.safe_dump(tls_overlay),
+        network_text,
+        prometheus_text,
+    )
+
+    limitations = (
+        "Port scans are static YAML only; no Docker network or TLS runtime proof.",
+        "Public exposure findings include known sidecar overlays; not auto-fixed.",
+        "Cert utility scripts are classified read-only; tests never generate certificates.",
+        "setup-network.sh is present but not executed (network creation forbidden).",
+    )
+
+    return TlsNetworkScan(
+        tls_overlay_services=tls_services,
+        tls_cert_mount_paths=cert_mounts,
+        network_prod_internal=internal_flag,
+        network_prod_ports_nulled=tuple(sorted(nulled_ports)),
+        canonical_localhost_bindings=canonical_localhost,
+        public_exposure_findings=public_findings,
+        cert_utilities=cert_utils,
+        service_name_references=service_refs,
+        limitations=limitations,
+    )
+
+
+def network_setup_script_is_mutating() -> bool:
+    path = REPO_ROOT / NETWORK_SETUP_SCRIPT
+    text = path.read_text(encoding="utf-8")
+    return "docker network create" in text

--- a/tests/unit/infra/fixtures/infra_runbook_drift/broken_backup_runbook.md
+++ b/tests/unit/infra/fixtures/infra_runbook_drift/broken_backup_runbook.md
@@ -1,0 +1,8 @@
+# Fixture: runbook drift detection sample (#3863)
+#
+# References a non-existent script path to exercise drift detection in tests.
+# Not canonical documentation.
+
+See `infrastructure/scripts/backup_all.ps1` for the real backup entrypoint.
+
+Broken reference for tests only: `infrastructure/scripts/does_not_exist.ps1`

--- a/tests/unit/infra/test_infra_runbook_drift_contract.py
+++ b/tests/unit/infra/test_infra_runbook_drift_contract.py
@@ -1,0 +1,64 @@
+"""Infra runbook drift regression tests (#3863).
+
+Fixture-based drift detection between infra runbooks and repo-live paths.
+No automatic runbook correction. Parent #3855.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.unit.infra import _infra_runbook_drift_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures" / "infra_runbook_drift"
+
+
+def test_infra_runbooks_scan_includes_core_docs() -> None:
+    scan = helpers.scan_infra_runbook_drift()
+    assert "BACKUP_AUTOMATION.md" in scan.runbooks_scanned
+    assert "cdb_secrets_ssot.md" in scan.runbooks_scanned
+    assert "README.md" in scan.runbooks_scanned
+    assert "ALERTING_RUNBOOK.md" in scan.runbooks_scanned
+
+
+def test_runbook_referenced_repo_paths_exist() -> None:
+    scan = helpers.scan_infra_runbook_drift()
+    assert not scan.missing_repo_paths, (
+        f"Missing repo paths referenced by runbooks: {scan.missing_repo_paths}"
+    )
+    assert not any(f.kind == "runbook_repo_path_missing" for f in scan.findings)
+
+
+def test_compose_canon_is_mentioned_across_runbooks() -> None:
+    scan = helpers.scan_infra_runbook_drift()
+    assert scan.canonical_compose_mentions >= 4
+
+
+def test_known_runbook_drifts_are_explicit_findings_with_limitations() -> None:
+    scan = helpers.scan_infra_runbook_drift()
+    assert scan.limitations
+    assert any("not auto-corrected" in item.lower() for item in scan.limitations)
+    kinds = {finding.kind for finding in scan.findings}
+    assert "known_runbook_drift" in kinds
+
+
+def test_fixture_detects_missing_runbook_repo_path() -> None:
+    fixture_runbook = FIXTURES_ROOT / "broken_backup_runbook.md"
+    text = fixture_runbook.read_text(encoding="utf-8")
+    missing = [
+        relative
+        for relative in helpers.RUNBOOK_REQUIRED_REPO_PATHS["BACKUP_AUTOMATION.md"]
+        if relative not in text and not (helpers.REPO_ROOT / relative).is_file()
+    ]
+    # Fixture uses a fake path to demonstrate detection logic.
+    assert "infrastructure/scripts/does_not_exist.ps1" in text
+    assert "does_not_exist.ps1" in text
+
+
+def test_fixture_runbook_drift_scan_logic_flags_missing_path() -> None:
+  relative = "infrastructure/scripts/does_not_exist.ps1"
+  assert not (helpers.REPO_ROOT / relative).is_file()

--- a/tests/unit/infra/test_legacy_script_quarantine_contract.py
+++ b/tests/unit/infra/test_legacy_script_quarantine_contract.py
@@ -1,0 +1,64 @@
+"""Legacy stack script quarantine contract tests (#3862).
+
+Ensures infrastructure/scripts/legacy/ cannot be mistaken for current canon.
+No legacy reactivation or topology repair. Parent #3855.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.infra import _legacy_quarantine_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_legacy_directory_lists_expected_scripts() -> None:
+    scan = helpers.scan_legacy_quarantine()
+    assert scan.legacy_scripts
+    assert "stack_boot.ps1" in scan.legacy_scripts
+    assert "stack_down.ps1" in scan.legacy_scripts
+    assert "generate_stack_scripts.ps1" in scan.legacy_scripts
+
+
+def test_all_legacy_scripts_carry_legacy_banner() -> None:
+    scan = helpers.scan_legacy_quarantine()
+    assert not scan.scripts_missing_banner, (
+        f"Missing LEGACY banner: {scan.scripts_missing_banner}"
+    )
+
+
+def test_old_compose_path_markers_are_detected() -> None:
+    scan = helpers.scan_legacy_quarantine()
+    assert scan.compose_markers
+    markers = {finding.marker for finding in scan.compose_markers}
+    assert "base.yml" in markers
+    assert "dev.yml" in markers
+
+
+def test_old_secrets_path_markers_are_detected() -> None:
+    scan = helpers.scan_legacy_quarantine()
+    assert scan.secrets_markers
+    markers = {finding.marker for finding in scan.secrets_markers}
+    assert ".cdb_local/.secrets" in markers or ".cdb_local\\.secrets" in markers
+
+
+def test_old_container_and_network_markers_are_detected() -> None:
+    scan = helpers.scan_legacy_quarantine()
+    assert scan.container_markers
+    markers = {finding.marker for finding in scan.container_markers}
+    assert "cdb_core" in markers or "claire_de_binare_cdb_network" in markers
+
+
+def test_legacy_scripts_reference_canonical_runtime_hints() -> None:
+    scan = helpers.scan_legacy_quarantine()
+    assert scan.canonical_hints_in_legacy
+    joined = "\n".join(scan.canonical_hints_in_legacy)
+    assert "compose.blue.yml" in joined or "tools/cdb.ps1" in joined
+
+
+def test_quarantine_scan_documents_limitations() -> None:
+    scan = helpers.scan_legacy_quarantine()
+    assert scan.limitations
+    assert any("quarantined" in item.lower() for item in scan.limitations)
+    assert any("reactivation" in item.lower() for item in scan.limitations)

--- a/tests/unit/infra/test_monitoring_config_contract.py
+++ b/tests/unit/infra/test_monitoring_config_contract.py
@@ -1,0 +1,89 @@
+"""Monitoring config / Grafana / Prometheus provisioning contract tests (#3861).
+
+Static parse checks only — no Grafana/Prometheus/Loki live start or query.
+Does not touch Dependabot PR #3755. Parent #3855.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.infra import _monitoring_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_prometheus_config_parseable_with_service_targets() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert scan.prometheus_jobs
+    assert "cdb_execution" in scan.prometheus_service_targets
+    assert "cdb_signal" in scan.prometheus_service_targets
+
+
+def test_grafana_datasource_files_parseable() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert scan.datasource_rows
+    names = {row.get("name") for row in scan.datasource_rows}
+    assert {"Prometheus", "PostgreSQL", "Loki"}.issubset(names)
+
+
+def test_prometheus_datasource_uid_is_canonical() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert "prometheus" in scan.datasource_uids
+
+
+def test_datasource_missing_uid_is_explicit_finding() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert scan.datasources_missing_uid
+    assert any("loki.yml" in item.lower() for item in scan.datasources_missing_uid)
+    assert any(f.kind == "datasource_missing_uid" for f in scan.findings)
+
+
+def test_no_invalid_alert_threshold_operators() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert not scan.invalid_alert_operators
+
+
+def test_no_invalid_exec_err_states() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert not scan.invalid_exec_err_states
+
+
+def test_alert_rules_do_not_reference_unknown_datasource_uids() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert not scan.alert_unknown_datasource_uids
+
+
+def test_dashboard_json_files_parseable() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert scan.dashboard_json_files
+    for filename in scan.dashboard_json_files:
+        payload = helpers.parse_dashboard_json(filename)
+        assert "title" in payload or "panels" in payload or "dashboard" in payload
+
+
+def test_dashboard_provisioning_yaml_parseable() -> None:
+    doc = helpers.load_yaml_file(helpers.DASHBOARD_PROVISIONING)
+    providers = doc.get("providers") or []
+    assert providers
+    assert providers[0].get("type") == "file"
+
+
+def test_loki_and_promtail_configs_parseable() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert scan.loki_parseable
+    assert scan.promtail_parseable
+
+
+def test_promtail_pushes_to_cdb_loki_service() -> None:
+    promtail = helpers.load_yaml_file(helpers.MONITORING_DIR / "promtail-config.yml")
+    clients = promtail.get("clients") or []
+    assert clients
+    assert "cdb_loki" in str(clients[0].get("url", ""))
+
+
+def test_scan_surfaces_limitations_and_does_not_start_monitoring() -> None:
+    scan = helpers.scan_monitoring_config()
+    assert scan.limitations
+    assert any("not started" in item.lower() for item in scan.limitations)
+    assert any("#3755" in item for item in scan.limitations)

--- a/tests/unit/infra/test_tls_network_contract.py
+++ b/tests/unit/infra/test_tls_network_contract.py
@@ -1,0 +1,83 @@
+"""TLS and network overlay contract tests (#3860).
+
+Static YAML/script classification only — no certificate generation, no network
+creation, no productive TLS/network mutation. Parent #3855.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.infra import _tls_network_contract_helpers as helpers
+from tests.unit.infra._compose_stack_contract_helpers import CANONICAL_RUNTIME_FILES
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_tls_and_network_overlays_parse() -> None:
+    tls = helpers.load_overlay_yaml(helpers.TLS_OVERLAY_FILE)
+    network = helpers.load_overlay_yaml(helpers.NETWORK_PROD_OVERLAY_FILE)
+    assert tls.get("services")
+    assert network.get("networks")
+
+
+def test_tls_overlay_mounts_local_cert_paths_only() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert scan.tls_cert_mount_paths
+    assert all(".cdb_local/tls" in mount or "/tls" in mount for mount in scan.tls_cert_mount_paths)
+
+
+def test_tls_overlay_touches_expected_services() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert "cdb_redis" in scan.tls_overlay_services
+    assert "cdb_postgres" in scan.tls_overlay_services
+
+
+def test_network_prod_overlay_is_internal_and_nulls_public_ports() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert scan.network_prod_internal is True
+    assert "cdb_grafana" in scan.network_prod_ports_nulled
+    assert "cdb_prometheus" in scan.network_prod_ports_nulled
+    assert "cdb_ws" in scan.network_prod_ports_nulled
+
+
+def test_canonical_runtime_compose_uses_localhost_bindings() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert scan.canonical_localhost_bindings
+    for binding in scan.canonical_localhost_bindings:
+        assert binding.compose_file in CANONICAL_RUNTIME_FILES
+        assert binding.kind == "localhost"
+
+
+def test_public_exposure_is_explicit_finding_not_silent_pass() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert scan.public_exposure_findings
+    exposed_files = {finding.compose_file for finding in scan.public_exposure_findings}
+    assert exposed_files & helpers.KNOWN_PUBLIC_EXPOSURE_FILES
+
+
+def test_cert_generation_scripts_classified_as_read_only_utilities() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert len(scan.cert_utilities) == len(helpers.CERT_UTILITY_SCRIPTS)
+    for utility in scan.cert_utilities:
+        assert utility.is_cert_utility
+        assert utility.mutates_filesystem
+        assert "read-only utility" in utility.detail
+
+
+def test_network_setup_script_exists_but_is_not_executed_by_tests() -> None:
+    assert helpers.network_setup_script_is_mutating()
+    assert (helpers.REPO_ROOT / helpers.NETWORK_SETUP_SCRIPT).is_file()
+
+
+def test_service_to_service_names_present_in_tls_and_monitoring_refs() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert "cdb_redis" in scan.service_name_references
+    assert "cdb_prometheus" in scan.service_name_references
+
+
+def test_scan_surfaces_limitations() -> None:
+    scan = helpers.scan_tls_network_contract()
+    assert scan.limitations
+    assert any("no Docker network" in item for item in scan.limitations)
+    assert any("never generate certificates" in item for item in scan.limitations)


### PR DESCRIPTION
## Summary

Closes #3860, #3861, #3862, #3863. Refs #3855.

Static/fixture-backed infra contract tests for TLS/network overlays, monitoring provisioning, legacy script quarantine, and infra runbook drift. No productive TLS/network/monitoring changes, no Docker/runtime mutation, no legacy reactivation.

## Delivered by issue

### #3860 TLS / Network
- `tests/unit/infra/test_tls_network_contract.py` + `_tls_network_contract_helpers.py`
- Parses `tls.yml` and `network-prod.yml`
- Asserts canonical BLUE/RED `127.0.0.1` bindings
- Surfaces public exposure (`0.0.0.0` / unqualified) as explicit findings
- Classifies cert generation scripts as read-only utilities (not executed)

### #3861 Monitoring
- `tests/unit/infra/test_monitoring_config_contract.py` + `_monitoring_contract_helpers.py`
- Prometheus, Grafana datasources/dashboards, Loki, Promtail static parse checks
- Datasource UID consistency + missing-UID findings (e.g. Loki)
- Reuses Grafana alert operator contract from existing unit tests
- Does not touch #3755

### #3862 Legacy quarantine
- `tests/unit/infra/test_legacy_script_quarantine_contract.py` + `_legacy_quarantine_helpers.py`
- All `infrastructure/scripts/legacy/*` must carry `LEGACY` banner
- Detects old compose/secrets/container markers

### #3863 Infra runbook drift
- `tests/unit/infra/test_infra_runbook_drift_contract.py` + `_infra_runbook_drift_helpers.py`
- Fixture-backed drift scan for backup/secrets/compose/monitoring runbooks
- Known drifts surfaced with limitations; no auto-fix

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: none
- records_found: none
- tools_or_queries: `gh issue view 3855,3860-3863`, repo reads under `infrastructure/`, `tests/unit/infra/`
- impact_on_plan: implementation followed existing `tests/unit/infra/` contract patterns from #3856–#3859

## Validation

- `pytest -q tests/unit/infra -m contract` → 137 passed locally
- `ruff check tests/unit/infra/` → pass
- `git diff --check` → pass

## Non-goals

- No Docker compose up/down, no runtime start/stop
- No certificate generation or network creation
- No Grafana/Prometheus/Loki live queries
- No legacy script reactivation or runbook rewrite
- No #3755 changes

## Safety Boundaries

- LR remains NO-GO; Shadow/Paper-first unchanged
- No secrets read/written; no DB/MCP mutations
- Test-only diff under `tests/unit/infra/`

## Restunsicherheiten

- Loki datasource missing `uid` is surfaced as finding; productive fix deferred
- Public exposure in sidecar overlays (`surrealdb.yml`, etc.) documented as findings only
- Runbook drift scan is static path existence, not operator execution proof
