### PR TITLE
docs(arvp): define gearbox design contracts

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -19,6 +19,7 @@ Repo-backed JSON/YAML schemas und Contract-Dokumente für Messages, Replay und C
 | Profitability league table | `profitability_league_table_model.v1.schema.json`, `profitability_league_table_report.v1.schema.json` | Ranking model and recommendation report contracts |
 | Profitability capital sleeves | `profitability_capital_sleeve_model.v1.schema.json`, `profitability_paper_accounting_report.v1.schema.json` | Sleeve-governance model and paper-accounting report contracts |
 | Profitability control room | `profitability_control_room_requirements.v1.schema.json`, `profitability_control_room_snapshot.v1.schema.json` | Control-room requirements and read-only snapshot contracts |
+| ARVP Gearbox (design) | `strategy_gear_registry.v1.schema.json`, `selector_decision.v1.schema.json`, `gear_reason_codes.v1.schema.json`, `protective_idle.v1.schema.json`, `loop_boundary.v1.schema.json` | Design-only gearbox contracts ([#3913](https://github.com/jannekbuengener/Claire_de_Binare/issues/3913)); selector output is not trade approval |
 
 ## Related canon (not duplicated here)
 

--- a/docs/contracts/examples/gear_reason_codes_valid.json
+++ b/docs/contracts/examples/gear_reason_codes_valid.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "gear_reason_codes.v1",
+  "codes": [
+    {
+      "code": "SELECTED",
+      "category": "selection",
+      "description": "Gear chosen for the current evaluation context."
+    },
+    {
+      "code": "PARKED",
+      "category": "lifecycle",
+      "description": "Gear exists but is not eligible for selection."
+    },
+    {
+      "code": "BLOCKED",
+      "category": "lifecycle",
+      "description": "Gear is explicitly blocked from selection."
+    },
+    {
+      "code": "IDLE",
+      "category": "lifecycle",
+      "description": "Protective Idle — no gear should trade."
+    },
+    {
+      "code": "EVIDENCE_GAP",
+      "category": "evidence",
+      "description": "Required evidence is missing or stale."
+    },
+    {
+      "code": "RISK_BLOCKED",
+      "category": "risk",
+      "description": "Risk gate would block action for this gear."
+    },
+    {
+      "code": "REGIME_MISMATCH",
+      "category": "regime",
+      "description": "Current regime is outside the gear scope."
+    },
+    {
+      "code": "NOT_RUNTIME_READY",
+      "category": "runtime",
+      "description": "Gear is replay-only or missing runtime adapter."
+    },
+    {
+      "code": "DATA_STALE",
+      "category": "data",
+      "description": "Market or data freshness requirements are not met."
+    },
+    {
+      "code": "CORRELATION_RISK",
+      "category": "correlation",
+      "description": "Cross-lane correlation exceeds allowed threshold."
+    },
+    {
+      "code": "SLEEVE_LIMIT",
+      "category": "sleeve",
+      "description": "Capital sleeve limit prevents engagement."
+    }
+  ]
+}

--- a/docs/contracts/examples/loop_boundary_valid.json
+++ b/docs/contracts/examples/loop_boundary_valid.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "loop_boundary.v1",
+  "learning_loop": {
+    "may_evaluate": [
+      "rank_gears",
+      "collect_evidence",
+      "produce_selector_advisory",
+      "update_gear_registry_state"
+    ],
+    "must_not": [
+      "submit_orders",
+      "bypass_risk_gate",
+      "bypass_kill_switch",
+      "bypass_execution_gate"
+    ]
+  },
+  "trading_loop": {
+    "may_act_only_after": ["risk_gate", "kill_switch", "execution_gate"],
+    "must_not": [
+      "collapse_learning_into_trading",
+      "treat_selector_as_order_approval",
+      "force_trade_from_idle"
+    ]
+  },
+  "selector_output_is_not_order_approval": true,
+  "evidence_does_not_replace_runtime_gates": true,
+  "loops_must_not_collapse": true
+}

--- a/docs/contracts/examples/protective_idle_valid.json
+++ b/docs/contracts/examples/protective_idle_valid.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "protective_idle.v1",
+  "idle_id": "idle-20260707-np-parallel-01",
+  "state": "PROTECTIVE_IDLE",
+  "is_valid_output": true,
+  "is_error": false,
+  "is_trade_approval": false,
+  "reason_codes": ["IDLE", "REGIME_MISMATCH"],
+  "trigger_sources": ["regime_mismatch", "missing_eligibility"],
+  "evidence_snapshot_ref": "docs/design/arvp_gearbox_design_contracts_3913.md"
+}

--- a/docs/contracts/examples/selector_decision_valid.json
+++ b/docs/contracts/examples/selector_decision_valid.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "selector_decision.v1",
+  "decision_id": "sel-20260707-np-parallel-01",
+  "selected_gear": null,
+  "eligible_gears": [
+    "gear-primary-breakout-v1-btcusdt",
+    "gear-donchian-breakout-v1-btcusdt"
+  ],
+  "rejected_gears": [
+    {
+      "gear_id": "gear-donchian-breakout-v1-btcusdt",
+      "reason_codes": ["REGIME_MISMATCH"]
+    }
+  ],
+  "reason_codes": ["IDLE", "REGIME_MISMATCH"],
+  "protective_idle_allowed": true,
+  "evidence_snapshot_ref": "docs/design/arvp_gearbox_design_contracts_3913.md",
+  "no_trade_approval": true,
+  "decision_scope": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1m",
+    "evaluation_window_ref": "HYP-NP-PARALLEL-2S-01"
+  }
+}

--- a/docs/contracts/examples/strategy_gear_registry_valid.json
+++ b/docs/contracts/examples/strategy_gear_registry_valid.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "strategy_gear_registry.v1",
+  "gear_id": "gear-primary-breakout-v1-btcusdt",
+  "strategy_id": "primary_breakout_v1",
+  "bot_id": "np-pb1-01",
+  "supported_modes": {
+    "shadow": true,
+    "paper": true,
+    "live": false
+  },
+  "runtime_readiness": "runtime",
+  "evidence_requirements": {
+    "lifecycle_state": "ELIGIBLE",
+    "ranking_ready": true,
+    "net_economics_ready": false,
+    "last_evidence_packet_ref": "docs/evidence/arvp_natural_paper_window_bank_readonly_feasibility_3742.md"
+  },
+  "allocation_profile": {
+    "rules_ref": "ALLOCATION_RULES_JSON:primary_breakout_v1",
+    "max_allocation_pct_hint": "0.25"
+  },
+  "risk_boundaries": {
+    "sleeve": "EXPERIMENTAL",
+    "exposure_cap_hint": "0.25",
+    "no_live_authority": true
+  },
+  "allowed_outputs": [
+    "selector_advisory",
+    "ranking_signal",
+    "evidence_snapshot",
+    "protective_idle_report"
+  ],
+  "known_limitations": [
+    "LR NO-GO — no live authority",
+    "Shared risk/execution path under parallel pilot"
+  ],
+  "routing_state": {
+    "lifecycle_state": "ELIGIBLE",
+    "eligible_for_shadow": true,
+    "eligible_for_paper": true,
+    "eligible_for_live": false
+  }
+}

--- a/docs/contracts/gear_reason_codes.v1.schema.json
+++ b/docs/contracts/gear_reason_codes.v1.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Gear Reason Codes v1",
+  "description": "Canonical taxonomy for gearbox selection, rejection, and idle reason codes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "codes"],
+  "properties": {
+    "schema_version": {
+      "const": "gear_reason_codes.v1"
+    },
+    "codes": {
+      "type": "array",
+      "minItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["code", "category", "description"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "SELECTED",
+              "PARKED",
+              "BLOCKED",
+              "IDLE",
+              "EVIDENCE_GAP",
+              "RISK_BLOCKED",
+              "REGIME_MISMATCH",
+              "NOT_RUNTIME_READY",
+              "DATA_STALE",
+              "CORRELATION_RISK",
+              "SLEEVE_LIMIT"
+            ]
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "selection",
+              "lifecycle",
+              "evidence",
+              "risk",
+              "regime",
+              "runtime",
+              "data",
+              "correlation",
+              "sleeve"
+            ]
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/contracts/loop_boundary.v1.schema.json
+++ b/docs/contracts/loop_boundary.v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Loop Boundary v1",
+  "description": "Separation contract between Learning Loop and Trading Loop in the CDB gearbox.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "learning_loop",
+    "trading_loop",
+    "selector_output_is_not_order_approval",
+    "evidence_does_not_replace_runtime_gates",
+    "loops_must_not_collapse"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "loop_boundary.v1"
+    },
+    "learning_loop": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["may_evaluate", "must_not"],
+      "properties": {
+        "may_evaluate": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "rank_gears",
+              "collect_evidence",
+              "produce_selector_advisory",
+              "update_gear_registry_state"
+            ]
+          }
+        },
+        "must_not": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "submit_orders",
+              "bypass_risk_gate",
+              "bypass_kill_switch",
+              "bypass_execution_gate"
+            ]
+          }
+        }
+      }
+    },
+    "trading_loop": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["may_act_only_after", "must_not"],
+      "properties": {
+        "may_act_only_after": {
+          "type": "array",
+          "minItems": 3,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["risk_gate", "kill_switch", "execution_gate"]
+          }
+        },
+        "must_not": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "collapse_learning_into_trading",
+              "treat_selector_as_order_approval",
+              "force_trade_from_idle"
+            ]
+          }
+        }
+      }
+    },
+    "selector_output_is_not_order_approval": {
+      "const": true
+    },
+    "evidence_does_not_replace_runtime_gates": {
+      "const": true
+    },
+    "loops_must_not_collapse": {
+      "const": true
+    }
+  }
+}

--- a/docs/contracts/protective_idle.v1.schema.json
+++ b/docs/contracts/protective_idle.v1.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Protective Idle v1",
+  "description": "Valid gearbox output when no gear should trade. Idle is not failure and not trade approval.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "idle_id",
+    "state",
+    "is_valid_output",
+    "is_error",
+    "is_trade_approval",
+    "reason_codes",
+    "trigger_sources",
+    "evidence_snapshot_ref"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "protective_idle.v1"
+    },
+    "idle_id": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128
+    },
+    "state": {
+      "const": "PROTECTIVE_IDLE"
+    },
+    "is_valid_output": {
+      "const": true
+    },
+    "is_error": {
+      "const": false
+    },
+    "is_trade_approval": {
+      "const": false
+    },
+    "reason_codes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "IDLE",
+          "EVIDENCE_GAP",
+          "RISK_BLOCKED",
+          "REGIME_MISMATCH",
+          "NOT_RUNTIME_READY",
+          "DATA_STALE",
+          "CORRELATION_RISK",
+          "SLEEVE_LIMIT",
+          "PARKED"
+        ]
+      }
+    },
+    "trigger_sources": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "evidence_gap",
+          "regime_mismatch",
+          "risk_block",
+          "missing_eligibility",
+          "unclear_market_state",
+          "global_gate_dirty"
+        ]
+      }
+    },
+    "evidence_snapshot_ref": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/docs/contracts/selector_decision.v1.schema.json
+++ b/docs/contracts/selector_decision.v1.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Selector Decision v1",
+  "description": "Advisory gearbox selector output. Selector output is not trade approval.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "decision_id",
+    "selected_gear",
+    "eligible_gears",
+    "rejected_gears",
+    "reason_codes",
+    "protective_idle_allowed",
+    "evidence_snapshot_ref",
+    "no_trade_approval",
+    "decision_scope"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "selector_decision.v1"
+    },
+    "decision_id": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128
+    },
+    "selected_gear": {
+      "type": ["string", "null"],
+      "pattern": "^gear-[a-z0-9][a-z0-9_-]{2,80}$"
+    },
+    "eligible_gears": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^gear-[a-z0-9][a-z0-9_-]{2,80}$"
+      }
+    },
+    "rejected_gears": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["gear_id", "reason_codes"],
+        "properties": {
+          "gear_id": {
+            "type": "string",
+            "pattern": "^gear-[a-z0-9][a-z0-9_-]{2,80}$"
+          },
+          "reason_codes": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "$ref": "#/definitions/gear_reason_code" }
+          }
+        }
+      }
+    },
+    "reason_codes": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/gear_reason_code" }
+    },
+    "protective_idle_allowed": {
+      "const": true
+    },
+    "evidence_snapshot_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "no_trade_approval": {
+      "const": true
+    },
+    "decision_scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["symbol", "timeframe", "evaluation_window_ref"],
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "pattern": "^[A-Z0-9]{3,20}$"
+        },
+        "timeframe": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20
+        },
+        "evaluation_window_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "definitions": {
+    "gear_reason_code": {
+      "type": "string",
+      "enum": [
+        "SELECTED",
+        "PARKED",
+        "BLOCKED",
+        "IDLE",
+        "EVIDENCE_GAP",
+        "RISK_BLOCKED",
+        "REGIME_MISMATCH",
+        "NOT_RUNTIME_READY",
+        "DATA_STALE",
+        "CORRELATION_RISK",
+        "SLEEVE_LIMIT"
+      ]
+    }
+  }
+}

--- a/docs/contracts/strategy_gear_registry.v1.schema.json
+++ b/docs/contracts/strategy_gear_registry.v1.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Strategy Gear Registry v1",
+  "description": "Design contract declaring a strategy lane as a controlled CDB gearbox gear. Not a trade approval, runtime contract, or live-readiness signal.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "gear_id",
+    "strategy_id",
+    "bot_id",
+    "supported_modes",
+    "runtime_readiness",
+    "evidence_requirements",
+    "allocation_profile",
+    "risk_boundaries",
+    "allowed_outputs",
+    "known_limitations",
+    "routing_state"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "strategy_gear_registry.v1"
+    },
+    "gear_id": {
+      "type": "string",
+      "pattern": "^gear-[a-z0-9][a-z0-9_-]{2,80}$"
+    },
+    "strategy_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "bot_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "supported_modes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["shadow", "paper", "live"],
+      "properties": {
+        "shadow": { "type": "boolean" },
+        "paper": { "type": "boolean" },
+        "live": { "type": "boolean" }
+      }
+    },
+    "runtime_readiness": {
+      "type": "string",
+      "enum": ["runtime", "replay_only"]
+    },
+    "evidence_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lifecycle_state",
+        "ranking_ready",
+        "net_economics_ready",
+        "last_evidence_packet_ref"
+      ],
+      "properties": {
+        "lifecycle_state": {
+          "type": "string",
+          "enum": ["PARKED", "ELIGIBLE", "SELECTED", "IDLE", "BLOCKED"]
+        },
+        "ranking_ready": { "type": "boolean" },
+        "net_economics_ready": { "type": "boolean" },
+        "last_evidence_packet_ref": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "allocation_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rules_ref", "max_allocation_pct_hint"],
+      "properties": {
+        "rules_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "max_allocation_pct_hint": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?$"
+        }
+      }
+    },
+    "risk_boundaries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sleeve", "no_live_authority"],
+      "properties": {
+        "sleeve": {
+          "type": "string",
+          "enum": ["EXPERIMENTAL", "PAPER", "CORE", "PROTECTIVE"]
+        },
+        "exposure_cap_hint": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?$"
+        },
+        "no_live_authority": {
+          "const": true
+        }
+      }
+    },
+    "allowed_outputs": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "selector_advisory",
+          "ranking_signal",
+          "evidence_snapshot",
+          "protective_idle_report"
+        ]
+      }
+    },
+    "known_limitations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "routing_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lifecycle_state",
+        "eligible_for_shadow",
+        "eligible_for_paper",
+        "eligible_for_live"
+      ],
+      "properties": {
+        "lifecycle_state": {
+          "type": "string",
+          "enum": ["PARKED", "ELIGIBLE", "SELECTED", "IDLE", "BLOCKED"]
+        },
+        "eligible_for_shadow": { "type": "boolean" },
+        "eligible_for_paper": { "type": "boolean" },
+        "eligible_for_live": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/docs/design/arvp_gearbox_design_contracts_3913.md
+++ b/docs/design/arvp_gearbox_design_contracts_3913.md
@@ -1,0 +1,194 @@
+# ARVP Gearbox Design Contracts (#3913)
+
+Status Class: **DESIGN_CONTRACT_ONLY** — no runtime authority, no trade approval  
+Issue: [#3913](https://github.com/jannekbuengener/Claire_de_Binare/issues/3913)  
+Parent: [#1900](https://github.com/jannekbuengener/Claire_de_Binare/issues/1900)  
+Related: [#3894](https://github.com/jannekbuengener/Claire_de_Binare/issues/3894) (closed feasibility)  
+Live-Readiness: **NO-GO**  
+Echtgeld: **not authorized**
+
+---
+
+## 1. Executive Summary
+
+Parallel `cdb_signal` is **infrastructure**, not the Gearbox end state. Before any
+2-strategy parallel natural-paper pilot ([#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912)),
+CDB defines five repo-backed design contracts:
+
+| Contract | Schema | Role |
+|----------|--------|------|
+| Gear Registry | `strategy_gear_registry.v1` | Declares a strategy lane as a controlled gear |
+| Selector Decision | `selector_decision.v1` | Advisory lane selection envelope |
+| Gear Reason Codes | `gear_reason_codes.v1` | Taxonomy for selection / rejection / idle |
+| Protective Idle | `protective_idle.v1` | Valid no-trade gearbox output |
+| Loop Boundary | `loop_boundary.v1` | Learning Loop vs Trading Loop separation |
+
+**Core doctrine:** continuous market coverage, not continuous trading. Always
+evaluating, never forcing. Selector output is **not** trade approval.
+
+Target flow (design reference only):
+
+```text
+Gear Registry → Eligibility/Selector → Sleeve Context → Risk → KillSwitch → Execution Gate → Paper/Testnet/Micro-Live Boundary
+```
+
+---
+
+## 2. Gear Lifecycle States
+
+| State | Meaning |
+|-------|---------|
+| `PARKED` | Candidate exists; not eligible for selection |
+| `ELIGIBLE` | Conditions and evidence allow consideration |
+| `SELECTED` | Selector chose this gear for the current context |
+| `IDLE` | Protective Idle — no gear should trade |
+| `BLOCKED` | Explicitly blocked (risk, evidence, regime, runtime) |
+
+Idle is **not** failure. It is capital protection.
+
+---
+
+## 3. Contract: `strategy_gear_registry.v1`
+
+Schema: [`docs/contracts/strategy_gear_registry.v1.schema.json`](../contracts/strategy_gear_registry.v1.schema.json)  
+Example: [`docs/contracts/examples/strategy_gear_registry_valid.json`](../contracts/examples/strategy_gear_registry_valid.json)
+
+A gear is **not** a strategy implementation. It is the controlled declaration of
+when a candidate lane may be considered.
+
+Minimum fields:
+
+- `gear_id`, `strategy_id`, `bot_id` (operational convention)
+- `supported_modes` — shadow / paper / live eligibility flags
+- `runtime_readiness` — `runtime` | `replay_only`
+- `evidence_requirements` — lifecycle, ranking, net economics refs
+- `allocation_profile` — link to allocation rules (not implementation)
+- `risk_boundaries` — sleeve, exposure caps, `no_live_authority`
+- `allowed_outputs` — advisory selector/ranking outputs only
+- `known_limitations` — explicit gaps
+
+Gear lifecycle state is carried in `routing_state.lifecycle_state`.
+
+---
+
+## 4. Contract: `selector_decision.v1`
+
+Schema: [`docs/contracts/selector_decision.v1.schema.json`](../contracts/selector_decision.v1.schema.json)  
+Example: [`docs/contracts/examples/selector_decision_valid.json`](../contracts/examples/selector_decision_valid.json)
+
+Selector output is **advisory**. It does not authorize orders.
+
+Minimum fields:
+
+- `selected_gear` — nullable; `null` means Protective Idle
+- `eligible_gears`, `rejected_gears`
+- `reason_codes[]` — from `gear_reason_codes.v1`
+- `protective_idle_allowed: true`
+- `evidence_snapshot_ref`
+- `no_trade_approval: true` (required, must be `true`)
+- `decision_scope` — symbol, timeframe, evaluation window
+
+---
+
+## 5. Contract: `gear_reason_codes.v1`
+
+Schema: [`docs/contracts/gear_reason_codes.v1.schema.json`](../contracts/gear_reason_codes.v1.schema.json)  
+Example: [`docs/contracts/examples/gear_reason_codes_valid.json`](../contracts/examples/gear_reason_codes_valid.json)
+
+Canonical codes (minimum set):
+
+| Code | Category |
+|------|----------|
+| `SELECTED` | Gear chosen for current context |
+| `PARKED` | Gear exists but not eligible |
+| `BLOCKED` | Explicit block |
+| `IDLE` | Protective Idle active |
+| `EVIDENCE_GAP` | Missing or stale evidence |
+| `RISK_BLOCKED` | Risk gate would block |
+| `REGIME_MISMATCH` | Regime outside gear scope |
+| `NOT_RUNTIME_READY` | Replay-only or adapter missing |
+| `DATA_STALE` | Market/data freshness failure |
+| `CORRELATION_RISK` | Cross-lane correlation too high |
+| `SLEEVE_LIMIT` | Capital sleeve cap reached |
+
+---
+
+## 6. Contract: `protective_idle.v1`
+
+Schema: [`docs/contracts/protective_idle.v1.schema.json`](../contracts/protective_idle.v1.schema.json)  
+Example: [`docs/contracts/examples/protective_idle_valid.json`](../contracts/examples/protective_idle_valid.json)
+
+Protective Idle semantics:
+
+- Idle is a **valid** gearbox output.
+- Idle is **not** an error or failed run.
+- Idle is **not** trading approval.
+- Idle may arise from: evidence gap, regime mismatch, risk block, missing
+  eligibility, unclear market state, or global gate dirtiness.
+
+ARVP evidence for [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912) must be able to document
+Protective Idle periods per lane without treating them as pilot failure.
+
+---
+
+## 7. Contract: `loop_boundary.v1`
+
+Schema: [`docs/contracts/loop_boundary.v1.schema.json`](../contracts/loop_boundary.v1.schema.json)  
+Example: [`docs/contracts/examples/loop_boundary_valid.json`](../contracts/examples/loop_boundary_valid.json)
+
+| Loop | May do | Must not do |
+|------|--------|-------------|
+| **Learning Loop** | Evaluate candidates, rank gears, collect evidence, produce selector advisories | Submit orders, bypass Risk/KillSwitch/Execution |
+| **Trading Loop** | Act only after Risk → KillSwitch → Execution Gate | Collapse evaluation into forced trading |
+
+Rules:
+
+- Selector output is **not** an order approval.
+- Evidence may **not** replace runtime gate checks.
+- Learning Loop and Trading Loop must **never** be collapsed.
+
+---
+
+## 8. Relationship to Follow-ups
+
+| Issue | Role vs Gearbox | How contracts apply |
+|-------|-----------------|---------------------|
+| [#3909](https://github.com/jannekbuengener/Claire_de_Binare/issues/3909) | Technical prerequisite — compose isolation | Each `cdb_signal` instance maps to one `gear_id` + `bot_id` in registry |
+| [#3910](https://github.com/jannekbuengener/Claire_de_Binare/issues/3910) | Technical prerequisite — allocation | `allocation_profile` links gear to `ALLOCATION_RULES_JSON` entries |
+| [#3911](https://github.com/jannekbuengener/Claire_de_Binare/issues/3911) | Technical prerequisite — ledger guards | Evidence extraction per `strategy_id`/`bot_id` supports per-gear provenance |
+| [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912) | Pilot execute — **not ready** | Alignment review against these contracts + separate RUNTIME-GO required |
+
+These follow-ups are **not** the Gearbox end state. They enable safe parallel
+observation as a controlled precursor.
+
+---
+
+## 9. Pilot Readiness (#3912)
+
+**#3912 is not ready** after this slice alone. Required before RUNTIME-GO:
+
+1. This design-contract delivery (docs + schemas + contract tests) — **this issue**
+2. [#3910](https://github.com/jannekbuengener/Claire_de_Binare/issues/3910) — Donchian allocation rules
+3. [#3909](https://github.com/jannekbuengener/Claire_de_Binare/issues/3909) — Compose multi-`cdb_signal` profile
+4. [#3911](https://github.com/jannekbuengener/Claire_de_Binare/issues/3911) — Ledger/evidence isolation guards
+5. Alignment review: pilot manifest documents gears, selector advisory-only posture, Protective Idle
+6. Explicit **RUNTIME-GO** for [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912)
+
+---
+
+## 10. Boundaries
+
+- LR **NO-GO** — no Live/Echtgeld authorization
+- No runtime, Docker, Compose, DB, Risk, Execution, or Allocation implementation
+- [#3893](https://github.com/jannekbuengener/Claire_de_Binare/issues/3893) untouched — separate single-strategy observation
+- [#205](https://github.com/jannekbuengener/Claire_de_Binare/issues/205) remains parked Gearbox anchor — reference only
+- Contracts do not unpark or rescope [#205](https://github.com/jannekbuengener/Claire_de_Binare/issues/205)
+
+---
+
+## 11. References
+
+- [Multi-Strategy Gearbox Architecture v1](https://gist.github.com/jannekbuengener/82db215ed91096d7d864cc51d73f0557)
+- [Gearbox Alignment Report](https://gist.github.com/jannekbuengener/cbca4d7e0e85b51e43d772ddfcabc102)
+- [`docs/design/arvp_multistrategy_parallel_natural_paper_feasibility_3894.md`](arvp_multistrategy_parallel_natural_paper_feasibility_3894.md)
+- [`docs/contracts/README.md`](../contracts/README.md)

--- a/tests/unit/arvp/_arvp_gearbox_contract_helpers.py
+++ b/tests/unit/arvp/_arvp_gearbox_contract_helpers.py
@@ -1,0 +1,52 @@
+"""Shared paths for ARVP gearbox design contract tests (#3913)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTRACTS_DIR = REPO_ROOT / "docs" / "contracts"
+DESIGN_DOC = (
+    REPO_ROOT / "docs" / "design" / "arvp_gearbox_design_contracts_3913.md"
+)
+
+GEARBOX_SCHEMAS: tuple[tuple[str, Path, Path], ...] = (
+    (
+        "strategy_gear_registry.v1",
+        CONTRACTS_DIR / "strategy_gear_registry.v1.schema.json",
+        CONTRACTS_DIR / "examples" / "strategy_gear_registry_valid.json",
+    ),
+    (
+        "selector_decision.v1",
+        CONTRACTS_DIR / "selector_decision.v1.schema.json",
+        CONTRACTS_DIR / "examples" / "selector_decision_valid.json",
+    ),
+    (
+        "gear_reason_codes.v1",
+        CONTRACTS_DIR / "gear_reason_codes.v1.schema.json",
+        CONTRACTS_DIR / "examples" / "gear_reason_codes_valid.json",
+    ),
+    (
+        "protective_idle.v1",
+        CONTRACTS_DIR / "protective_idle.v1.schema.json",
+        CONTRACTS_DIR / "examples" / "protective_idle_valid.json",
+    ),
+    (
+        "loop_boundary.v1",
+        CONTRACTS_DIR / "loop_boundary.v1.schema.json",
+        CONTRACTS_DIR / "examples" / "loop_boundary_valid.json",
+    ),
+)
+
+REQUIRED_REASON_CODES: frozenset[str] = frozenset(
+    {
+        "SELECTED",
+        "PARKED",
+        "BLOCKED",
+        "IDLE",
+        "EVIDENCE_GAP",
+        "RISK_BLOCKED",
+        "REGIME_MISMATCH",
+        "NOT_RUNTIME_READY",
+    }
+)

--- a/tests/unit/arvp/test_arvp_gearbox_design_contracts_3913.py
+++ b/tests/unit/arvp/test_arvp_gearbox_design_contracts_3913.py
@@ -1,0 +1,104 @@
+"""ARVP gearbox design contract tests (#3913).
+
+Validates repo-backed gearbox design docs and JSON schemas. No runtime, no live
+GitHub, no trade-approval claims.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from jsonschema import Draft7Validator
+
+from tests.unit.arvp import _arvp_gearbox_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def _load_json(path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.mark.parametrize(
+    ("contract_name", "schema_path", "example_path"),
+    helpers.GEARBOX_SCHEMAS,
+)
+def test_gearbox_schema_example_validates(
+    contract_name: str,
+    schema_path,
+    example_path,
+) -> None:
+    assert schema_path.is_file(), f"missing schema for {contract_name}"
+    assert example_path.is_file(), f"missing example for {contract_name}"
+    schema = _load_json(schema_path)
+    example = _load_json(example_path)
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda e: e.message)
+    assert not errors, [e.message for e in errors]
+
+
+def test_design_doc_exists_and_references_all_five_contracts() -> None:
+    text = helpers.DESIGN_DOC.read_text(encoding="utf-8")
+    for contract_name, schema_path, _example_path in helpers.GEARBOX_SCHEMAS:
+        assert contract_name in text
+        rel = schema_path.relative_to(helpers.REPO_ROOT).as_posix()
+        assert rel in text
+
+
+def test_design_doc_declares_selector_not_trade_approval() -> None:
+    text = helpers.DESIGN_DOC.read_text(encoding="utf-8").lower()
+    assert "not trade approval" in text or "not** trade approval" in text
+    assert "no_trade_approval" in text
+
+
+def test_design_doc_declares_protective_idle_valid() -> None:
+    text = helpers.DESIGN_DOC.read_text(encoding="utf-8")
+    assert "Protective Idle" in text
+    assert "not failure" in text.lower() or "not** failure" in text
+
+
+def test_design_doc_separates_learning_and_trading_loops() -> None:
+    text = helpers.DESIGN_DOC.read_text(encoding="utf-8")
+    assert "Learning Loop" in text
+    assert "Trading Loop" in text
+    assert "never" in text.lower()
+
+
+def test_design_doc_marks_lr_no_go_and_3912_not_ready() -> None:
+    text = helpers.DESIGN_DOC.read_text(encoding="utf-8")
+    assert "NO-GO" in text
+    assert "#3912" in text
+    assert "not ready" in text.lower()
+
+
+def test_design_doc_classifies_3909_3911_as_prerequisites() -> None:
+    text = helpers.DESIGN_DOC.read_text(encoding="utf-8")
+    for issue in ("#3909", "#3910", "#3911"):
+        assert issue in text
+    assert "prerequisite" in text.lower() or "Technical prerequisite" in text
+
+
+def test_selector_example_enforces_no_trade_approval() -> None:
+    payload = _load_json(helpers.GEARBOX_SCHEMAS[1][2])
+    assert payload["no_trade_approval"] is True
+
+
+def test_protective_idle_example_is_valid_non_error_non_approval() -> None:
+    payload = _load_json(helpers.GEARBOX_SCHEMAS[3][2])
+    assert payload["is_valid_output"] is True
+    assert payload["is_error"] is False
+    assert payload["is_trade_approval"] is False
+
+
+def test_gear_reason_codes_include_required_minimum_set() -> None:
+    payload = _load_json(helpers.GEARBOX_SCHEMAS[2][2])
+    codes = {entry["code"] for entry in payload["codes"]}
+    assert helpers.REQUIRED_REASON_CODES.issubset(codes)
+
+
+def test_loop_boundary_forbids_selector_as_order_approval() -> None:
+    payload = _load_json(helpers.GEARBOX_SCHEMAS[4][2])
+    assert payload["selector_output_is_not_order_approval"] is True
+    assert "treat_selector_as_order_approval" in payload["trading_loop"]["must_not"]


### PR DESCRIPTION
## Summary

- Adds repo-backed ARVP Gearbox design contracts for issue #3913
- Documents five v1 contracts with JSON schemas, examples, and contract tests
- Aligns parallel-paper follow-ups (#3909–#3911) with Gearbox end state without opening runtime scope

Closes #3913

Refs #3894
Refs #3909
Refs #3910
Refs #3911
Refs #3912
Refs #205

## Design Contracts

| Contract | Schema | Doc |
|----------|--------|-----|
| `strategy_gear_registry.v1` | `docs/contracts/strategy_gear_registry.v1.schema.json` | `docs/design/arvp_gearbox_design_contracts_3913.md` |
| `selector_decision.v1` | `docs/contracts/selector_decision.v1.schema.json` | same |
| `gear_reason_codes.v1` | `docs/contracts/gear_reason_codes.v1.schema.json` | same |
| `protective_idle.v1` | `docs/contracts/protective_idle.v1.schema.json` | same |
| `loop_boundary.v1` | `docs/contracts/loop_boundary.v1.schema.json` | same |

## Validation

- `pytest -q tests/unit/arvp/test_arvp_gearbox_design_contracts_3913.py` — 15 passed
- `ruff check` on new Python files — clean
- `git diff --check` — clean

## Non-goals

- No runtime, Docker, Compose, DB, Risk, Execution, or Allocation changes
- No parallel pilot execution or #3912 RUNTIME-GO
- No #205 unpark or rescope
- No #3893 operational touch
- No new trading strategy implementation

## Safety Boundaries

- LR remains **NO-GO**
- Selector output is **not** trade approval
- Protective Idle is a valid gearbox state
- Learning Loop and Trading Loop remain separated
- #3912 remains **not ready** until technical prerequisites + alignment review + separate RUNTIME-GO
