### PR TITLE
test(arvp): add runtime p0 chain calibration and campaign contracts

### DIFF
--- a/tests/fixtures/arvp/calibration/aligned_happy_path/paper_reference_window.json
+++ b/tests/fixtures/arvp/calibration/aligned_happy_path/paper_reference_window.json
@@ -1,0 +1,51 @@
+{
+  "contract_version": "arvp_paper_reference_window.v1",
+  "end_ts_ms_utc": 1704153600000,
+  "events": [
+    {
+      "correlation_id": "c0",
+      "event_pk": "s0",
+      "event_type": "SIGNAL",
+      "payload": {
+        "strategy_id": "primary_breakout_v1"
+      },
+      "signal_id": "sig-0",
+      "symbol": "BTCUSDT",
+      "timestamp_ms": 1704067200000
+    },
+    {
+      "correlation_id": "c0",
+      "decision_id": "dec-0",
+      "event_pk": "o0",
+      "event_type": "ORDER",
+      "order_id": "paper_000",
+      "payload": {
+        "strategy_id": "primary_breakout_v1"
+      },
+      "signal_id": "sig-0",
+      "symbol": "BTCUSDT",
+      "timestamp_ms": 1704067320000
+    },
+    {
+      "correlation_id": "c0",
+      "decision_id": "dec-0",
+      "event_pk": "f0",
+      "event_type": "FILL",
+      "fill_id": "fill-0",
+      "order_id": "paper_000",
+      "payload": {
+        "strategy_id": "primary_breakout_v1"
+      },
+      "signal_id": "sig-0",
+      "symbol": "BTCUSDT",
+      "timestamp_ms": 1704067380000
+    }
+  ],
+  "extracted_at_utc": "2026-04-24T00:00:00+00:00",
+  "extracted_by": "unit-test",
+  "source_query_intent": "arvp-p0-contract",
+  "source_table": "public.correlation_ledger",
+  "start_ts_ms_utc": 1704067200000,
+  "strategy_id": "primary_breakout_v1",
+  "symbol": "BTCUSDT"
+}

--- a/tests/fixtures/arvp/calibration/aligned_happy_path/replay_report.json
+++ b/tests/fixtures/arvp/calibration/aligned_happy_path/replay_report.json
@@ -1,0 +1,52 @@
+{
+  "artifact_manifest": {
+    "envelope_log_uri": "none",
+    "event_loop_states_uri": "none",
+    "report_artifact_uri": "report.json"
+  },
+  "dataset_summary": {
+    "period_end_ts_ms": 1704153600000,
+    "period_start_ts_ms": 1704067200000
+  },
+  "envelope_summary": {
+    "decision_envelopes_total": 0,
+    "fill_envelopes_total": 2,
+    "order_envelopes_total": 2
+  },
+  "execution_result": {
+    "decisions_made": 0,
+    "envelope_hashes": [],
+    "events_processed": 10,
+    "fills_recorded": 2,
+    "orders_placed": 2,
+    "run_id": "replay-aabbccddee11-0001"
+  },
+  "metrics": {
+    "buy_signals_total": 2,
+    "closed_trades_total": 2,
+    "sell_signals_total": 1,
+    "signals_total": 3
+  },
+  "replay_integrity": {
+    "envelope_chain_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "envelope_count": 0,
+    "event_loop_states_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "integrity_ok": true,
+    "run_id": "replay-aabbccddee11-0001"
+  },
+  "report_type": "shadow_replay",
+  "run_spec": {
+    "code_commit": "aaaaaaa",
+    "end_ts_ms": 1704153600000,
+    "metadata": {
+      "dataset_fingerprint": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "replay_run_id": "replay-aabbccddee11-0001",
+    "run_mode": "shadow",
+    "start_ts_ms": 1704067200000,
+    "strategy_id": "primary_breakout_v1",
+    "symbol": "BTCUSDT"
+  },
+  "schema_version": "replay_report.v1",
+  "strategy_id": "primary_breakout_v1"
+}

--- a/tests/fixtures/arvp/event_chain/complete_chain_paper_order.json
+++ b/tests/fixtures/arvp/event_chain/complete_chain_paper_order.json
@@ -1,0 +1,33 @@
+{
+  "description": "Fixture-only SIGNAL→DECISION→ORDER(paper_)→FILL chain for ARVP P0 contract (#3821).",
+  "events": [
+    {
+      "id": 101,
+      "ts_ms": "2026-06-11T11:45:00Z",
+      "event_type": "SIGNAL",
+      "status": "active",
+      "lineage_hash": "lineage-arvp-3821"
+    },
+    {
+      "id": 102,
+      "ts_ms": "2026-06-11T11:46:00Z",
+      "event_type": "DECISION",
+      "status": "executed",
+      "lineage_hash": "lineage-arvp-3821"
+    },
+    {
+      "id": 103,
+      "ts_ms": "2026-06-11T11:47:00Z",
+      "event_type": "ORDER(paper_)",
+      "status": "filled",
+      "lineage_hash": "lineage-arvp-3821"
+    },
+    {
+      "id": 104,
+      "ts_ms": "2026-06-11T11:48:00Z",
+      "event_type": "FILL",
+      "status": "confirmed",
+      "lineage_hash": "lineage-arvp-3821"
+    }
+  ]
+}

--- a/tests/fixtures/arvp/event_chain/malformed_missing_ts.json
+++ b/tests/fixtures/arvp/event_chain/malformed_missing_ts.json
@@ -1,0 +1,10 @@
+{
+  "description": "Malformed ledger events — must not promote (#3821).",
+  "events": [
+    {
+      "id": 1,
+      "event_type": "SIGNAL",
+      "status": "active"
+    }
+  ]
+}

--- a/tests/fixtures/arvp/event_chain/signal_decision.json
+++ b/tests/fixtures/arvp/event_chain/signal_decision.json
@@ -1,0 +1,19 @@
+{
+  "description": "Partial chain: SIGNAL+DECISION — must not promote (#3821).",
+  "events": [
+    {
+      "id": 1,
+      "ts_ms": "2026-06-10T10:00:00Z",
+      "event_type": "SIGNAL",
+      "status": "active",
+      "lineage_hash": "partial-2"
+    },
+    {
+      "id": 2,
+      "ts_ms": "2026-06-10T10:01:00Z",
+      "event_type": "DECISION",
+      "status": "executed",
+      "lineage_hash": "partial-2"
+    }
+  ]
+}

--- a/tests/fixtures/arvp/event_chain/signal_decision_order.json
+++ b/tests/fixtures/arvp/event_chain/signal_decision_order.json
@@ -1,0 +1,26 @@
+{
+  "description": "Partial chain: SIGNAL+DECISION+ORDER — missing FILL (#3821).",
+  "events": [
+    {
+      "id": 1,
+      "ts_ms": "2026-06-10T10:00:00Z",
+      "event_type": "SIGNAL",
+      "status": "active",
+      "lineage_hash": "partial-3"
+    },
+    {
+      "id": 2,
+      "ts_ms": "2026-06-10T10:01:00Z",
+      "event_type": "DECISION",
+      "status": "executed",
+      "lineage_hash": "partial-3"
+    },
+    {
+      "id": 3,
+      "ts_ms": "2026-06-10T10:02:00Z",
+      "event_type": "ORDER(paper_)",
+      "status": "filled",
+      "lineage_hash": "partial-3"
+    }
+  ]
+}

--- a/tests/fixtures/arvp/event_chain/signal_only.json
+++ b/tests/fixtures/arvp/event_chain/signal_only.json
@@ -1,0 +1,12 @@
+{
+  "description": "Partial chain: SIGNAL only — must not promote to complete_chain (#3821).",
+  "events": [
+    {
+      "id": 1,
+      "ts_ms": "2026-06-10T10:00:00Z",
+      "event_type": "SIGNAL",
+      "status": "active",
+      "lineage_hash": "partial-1"
+    }
+  ]
+}

--- a/tests/fixtures/arvp_campaigns/probe_set_candles_gap.json
+++ b/tests/fixtures/arvp_campaigns/probe_set_candles_gap.json
@@ -1,0 +1,77 @@
+[
+  {
+    "probe": "host",
+    "status": "ok",
+    "evidence": {
+      "uptime_seconds": 86400,
+      "sleep_wake_indicators": ["none detected"]
+    },
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "docker",
+    "status": "ok",
+    "evidence": {
+      "containers": [],
+      "total_targets": 2,
+      "running": 2,
+      "healthy": 2,
+      "missing": 0
+    },
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "safety",
+    "status": "ok",
+    "evidence": {"all_flags_match_expected": true},
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "db_readonly",
+    "status": "ok",
+    "evidence": {"connectivity": "ok"},
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "candles",
+    "status": "blocked",
+    "evidence": {
+      "latest_price": 62100.5,
+      "gap_detected": true,
+      "largest_gap_minutes": 12.0,
+      "recent_gaps_minutes": [12.0],
+      "gap_threshold_minutes": 3
+    },
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": ["candle gap(s) >3 min detected: [12.0]"],
+    "no_mutation": true
+  },
+  {
+    "probe": "correlation_ledger",
+    "status": "ok",
+    "evidence": {
+      "latest_event": null,
+      "events_since_campaign_start": 0,
+      "events_by_type_status": []
+    },
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "regime",
+    "status": "ok",
+    "evidence": {"current_regime": "RANGE"},
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  }
+]

--- a/tests/fixtures/arvp_campaigns/probe_set_docker_blocked.json
+++ b/tests/fixtures/arvp_campaigns/probe_set_docker_blocked.json
@@ -1,0 +1,71 @@
+[
+  {
+    "probe": "host",
+    "status": "ok",
+    "evidence": {
+      "uptime_seconds": 86400,
+      "sleep_wake_indicators": ["none detected"]
+    },
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "docker",
+    "status": "blocked",
+    "evidence": {
+      "containers": [],
+      "total_targets": 2,
+      "running": 0,
+      "healthy": 0,
+      "missing": 2
+    },
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": ["runtime unavailable: required containers not running"],
+    "no_mutation": true
+  },
+  {
+    "probe": "safety",
+    "status": "ok",
+    "evidence": {"all_flags_match_expected": true},
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "db_readonly",
+    "status": "ok",
+    "evidence": {"connectivity": "ok"},
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "candles",
+    "status": "ok",
+    "evidence": {"latest_price": 62100.5, "gap_detected": false},
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "correlation_ledger",
+    "status": "ok",
+    "evidence": {
+      "latest_event": null,
+      "events_since_campaign_start": 0,
+      "events_by_type_status": []
+    },
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  },
+  {
+    "probe": "regime",
+    "status": "ok",
+    "evidence": {"current_regime": "RANGE"},
+    "observed_at_utc": "2026-06-10T12:00:00Z",
+    "limitations": [],
+    "no_mutation": true
+  }
+]

--- a/tests/unit/arvp/_arvp_calibration_gate_helpers.py
+++ b/tests/unit/arvp/_arvp_calibration_gate_helpers.py
@@ -1,0 +1,245 @@
+"""Shared helpers for ARVP calibration gate regression contract tests (#3822)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from core.replay.arvp_gate import (
+    ARVPEvidenceBundle,
+    ARVPGateVerdict,
+    build_arvp_gate_verdict,
+)
+from core.replay.replay_vs_paper_compare import ComparePaths, compare_from_paths
+from core.replay.run_registry import ReplayRunRecord
+from core.replay.shadow_compare import ShadowComparisonResult
+from core.replay.simulator_calibration_report import (
+    SimulatorCalibrationReport,
+    build_simulator_calibration_report,
+)
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "arvp" / "calibration"
+
+
+@dataclass(frozen=True)
+class CalibrationPipelineResult:
+    comparison: ShadowComparisonResult
+    calibration: SimulatorCalibrationReport
+    gate: ARVPGateVerdict
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def replay_report(
+    *,
+    symbol: str = "BTCUSDT",
+    strategy_id: str = "primary_breakout_v1",
+    signals: int = 3,
+    fills: int = 2,
+    orders: int = 2,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "replay_report.v1",
+        "report_type": "shadow_replay",
+        "strategy_id": strategy_id,
+        "run_spec": {
+            "replay_run_id": "replay-aabbccddee11-0001",
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "start_ts_ms": 1704067200000,
+            "end_ts_ms": 1704153600000,
+            "code_commit": "a" * 7,
+            "run_mode": "shadow",
+            "metadata": {"dataset_fingerprint": "b" * 64},
+        },
+        "execution_result": {
+            "run_id": "replay-aabbccddee11-0001",
+            "events_processed": 10,
+            "decisions_made": 0,
+            "orders_placed": orders,
+            "fills_recorded": fills,
+            "envelope_hashes": [],
+        },
+        "replay_integrity": {
+            "run_id": "replay-aabbccddee11-0001",
+            "envelope_count": 0,
+            "envelope_chain_hash": "c" * 64,
+            "event_loop_states_hash": "c" * 64,
+            "integrity_ok": True,
+        },
+        "envelope_summary": {
+            "decision_envelopes_total": 0,
+            "order_envelopes_total": orders,
+            "fill_envelopes_total": fills,
+        },
+        "artifact_manifest": {
+            "envelope_log_uri": "none",
+            "event_loop_states_uri": "none",
+            "report_artifact_uri": "report.json",
+        },
+        "dataset_summary": {
+            "period_start_ts_ms": 1704067200000,
+            "period_end_ts_ms": 1704153600000,
+        },
+        "metrics": {
+            "signals_total": signals,
+            "buy_signals_total": max(1, signals - 1),
+            "sell_signals_total": 1,
+            "closed_trades_total": fills,
+        },
+    }
+
+
+def paper_reference_window(
+    *,
+    symbol: str = "BTCUSDT",
+    strategy_id: str = "primary_breakout_v1",
+    signal_count: int = 1,
+    order_count: int = 1,
+    fill_count: int = 1,
+) -> dict[str, Any]:
+    start = 1704067200000
+    end = 1704153600000
+    events: list[dict[str, Any]] = []
+    for i in range(signal_count):
+        events.append(
+            {
+                "event_pk": f"s{i}",
+                "correlation_id": f"c{i}",
+                "event_type": "SIGNAL",
+                "symbol": symbol,
+                "timestamp_ms": start + i * 60_000,
+                "payload": {"strategy_id": strategy_id},
+                "signal_id": f"sig-{i}",
+            }
+        )
+    for i in range(order_count):
+        events.append(
+            {
+                "event_pk": f"o{i}",
+                "correlation_id": f"c{i}",
+                "event_type": "ORDER",
+                "symbol": symbol,
+                "timestamp_ms": start + 120_000 + i * 60_000,
+                "payload": {"strategy_id": strategy_id},
+                "order_id": f"paper_{i:03d}",
+                "signal_id": f"sig-{i}",
+                "decision_id": f"dec-{i}",
+            }
+        )
+    for i in range(fill_count):
+        events.append(
+            {
+                "event_pk": f"f{i}",
+                "correlation_id": f"c{i}",
+                "event_type": "FILL",
+                "symbol": symbol,
+                "timestamp_ms": start + 180_000 + i * 60_000,
+                "payload": {"strategy_id": strategy_id},
+                "order_id": f"paper_{i:03d}",
+                "fill_id": f"fill-{i}",
+                "signal_id": f"sig-{i}",
+                "decision_id": f"dec-{i}",
+            }
+        )
+    return {
+        "contract_version": "arvp_paper_reference_window.v1",
+        "strategy_id": strategy_id,
+        "symbol": symbol,
+        "start_ts_ms_utc": start,
+        "end_ts_ms_utc": end,
+        "source_table": "public.correlation_ledger",
+        "source_query_intent": "arvp-p0-contract",
+        "extracted_at_utc": "2026-04-24T00:00:00+00:00",
+        "extracted_by": "unit-test",
+        "events": events,
+    }
+
+
+def run_calibration_pipeline(
+    tmp_path: Path,
+    *,
+    replay: dict[str, Any],
+    paper: dict[str, Any],
+    record_overrides: dict[str, Any] | None = None,
+    shadow: ShadowComparisonResult | None = None,
+) -> CalibrationPipelineResult:
+    replay_path = tmp_path / "report.json"
+    paper_path = tmp_path / "paper_reference_window.json"
+    _write_json(replay_path, replay)
+    _write_json(paper_path, paper)
+
+    comparison = compare_from_paths(
+        ComparePaths(replay_report_json=replay_path, paper_reference_json=paper_path)
+    )
+    calibration = build_simulator_calibration_report(comparison)
+
+    record_defaults: dict[str, Any] = {
+        "run_id": "replay-aabbccddee11-0001",
+        "status": "completed",
+        "mode": "baseline",
+        "strategy_id": replay.get("strategy_id", "primary_breakout_v1"),
+        "symbol": replay["run_spec"]["symbol"],
+        "dataset_fingerprint": "a" * 64,
+        "scheduler_profile": "2x",
+        "execution_provenance_id": "bt-0123456789abcdef",
+        "artifact_root": "artifacts/replay_reports/replay-aabbccddee11-0001",
+        "deterministic_replay_ok": True,
+        "failure_reason": None,
+        "started_at_utc": "2026-04-22T14:00:00+00:00",
+        "finished_at_utc": "2026-04-22T14:00:05+00:00",
+    }
+    if record_overrides:
+        record_defaults.update(record_overrides)
+    record = ReplayRunRecord(**record_defaults)
+
+    gate_shadow = shadow if shadow is not None else comparison
+    bundle = ARVPEvidenceBundle(record=record, shadow=gate_shadow)
+    gate = build_arvp_gate_verdict(bundle)
+    return CalibrationPipelineResult(
+        comparison=comparison, calibration=calibration, gate=gate
+    )
+
+
+def comparison_for_calibration(
+    *,
+    status: str = "aligned",
+    fill_rate_delta: Decimal | None = Decimal("0.10"),
+    fill_count_delta: int = 0,
+    inferred_unfilled_count_delta: int = 0,
+    alignment_issue: str | None = None,
+) -> ShadowComparisonResult:
+    return ShadowComparisonResult(
+        comparison_fingerprint="f" * 64,
+        status=status,
+        alignment_issue=alignment_issue,
+        replay_run_id="replay-aabbccddee11-0001",
+        paper_provenance_id="paper-run-001",
+        symbol="BTCUSDT",
+        strategy_id="primary_breakout_v1",
+        signal_count_delta=0,
+        order_count_delta=0,
+        fill_count_delta=fill_count_delta,
+        inferred_unfilled_count_delta=inferred_unfilled_count_delta,
+        actual_reject_count_delta=None,
+        fill_rate_replay=None,
+        fill_rate_paper=None,
+        fill_rate_delta=fill_rate_delta,
+        window_start_utc_replay="2024-01-01T00:00:00+00:00",
+        window_end_utc_replay="2024-01-02T00:00:00+00:00",
+        window_start_utc_paper="2024-01-01T00:00:00+00:00",
+        window_end_utc_paper="2024-01-02T00:00:00+00:00",
+    )
+
+
+def write_fixture_bundle(name: str, replay: dict[str, Any], paper: dict[str, Any]) -> None:
+    target = _FIXTURE_DIR / name
+    target.mkdir(parents=True, exist_ok=True)
+    _write_json(target / "replay_report.json", replay)
+    _write_json(target / "paper_reference_window.json", paper)

--- a/tests/unit/arvp/_arvp_event_chain_helpers.py
+++ b/tests/unit/arvp/_arvp_event_chain_helpers.py
@@ -1,0 +1,47 @@
+"""Shared helpers for ARVP runtime event-chain contract tests (#3821)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tools.arvp_chain_detector import ChainDetector
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "arvp" / "event_chain"
+
+_FORBIDDEN_OUTPUT_KEYWORDS = ("Live-Go", "Echtgeld", "live_trading", "auto-merge")
+_FORBIDDEN_SOURCE_KEYWORDS = (
+    "Live-Go",
+    "Echtgeld-Go",
+    "auto-merge",
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "gh issue close",
+)
+
+
+def load_event_chain_fixture(name: str) -> list[dict[str, Any]]:
+    payload = json.loads((_FIXTURE_DIR / name).read_text(encoding="utf-8"))
+    events = payload.get("events", payload)
+    if not isinstance(events, list):
+        raise ValueError(f"fixture {name} must contain an events list")
+    return events
+
+
+def detect_chain_from_fixture(name: str) -> dict[str, Any]:
+    return ChainDetector(events=load_event_chain_fixture(name)).detect()
+
+
+def assert_no_live_keywords_in_output(result: dict[str, Any]) -> None:
+    output = json.dumps(result, default=str)
+    for keyword in _FORBIDDEN_OUTPUT_KEYWORDS:
+        assert keyword not in output, f"forbidden keyword in chain output: {keyword}"
+
+
+def assert_chain_detector_source_boundaries() -> None:
+    source_path = Path(__file__).resolve().parents[3] / "tools" / "arvp_chain_detector.py"
+    source = source_path.read_text(encoding="utf-8")
+    for keyword in _FORBIDDEN_SOURCE_KEYWORDS:
+        assert keyword not in source, f"forbidden keyword in chain detector: {keyword}"

--- a/tests/unit/arvp/test_arvp_calibration_gate_regression_contract.py
+++ b/tests/unit/arvp/test_arvp_calibration_gate_regression_contract.py
@@ -1,0 +1,186 @@
+"""Fixture-only Replay→Paper→Compare→Calibration→Gate regression contract (#3822)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from core.replay.arvp_gate import ARVPEvidenceBundle, build_arvp_gate_verdict
+from core.replay.replay_vs_paper_compare import ComparePaths, compare_from_paths
+from core.replay.run_registry import ReplayRunRecord
+from core.replay.simulator_calibration_report import build_simulator_calibration_report
+
+from tests.unit.arvp._arvp_calibration_gate_helpers import (
+    comparison_for_calibration,
+    paper_reference_window,
+    replay_report,
+    run_calibration_pipeline,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+_FIXTURE_ALIGNED = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "arvp"
+    / "calibration"
+    / "aligned_happy_path"
+)
+
+
+def test_aligned_happy_path_compare_calibration_gate_pass(tmp_path: Path) -> None:
+    pipeline = run_calibration_pipeline(
+        tmp_path,
+        replay=replay_report(signals=3, orders=2, fills=2),
+        paper=paper_reference_window(signal_count=1, order_count=1, fill_count=1),
+    )
+    assert pipeline.comparison.status == "aligned"
+    assert pipeline.calibration.status == "aligned"
+    assert pipeline.calibration.drift_classification in {
+        "optimistic",
+        "pessimistic",
+        "ambiguous",
+    }
+    assert len(pipeline.calibration.calibration_fingerprint) == 64
+    assert pipeline.gate.verdict == "pass"
+    assert pipeline.gate.blocking_findings == ()
+
+
+def test_aligned_fixture_bundle_roundtrip(tmp_path: Path) -> None:
+    replay_path = _FIXTURE_ALIGNED / "replay_report.json"
+    paper_path = _FIXTURE_ALIGNED / "paper_reference_window.json"
+    assert replay_path.is_file()
+    assert paper_path.is_file()
+
+    comparison = compare_from_paths(
+        ComparePaths(replay_report_json=replay_path, paper_reference_json=paper_path)
+    )
+    calibration = build_simulator_calibration_report(comparison)
+    record = ReplayRunRecord(
+        run_id="replay-aabbccddee11-0001",
+        status="completed",
+        mode="baseline",
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        dataset_fingerprint="a" * 64,
+        scheduler_profile="2x",
+        execution_provenance_id="bt-0123456789abcdef",
+        artifact_root="artifacts/replay_reports/replay-aabbccddee11-0001",
+        deterministic_replay_ok=True,
+        failure_reason=None,
+        started_at_utc="2026-04-22T14:00:00+00:00",
+        finished_at_utc="2026-04-22T14:00:05+00:00",
+    )
+    gate = build_arvp_gate_verdict(ARVPEvidenceBundle(record=record, shadow=comparison))
+    assert comparison.status == "aligned"
+    assert calibration.drift_classification in {"optimistic", "pessimistic", "ambiguous"}
+    assert gate.verdict == "pass"
+
+
+def test_symbol_mismatch_is_unusable_fail_closed(tmp_path: Path) -> None:
+    pipeline = run_calibration_pipeline(
+        tmp_path,
+        replay=replay_report(symbol="BTCUSDT"),
+        paper=paper_reference_window(symbol="ETHUSDT"),
+    )
+    assert pipeline.comparison.status == "unusable"
+    assert pipeline.calibration.status == "unusable"
+    assert pipeline.calibration.drift_classification == "unusable"
+    assert pipeline.gate.verdict == "fail"
+    assert pipeline.gate.blocking_findings
+
+
+def test_missing_replay_artifact_fail_closed(tmp_path: Path) -> None:
+    paper_path = tmp_path / "paper.json"
+    paper_path.write_text("{}", encoding="utf-8")
+    missing_replay = tmp_path / "missing_report.json"
+    with pytest.raises(Exception):
+        compare_from_paths(
+            ComparePaths(
+                replay_report_json=missing_replay,
+                paper_reference_json=paper_path,
+            )
+        )
+
+
+def test_running_replay_record_blocks_gate_without_promotion(tmp_path: Path) -> None:
+    pipeline = run_calibration_pipeline(
+        tmp_path,
+        replay=replay_report(),
+        paper=paper_reference_window(),
+        record_overrides={"status": "running", "finished_at_utc": None},
+    )
+    assert pipeline.comparison.status == "aligned"
+    assert pipeline.gate.verdict == "blocked"
+    assert pipeline.gate.blocking_findings == ()
+
+
+def test_failed_replay_record_fail_closed_gate(tmp_path: Path) -> None:
+    pipeline = run_calibration_pipeline(
+        tmp_path,
+        replay=replay_report(),
+        paper=paper_reference_window(),
+        record_overrides={
+            "status": "failed",
+            "failure_reason": "deterministic_verify_mismatch",
+        },
+    )
+    assert pipeline.gate.verdict == "fail"
+    assert any("run_failed" in f for f in pipeline.gate.blocking_findings)
+
+
+@pytest.mark.parametrize(
+    ("fill_rate_delta", "expected_drift"),
+    [
+        (Decimal("0.02"), "optimistic"),
+        (Decimal("-0.02"), "pessimistic"),
+    ],
+)
+def test_simulator_drift_classifications(
+    fill_rate_delta: Decimal, expected_drift: str
+) -> None:
+    comparison = comparison_for_calibration(fill_rate_delta=fill_rate_delta)
+    report = build_simulator_calibration_report(comparison)
+    assert report.drift_classification == expected_drift
+    assert len(report.calibration_fingerprint) == 64
+
+
+def test_ambiguous_drift_when_proxy_signals_conflict() -> None:
+    comparison = comparison_for_calibration(
+        fill_rate_delta=None, fill_count_delta=5, inferred_unfilled_count_delta=3
+    )
+    report = build_simulator_calibration_report(comparison)
+    assert report.drift_classification == "ambiguous"
+    assert any("mixed_signals" in note for note in report.notes)
+
+
+def test_calibration_fingerprint_is_deterministic() -> None:
+    comparison = comparison_for_calibration(fill_rate_delta=Decimal("0.01"))
+    first = build_simulator_calibration_report(comparison)
+    second = build_simulator_calibration_report(comparison)
+    assert first.calibration_fingerprint == second.calibration_fingerprint
+
+
+def test_gate_fingerprint_changes_when_shadow_misaligned(tmp_path: Path) -> None:
+    aligned = run_calibration_pipeline(
+        tmp_path / "aligned",
+        replay=replay_report(),
+        paper=paper_reference_window(),
+    )
+    misaligned = run_calibration_pipeline(
+        tmp_path / "misaligned",
+        replay=replay_report(),
+        paper=paper_reference_window(),
+        shadow=comparison_for_calibration(
+            status="misaligned",
+            alignment_issue="misaligned: no temporal overlap",
+            fill_rate_delta=None,
+        ),
+    )
+    assert aligned.gate.verdict == "pass"
+    assert misaligned.gate.verdict == "fail"
+    assert (
+        aligned.gate.verdict_fingerprint != misaligned.gate.verdict_fingerprint
+    )

--- a/tests/unit/arvp/test_arvp_campaign_supervisor_state_machine_contract.py
+++ b/tests/unit/arvp/test_arvp_campaign_supervisor_state_machine_contract.py
@@ -1,0 +1,219 @@
+"""Campaign supervisor state-machine contract tests (#3823).
+
+Terminal states, probe-layer boundaries, chain detector integration, and
+GitHub reporter read-only semantics. No Docker, Windows supervisor, or live GitHub.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from tools.arvp_campaign_supervisor import (
+    EXIT_BLOCKED_DB_READONLY,
+    EXIT_BLOCKED_GOVERNANCE,
+    EXIT_BLOCKED_RUNTIME,
+    EXIT_CHAIN_FOUND,
+    EXIT_CODE_MAP,
+    EXIT_INTERRUPTED,
+    EXIT_TIMEOUT_NO_CHAIN,
+    STATE_BLOCKED_DB_READONLY,
+    STATE_BLOCKED_GOVERNANCE,
+    STATE_BLOCKED_RUNTIME,
+    STATE_CHAIN_FOUND,
+    STATE_INTERRUPTED,
+    STATE_RUNNING,
+    STATE_TIMEOUT_NO_CHAIN,
+    detect_chain,
+    evaluate_state,
+    load_manifest,
+)
+from tools.arvp_chain_detector import ChainDetector
+from tools.arvp_github_reporter import GitHubReporter, render_body
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "arvp_campaigns"
+
+_TERMINAL_STATES = (
+    STATE_CHAIN_FOUND,
+    STATE_TIMEOUT_NO_CHAIN,
+    STATE_INTERRUPTED,
+    STATE_BLOCKED_RUNTIME,
+    STATE_BLOCKED_DB_READONLY,
+    STATE_BLOCKED_GOVERNANCE,
+)
+
+_PROBE_CASES = (
+    ("probe_set_complete_chain.json", STATE_CHAIN_FOUND, EXIT_CHAIN_FOUND),
+    ("probe_set_all_ok_running.json", STATE_RUNNING, None),
+    ("probe_set_host_interrupted.json", STATE_INTERRUPTED, EXIT_INTERRUPTED),
+    ("probe_set_docker_blocked.json", STATE_BLOCKED_RUNTIME, EXIT_BLOCKED_RUNTIME),
+    ("probe_set_db_blocked.json", STATE_BLOCKED_DB_READONLY, EXIT_BLOCKED_DB_READONLY),
+    ("probe_set_candles_gap.json", STATE_BLOCKED_DB_READONLY, EXIT_BLOCKED_DB_READONLY),
+    ("probe_set_safety_blocked.json", STATE_BLOCKED_RUNTIME, EXIT_BLOCKED_RUNTIME),
+)
+
+
+def _load_fixture(name: str) -> list[dict]:
+    path = _FIXTURE_DIR / name
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _minimal_manifest(**overrides: object) -> dict:
+    manifest = {
+        "schema_version": "1.0",
+        "campaign_id": "arvp_p0_contract",
+        "parent_issue": 3820,
+        "related_issues": [3821, 3822, 3823],
+        "symbol": "BTCUSDT",
+        "strategy_id": "primary_breakout_v1",
+        "evidence_class": "natural_paper_evidence",
+        "start_utc": "2026-06-10T08:00:00Z",
+        "timeout_utc": "2099-01-01T00:00:00Z",
+        "max_duration_hours": 8.0,
+        "start_criteria": {"pre_documented": True},
+        "safety_flags": {
+            "mock_trading": True,
+            "use_real_balance": False,
+            "dry_run": True,
+            "mexc_testnet": True,
+        },
+        "runtime_targets": ["cdb_execution", "cdb_regime"],
+        "db_readonly_targets": ["public.correlation_ledger"],
+        "evidence_doc": "docs/evidence/test.md",
+        "evidence_log_jsonl": "artifacts/test/evidence.jsonl",
+        "github_reporting": {
+            "post_on_issue_3820": True,
+            "pr_create_on_chain_found": True,
+            "issue_close_after_acceptance": False,
+        },
+        "allowed_statuses": ["running", "chain_found"],
+        "terminal_statuses": ["chain_found"],
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+def test_manifest_campaign_3_declares_all_terminal_states() -> None:
+    manifest = yaml.safe_load((_FIXTURE_DIR / "manifest_campaign_3.yaml").read_text())
+    terminal = {str(s).upper() for s in manifest["terminal_statuses"]}
+    expected = {
+        "CHAIN_FOUND",
+        "TIMEOUT_NO_CHAIN",
+        "INTERRUPTED",
+        "BLOCKED_RUNTIME",
+        "BLOCKED_DB_READONLY",
+        "BLOCKED_GOVERNANCE",
+    }
+    assert expected.issubset(terminal)
+
+
+@pytest.mark.parametrize("fixture_name,expected_state,expected_exit", _PROBE_CASES)
+def test_evaluate_state_from_fixture_probe_sets(
+    fixture_name: str, expected_state: str, expected_exit: int | None
+) -> None:
+    probes = _load_fixture(fixture_name)
+    manifest = _minimal_manifest()
+    if expected_state == STATE_TIMEOUT_NO_CHAIN:
+        manifest["timeout_utc"] = "2020-01-01T00:00:00Z"
+    state = evaluate_state(probes, manifest, cycle_count=1)
+    assert state == expected_state
+    if expected_exit is not None:
+        assert EXIT_CODE_MAP[state] == expected_exit
+
+
+def test_timeout_no_chain_when_past_deadline_without_chain() -> None:
+    probes = _load_fixture("probe_set_all_ok_running.json")
+    manifest = _minimal_manifest(timeout_utc="2020-01-01T00:00:00Z")
+    assert evaluate_state(probes, manifest, 3) == STATE_TIMEOUT_NO_CHAIN
+
+
+def test_partial_chain_never_triggers_chain_found() -> None:
+    probes = _load_fixture("probe_set_partial_chain.json")
+    manifest = _minimal_manifest()
+    assert evaluate_state(probes, manifest, 1) == STATE_RUNNING
+    assert detect_chain(probes) is None
+
+
+def test_chain_detector_integration_from_complete_chain_fixture() -> None:
+    probes = _load_fixture("probe_set_complete_chain.json")
+    chain = detect_chain(probes)
+    assert chain is not None
+    assert chain["chain_status"] == "complete_chain"
+    assert chain["complete"] is True
+    ledger = next(p for p in probes if p["probe"] == "correlation_ledger")
+    detector = ChainDetector.from_probe_result(ledger)
+    assert detector.classify() == "complete_chain"
+
+
+def test_state_transition_running_to_chain_found_is_deterministic() -> None:
+    running = _load_fixture("probe_set_all_ok_running.json")
+    complete = _load_fixture("probe_set_complete_chain.json")
+    manifest = _minimal_manifest()
+    assert evaluate_state(running, manifest, 1) == STATE_RUNNING
+    assert evaluate_state(complete, manifest, 2) == STATE_CHAIN_FOUND
+
+
+@pytest.mark.parametrize("state", _TERMINAL_STATES)
+def test_github_reporter_renders_terminal_without_auto_close(state: str) -> None:
+    entry = {
+        "observed_at_utc": "2026-06-10T12:00:00Z",
+        "cycle": 1,
+        "campaign_id": "arvp_p0_contract",
+        "state": state,
+        "probe_statuses": {"host": "ok"},
+        "event_count_since_start": 0,
+        "chain_detected": state == STATE_CHAIN_FOUND,
+        "no_mutation": True,
+        "limitations": [],
+    }
+    body = render_body(state, entry, _minimal_manifest())
+    assert "LR remains NO-GO" in body
+    assert "closes #" not in body.lower()
+    assert "gh issue close" not in body
+
+
+def test_github_reporter_dry_run_never_calls_subprocess() -> None:
+    reporter = GitHubReporter(_minimal_manifest())
+    entry = {
+        "state": STATE_TIMEOUT_NO_CHAIN,
+        "campaign_id": "arvp_p0_contract",
+        "observed_at_utc": "2026-06-10T12:00:00Z",
+        "probe_statuses": {"host": "ok"},
+        "event_count_since_start": 0,
+        "chain_detected": False,
+        "no_mutation": True,
+        "limitations": [],
+    }
+    with patch("subprocess.run") as mock_run:
+        results = reporter.report_terminal(entry)
+        mock_run.assert_not_called()
+    assert all(r["action"].startswith("dry_run_") for r in results)
+
+
+def test_blocked_governance_exit_code_is_distinct() -> None:
+    assert EXIT_CODE_MAP[STATE_BLOCKED_GOVERNANCE] == EXIT_BLOCKED_GOVERNANCE
+    codes = list(EXIT_CODE_MAP.values())
+    assert len(codes) == len(set(codes))
+
+
+def test_all_probe_fixtures_mark_no_mutation() -> None:
+    for name in os.listdir(_FIXTURE_DIR):
+        if not name.startswith("probe_set_") or not name.endswith(".json"):
+            continue
+        for probe in _load_fixture(name):
+            assert probe.get("no_mutation") is True, f"{name}:{probe.get('probe')}"
+
+
+def test_load_manifest_from_campaign_fixture() -> None:
+    path = str(_FIXTURE_DIR / "manifest_campaign_3.yaml")
+    manifest = load_manifest(path)
+    assert manifest["campaign_id"] == "test_campaign_3"
+    assert manifest["github_reporting"]["issue_close_after_acceptance"] is False

--- a/tests/unit/arvp/test_arvp_runtime_event_chain_contract.py
+++ b/tests/unit/arvp/test_arvp_runtime_event_chain_contract.py
@@ -1,0 +1,105 @@
+"""Fixture-based ARVP runtime event-chain contract tests (#3821).
+
+Paper runtime chain SIGNAL → DECISION → ORDER → FILL via ChainDetector.
+No Docker, network, DB, exchange, or live GitHub.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.arvp_chain_detector import ChainDetector, normalize_event_type
+
+from tests.unit.arvp._arvp_event_chain_helpers import (
+    assert_chain_detector_source_boundaries,
+    assert_no_live_keywords_in_output,
+    detect_chain_from_fixture,
+    load_event_chain_fixture,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+_PARTIAL_FIXTURES = (
+    ("signal_only.json", "signal_only"),
+    ("signal_decision.json", "signal_decision"),
+    ("signal_decision_order.json", "signal_decision_order"),
+)
+
+
+def test_complete_chain_with_order_paper_prefix_promotes_export_trigger() -> None:
+    result = detect_chain_from_fixture("complete_chain_paper_order.json")
+    assert result["complete"] is True
+    assert result["chain_status"] == "complete_chain"
+    assert "ORDER" in result["observed_types"]
+    assert result["export_trigger"]["export_candidate"] is True
+    assert result["export_trigger"]["evidence_class"] == "natural_paper_evidence"
+    assert result["no_mutation"] is True
+    assert_no_live_keywords_in_output(result)
+
+
+@pytest.mark.parametrize("fixture_name,expected_status", _PARTIAL_FIXTURES)
+def test_partial_chains_never_promote_to_complete(
+    fixture_name: str, expected_status: str
+) -> None:
+    result = detect_chain_from_fixture(fixture_name)
+    assert result["complete"] is False
+    assert result["chain_status"] == expected_status
+    assert "export_trigger" not in result
+
+
+def test_malformed_events_fail_closed_without_complete_chain() -> None:
+    result = detect_chain_from_fixture("malformed_missing_ts.json")
+    assert result["complete"] is False
+    assert result["chain_status"] == "malformed_chain"
+    assert "export_trigger" not in result
+    assert any("malformed" in lim for lim in result["limitations"])
+
+
+def test_order_paper_prefix_normalizes_to_order_type() -> None:
+    assert normalize_event_type("ORDER(paper_)") == "ORDER"
+    events = load_event_chain_fixture("complete_chain_paper_order.json")
+    paper_orders = [e for e in events if "ORDER(paper_)" in e.get("event_type", "")]
+    assert len(paper_orders) == 1
+    detector = ChainDetector(events=events)
+    assert detector.classify() == "complete_chain"
+
+
+def test_probe_result_partial_chain_does_not_export() -> None:
+    probe = {
+        "status": "ok",
+        "evidence": {
+            "events_since_campaign_start": 2,
+            "events_by_type_status": [
+                {"event_type": "SIGNAL", "status": "active", "count": 1},
+                {"event_type": "DECISION", "status": "executed", "count": 1},
+            ],
+            "events": load_event_chain_fixture("signal_decision.json"),
+        },
+    }
+    result = ChainDetector.from_probe_result(probe).detect()
+    assert result["complete"] is False
+    assert result["chain_status"] == "signal_decision"
+    assert "export_trigger" not in result
+
+
+def test_chain_detector_source_has_no_secret_or_mutation_keywords() -> None:
+    assert_chain_detector_source_boundaries()
+
+
+def test_all_fixture_outputs_serialize_without_live_go_keywords() -> None:
+    for name in (
+        "complete_chain_paper_order.json",
+        "signal_only.json",
+        "signal_decision.json",
+        "signal_decision_order.json",
+        "malformed_missing_ts.json",
+    ):
+        assert_no_live_keywords_in_output(detect_chain_from_fixture(name))
+
+
+def test_complete_chain_event_ids_are_deterministic() -> None:
+    first = detect_chain_from_fixture("complete_chain_paper_order.json")
+    second = detect_chain_from_fixture("complete_chain_paper_order.json")
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)


### PR DESCRIPTION
## Summary

Closes #3821
Closes #3822
Closes #3823
Refs #3820

Fixture-only ARVP P0 contract suites for runtime event chain, replay-to-paper calibration gate regression, and campaign supervisor terminal state machines.

## Delivered by issue

### #3821 Runtime event-chain contract
- \	ests/unit/arvp/test_arvp_runtime_event_chain_contract.py\
- Fixtures under \	ests/fixtures/arvp/event_chain/\
- Complete SIGNAL→DECISION→ORDER(paper_)→FILL chain + negative partial/malformed chains
- Teilketten werden nicht als complete_chain promoted; no-secret/no-live assertions

### #3822 Replay-to-paper calibration gate regression
- \	ests/unit/arvp/test_arvp_calibration_gate_regression_contract.py\
- Helpers + aligned fixture bundle under \	ests/fixtures/arvp/calibration/aligned_happy_path/\
- Replay→Paper→Compare→Calibration→Gate happy path + fail-closed/unusable/blocked cases
- Deterministic fingerprints for calibration and gate verdicts

### #3823 Campaign supervisor state machine
- \	ests/unit/arvp/test_arvp_campaign_supervisor_state_machine_contract.py\
- New probe fixtures: docker blocked (runtime unavailable), candles gap
- Terminal states: chain_found, timeout_no_chain, interrupted, blocked_runtime, blocked_db_readonly, blocked_governance (manifest/reporter/exit codes)
- GitHub reporter remains comment/PR dry-run only; no auto-close

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true; context_tool_status: available; records_found: none
- repo_fallback_reason: insufficient_evidence
- GitHub live issues #3820-#3823 verified open; #3893 out of scope (runtime observation running)

## Validation
- \pytest -q tests/unit/arvp/\ — 43 passed
- \uff check tests/unit/arvp/\ — clean
- No Docker, live DB, exchange, or GitHub writes in tests

## Non-goals
- No ARVP architecture changes
- No runtime/service mutation
- No live trading or LR change (remains NO-GO)
- #3893 runtime observation untouched
- #3755 / Dependabot out of scope

## Safety Boundaries
- Shadow/Paper-first; fixture-only CI
- No productive DB writes, no MCP mutations, no secrets

## Restunsicherheiten
- \valuate_state\ maps safety-flag drift to \BLOCKED_RUNTIME\ (not \BLOCKED_GOVERNANCE\) — contract tests document current behavior; governance terminal enum remains manifest/reporter covered

Made with [Cursor](https://cursor.com)