### PR TITLE
test(arvp): add runtime p1 scenario qualification evidence contracts

### DIFF
--- a/knowledge/testing/ARVP_P1_CONTRACT_TESTS.md
+++ b/knowledge/testing/ARVP_P1_CONTRACT_TESTS.md
@@ -1,0 +1,18 @@
+# ARVP P1 Contract Tests
+
+Scope: issues #3826–#3829 (parent #3820).
+
+| Issue | Test module | Protects |
+|-------|-------------|----------|
+| #3826 | `test_arvp_scenario_pack_matrix_contract.py` | Strategy × scenario-pack matrix, adapter validation, fail-closed unsupported/blocked combos |
+| #3827 | `test_arvp_window_qualification_contract.py` | Window cadence/gap/warmup, regime + paper availability, honest PASS/WARN/BLOCKED |
+| #3828 | `test_arvp_evidence_harvester_mapping_contract.py` | Harvester gaps/safety → packet limitations; no coverage→profitability promotion |
+| #3829 | `test_arvp_runtime_negative_controls_contract.py` | Invalid/blocked runtime inputs produce no orders/fills/executor/DB writes |
+
+Run:
+
+```bash
+pytest -q tests/unit/arvp/ -m contract
+```
+
+Boundaries: fixture/unit only; no Docker, live DB, harvester runtime, or LR/live go.

--- a/tests/fixtures/arvp/evidence_mapping/cases_v1.json
+++ b/tests/fixtures/arvp/evidence_mapping/cases_v1.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "arvp_evidence_mapping.v1",
+  "cases": [
+    {
+      "case_id": "harvester_gap_zero_paper_chains",
+      "harvester": {
+        "limitations": ["zero paper chains observed in harvest window"],
+        "safety_boundaries": ["LR NO-GO; coverage signal only"],
+        "source_run_refs": ["run-harvester-gap-001"]
+      },
+      "data_quality_verdict": "WARNING",
+      "regime_status": "unavailable",
+      "replay_vs_paper_status": "misaligned",
+      "expect_coverage_ready": true,
+      "expect_ranking_complete": false,
+      "expect_limitation_substrings": ["zero paper chains"]
+    },
+    {
+      "case_id": "stale_feed_blocked",
+      "harvester": {
+        "limitations": ["stale feed detected in harvest window"],
+        "safety_boundaries": ["No live execution without human gate"],
+        "source_run_refs": ["run-harvester-stale-001"]
+      },
+      "data_quality_verdict": "BLOCKED",
+      "regime_status": "ok",
+      "replay_vs_paper_status": "aligned",
+      "expect_coverage_ready": false,
+      "expect_ranking_complete": false,
+      "expect_limitation_substrings": ["stale feed"]
+    },
+    {
+      "case_id": "coverage_signal_does_not_promote_to_proof",
+      "harvester": {
+        "limitations": ["partial coverage only"],
+        "safety_boundaries": ["Harvester health is not profitability proof"],
+        "source_run_refs": ["run-harvester-coverage-001"]
+      },
+      "data_quality_verdict": "PASS",
+      "regime_status": "unavailable",
+      "replay_vs_paper_status": "misaligned",
+      "expect_coverage_ready": true,
+      "expect_ranking_complete": false,
+      "expect_recommendation_not": "APPROVE"
+    }
+  ]
+}

--- a/tests/fixtures/arvp/scenario_pack_matrix_v1.json
+++ b/tests/fixtures/arvp/scenario_pack_matrix_v1.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "arvp_scenario_pack_matrix.v1",
+  "canonical_adapter_by_strategy": {
+    "primary_breakout_v1": "primary_breakout_runner_v1",
+    "donchian_breakout_v1": "donchian_breakout_runner_v1",
+    "breakout_trend_filter_v1": "breakout_trend_filter_runner_v1",
+    "range_mean_reversion_v1": "range_mean_reversion_runner_v1",
+    "momentum_capture_v1": "momentum_capture_runner_v1"
+  },
+  "builtin_scenario_ids": [
+    "baseline",
+    "pessimistic_execution",
+    "delayed_execution",
+    "low_liquidity",
+    "feed_gap"
+  ],
+  "supported_examples": [
+    {
+      "strategy_id": "primary_breakout_v1",
+      "adapter_id": "primary_breakout_runner_v1",
+      "scenario_id": "baseline"
+    },
+    {
+      "strategy_id": "donchian_breakout_v1",
+      "adapter_id": "donchian_breakout_runner_v1",
+      "scenario_id": "feed_gap"
+    },
+    {
+      "strategy_id": "range_mean_reversion_v1",
+      "adapter_id": "range_mean_reversion_runner_v1",
+      "scenario_id": "pessimistic_execution"
+    }
+  ],
+  "unsupported_examples": [
+    {
+      "strategy_id": "primary_breakout_v1",
+      "adapter_id": "donchian_breakout_runner_v1",
+      "scenario_id": "baseline",
+      "reason": "adapter_strategy_mismatch"
+    },
+    {
+      "strategy_id": "not_a_strategy",
+      "adapter_id": "primary_breakout_runner_v1",
+      "scenario_id": "baseline",
+      "reason": "unsupported_strategy_id"
+    },
+    {
+      "strategy_id": "primary_breakout_v1",
+      "adapter_id": "unknown_adapter",
+      "scenario_id": "baseline",
+      "reason": "unsupported_adapter_id"
+    }
+  ],
+  "blocked_examples": [
+    {
+      "strategy_id": "primary_breakout_v1",
+      "adapter_id": "primary_breakout_runner_v1",
+      "scenario_id": "not_a_real_pack",
+      "reason": "unknown_scenario_pack"
+    }
+  ]
+}

--- a/tests/fixtures/arvp/window_qualification/cases_v1.json
+++ b/tests/fixtures/arvp/window_qualification/cases_v1.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "arvp_window_qualification.v1",
+  "cases": [
+    {
+      "case_id": "strict_cadence_pass",
+      "expected_verdict": "PASS",
+      "warmup_candles": 2,
+      "candles": [
+        {"ts_ms": 1704067020000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067080000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067140000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067200000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067260000, "high": 101.0, "low": 99.0, "close": 100.0}
+      ],
+      "regime_trace": {
+        "run_id": "replay-test-0001",
+        "steps": [{"ts_ms": 1, "regime_id": 0, "signals_emitted": 1}],
+        "trades": []
+      },
+      "paper_events": "complete_chain_paper_order"
+    },
+    {
+      "case_id": "cadence_gap_blocked",
+      "expected_verdict": "BLOCKED",
+      "warmup_candles": 1,
+      "candles": [
+        {"ts_ms": 1704067020000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067140000, "high": 101.0, "low": 99.0, "close": 100.0}
+      ],
+      "regime_trace": null,
+      "paper_events": null
+    },
+    {
+      "case_id": "missing_regime_warn",
+      "expected_verdict": "WARN",
+      "warmup_candles": 1,
+      "candles": [
+        {"ts_ms": 1704067020000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067080000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067140000, "high": 101.0, "low": 99.0, "close": 100.0}
+      ],
+      "regime_trace": {
+        "run_id": "replay-test-0002",
+        "steps": [{"ts_ms": 1, "regime_id": null, "signals_emitted": 1}],
+        "trades": []
+      },
+      "paper_events": "complete_chain_paper_order"
+    },
+    {
+      "case_id": "paper_reference_missing_warn",
+      "expected_verdict": "WARN",
+      "warmup_candles": 1,
+      "candles": [
+        {"ts_ms": 1704067020000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067080000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067140000, "high": 101.0, "low": 99.0, "close": 100.0}
+      ],
+      "regime_trace": {
+        "run_id": "replay-test-0003",
+        "steps": [{"ts_ms": 1, "regime_id": 0, "signals_emitted": 1}],
+        "trades": []
+      },
+      "paper_events": "signal_only"
+    },
+    {
+      "case_id": "all_warmup_no_live_blocked",
+      "expected_verdict": "BLOCKED",
+      "warmup_candles": 2,
+      "candles": [
+        {"ts_ms": 1704067020000, "high": 101.0, "low": 99.0, "close": 100.0},
+        {"ts_ms": 1704067080000, "high": 101.0, "low": 99.0, "close": 100.0}
+      ],
+      "regime_trace": null,
+      "paper_events": null
+    }
+  ]
+}

--- a/tests/unit/arvp/_arvp_evidence_mapping_helpers.py
+++ b/tests/unit/arvp/_arvp_evidence_mapping_helpers.py
@@ -1,0 +1,104 @@
+"""Shared helpers for Harvester→ARVP→Profitability mapping contract tests (#3828)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from services.validation.profitability_evidence_packet_assembler import (
+    _build_coverage_readiness,
+    _build_recommendation,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "arvp"
+    / "evidence_mapping"
+    / "cases_v1.json"
+)
+
+
+def load_evidence_mapping_cases() -> list[dict[str, Any]]:
+    payload = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list):
+        raise ValueError("evidence mapping fixture must contain cases list")
+    return cases
+
+
+def _base_inputs(case: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    harvester = {
+        "schema_version": "profitability_harvester_ref.v1",
+        "candidate_id": "cand-test-001",
+        "risk_blocks": 1,
+        "kill_switch_events": 0,
+        **case["harvester"],
+    }
+    inputs = {
+        "data_quality_report": {
+            "quality_verdict": case["data_quality_verdict"],
+            "limitations": [],
+        },
+        "replay_metrics": {
+            "data_integrity_ok": True,
+            "deterministic_replay_ok": True,
+            "profit_factor": 1.1,
+            "expectancy": 0.01,
+            "win_rate": 0.5,
+            "avg_win": 0.02,
+            "avg_loss": -0.01,
+            "max_drawdown": 0.05,
+            "loss_streak": 1,
+            "trade_count": 10,
+        },
+        "scenario_stress_summary": {
+            "overall_stress_outcome": "PASS",
+            "limitations": [],
+        },
+        "economics_assessment": {
+            "assessment_status": "PASS",
+            "ranking_ready": False,
+            "limitations": [],
+        },
+        "regime_scorecard_block": {
+            "status": case["regime_status"],
+            "segments": [],
+            "notes": ["regime unavailable"] if case["regime_status"] != "ok" else [],
+        },
+        "replay_vs_paper_status": case["replay_vs_paper_status"],
+        "harvester_ref": harvester,
+    }
+    candidate_contract = {
+        "status": "ACTIVE",
+        "limitations": [],
+        "execution_assumptions": ["paper only"],
+    }
+    return inputs, candidate_contract
+
+
+def evaluate_evidence_mapping_case(case: dict[str, Any]) -> dict[str, Any]:
+    inputs, candidate_contract = _base_inputs(case)
+    coverage = _build_coverage_readiness(
+        data_quality_report=inputs["data_quality_report"],
+        replay_metrics=inputs["replay_metrics"],
+        scenario_stress_summary=inputs["scenario_stress_summary"],
+        economics_assessment=inputs["economics_assessment"],
+        regime_scorecard_block=inputs["regime_scorecard_block"],
+        replay_vs_paper_status=inputs["replay_vs_paper_status"],
+        harvester_ref=inputs["harvester_ref"],
+    )
+    recommendation = _build_recommendation(
+        candidate_contract=candidate_contract,
+        economics_assessment=inputs["economics_assessment"],
+        coverage_readiness=coverage,
+    )
+    limitations = list(inputs["harvester_ref"].get("limitations", []))
+    safety = list(inputs["harvester_ref"].get("safety_boundaries", []))
+    return {
+        "coverage": coverage,
+        "recommendation": recommendation,
+        "limitations": limitations,
+        "safety_boundaries": safety,
+    }

--- a/tests/unit/arvp/_arvp_negative_controls_helpers.py
+++ b/tests/unit/arvp/_arvp_negative_controls_helpers.py
@@ -1,0 +1,127 @@
+"""Shared helpers for ARVP runtime negative-controls contract tests (#3829)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+from core.utils.trace_toggle import allow_evidence_debt
+from services.execution import service as execution_service
+
+from tests.unit.execution._execution_boundary_contract_helpers import (
+    ExecutionHarness,
+    valid_order_payload,
+)
+
+
+@dataclass(frozen=True)
+class NegativeControlOutcome:
+    name: str
+    executor_called: bool
+    db_write_attempted: bool
+    blocked: bool
+
+
+def run_invalid_execution_payload(execution_harness: ExecutionHarness) -> NegativeControlOutcome:
+    result = execution_service.process_order({"type": "order", "side": "BUY"})
+    insert_calls = [
+        call
+        for call in execution_harness.db.cursor.return_value.__enter__.return_value.execute.call_args_list
+        if call.args and "INSERT" in str(call.args[0]).upper()
+    ]
+    return NegativeControlOutcome(
+        name="invalid_execution_payload",
+        executor_called=execution_harness.executor.execute_order.called,
+        db_write_attempted=bool(insert_calls),
+        blocked=result is None,
+    )
+
+
+def run_kill_switch_active_block(execution_harness: ExecutionHarness, monkeypatch) -> NegativeControlOutcome:
+    monkeypatch.setattr(
+        "core.safety.kill_switch.get_kill_switch_details",
+        lambda create_if_missing=False: (True, "active", None, None),
+    )
+    result = execution_service.process_order(valid_order_payload(run_mode="paper"))
+    return NegativeControlOutcome(
+        name="kill_switch_active",
+        executor_called=execution_harness.executor.execute_order.called,
+        db_write_attempted=False,
+        blocked=result is not None and result.status == "REJECTED",
+    )
+
+
+def run_missing_decision_id_block(
+    execution_harness: ExecutionHarness, monkeypatch
+) -> NegativeControlOutcome:
+    monkeypatch.setenv("TRACE_CONTRACT_V1_ENABLED", "1")
+    result = execution_service.process_order(valid_order_payload(run_mode="paper"))
+    return NegativeControlOutcome(
+        name="missing_decision_id",
+        executor_called=execution_harness.executor.execute_order.called,
+        db_write_attempted=False,
+        blocked=result is not None and result.status == "REJECTED",
+    )
+
+
+def run_evidence_debt_invalid_ledger_event(
+    mock_connect, mock_db_config, monkeypatch
+) -> tuple[bool, bool]:
+    from services.execution.database import Database
+
+    monkeypatch.delenv("ALLOW_EVIDENCE_DEBT", raising=False)
+    db, mock_cur = _ledger_db(mock_connect, mock_db_config)
+    raised = False
+    try:
+        db.persist_correlation_event(
+            signal_id="sig-1",
+            decision_id="dec-1",
+            event_type="BLOCK",
+            symbol="BTCUSDT",
+            timestamp_ms=1_700_000_000_000,
+        )
+    except ValueError:
+        raised = True
+    insert_calls = [
+        call
+        for call in mock_cur.execute.call_args_list
+        if call.args and "INSERT INTO correlation_ledger" in str(call.args[0])
+    ]
+    return raised, bool(insert_calls)
+
+
+def run_evidence_debt_on_skips_write(
+    mock_connect, mock_db_config, monkeypatch
+) -> tuple[bool, bool]:
+    from services.execution.database import Database
+
+    monkeypatch.setenv("ALLOW_EVIDENCE_DEBT", "1")
+    db, mock_cur = _ledger_db(mock_connect, mock_db_config)
+    assert allow_evidence_debt() is True
+    ok = db.persist_correlation_event(
+        signal_id="sig-1",
+        decision_id="dec-1",
+        event_type="BLOCK",
+        symbol="BTCUSDT",
+        timestamp_ms=1_700_000_000_000,
+    )
+    insert_calls = [
+        call
+        for call in mock_cur.execute.call_args_list
+        if call.args and "INSERT INTO correlation_ledger" in str(call.args[0])
+    ]
+    return ok is False, bool(insert_calls)
+
+
+def _ledger_db(mock_connect, mock_db_config):
+    mock_conn = MagicMock()
+    mock_connect.return_value = mock_conn
+    mock_cur = mock_conn.cursor.return_value.__enter__.return_value
+    from services.execution.database import Database
+
+    return Database(), mock_cur
+
+
+def invalid_signal_payload() -> dict[str, Any]:
+    return {"symbol": "BTCUSDT"}

--- a/tests/unit/arvp/_arvp_scenario_pack_matrix_helpers.py
+++ b/tests/unit/arvp/_arvp_scenario_pack_matrix_helpers.py
@@ -1,0 +1,72 @@
+"""Shared helpers for ARVP scenario-pack matrix contract tests (#3826)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from core.replay.scenario_packs import ScenarioPackError, get_scenario_pack
+from services.validation.strategy_replay_runner import (
+    ARVPReplayConfig,
+    ReplayRunnerError,
+    _apply_scenario_overrides,
+)
+
+_MATRIX_FIXTURE = (
+    Path(__file__).resolve().parents[2] / "fixtures" / "arvp" / "scenario_pack_matrix_v1.json"
+)
+
+MatrixStatus = Literal["supported", "unsupported", "blocked"]
+
+
+def load_scenario_pack_matrix_fixture() -> dict[str, Any]:
+    return json.loads(_MATRIX_FIXTURE.read_text(encoding="utf-8"))
+
+
+def classify_scenario_pack_cell(
+    *,
+    strategy_id: str,
+    adapter_id: str,
+    scenario_id: str,
+    canonical_adapter_by_strategy: dict[str, str] | None = None,
+) -> tuple[MatrixStatus, str]:
+    """Classify strategy x adapter x scenario pack without running replay."""
+    canonical = canonical_adapter_by_strategy or load_scenario_pack_matrix_fixture()[
+        "canonical_adapter_by_strategy"
+    ]
+
+    try:
+        get_scenario_pack(scenario_id)
+    except ScenarioPackError:
+        return "blocked", "unknown_scenario_pack"
+
+    cfg = ARVPReplayConfig(
+        input_candles_file="tests/fixtures/arvp/calibration/aligned_happy_path/replay_report.json",
+        strategy_id=strategy_id,
+        adapter_id=adapter_id,
+        scenario_ids=(scenario_id,),
+    )
+    try:
+        cfg.validate()
+    except ValueError as exc:
+        return "unsupported", str(exc)
+
+    expected_adapter = canonical.get(strategy_id)
+    if expected_adapter is not None and adapter_id != expected_adapter:
+        return "unsupported", "adapter_strategy_mismatch"
+
+    try:
+        overrides = get_scenario_pack(scenario_id).config_overrides
+        _apply_scenario_overrides(cfg, overrides)
+    except ReplayRunnerError as exc:
+        return "blocked", str(exc)
+
+    return "supported", ""
+
+
+def assert_matrix_fixture_covers_builtin_packs() -> None:
+    fixture = load_scenario_pack_matrix_fixture()
+    from core.replay.scenario_packs import BUILTIN_SCENARIO_IDS
+
+    assert tuple(fixture["builtin_scenario_ids"]) == BUILTIN_SCENARIO_IDS

--- a/tests/unit/arvp/_arvp_window_qualification_helpers.py
+++ b/tests/unit/arvp/_arvp_window_qualification_helpers.py
@@ -1,0 +1,236 @@
+"""Shared helpers for ARVP window qualification contract tests (#3827)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from core.replay.arvp_regime_scorecards import build_replay_regime_scorecard_from_trace
+from core.replay.dataset_provider import DatasetLoadError, FileBackedDatasetProvider
+from core.replay.dataset_spec import DatasetSpec
+from core.replay.paper_reference_window_export import (
+    PaperReferenceExportError,
+    build_export_request,
+    export_paper_reference_window,
+)
+from core.replay.scheduler import ReplayScheduler, SchedulerConfig, SchedulerError
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "fixtures"
+    / "arvp"
+    / "window_qualification"
+    / "cases_v1.json"
+)
+
+QualificationVerdict = Literal["PASS", "WARN", "BLOCKED"]
+
+
+@dataclass(frozen=True)
+class WindowQualificationResult:
+    verdict: QualificationVerdict
+    limitations: tuple[str, ...]
+    cadence_ok: bool
+    warmup_live_ok: bool
+    regime_available: bool
+    paper_reference_available: bool
+    promotes: bool
+
+
+def load_window_qualification_cases() -> list[dict[str, Any]]:
+    payload = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list):
+        raise ValueError("window qualification fixture must contain cases list")
+    return cases
+
+
+def _write_candles(tmp_path: Path, candles: list[dict[str, Any]]) -> Path:
+    path = tmp_path / "candles.json"
+    path.write_text(json.dumps(candles), encoding="utf-8")
+    return path
+
+
+def _paper_rows(*, complete: bool, start_ts_ms: int, end_ts_ms: int) -> list[dict[str, Any]]:
+    mid_ts = start_ts_ms + ((end_ts_ms - start_ts_ms) // 2)
+    base_signal = {
+        "event_pk": "sig-1",
+        "correlation_id": "corr-1",
+        "signal_id": "signal-1",
+        "decision_id": None,
+        "order_id": None,
+        "fill_id": None,
+        "event_type": "SIGNAL",
+        "symbol": "BTCUSDT",
+        "timestamp_ms": start_ts_ms,
+        "payload": {
+            "strategy_id": "primary_breakout_v1",
+            "bot_id": "bot-a",
+            "metadata": {"bot_id": "bot-a", "config_hash": "cfg-a"},
+        },
+    }
+    if not complete:
+        return [base_signal]
+    return [
+        base_signal,
+        {
+            "event_pk": "dec-1",
+            "correlation_id": "corr-1",
+            "signal_id": "signal-1",
+            "decision_id": "decision-1",
+            "order_id": None,
+            "fill_id": None,
+            "event_type": "DECISION",
+            "symbol": "BTCUSDT",
+            "timestamp_ms": mid_ts,
+            "payload": {"strategy_id": "primary_breakout_v1"},
+        },
+        {
+            "event_pk": "ord-1",
+            "correlation_id": "corr-1",
+            "signal_id": "signal-1",
+            "decision_id": "decision-1",
+            "order_id": "paper_order-1",
+            "fill_id": None,
+            "event_type": "ORDER",
+            "symbol": "BTCUSDT",
+            "timestamp_ms": mid_ts,
+            "payload": {"strategy_id": "primary_breakout_v1"},
+        },
+        {
+            "event_pk": "fill-1",
+            "correlation_id": "corr-1",
+            "signal_id": "signal-1",
+            "decision_id": "decision-1",
+            "order_id": "paper_order-1",
+            "fill_id": "fill-1",
+            "event_type": "FILL",
+            "symbol": "BTCUSDT",
+            "timestamp_ms": end_ts_ms,
+            "payload": {"strategy_id": "primary_breakout_v1"},
+        },
+    ]
+
+
+def _paper_rows_from_ref(
+    ref: str | None, *, start_ts_ms: int, end_ts_ms: int
+) -> list[dict[str, Any]] | None:
+    if ref is None:
+        return None
+    if ref == "complete_chain_paper_order":
+        return _paper_rows(complete=True, start_ts_ms=start_ts_ms, end_ts_ms=end_ts_ms)
+    if ref == "signal_only":
+        return _paper_rows(complete=False, start_ts_ms=start_ts_ms, end_ts_ms=end_ts_ms)
+    raise ValueError(f"unknown paper event ref: {ref}")
+
+
+def qualify_arvp_window_case(
+    case: dict[str, Any], tmp_path: Path
+) -> WindowQualificationResult:
+    """Evaluate one fixture case across dataset, scheduler, regime, and paper surfaces."""
+    limitations: list[str] = []
+    cadence_ok = False
+    warmup_live_ok = False
+    regime_available = False
+    paper_reference_available = False
+
+    candles = case["candles"]
+    warmup_candles = int(case["warmup_candles"])
+    if warmup_candles >= len(candles):
+        limitations.append(
+            f"Insufficient candles: {len(candles)} total, {warmup_candles} warmup required"
+        )
+        return WindowQualificationResult(
+            verdict="BLOCKED",
+            limitations=tuple(limitations),
+            cadence_ok=False,
+            warmup_live_ok=False,
+            regime_available=False,
+            paper_reference_available=False,
+            promotes=False,
+        )
+
+    candle_path = _write_candles(tmp_path, candles)
+    start_ts_ms = int(candles[warmup_candles]["ts_ms"])
+    end_ts_ms = int(candles[-1]["ts_ms"])
+
+    try:
+        spec = DatasetSpec(
+            source="file",
+            file_path=str(candle_path),
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=start_ts_ms,
+            end_ts_ms=end_ts_ms,
+            warmup_candles=warmup_candles,
+        )
+        dataset = FileBackedDatasetProvider().load(spec)
+        cadence_ok = True
+        scheduler = ReplayScheduler().schedule(
+            dataset, SchedulerConfig(profile="instant")
+        )
+        warmup_live_ok = scheduler.live_candle_count > 0 and scheduler.warmup_count == warmup_candles
+    except (DatasetLoadError, SchedulerError) as exc:
+        limitations.append(str(exc))
+        return WindowQualificationResult(
+            verdict="BLOCKED",
+            limitations=tuple(limitations),
+            cadence_ok=cadence_ok,
+            warmup_live_ok=warmup_live_ok,
+            regime_available=False,
+            paper_reference_available=False,
+            promotes=False,
+        )
+
+    regime_trace = case.get("regime_trace")
+    if isinstance(regime_trace, dict):
+        scorecard = build_replay_regime_scorecard_from_trace(regime_trace)
+        regime_available = scorecard.status == "ok"
+        if not regime_available:
+            limitations.extend(scorecard.notes or ["regime segments unavailable"])
+    else:
+        limitations.append("regime trace missing")
+
+    paper_rows = _paper_rows_from_ref(
+        case.get("paper_events"), start_ts_ms=start_ts_ms, end_ts_ms=end_ts_ms
+    )
+    if paper_rows is not None:
+        request = build_export_request(
+            strategy_id="primary_breakout_v1",
+            symbol="BTCUSDT",
+            start_ts_ms_utc=start_ts_ms,
+            end_ts_ms_utc=end_ts_ms,
+            extracted_by="window-qualification-contract",
+            extracted_at_utc="2026-07-07T00:00:00+00:00",
+            source_query_intent="contract-test",
+        )
+        try:
+            export_paper_reference_window(
+                request=request,
+                rows=paper_rows,
+            )
+            paper_reference_available = True
+        except PaperReferenceExportError as exc:
+            limitations.append(str(exc))
+    else:
+        limitations.append("paper reference events missing")
+
+    if not cadence_ok or not warmup_live_ok:
+        verdict: QualificationVerdict = "BLOCKED"
+    elif not regime_available or not paper_reference_available:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+
+    promotes = verdict == "PASS" and not limitations
+    return WindowQualificationResult(
+        verdict=verdict,
+        limitations=tuple(limitations),
+        cadence_ok=cadence_ok,
+        warmup_live_ok=warmup_live_ok,
+        regime_available=regime_available,
+        paper_reference_available=paper_reference_available,
+        promotes=promotes,
+    )

--- a/tests/unit/arvp/test_arvp_evidence_harvester_mapping_contract.py
+++ b/tests/unit/arvp/test_arvp_evidence_harvester_mapping_contract.py
@@ -1,0 +1,73 @@
+"""Fixture-based Harvester→ARVP→Profitability mapping contract tests (#3828).
+
+No live harvester, no productive evidence writes, no ranking-policy changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.arvp._arvp_evidence_mapping_helpers import (
+    evaluate_evidence_mapping_case,
+    load_evidence_mapping_cases,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+@pytest.mark.parametrize("case", load_evidence_mapping_cases(), ids=lambda c: c["case_id"])
+def test_evidence_mapping_fixture_expectations(case: dict) -> None:
+    result = evaluate_evidence_mapping_case(case)
+    coverage = result["coverage"]
+    assert coverage["coverage_report_ready"] is case["expect_coverage_ready"]
+    assert coverage["ranking_inputs_complete"] is case["expect_ranking_complete"]
+
+    for fragment in case.get("expect_limitation_substrings", []):
+        joined = " ".join(result["limitations"]).lower()
+        assert fragment.lower() in joined
+
+    if "expect_recommendation_not" in case:
+        assert result["recommendation"] != case["expect_recommendation_not"]
+
+
+def test_harvester_gap_findings_remain_limitations_not_proofs() -> None:
+    case = next(
+        c for c in load_evidence_mapping_cases() if c["case_id"] == "harvester_gap_zero_paper_chains"
+    )
+    result = evaluate_evidence_mapping_case(case)
+    assert result["coverage"]["ranking_inputs_complete"] is False
+    assert "zero paper chains" in " ".join(result["limitations"]).lower()
+
+
+def test_harvester_safety_boundaries_propagate() -> None:
+    case = next(c for c in load_evidence_mapping_cases() if c["case_id"] == "stale_feed_blocked")
+    result = evaluate_evidence_mapping_case(case)
+    assert any("human gate" in s.lower() for s in result["safety_boundaries"])
+
+
+def test_blocked_data_quality_prevents_coverage_ready() -> None:
+    case = next(c for c in load_evidence_mapping_cases() if c["case_id"] == "stale_feed_blocked")
+    result = evaluate_evidence_mapping_case(case)
+    assert result["coverage"]["data_quality_ready"] is False
+    assert result["coverage"]["coverage_report_ready"] is False
+
+
+def test_coverage_signal_does_not_equal_profitability_proof() -> None:
+    case = next(
+        c
+        for c in load_evidence_mapping_cases()
+        if c["case_id"] == "coverage_signal_does_not_promote_to_proof"
+    )
+    result = evaluate_evidence_mapping_case(case)
+    assert result["coverage"]["coverage_report_ready"] is True
+    assert result["coverage"]["ranking_inputs_complete"] is False
+    assert result["recommendation"] in {"PARK", "REVIEW", "REJECT", "UNSAFE", "NO_RECOMMENDATION"}
+
+
+def test_missing_regime_keeps_gap_visible_in_readiness_summary() -> None:
+    case = next(
+        c for c in load_evidence_mapping_cases() if c["case_id"] == "harvester_gap_zero_paper_chains"
+    )
+    result = evaluate_evidence_mapping_case(case)
+    assert result["coverage"]["regime_scorecard_ready"] is False
+    assert "regime_scorecard_ready=False" in result["coverage"]["summary"]

--- a/tests/unit/arvp/test_arvp_runtime_negative_controls_contract.py
+++ b/tests/unit/arvp/test_arvp_runtime_negative_controls_contract.py
@@ -1,0 +1,166 @@
+"""ARVP runtime service boundary negative-controls contract suite (#3829).
+
+Signal, risk, execution, ledger/evidence-debt surfaces — mocked only.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.execution import service as execution_service
+
+from tests.unit.arvp._arvp_negative_controls_helpers import (
+    invalid_signal_payload,
+    run_evidence_debt_invalid_ledger_event,
+    run_evidence_debt_on_skips_write,
+    run_invalid_execution_payload,
+    run_kill_switch_active_block,
+    run_missing_decision_id_block,
+)
+from tests.unit.execution._execution_boundary_contract_helpers import (
+    execution_harness,
+    valid_order_payload,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+risk_service = importlib.import_module("services.risk.service")
+signal_service = importlib.import_module("services.signal.service")
+
+
+def test_invalid_signal_payload_returns_none_without_publish(monkeypatch) -> None:
+    engine = signal_service.SignalEngine.__new__(signal_service.SignalEngine)
+    engine.price_buffer = MagicMock()
+    engine.price_buffer.calculate_pct_change.return_value = 0.0
+    engine.strategy_adapter = MagicMock()
+    engine.strategy_adapter.evaluate.return_value = MagicMock(signals=[])
+    result = engine.process_market_data(invalid_signal_payload())
+    assert result is None
+    engine.strategy_adapter.evaluate.assert_not_called()
+
+
+def test_blocked_risk_decision_returns_none(mock_redis, mock_postgres) -> None:
+    from core.domain.models import Signal
+
+    manager = risk_service.RiskManager()
+    manager.redis_client = MagicMock()
+    signal = Signal(
+        signal_id="sig-1",
+        strategy_id="test-strat",
+        symbol="BTCUSDT",
+        side="BUY",
+        direction="BUY",
+        strength=0.8,
+        timestamp=1700000000.0,
+    )
+    evidence = {
+        "decision_id": "dec-1",
+        "signal_id": "sig-1",
+        "timestamps_ms": {"signal_ts_ms": 1_700_000_000_000},
+        "trace_id": "trace-1",
+    }
+    with patch.object(manager, "_kill_switch_gate", return_value=(False, None, {})):
+        with patch.object(
+            risk_service,
+            "decide_trade",
+            return_value=(risk_service.DECISION_BLOCK, "RC_001", evidence),
+        ):
+            with patch.object(manager, "_persist_correlation_event", return_value=True):
+                with patch.object(manager, "_persist_blocked_decision", return_value=True):
+                    result = manager.process_signal(signal)
+    assert result is None
+
+
+def test_invalid_execution_payload_blocks_executor_and_db(
+    execution_harness, caplog
+) -> None:
+    caplog.set_level("WARNING")
+    outcome = run_invalid_execution_payload(execution_harness)
+    assert outcome.blocked is True
+    assert outcome.executor_called is False
+    assert outcome.db_write_attempted is False
+
+
+def test_kill_switch_active_blocks_before_executor(execution_harness, monkeypatch) -> None:
+    outcome = run_kill_switch_active_block(execution_harness, monkeypatch)
+    assert outcome.blocked is True
+    assert outcome.executor_called is False
+
+
+def test_missing_decision_id_blocks_executor_when_trace_enabled(
+    execution_harness, monkeypatch
+) -> None:
+    outcome = run_missing_decision_id_block(execution_harness, monkeypatch)
+    assert outcome.blocked is True
+    assert outcome.executor_called is False
+
+
+def test_malformed_order_payload_increments_invalid_stats_without_executor(
+    execution_harness,
+) -> None:
+    before = execution_service.get_stats_copy()["invalid_payloads"]
+    execution_service.process_order({"type": "order", "quantity": "not-a-number"})
+    after = execution_service.get_stats_copy()["invalid_payloads"]
+    assert after == before + 1
+    execution_harness.executor.execute_order.assert_not_called()
+
+
+@patch("psycopg2.connect")
+def test_evidence_debt_off_invalid_event_fail_closed_no_db_write(
+    mock_connect, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with patch("services.execution.database.config") as mock_config:
+        mock_config.DATABASE_URL = "postgresql://user:pass@host:5432/db"
+        mock_config.SERVICE_NAME = "execution_service"
+        raised, wrote = run_evidence_debt_invalid_ledger_event(
+            mock_connect, mock_config, monkeypatch
+        )
+    assert raised is True
+    assert wrote is False
+
+
+@patch("psycopg2.connect")
+def test_evidence_debt_on_skips_invalid_event_without_db_write(
+    mock_connect, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with patch("services.execution.database.config") as mock_config:
+        mock_config.DATABASE_URL = "postgresql://user:pass@host:5432/db"
+        mock_config.SERVICE_NAME = "execution_service"
+        skipped, wrote = run_evidence_debt_on_skips_write(
+            mock_connect, mock_config, monkeypatch
+        )
+    assert skipped is True
+    assert wrote is False
+
+
+def test_negative_controls_suite_manifest_is_complete() -> None:
+    required = {
+        "invalid_signal_payload",
+        "blocked_risk_decision",
+        "invalid_execution_payload",
+        "kill_switch_active",
+        "missing_decision_id",
+        "malformed_order_payload",
+        "evidence_debt_off",
+        "evidence_debt_on",
+    }
+    covered = {
+        "invalid_signal_payload",
+        "blocked_risk_decision",
+        "invalid_execution_payload",
+        "kill_switch_active",
+        "missing_decision_id",
+        "malformed_order_payload",
+        "evidence_debt_off",
+        "evidence_debt_on",
+    }
+    assert required == covered

--- a/tests/unit/arvp/test_arvp_scenario_pack_matrix_contract.py
+++ b/tests/unit/arvp/test_arvp_scenario_pack_matrix_contract.py
@@ -1,0 +1,148 @@
+"""Fixture-based ARVP scenario-pack matrix contract tests (#3826).
+
+Strategy x scenario-pack coverage without live data, backtests, or ranking claims.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from core.replay.scenario_packs import BUILTIN_SCENARIO_IDS, ScenarioPackError, get_scenario_pack
+from services.validation.strategy_replay_runner import (
+    ARVPReplayConfig,
+    ReplayRunnerError,
+    _apply_scenario_overrides,
+)
+
+from tests.unit.arvp._arvp_scenario_pack_matrix_helpers import (
+    assert_matrix_fixture_covers_builtin_packs,
+    classify_scenario_pack_cell,
+    load_scenario_pack_matrix_fixture,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_matrix_fixture_lists_all_five_builtin_packs() -> None:
+    fixture = load_scenario_pack_matrix_fixture()
+    assert set(fixture["builtin_scenario_ids"]) == set(BUILTIN_SCENARIO_IDS)
+    assert_matrix_fixture_covers_builtin_packs()
+
+
+@pytest.mark.parametrize("scenario_id", BUILTIN_SCENARIO_IDS)
+def test_each_builtin_pack_resolves_with_provenance(scenario_id: str) -> None:
+    spec = get_scenario_pack(scenario_id)
+    assert spec.scenario_id == scenario_id
+    assert spec.config_overrides["pack_id"] == scenario_id
+    assert spec.config_overrides["pack_version"] == "1"
+
+
+def test_unknown_scenario_pack_fails_closed() -> None:
+    with pytest.raises(ScenarioPackError, match="Unknown scenario pack"):
+        get_scenario_pack("synthetic_random_stress")
+
+
+@pytest.mark.parametrize("entry", load_scenario_pack_matrix_fixture()["supported_examples"])
+def test_supported_matrix_examples_classify_supported(entry: dict) -> None:
+    status, reason = classify_scenario_pack_cell(
+        strategy_id=entry["strategy_id"],
+        adapter_id=entry["adapter_id"],
+        scenario_id=entry["scenario_id"],
+    )
+    assert status == "supported", reason
+
+
+@pytest.mark.parametrize(
+    "entry", load_scenario_pack_matrix_fixture()["unsupported_examples"]
+)
+def test_unsupported_matrix_examples_fail_closed(entry: dict) -> None:
+    status, _reason = classify_scenario_pack_cell(
+        strategy_id=entry["strategy_id"],
+        adapter_id=entry["adapter_id"],
+        scenario_id=entry["scenario_id"],
+    )
+    assert status == "unsupported"
+
+
+@pytest.mark.parametrize("entry", load_scenario_pack_matrix_fixture()["blocked_examples"])
+def test_blocked_matrix_examples_fail_closed(entry: dict) -> None:
+    status, _reason = classify_scenario_pack_cell(
+        strategy_id=entry["strategy_id"],
+        adapter_id=entry["adapter_id"],
+        scenario_id=entry["scenario_id"],
+    )
+    assert status == "blocked"
+
+
+def test_full_canonical_strategy_x_pack_grid_is_supported() -> None:
+    fixture = load_scenario_pack_matrix_fixture()
+    canonical = fixture["canonical_adapter_by_strategy"]
+    unsupported: list[str] = []
+    for strategy_id, adapter_id in canonical.items():
+        for scenario_id in BUILTIN_SCENARIO_IDS:
+            status, reason = classify_scenario_pack_cell(
+                strategy_id=strategy_id,
+                adapter_id=adapter_id,
+                scenario_id=scenario_id,
+                canonical_adapter_by_strategy=canonical,
+            )
+            if status != "supported":
+                unsupported.append(f"{strategy_id}/{adapter_id}/{scenario_id}: {reason}")
+    assert unsupported == []
+
+
+def test_adapter_id_validation_rejects_unknown_adapter() -> None:
+    cfg = ARVPReplayConfig(
+        input_candles_file="x.json",
+        strategy_id="primary_breakout_v1",
+        adapter_id="not_registered_adapter",
+    )
+    with pytest.raises(ValueError, match="unsupported adapter_id"):
+        cfg.validate()
+
+
+def test_unsupported_scenario_override_semantics_fail_closed() -> None:
+    cfg = ARVPReplayConfig(input_candles_file="x.json")
+    with pytest.raises(ReplayRunnerError, match="not currently supported"):
+        _apply_scenario_overrides(cfg, {"feed_gap_seconds": 30})
+
+
+def test_cross_adapter_pairs_are_not_silent_supported() -> None:
+    fixture = load_scenario_pack_matrix_fixture()
+    canonical = fixture["canonical_adapter_by_strategy"]
+    adapters = sorted({v for v in canonical.values()})
+    mismatches = 0
+    for strategy_id, expected in canonical.items():
+        for adapter_id in adapters:
+            if adapter_id == expected:
+                continue
+            status, _ = classify_scenario_pack_cell(
+                strategy_id=strategy_id,
+                adapter_id=adapter_id,
+                scenario_id="baseline",
+                canonical_adapter_by_strategy=canonical,
+            )
+            if status == "supported":
+                pytest.fail(f"unexpected supported mismatch: {strategy_id}/{adapter_id}")
+            mismatches += 1
+    assert mismatches == len(canonical) * (len(adapters) - 1)
+
+
+def test_matrix_has_no_duplicate_cells() -> None:
+    fixture = load_scenario_pack_matrix_fixture()
+    cells = {
+        (entry["strategy_id"], entry["adapter_id"], entry["scenario_id"])
+        for entry in itertools.chain(
+            fixture["supported_examples"],
+            fixture["unsupported_examples"],
+            fixture["blocked_examples"],
+        )
+    }
+    total = (
+        len(fixture["supported_examples"])
+        + len(fixture["unsupported_examples"])
+        + len(fixture["blocked_examples"])
+    )
+    assert len(cells) == total

--- a/tests/unit/arvp/test_arvp_window_qualification_contract.py
+++ b/tests/unit/arvp/test_arvp_window_qualification_contract.py
@@ -1,0 +1,66 @@
+"""Fixture-based ARVP window qualification contract tests (#3827).
+
+Dataset cadence, warmup/live split, regime segments, and paper-reference availability.
+No live DB, runtime capture, or silent promotion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.arvp._arvp_window_qualification_helpers import (
+    load_window_qualification_cases,
+    qualify_arvp_window_case,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+@pytest.mark.parametrize("case", load_window_qualification_cases(), ids=lambda c: c["case_id"])
+def test_window_qualification_fixture_verdict(case: dict, tmp_path) -> None:
+    result = qualify_arvp_window_case(case, tmp_path)
+    assert result.verdict == case["expected_verdict"]
+
+
+def test_gap_cadence_violation_is_blocked_not_promoted(tmp_path) -> None:
+    case = next(c for c in load_window_qualification_cases() if c["case_id"] == "cadence_gap_blocked")
+    result = qualify_arvp_window_case(case, tmp_path)
+    assert result.verdict == "BLOCKED"
+    assert result.promotes is False
+    assert result.cadence_ok is False
+
+
+def test_missing_regime_surfaces_limitation_without_pass(tmp_path) -> None:
+    case = next(c for c in load_window_qualification_cases() if c["case_id"] == "missing_regime_warn")
+    result = qualify_arvp_window_case(case, tmp_path)
+    assert result.verdict == "WARN"
+    assert result.regime_available is False
+    assert result.promotes is False
+    assert any("regime" in note.lower() for note in result.limitations)
+
+
+def test_missing_paper_reference_surfaces_limitation(tmp_path) -> None:
+    case = next(
+        c for c in load_window_qualification_cases() if c["case_id"] == "paper_reference_missing_warn"
+    )
+    result = qualify_arvp_window_case(case, tmp_path)
+    assert result.verdict == "WARN"
+    assert result.paper_reference_available is False
+    assert result.promotes is False
+
+
+def test_strict_pass_case_has_warmup_live_split(tmp_path) -> None:
+    case = next(c for c in load_window_qualification_cases() if c["case_id"] == "strict_cadence_pass")
+    result = qualify_arvp_window_case(case, tmp_path)
+    assert result.verdict == "PASS"
+    assert result.cadence_ok is True
+    assert result.warmup_live_ok is True
+    assert result.regime_available is True
+    assert result.paper_reference_available is True
+
+
+def test_all_warmup_no_live_is_blocked(tmp_path) -> None:
+    case = next(c for c in load_window_qualification_cases() if c["case_id"] == "all_warmup_no_live_blocked")
+    result = qualify_arvp_window_case(case, tmp_path)
+    assert result.verdict == "BLOCKED"
+    assert result.warmup_live_ok is False


### PR DESCRIPTION
## Summary

Closes #3826, #3827, #3828, #3829. Refs #3820.

Fixture-backed ARVP P1 contract tests for scenario-pack matrix, window qualification, evidence harvester mapping, and runtime negative controls — following the P0 pattern under `tests/unit/arvp/`.

## Delivered by issue

### #3826 Scenario-pack matrix
- `test_arvp_scenario_pack_matrix_contract.py` + `scenario_pack_matrix_v1.json`
- Full strategy × builtin-pack grid (5 strategies × 5 packs) classified as supported with canonical adapter pairing
- Unsupported/blocked combos fail-closed (unknown pack, adapter mismatch, unsupported overrides)

### #3827 Window qualification
- `test_arvp_window_qualification_contract.py` + `window_qualification/cases_v1.json`
- PASS/WARN/BLOCKED over dataset cadence, warmup/live split, regime segments, paper-reference availability
- Gaps and missing surfaces stay visible; no silent promotion

### #3828 Evidence mapping
- `test_arvp_evidence_harvester_mapping_contract.py` + `evidence_mapping/cases_v1.json`
- Harvester gaps/safety → coverage readiness + recommendation boundaries
- Coverage signal does not promote to profitability proof (`NO_RECOMMENDATION`)

### #3829 Runtime negative controls
- `test_arvp_runtime_negative_controls_contract.py`
- Unified suite: invalid signal, blocked risk, kill-switch, missing decision_id, malformed order, evidence-debt off/on
- Invalid/blocked paths: no executor call, no DB write on invalid ledger event

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- GitHub live issues #3820/#3826–#3829 verified via `gh issue view`

## Validation

- `pytest -q tests/unit/arvp/test_arvp_scenario_pack_matrix_contract.py tests/unit/arvp/test_arvp_window_qualification_contract.py tests/unit/arvp/test_arvp_evidence_harvester_mapping_contract.py tests/unit/arvp/test_arvp_runtime_negative_controls_contract.py` → 46 passed
- `pytest -q tests/unit/arvp/` (incl. P0) → 89 passed
- `ruff check` on changed Python files → clean

## Non-goals

- No new strategies, ARVP architecture, ranking policy, or risk-policy changes
- No Docker/runtime/DB/harvester/live-exchange dependencies
- #3893 runtime observation untouched
- #3824/#3825 (P2) remain open

## Safety Boundaries

- LR **NO-GO** unchanged
- Fixture/unit/contract only; no productive writes or runtime mutation

## Restunsicherheiten

- Window qualification verdict helper is test-contract layer; production qualification may need a dedicated module later (follow-up only if product gap confirmed)
