### PR TITLE
test(runtime): add main runtime p2 map and drift contracts

### DIFF
--- a/.github/control-plane/generated/agent-main-runtime-test-map.json
+++ b/.github/control-plane/generated/agent-main-runtime-test-map.json
@@ -1,0 +1,201 @@
+{
+  "schema_version": "1",
+  "coverage": "partial",
+  "catalog_scope": "agent-facing-main-runtime-test-map-p2",
+  "limitations": [
+    "Partial coverage only \u2014 not all runtime services have contract-test entries.",
+    "Eventflow surfaces allocation, candles, ws, and db_writer are not mapped here.",
+    "Map lists primary P0/P1 contract tests; broader unit suites are out of scope.",
+    "Missing mappings are surfaced explicitly; absence does not imply no tests exist.",
+    "No coverage percentage or complete-coverage claim."
+  ],
+  "required_surfaces": [
+    "execution",
+    "market",
+    "regime",
+    "risk",
+    "signal",
+    "validation"
+  ],
+  "mapped_surfaces": [
+    "execution",
+    "market",
+    "regime",
+    "risk",
+    "signal",
+    "validation"
+  ],
+  "missing_required_surfaces": [],
+  "known_unmapped_runtime_surfaces": [
+    {
+      "service": "cdb_candles",
+      "reason": "no dedicated P0/P1 contract-test entry in this map"
+    },
+    {
+      "service": "cdb_allocation",
+      "reason": "no dedicated P0/P1 contract-test entry in this map"
+    },
+    {
+      "service": "cdb_ws",
+      "reason": "RED stack feed; no dedicated main-runtime contract entry"
+    },
+    {
+      "service": "cdb_db_writer",
+      "reason": "persistence consumer; covered indirectly via IO contract"
+    }
+  ],
+  "entry_count": 18,
+  "canonical_entry_count": 14,
+  "supplemental_entry_count": 4,
+  "entries": [
+    {
+      "surface": "market",
+      "behavior": "ingest candles and publish market_state with fail-closed validation",
+      "service": "cdb_market",
+      "test": "tests/unit/market/test_market_candles_ingestion_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3831"
+    },
+    {
+      "surface": "regime",
+      "behavior": "classify market regime and emit UNKNOWN on invalid candles",
+      "service": "cdb_regime",
+      "test": "tests/unit/regime/test_regime_service_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3832"
+    },
+    {
+      "surface": "regime",
+      "behavior": "regime_id semantics and risk-boundary mapping",
+      "service": "cdb_regime",
+      "test": "tests/unit/regime/test_regime_id_semantics_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3832"
+    },
+    {
+      "surface": "signal",
+      "behavior": "signal core fail-closed and config hash contract",
+      "service": "cdb_signal",
+      "test": "tests/unit/signal/test_signal_core_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3833"
+    },
+    {
+      "surface": "signal",
+      "behavior": "optimizer stub contract and unknown adapter fail-closed",
+      "service": "cdb_signal",
+      "test": "tests/unit/signal/test_optimizer_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3833"
+    },
+    {
+      "surface": "signal",
+      "behavior": "market classifier warmup and UNKNOWN emit contract",
+      "service": "cdb_signal",
+      "test": "tests/unit/signal/test_market_classifier_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3832"
+    },
+    {
+      "surface": "risk",
+      "behavior": "decision matrix allow/block semantics",
+      "service": "cdb_risk",
+      "test": "tests/unit/risk/test_decision_matrix_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3834"
+    },
+    {
+      "surface": "risk",
+      "behavior": "reason-code contract and fail-closed blocking",
+      "service": "cdb_risk",
+      "test": "tests/unit/risk/test_reason_codes_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3834"
+    },
+    {
+      "surface": "risk",
+      "behavior": "live-trading gate blocks without explicit confirmation",
+      "service": "cdb_risk",
+      "test": "tests/unit/risk/test_live_trading_gate_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3834"
+    },
+    {
+      "surface": "execution",
+      "behavior": "paper/live boundary and mock-trading fail-closed",
+      "service": "cdb_execution",
+      "test": "tests/unit/execution/test_execution_boundary_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3835"
+    },
+    {
+      "surface": "execution",
+      "behavior": "order state-machine transitions",
+      "service": "cdb_execution",
+      "test": "tests/unit/execution/test_state_machine_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3835"
+    },
+    {
+      "surface": "execution",
+      "behavior": "paper order result contract",
+      "service": "cdb_execution",
+      "test": "tests/unit/execution/test_paper_order_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3835"
+    },
+    {
+      "surface": "validation",
+      "behavior": "profitability validation regression and evidence-only scoring",
+      "service": "cdb_validation",
+      "test": "tests/unit/validation/test_profitability_validation_regression_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3840"
+    },
+    {
+      "surface": "validation",
+      "behavior": "stimulus regime signal contract",
+      "service": "cdb_validation",
+      "test": "tests/unit/validation/test_stimulus_regime_signal_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3840"
+    },
+    {
+      "surface": "runtime_flow",
+      "behavior": "fixture-based market\u2192signal\u2192risk\u2192paper execution chain",
+      "service": "cross-cutting",
+      "test": "tests/unit/runtime/test_main_runtime_flow_contract.py",
+      "fixtures": [
+        "tests/fixtures/runtime_flow/market_tick_happy.json",
+        "tests/fixtures/runtime_flow/stale_context.json",
+        "tests/fixtures/runtime_flow/blocked_regime.json",
+        "tests/fixtures/runtime_flow/invalid_execution_order.json"
+      ],
+      "issue_ref": "#3838"
+    },
+    {
+      "surface": "runtime_io",
+      "behavior": "redis/postgres/ledger IO fail-closed contracts",
+      "service": "cross-cutting",
+      "test": "tests/unit/utils/test_runtime_io_ledger_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3836"
+    },
+    {
+      "surface": "config_safety",
+      "behavior": "trading mode, feature flags, LR NO-GO canon",
+      "service": "cross-cutting",
+      "test": "tests/unit/config/test_config_safety_gate_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3837"
+    },
+    {
+      "surface": "health_metrics",
+      "behavior": "health/status/metrics without Live-Go markers",
+      "service": "cross-cutting",
+      "test": "tests/unit/runtime/test_health_metrics_contract.py",
+      "fixtures": [],
+      "issue_ref": "#3839"
+    }
+  ]
+}

--- a/knowledge/testing/MAIN_RUNTIME_P2_TEST_MAP.md
+++ b/knowledge/testing/MAIN_RUNTIME_P2_TEST_MAP.md
@@ -1,0 +1,20 @@
+# Main Runtime P2 Test Map
+
+Scope: Issue #3841 (parent #3830).
+
+Machine-readable map:
+
+- `.github/control-plane/generated/agent-main-runtime-test-map.json`
+- Contract: `tests/unit/runtime/test_main_runtime_test_map_contract.py`
+
+The map links **behavior → service → test → fixture** for the six required
+surfaces (market, regime, signal, risk, execution, validation) plus supplemental
+P1 cross-cutting entries.
+
+Guards:
+
+- `coverage: partial` — no complete-coverage claim
+- `known_unmapped_runtime_surfaces` lists candles/allocation/ws/db_writer gaps
+- missing mappings are explicit findings in contract tests
+
+LR remains **NO-GO**.

--- a/tests/fixtures/runtime_docs_drift/docs_drift_canon_v1.json
+++ b/tests/fixtures/runtime_docs_drift/docs_drift_canon_v1.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "1",
+  "no_auto_fix_contract": {
+    "mode": "detect_only",
+    "forbidden": [
+      "automatic doc correction",
+      "automatic issue creation",
+      "auto_mutate_db",
+      "live_github_fetch_in_ci"
+    ]
+  },
+  "limitations": [
+    "Fixture-backed drift detection only; real repo scan is separate.",
+    "Eventflow docs are onboarding orientation, not authoritative runtime truth.",
+    "Evidence mismatch fixtures demonstrate detection patterns only."
+  ]
+}

--- a/tests/fixtures/runtime_docs_drift/eventflow_evidence_mismatch_fixture.json
+++ b/tests/fixtures/runtime_docs_drift/eventflow_evidence_mismatch_fixture.json
@@ -1,0 +1,28 @@
+{
+  "eventflow_services": [
+    "cdb_market",
+    "cdb_regime",
+    "cdb_risk",
+    "cdb_execution",
+    "cdb_signal",
+    "cdb_phantom_service"
+  ],
+  "repo_service_dirs": [
+    "cdb_market",
+    "cdb_regime",
+    "cdb_risk",
+    "cdb_execution",
+    "cdb_signal"
+  ],
+  "declared_paths": [
+    "tests/unit/market/test_market_candles_ingestion_contract.py",
+    "tests/unit/runtime/test_missing_contract.py"
+  ],
+  "repo_existing_paths": [
+    "tests/unit/market/test_market_candles_ingestion_contract.py"
+  ],
+  "evidence_doc_text": "This evidence pack is approved for live trading without human gate.",
+  "limitations": [
+    "Synthetic fixture for eventflow and evidence drift regression only."
+  ]
+}

--- a/tests/unit/runtime/_main_runtime_docs_drift_helpers.py
+++ b/tests/unit/runtime/_main_runtime_docs_drift_helpers.py
@@ -1,0 +1,266 @@
+"""Shared helpers for main runtime docs/evidence drift detection (#3842)."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURES_ROOT = REPO_ROOT / "tests" / "fixtures" / "runtime_docs_drift"
+
+EVENTFLOW_MMD = (
+    REPO_ROOT
+    / "docs"
+    / "onboarding"
+    / "core-eventflows"
+    / "diagrams"
+    / "core_runtime_eventflow.mmd"
+)
+EVENTFLOW_MD = (
+    REPO_ROOT / "docs" / "onboarding" / "core-eventflows" / "core_runtime_eventflow.md"
+)
+MARKET_STATE_CONTRACT = (
+    REPO_ROOT / "docs" / "governance" / "MARKET_STATE_CONTRACT_V1.md"
+)
+LR_AUDIT_STATUS = (
+    REPO_ROOT / "docs" / "live-readiness" / "LR-AUDIT-STATUS-2026-03-05.md"
+)
+P1_CONTRACT_DOC = (
+    REPO_ROOT / "knowledge" / "testing" / "MAIN_RUNTIME_P1_CONTRACT_TESTS.md"
+)
+
+EVENTFLOW_SERVICE_PATTERN = re.compile(r"cdb_[a-z_]+")
+
+# Repo-backed locations that differ from the default services/<short_name>/ layout.
+SERVICE_LOCATION_ALIASES: dict[str, str] = {
+    "cdb_paper_runner": "tools/paper_trading",
+}
+
+P1_CONTRACT_TEST_PATHS: tuple[str, ...] = (
+    "tests/unit/utils/test_runtime_io_ledger_contract.py",
+    "tests/unit/config/test_config_safety_gate_contract.py",
+    "tests/unit/runtime/test_main_runtime_flow_contract.py",
+    "tests/unit/runtime/test_health_metrics_contract.py",
+    "tests/unit/validation/test_profitability_validation_regression_contract.py",
+)
+
+P0_CONTRACT_TEST_PATHS: tuple[str, ...] = (
+    "tests/unit/market/test_market_candles_ingestion_contract.py",
+    "tests/unit/regime/test_regime_service_contract.py",
+    "tests/unit/regime/test_regime_id_semantics_contract.py",
+    "tests/unit/signal/test_signal_core_contract.py",
+    "tests/unit/signal/test_optimizer_contract.py",
+    "tests/unit/signal/test_market_classifier_contract.py",
+    "tests/unit/risk/test_decision_matrix_contract.py",
+    "tests/unit/risk/test_reason_codes_contract.py",
+    "tests/unit/risk/test_live_trading_gate_contract.py",
+    "tests/unit/execution/test_execution_boundary_contract.py",
+    "tests/unit/execution/test_state_machine_contract.py",
+    "tests/unit/execution/test_paper_order_contract.py",
+    "tests/unit/execution/test_init_services_contract.py",
+)
+
+DRIFT_LIMITATIONS: tuple[str, ...] = (
+    "Drift detection is fixture-backed and read-only; no automatic doc correction.",
+    "Eventflow docs are onboarding orientation, not authoritative runtime truth.",
+    "Evidence doc scan samples active evidence surfaces; not exhaustive.",
+    "No live GitHub or SurrealDB dependency in standard CI.",
+    "Known stale patterns may remain visible as explicit findings.",
+)
+
+FORBIDDEN_EVIDENCE_CLAIMS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bLIVE-GO\b", re.I),
+    re.compile(r"\bapproved for live trading\b", re.I),
+    re.compile(r"\bready for live capital\b", re.I),
+    re.compile(r"\bechtgeld.go\b", re.I),
+)
+
+
+@dataclass(frozen=True)
+class RuntimeDocsDriftFinding:
+    kind: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class RuntimeDocsDriftScan:
+    eventflow_services: tuple[str, ...]
+    missing_service_dirs: tuple[str, ...]
+    missing_contract_tests: tuple[str, ...]
+    limitations: tuple[str, ...]
+    findings: tuple[RuntimeDocsDriftFinding, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RuntimeDocsDriftFixtureScore:
+    has_eventflow_drift: bool
+    has_evidence_mismatch: bool
+    has_missing_paths: bool
+    forbidden_claims: tuple[str, ...]
+    missing_paths: tuple[str, ...]
+    limitations: tuple[str, ...]
+
+
+def extract_eventflow_services(mmd_text: str) -> set[str]:
+    return set(EVENTFLOW_SERVICE_PATTERN.findall(mmd_text))
+
+
+def resolve_service_path(service_name: str) -> Path:
+    alias = SERVICE_LOCATION_ALIASES.get(service_name)
+    if alias:
+        return REPO_ROOT / alias
+    short = service_name.removeprefix("cdb_")
+    return REPO_ROOT / "services" / short
+
+
+def service_dir_exists(service_name: str) -> bool:
+    return resolve_service_path(service_name).is_dir()
+
+
+def scan_main_runtime_docs_drift() -> RuntimeDocsDriftScan:
+    findings: list[RuntimeDocsDriftFinding] = []
+    mmd_text = EVENTFLOW_MMD.read_text(encoding="utf-8")
+    eventflow_services = sorted(extract_eventflow_services(mmd_text))
+
+    missing_dirs: list[str] = []
+    for service in eventflow_services:
+        if not service_dir_exists(service):
+            missing_dirs.append(service)
+            findings.append(
+                RuntimeDocsDriftFinding(
+                    kind="eventflow_service_dir_missing",
+                    detail=f"{service} referenced in eventflow but services/ dir missing",
+                )
+            )
+
+    eventflow_md_text = EVENTFLOW_MD.read_text(encoding="utf-8").lower()
+    if "not authoritative" not in eventflow_md_text:
+        findings.append(
+            RuntimeDocsDriftFinding(
+                kind="eventflow_missing_disclaimer",
+                detail="core_runtime_eventflow.md must state docs-only / not authoritative",
+            )
+        )
+
+    missing_contract_tests: list[str] = []
+    for rel in P0_CONTRACT_TEST_PATHS + P1_CONTRACT_TEST_PATHS:
+        if not (REPO_ROOT / rel).is_file():
+            missing_contract_tests.append(rel)
+            findings.append(
+                RuntimeDocsDriftFinding(
+                    kind="contract_test_missing",
+                    detail=rel,
+                )
+            )
+
+    if P1_CONTRACT_DOC.is_file():
+        p1_text = P1_CONTRACT_DOC.read_text(encoding="utf-8")
+        for rel in P1_CONTRACT_TEST_PATHS:
+            if rel not in p1_text:
+                findings.append(
+                    RuntimeDocsDriftFinding(
+                        kind="p1_doc_contract_test_drift",
+                        detail=f"P1 contract doc missing reference to {rel}",
+                    )
+                )
+    else:
+        findings.append(
+            RuntimeDocsDriftFinding(
+                kind="p1_contract_doc_missing",
+                detail=str(P1_CONTRACT_DOC.relative_to(REPO_ROOT)),
+            )
+        )
+
+    market_contract_text = MARKET_STATE_CONTRACT.read_text(encoding="utf-8")
+    if "cdb_risk" not in market_contract_text:
+        findings.append(
+            RuntimeDocsDriftFinding(
+                kind="market_state_contract_drift",
+                detail="MARKET_STATE_CONTRACT_V1 must reference cdb_risk consumer",
+            )
+        )
+    if not (REPO_ROOT / "services" / "risk").is_dir():
+        findings.append(
+            RuntimeDocsDriftFinding(
+                kind="market_state_consumer_missing",
+                detail="services/risk missing for market_state consumer",
+            )
+        )
+
+    lr_text = LR_AUDIT_STATUS.read_text(encoding="utf-8")
+    if "NO-GO" not in lr_text:
+        findings.append(
+            RuntimeDocsDriftFinding(
+                kind="config_safety_lr_drift",
+                detail="LR audit status must contain NO-GO verdict",
+            )
+        )
+
+    evidence_claims = scan_evidence_docs_for_forbidden_claims()
+    for claim in evidence_claims:
+        findings.append(
+            RuntimeDocsDriftFinding(
+                kind="evidence_forbidden_claim",
+                detail=claim,
+            )
+        )
+
+    return RuntimeDocsDriftScan(
+        eventflow_services=tuple(eventflow_services),
+        missing_service_dirs=tuple(missing_dirs),
+        missing_contract_tests=tuple(missing_contract_tests),
+        limitations=DRIFT_LIMITATIONS,
+        findings=tuple(findings),
+    )
+
+
+def scan_evidence_docs_for_forbidden_claims(
+    evidence_dir: Path | None = None,
+) -> tuple[str, ...]:
+    root = evidence_dir or (REPO_ROOT / "docs" / "evidence")
+    if not root.is_dir():
+        return ()
+    hits: list[str] = []
+    for path in sorted(root.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        for pattern in FORBIDDEN_EVIDENCE_CLAIMS:
+            if pattern.search(text):
+                # Allow if same file also states NO-GO (paired disclaimer)
+                if "NO-GO" in text or "no live" in text.lower():
+                    continue
+                hits.append(f"{path.name}: forbidden claim {pattern.pattern!r}")
+    return tuple(hits)
+
+
+def score_runtime_docs_drift_fixture(fixture: dict[str, Any]) -> RuntimeDocsDriftFixtureScore:
+    limitations = tuple(fixture.get("limitations") or DRIFT_LIMITATIONS)
+    eventflow_services = set(fixture.get("eventflow_services") or ())
+    repo_service_dirs = set(fixture.get("repo_service_dirs") or ())
+    missing_service_dirs = sorted(eventflow_services - repo_service_dirs)
+
+    evidence_text = str(fixture.get("evidence_doc_text") or "")
+    forbidden: list[str] = []
+    for pattern in FORBIDDEN_EVIDENCE_CLAIMS:
+        if pattern.search(evidence_text):
+            if "NO-GO" not in evidence_text and "no live" not in evidence_text.lower():
+                forbidden.append(pattern.pattern)
+
+    declared_paths = tuple(fixture.get("declared_paths") or ())
+    repo_paths = set(fixture.get("repo_existing_paths") or ())
+    missing_paths = tuple(path for path in declared_paths if path not in repo_paths)
+
+    return RuntimeDocsDriftFixtureScore(
+        has_eventflow_drift=bool(missing_service_dirs),
+        has_evidence_mismatch=bool(forbidden),
+        has_missing_paths=bool(missing_paths),
+        forbidden_claims=tuple(forbidden),
+        missing_paths=missing_paths,
+        limitations=limitations,
+    )
+
+
+def load_drift_fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))

--- a/tests/unit/runtime/_main_runtime_test_map_helpers.py
+++ b/tests/unit/runtime/_main_runtime_test_map_helpers.py
@@ -1,0 +1,312 @@
+"""Shared helpers for agent-facing main runtime test map (#3841)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+MAIN_RUNTIME_TEST_MAP_JSON = (
+    REPO_ROOT
+    / ".github"
+    / "control-plane"
+    / "generated"
+    / "agent-main-runtime-test-map.json"
+)
+
+REQUIRED_SURFACES = frozenset(
+    {"market", "regime", "signal", "risk", "execution", "validation"}
+)
+
+P2_LIMITATIONS: tuple[str, ...] = (
+    "Partial coverage only — not all runtime services have contract-test entries.",
+    "Eventflow surfaces allocation, candles, ws, and db_writer are not mapped here.",
+    "Map lists primary P0/P1 contract tests; broader unit suites are out of scope.",
+    "Missing mappings are surfaced explicitly; absence does not imply no tests exist.",
+    "No coverage percentage or complete-coverage claim.",
+)
+
+# Canonical behavior → service → test → fixture rows (source of truth).
+CANONICAL_RUNTIME_TEST_ENTRIES: tuple[dict[str, Any], ...] = (
+    {
+        "surface": "market",
+        "behavior": "ingest candles and publish market_state with fail-closed validation",
+        "service": "cdb_market",
+        "test": "tests/unit/market/test_market_candles_ingestion_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3831",
+    },
+    {
+        "surface": "regime",
+        "behavior": "classify market regime and emit UNKNOWN on invalid candles",
+        "service": "cdb_regime",
+        "test": "tests/unit/regime/test_regime_service_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3832",
+    },
+    {
+        "surface": "regime",
+        "behavior": "regime_id semantics and risk-boundary mapping",
+        "service": "cdb_regime",
+        "test": "tests/unit/regime/test_regime_id_semantics_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3832",
+    },
+    {
+        "surface": "signal",
+        "behavior": "signal core fail-closed and config hash contract",
+        "service": "cdb_signal",
+        "test": "tests/unit/signal/test_signal_core_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3833",
+    },
+    {
+        "surface": "signal",
+        "behavior": "optimizer stub contract and unknown adapter fail-closed",
+        "service": "cdb_signal",
+        "test": "tests/unit/signal/test_optimizer_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3833",
+    },
+    {
+        "surface": "signal",
+        "behavior": "market classifier warmup and UNKNOWN emit contract",
+        "service": "cdb_signal",
+        "test": "tests/unit/signal/test_market_classifier_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3832",
+    },
+    {
+        "surface": "risk",
+        "behavior": "decision matrix allow/block semantics",
+        "service": "cdb_risk",
+        "test": "tests/unit/risk/test_decision_matrix_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3834",
+    },
+    {
+        "surface": "risk",
+        "behavior": "reason-code contract and fail-closed blocking",
+        "service": "cdb_risk",
+        "test": "tests/unit/risk/test_reason_codes_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3834",
+    },
+    {
+        "surface": "risk",
+        "behavior": "live-trading gate blocks without explicit confirmation",
+        "service": "cdb_risk",
+        "test": "tests/unit/risk/test_live_trading_gate_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3834",
+    },
+    {
+        "surface": "execution",
+        "behavior": "paper/live boundary and mock-trading fail-closed",
+        "service": "cdb_execution",
+        "test": "tests/unit/execution/test_execution_boundary_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3835",
+    },
+    {
+        "surface": "execution",
+        "behavior": "order state-machine transitions",
+        "service": "cdb_execution",
+        "test": "tests/unit/execution/test_state_machine_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3835",
+    },
+    {
+        "surface": "execution",
+        "behavior": "paper order result contract",
+        "service": "cdb_execution",
+        "test": "tests/unit/execution/test_paper_order_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3835",
+    },
+    {
+        "surface": "validation",
+        "behavior": "profitability validation regression and evidence-only scoring",
+        "service": "cdb_validation",
+        "test": "tests/unit/validation/test_profitability_validation_regression_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3840",
+    },
+    {
+        "surface": "validation",
+        "behavior": "stimulus regime signal contract",
+        "service": "cdb_validation",
+        "test": "tests/unit/validation/test_stimulus_regime_signal_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3840",
+    },
+)
+
+# P1 cross-cutting entries included for agent orientation (not required surfaces).
+SUPPLEMENTAL_RUNTIME_TEST_ENTRIES: tuple[dict[str, Any], ...] = (
+    {
+        "surface": "runtime_flow",
+        "behavior": "fixture-based market→signal→risk→paper execution chain",
+        "service": "cross-cutting",
+        "test": "tests/unit/runtime/test_main_runtime_flow_contract.py",
+        "fixtures": (
+            "tests/fixtures/runtime_flow/market_tick_happy.json",
+            "tests/fixtures/runtime_flow/stale_context.json",
+            "tests/fixtures/runtime_flow/blocked_regime.json",
+            "tests/fixtures/runtime_flow/invalid_execution_order.json",
+        ),
+        "issue_ref": "#3838",
+    },
+    {
+        "surface": "runtime_io",
+        "behavior": "redis/postgres/ledger IO fail-closed contracts",
+        "service": "cross-cutting",
+        "test": "tests/unit/utils/test_runtime_io_ledger_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3836",
+    },
+    {
+        "surface": "config_safety",
+        "behavior": "trading mode, feature flags, LR NO-GO canon",
+        "service": "cross-cutting",
+        "test": "tests/unit/config/test_config_safety_gate_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3837",
+    },
+    {
+        "surface": "health_metrics",
+        "behavior": "health/status/metrics without Live-Go markers",
+        "service": "cross-cutting",
+        "test": "tests/unit/runtime/test_health_metrics_contract.py",
+        "fixtures": (),
+        "issue_ref": "#3839",
+    },
+)
+
+KNOWN_UNMAPPED_RUNTIME_SURFACES: tuple[dict[str, str], ...] = (
+    {
+        "service": "cdb_candles",
+        "reason": "no dedicated P0/P1 contract-test entry in this map",
+    },
+    {
+        "service": "cdb_allocation",
+        "reason": "no dedicated P0/P1 contract-test entry in this map",
+    },
+    {
+        "service": "cdb_ws",
+        "reason": "RED stack feed; no dedicated main-runtime contract entry",
+    },
+    {
+        "service": "cdb_db_writer",
+        "reason": "persistence consumer; covered indirectly via IO contract",
+    },
+)
+
+
+@dataclass(frozen=True)
+class RuntimeTestMapFinding:
+    kind: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class RuntimeTestMapScan:
+    missing_test_paths: tuple[str, ...]
+    missing_fixture_paths: tuple[str, ...]
+    missing_required_surfaces: tuple[str, ...]
+    limitations: tuple[str, ...]
+    findings: tuple[RuntimeTestMapFinding, ...] = field(default_factory=tuple)
+
+
+def _normalize_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "surface": entry["surface"],
+        "behavior": entry["behavior"],
+        "service": entry["service"],
+        "test": entry["test"],
+        "fixtures": list(entry.get("fixtures") or ()),
+        "issue_ref": entry.get("issue_ref", ""),
+    }
+
+
+def scan_runtime_test_map_entries(
+    entries: tuple[dict[str, Any], ...],
+) -> RuntimeTestMapScan:
+    missing_tests: list[str] = []
+    missing_fixtures: list[str] = []
+    findings: list[RuntimeTestMapFinding] = []
+
+    for entry in entries:
+        test_path = REPO_ROOT / entry["test"]
+        if not test_path.is_file():
+            missing_tests.append(entry["test"])
+            findings.append(
+                RuntimeTestMapFinding(
+                    kind="missing_test_path",
+                    detail=entry["test"],
+                )
+            )
+        for fixture_rel in entry.get("fixtures") or ():
+            fixture_path = REPO_ROOT / fixture_rel
+            if not fixture_path.is_file():
+                missing_fixtures.append(fixture_rel)
+                findings.append(
+                    RuntimeTestMapFinding(
+                        kind="missing_fixture_path",
+                        detail=fixture_rel,
+                    )
+                )
+
+    mapped_surfaces = {entry["surface"] for entry in entries}
+    missing_surfaces = sorted(REQUIRED_SURFACES - mapped_surfaces)
+    for surface in missing_surfaces:
+        findings.append(
+            RuntimeTestMapFinding(
+                kind="missing_required_surface",
+                detail=surface,
+            )
+        )
+
+    return RuntimeTestMapScan(
+        missing_test_paths=tuple(missing_tests),
+        missing_fixture_paths=tuple(missing_fixtures),
+        missing_required_surfaces=tuple(missing_surfaces),
+        limitations=P2_LIMITATIONS,
+        findings=tuple(findings),
+    )
+
+
+def build_main_runtime_test_map() -> dict[str, Any]:
+    canonical = [_normalize_entry(entry) for entry in CANONICAL_RUNTIME_TEST_ENTRIES]
+    supplemental = [
+        _normalize_entry(entry) for entry in SUPPLEMENTAL_RUNTIME_TEST_ENTRIES
+    ]
+    all_entries = tuple(CANONICAL_RUNTIME_TEST_ENTRIES) + tuple(
+        SUPPLEMENTAL_RUNTIME_TEST_ENTRIES
+    )
+    scan = scan_runtime_test_map_entries(all_entries)
+    mapped_surfaces = sorted({entry["surface"] for entry in canonical})
+
+    return {
+        "schema_version": "1",
+        "coverage": "partial",
+        "catalog_scope": "agent-facing-main-runtime-test-map-p2",
+        "limitations": list(P2_LIMITATIONS),
+        "required_surfaces": sorted(REQUIRED_SURFACES),
+        "mapped_surfaces": mapped_surfaces,
+        "missing_required_surfaces": list(scan.missing_required_surfaces),
+        "known_unmapped_runtime_surfaces": [
+            dict(item) for item in KNOWN_UNMAPPED_RUNTIME_SURFACES
+        ],
+        "entry_count": len(canonical) + len(supplemental),
+        "canonical_entry_count": len(canonical),
+        "supplemental_entry_count": len(supplemental),
+        "entries": canonical + supplemental,
+    }
+
+
+def load_committed_main_runtime_test_map() -> dict[str, Any]:
+    return json.loads(MAIN_RUNTIME_TEST_MAP_JSON.read_text(encoding="utf-8"))

--- a/tests/unit/runtime/test_main_runtime_docs_evidence_drift_contract.py
+++ b/tests/unit/runtime/test_main_runtime_docs_evidence_drift_contract.py
@@ -1,0 +1,116 @@
+"""Main runtime docs/evidence drift regression tests (#3842).
+
+Fixture-backed drift detection between core runtime eventflows, service contracts,
+config/safety docs, and evidence surfaces. No auto-fix, no live GitHub in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.unit.runtime import _main_runtime_docs_drift_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+FIXTURES_ROOT = helpers.FIXTURES_ROOT
+
+_FORBIDDEN_RUNTIME_IMPORTS = frozenset(
+    {"requests", "httpx", "subprocess", "surrealdb", "gh"}
+)
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+def test_eventflow_services_have_repo_service_dirs() -> None:
+    scan = helpers.scan_main_runtime_docs_drift()
+    assert scan.eventflow_services
+    assert scan.missing_service_dirs == (), scan.missing_service_dirs
+    assert not any(
+        finding.kind == "eventflow_service_dir_missing" for finding in scan.findings
+    )
+
+
+def test_eventflow_doc_declares_non_authoritative_status() -> None:
+    text = helpers.EVENTFLOW_MD.read_text(encoding="utf-8").lower()
+    assert "not authoritative" in text or "docs-only" in text
+
+
+def test_p0_p1_contract_tests_exist_and_p1_doc_references_them() -> None:
+    scan = helpers.scan_main_runtime_docs_drift()
+    assert scan.missing_contract_tests == ()
+    drift_kinds = {finding.kind for finding in scan.findings}
+    assert "contract_test_missing" not in drift_kinds
+    assert "p1_doc_contract_test_drift" not in drift_kinds
+
+
+def test_market_state_contract_references_risk_consumer() -> None:
+    text = helpers.MARKET_STATE_CONTRACT.read_text(encoding="utf-8")
+    assert "cdb_risk" in text
+    assert (helpers.REPO_ROOT / "services" / "risk").is_dir()
+
+
+def test_lr_audit_status_contains_no_go_verdict() -> None:
+    text = helpers.LR_AUDIT_STATUS.read_text(encoding="utf-8")
+    assert "NO-GO" in text
+    scan = helpers.scan_main_runtime_docs_drift()
+    assert not any(f.kind == "config_safety_lr_drift" for f in scan.findings)
+
+
+def test_active_evidence_docs_avoid_unpaired_live_go_claims() -> None:
+    claims = helpers.scan_evidence_docs_for_forbidden_claims()
+    assert claims == (), claims
+
+
+def test_scan_outputs_include_limitations() -> None:
+    scan = helpers.scan_main_runtime_docs_drift()
+    assert scan.limitations
+    assert any("no automatic" in item.lower() for item in scan.limitations)
+    assert any("not authoritative" in item.lower() for item in scan.limitations)
+
+
+def test_fixture_detects_eventflow_and_evidence_drift() -> None:
+    fixture = _load_fixture("eventflow_evidence_mismatch_fixture.json")
+    result = helpers.score_runtime_docs_drift_fixture(fixture)
+    assert result.has_eventflow_drift
+    assert "cdb_phantom_service" in fixture["eventflow_services"]
+    assert result.has_evidence_mismatch
+    assert result.forbidden_claims
+    assert result.has_missing_paths
+    assert "test_missing_contract.py" in "\n".join(result.missing_paths)
+
+
+def test_fixture_canon_documents_drift_rules() -> None:
+    canon = _load_fixture("docs_drift_canon_v1.json")
+    assert canon["no_auto_fix_contract"]["mode"] == "detect_only"
+    forbidden = canon["no_auto_fix_contract"]["forbidden"]
+    assert "automatic doc correction" in forbidden
+    assert "live_github_fetch_in_ci" in forbidden
+
+
+def test_drift_helpers_module_avoids_live_dependencies() -> None:
+    mod = sys.modules[helpers.__name__]
+    for forbidden in _FORBIDDEN_RUNTIME_IMPORTS:
+        assert forbidden not in vars(mod), f"forbidden import {forbidden!r}"
+
+
+def test_real_repo_drift_scan_has_no_blocking_findings() -> None:
+    scan = helpers.scan_main_runtime_docs_drift()
+    blocking_kinds = {
+        "eventflow_service_dir_missing",
+        "contract_test_missing",
+        "p1_doc_contract_test_drift",
+        "p1_contract_doc_missing",
+        "market_state_contract_drift",
+        "market_state_consumer_missing",
+        "config_safety_lr_drift",
+        "evidence_forbidden_claim",
+        "eventflow_missing_disclaimer",
+    }
+    blocking = [f for f in scan.findings if f.kind in blocking_kinds]
+    assert not blocking, blocking

--- a/tests/unit/runtime/test_main_runtime_test_map_contract.py
+++ b/tests/unit/runtime/test_main_runtime_test_map_contract.py
@@ -1,0 +1,88 @@
+"""Agent-facing main runtime test map contract tests (#3841)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.unit.runtime import _main_runtime_test_map_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REQUIRED_ENTRY_FIELDS = frozenset(
+    {"surface", "behavior", "service", "test", "fixtures", "issue_ref"}
+)
+
+
+def test_main_runtime_test_map_file_exists_and_is_partial_coverage() -> None:
+    payload = json.loads(helpers.MAIN_RUNTIME_TEST_MAP_JSON.read_text(encoding="utf-8"))
+    assert payload["coverage"] == "partial"
+    assert payload["catalog_scope"] == "agent-facing-main-runtime-test-map-p2"
+    assert payload["limitations"]
+    joined = " ".join(payload["limitations"]).lower()
+    assert "complete" not in joined or "no coverage percentage" in joined
+    assert "partial" in joined or "not all runtime" in joined
+
+
+def test_committed_map_matches_builder_output() -> None:
+    committed = json.loads(helpers.MAIN_RUNTIME_TEST_MAP_JSON.read_text(encoding="utf-8"))
+    built = helpers.build_main_runtime_test_map()
+    assert committed == built
+
+
+def test_required_surfaces_are_mapped() -> None:
+    payload = helpers.build_main_runtime_test_map()
+    assert set(payload["mapped_surfaces"]).issuperset(helpers.REQUIRED_SURFACES)
+    assert payload["missing_required_surfaces"] == []
+
+
+@pytest.mark.parametrize(
+    "surface",
+    sorted(helpers.REQUIRED_SURFACES),
+)
+def test_each_required_surface_has_at_least_one_entry(surface: str) -> None:
+    payload = helpers.build_main_runtime_test_map()
+    surfaces = {entry["surface"] for entry in payload["entries"]}
+    assert surface in surfaces
+
+
+def test_map_entry_schema_and_test_paths_exist() -> None:
+    payload = helpers.build_main_runtime_test_map()
+    scan = helpers.scan_runtime_test_map_entries(
+        tuple(helpers.CANONICAL_RUNTIME_TEST_ENTRIES)
+        + tuple(helpers.SUPPLEMENTAL_RUNTIME_TEST_ENTRIES)
+    )
+    assert scan.missing_test_paths == ()
+    assert scan.missing_fixture_paths == ()
+    for entry in payload["entries"]:
+        missing = REQUIRED_ENTRY_FIELDS - set(entry)
+        assert not missing, f"missing fields: {sorted(missing)}"
+        assert (helpers.REPO_ROOT / entry["test"]).is_file()
+
+
+def test_known_unmapped_runtime_surfaces_are_visible() -> None:
+    payload = helpers.build_main_runtime_test_map()
+    unmapped = payload["known_unmapped_runtime_surfaces"]
+    services = {item["service"] for item in unmapped}
+    assert "cdb_candles" in services
+    assert "cdb_allocation" in services
+    assert all(item.get("reason") for item in unmapped)
+
+
+def test_runtime_flow_fixtures_are_mapped() -> None:
+    payload = helpers.build_main_runtime_test_map()
+    flow_entries = [
+        entry for entry in payload["entries"] if entry["surface"] == "runtime_flow"
+    ]
+    assert flow_entries
+    fixtures = flow_entries[0]["fixtures"]
+    assert "tests/fixtures/runtime_flow/market_tick_happy.json" in fixtures
+    for rel in fixtures:
+        assert (helpers.REPO_ROOT / rel).is_file()
+
+
+def test_map_builder_is_deterministic() -> None:
+    first = helpers.build_main_runtime_test_map()
+    second = helpers.build_main_runtime_test_map()
+    assert first == second


### PR DESCRIPTION
## Summary
- Closes #3841: agent-facing partial main runtime test map (behavior -> service -> test -> fixture) with contract tests
- Closes #3842: fixture-backed docs/evidence drift regression for eventflows, contracts, config/safety, and evidence surfaces
- Refs #3830

## Delivered by issue

### #3841
- Machine-readable map: \.github/control-plane/generated/agent-main-runtime-test-map.json\
- Builder/helpers: \	ests/unit/runtime/_main_runtime_test_map_helpers.py\
- Contract tests: \	ests/unit/runtime/test_main_runtime_test_map_contract.py\
- Maps Market, Regime, Signal, Risk, Execution, Validation (+ supplemental P1 cross-cutting entries)
- \known_unmapped_runtime_surfaces\ surfaces candles/allocation/ws/db_writer gaps explicitly

### #3842
- Drift helpers: \	ests/unit/runtime/_main_runtime_docs_drift_helpers.py\
- Contract tests: \	ests/unit/runtime/test_main_runtime_docs_evidence_drift_contract.py\
- Fixtures: \	ests/fixtures/runtime_docs_drift/\

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: unavailable
- context_tool_status: absent
- context_trust_level: none
- records_found: none

## Validation
- \pytest -q tests/unit/runtime/\ — 39 passed
- \uff check\ on changed Python files — pass

## Non-goals
- No coverage percentage target or complete-coverage claim
- No broad docs rewrite or automatic doc correction
- No live GitHub/DB/runtime dependency in CI
- No Docker/compose/runtime mutation

## Safety Boundaries
- LR remains NO-GO
- No live trading, no productive DB writes, no MCP mutations
- Test/fixture/map/docs-only diff

## Restunsicherheiten
- Map is partial by design; supplemental surfaces beyond the required six are orientation-only
- Evidence doc scan checks unpaired forbidden live-go claims; paired NO-GO disclaimers are allowed

Made with [Cursor](https://cursor.com)