### PR TITLE
feat(arvp): add multi-cdb_signal compose profile

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,60 @@
+# Campaign manifests
+
+Campaign-scoped runtime overlays for bounded ARVP natural-paper observations.
+These files are **not** canonical defaults. LR remains **NO-GO**; no Live/Echtgeld
+authorization from manifest presence alone.
+
+## Parallel natural-paper (2-strategy)
+
+| Artifact | Purpose |
+|----------|---------|
+| `runtime_np_parallel_signal_compose_override.yml` | Two `cdb_signal` instances: `cdb_signal_pb1` (`primary_breakout_v1`) and `cdb_signal_donchian` (`donchian_breakout_v1`) with distinct ports and non-empty `SIGNAL_BOT_ID` values (#3909) |
+| `runtime_np_parallel_allocation_compose_override.yml` | Conservative per-strategy allocation caps for shared capital pool (#3910 / #3915) |
+
+Hypothesis: `HYP-NP-PARALLEL-2S-01`.
+
+### Static validation (no `up` / `down` / `restart`)
+
+```powershell
+$env:SECRETS_PATH = "<path-to-secrets>"
+docker compose `
+  -f infrastructure/compose/compose.red.yml `
+  -f manifests/runtime_np_parallel_signal_compose_override.yml `
+  config
+```
+
+Full parallel stack (signal + allocation overrides):
+
+```powershell
+docker compose `
+  -f infrastructure/compose/compose.blue.yml `
+  -f infrastructure/compose/compose.red.yml `
+  -f manifests/runtime_np_parallel_signal_compose_override.yml `
+  -f manifests/runtime_np_parallel_allocation_compose_override.yml `
+  config
+```
+
+### Application gates
+
+- **Separate RUNTIME-GO required** before any `docker compose up`.
+- **#3912** (parallel pilot execute) remains **NOT READY** until:
+  - #3911 ledger/evidence isolation guards land
+  - alignment review against gearbox design contracts (#3913)
+  - explicit RUNTIME-GO
+- **#3893** (single-strategy Donchian 24h observation) is a **separate lane** — do not conflate or schedule against without coordination.
+
+### Risk-side filter contract (topic/stream isolation)
+
+Both parallel signal instances publish to the **shared** Redis pub/sub topic `signals`
+and stream `stream.signals` (default `SIGNAL_OUTPUT_STREAM`). `cdb_risk` subscribes
+to the shared bus and routes decisions using payload `strategy_id` and `bot_id`.
+
+Per-publisher topic partitioning is **not** implemented in this slice. Runtime
+ledger/evidence isolation guards are tracked in **#3911**.
+
+## Single-strategy prior art
+
+| Artifact | Purpose |
+|----------|---------|
+| `runtime_3792_signal_compose_override.yml` | Swap canonical `cdb_signal` to `donchian_breakout_v1` for #3792 |
+| `campaign_3792_donchian_np_01.yaml` | Campaign manifest referencing the #3792 signal override |

--- a/manifests/runtime_np_parallel_signal_compose_override.yml
+++ b/manifests/runtime_np_parallel_signal_compose_override.yml
@@ -1,0 +1,115 @@
+# Campaign-scoped compose override for parallel natural-paper (#3909 / #3912 prerequisite).
+# Hypothesis: HYP-NP-PARALLEL-2S-01 (primary_breakout_v1 + donchian_breakout_v1).
+# Apply only after separate RUNTIME-GO; not canonical default.
+# Combine with manifests/runtime_np_parallel_allocation_compose_override.yml for allocation caps.
+# LR NO-GO — no Live/Echtgeld authorization from this manifest.
+# #3912 remains NOT READY until #3911 ledger guards + alignment review + RUNTIME-GO.
+# #3893 stays a separate single-strategy observation lane — do not conflate.
+#
+# Static validation (no runtime start):
+#   docker compose -f infrastructure/compose/compose.red.yml \
+#     -f manifests/runtime_np_parallel_signal_compose_override.yml config
+#
+# Risk-side filter contract (G3): both instances publish to shared Redis topic `signals`
+# and stream `stream.signals`. cdb_risk consumes the shared bus and routes by payload
+# `strategy_id` / `bot_id`. Ledger/evidence isolation guards are #3911 — not in this slice.
+
+services:
+  cdb_signal:
+    profiles:
+      - single-signal-default
+
+  cdb_signal_pb1:
+    build:
+      context: ..
+      dockerfile: services/signal/Dockerfile
+    container_name: cdb_signal_pb1
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: primary_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-pb1-parallel-01
+      SIGNAL_ENTRY_LOOKBACK_MIN: "240"
+      SIGNAL_EXIT_LOOKBACK_MIN: "120"
+      SIGNAL_BREAKOUT_BUFFER: "0.0005"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "60"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8015"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8015:8015"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8015/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network
+
+  cdb_signal_donchian:
+    build:
+      context: ..
+      dockerfile: services/signal/Dockerfile
+    container_name: cdb_signal_donchian
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: donchian_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-donchian-parallel-01
+      SIGNAL_ENTRY_CHANNEL_BARS: "20"
+      SIGNAL_EXIT_CHANNEL_BARS: "10"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "30"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8016"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8016:8016"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8016/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network

--- a/services/signal/README.md
+++ b/services/signal/README.md
@@ -27,6 +27,21 @@ Start im RED-Stack:
 docker compose -f infrastructure/compose/compose.red.yml up -d cdb_signal
 ```
 
+Parallel natural-paper (campaign-scoped, **not** canonical default; requires separate
+RUNTIME-GO; #3912 remains NOT READY):
+
+```powershell
+# Static validation only in CI/docs — do not run up without RUNTIME-GO
+docker compose `
+  -f infrastructure/compose/compose.red.yml `
+  -f manifests/runtime_np_parallel_signal_compose_override.yml `
+  config
+```
+
+See `manifests/README.md` for `cdb_signal_pb1` / `cdb_signal_donchian` bot-id
+convention, allocation override pairing, and risk-side filter contract (#3911).
+LR remains **NO-GO**.
+
 ## Key Config
 
 - `SIGNAL_STRATEGY_ID`

--- a/tests/unit/arvp/test_arvp_np_parallel_signal_compose_contract_3909.py
+++ b/tests/unit/arvp/test_arvp_np_parallel_signal_compose_contract_3909.py
@@ -1,0 +1,186 @@
+"""Parallel natural-paper multi-cdb_signal compose contract tests (#3909)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_RED = REPO_ROOT / "infrastructure" / "compose" / "compose.red.yml"
+SIGNAL_OVERRIDE = (
+    REPO_ROOT / "manifests" / "runtime_np_parallel_signal_compose_override.yml"
+)
+MANIFESTS_README = REPO_ROOT / "manifests" / "README.md"
+SIGNAL_README = REPO_ROOT / "services" / "signal" / "README.md"
+
+PARALLEL_SERVICES = ("cdb_signal_pb1", "cdb_signal_donchian")
+EXPECTED_STRATEGY_IDS = {
+    "cdb_signal_pb1": "primary_breakout_v1",
+    "cdb_signal_donchian": "donchian_breakout_v1",
+}
+EXPECTED_BOT_IDS = {
+    "cdb_signal_pb1": "np-pb1-parallel-01",
+    "cdb_signal_donchian": "np-donchian-parallel-01",
+}
+EXPECTED_PORTS = {
+    "cdb_signal_pb1": "8015",
+    "cdb_signal_donchian": "8016",
+}
+
+COMPOSE_SECRET_FILES = (
+    "REDIS_PASSWORD",
+    "POSTGRES_PASSWORD",
+    "POSTGRES_PASSWORD_DSN",
+    "GRAFANA_PASSWORD",
+    "SMTP_USER",
+    "SMTP_PASSWORD",
+    "SMTP_FROM",
+    "ALERT_EMAIL_TO",
+)
+
+
+def _write_compose_secrets_stub(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in COMPOSE_SECRET_FILES:
+        (directory / name).write_text("stub\n", encoding="utf-8")
+    return directory
+
+
+def _load_override() -> dict:
+    return yaml.safe_load(SIGNAL_OVERRIDE.read_text(encoding="utf-8"))
+
+
+def _service_env(service_name: str) -> dict[str, str]:
+    override = _load_override()
+    env = override["services"][service_name]["environment"]
+    return {key: str(value) for key, value in env.items()}
+
+
+def test_override_declares_two_parallel_signal_services() -> None:
+    override = _load_override()
+    services = set(override["services"])
+    assert set(PARALLEL_SERVICES).issubset(services)
+
+
+def test_canonical_cdb_signal_is_profile_gated() -> None:
+    override = _load_override()
+    profiles = override["services"]["cdb_signal"]["profiles"]
+    assert profiles == ["single-signal-default"]
+
+
+@pytest.mark.parametrize("service_name", PARALLEL_SERVICES)
+def test_parallel_service_has_distinct_container_name(service_name: str) -> None:
+    override = _load_override()
+    container_name = override["services"][service_name]["container_name"]
+    assert container_name == service_name
+
+
+@pytest.mark.parametrize("service_name", PARALLEL_SERVICES)
+def test_parallel_service_has_distinct_signal_port(service_name: str) -> None:
+    env = _service_env(service_name)
+    assert env["SIGNAL_PORT"] == EXPECTED_PORTS[service_name]
+
+
+@pytest.mark.parametrize("service_name", PARALLEL_SERVICES)
+def test_parallel_service_has_expected_strategy_id(service_name: str) -> None:
+    env = _service_env(service_name)
+    assert env["SIGNAL_STRATEGY_ID"] == EXPECTED_STRATEGY_IDS[service_name]
+
+
+@pytest.mark.parametrize("service_name", PARALLEL_SERVICES)
+def test_parallel_service_has_non_empty_signal_bot_id(service_name: str) -> None:
+    env = _service_env(service_name)
+    bot_id = env["SIGNAL_BOT_ID"].strip()
+    assert bot_id
+    assert bot_id == EXPECTED_BOT_IDS[service_name]
+
+
+def test_signal_bot_ids_are_distinct_across_instances() -> None:
+    bot_ids = [EXPECTED_BOT_IDS[name] for name in PARALLEL_SERVICES]
+    assert len(bot_ids) == len(set(bot_ids))
+
+
+def test_host_ports_do_not_collide_with_canonical_signal() -> None:
+    override = _load_override()
+    canonical = yaml.safe_load(COMPOSE_RED.read_text(encoding="utf-8"))
+    canonical_port = canonical["services"]["cdb_signal"]["ports"][0]
+    assert "8005" in canonical_port
+
+    parallel_ports = []
+    for service_name in PARALLEL_SERVICES:
+        port_mapping = override["services"][service_name]["ports"][0]
+        parallel_ports.append(port_mapping)
+        assert "8005" not in port_mapping
+    assert len(parallel_ports) == len(set(parallel_ports))
+
+
+def test_override_header_documents_lr_no_go_and_pilot_not_ready() -> None:
+    header = SIGNAL_OVERRIDE.read_text(encoding="utf-8").lower()
+    assert "lr no-go" in header
+    assert "#3912" in header
+    assert "not ready" in header
+    assert "runtime-go" in header
+    assert "#3893" in header
+
+
+def test_override_documents_risk_side_filter_contract() -> None:
+    header = SIGNAL_OVERRIDE.read_text(encoding="utf-8").lower()
+    assert "risk-side filter" in header or "risk-side filter contract" in header
+    assert "strategy_id" in header
+    assert "#3911" in header
+
+
+def test_manifests_readme_documents_campaign_scope_and_no_runtime_go() -> None:
+    text = MANIFESTS_README.read_text(encoding="utf-8").lower()
+    assert "runtime_np_parallel_signal_compose_override.yml" in text
+    assert "no-go" in text
+    assert "#3912" in text
+    assert "not ready" in text
+    assert "runtime-go" in text
+
+
+def test_signal_readme_links_parallel_override() -> None:
+    text = SIGNAL_README.read_text(encoding="utf-8")
+    assert "runtime_np_parallel_signal_compose_override.yml" in text
+
+
+def test_pilot_issue_3912_is_not_freed_by_compose_delivery() -> None:
+    """#3909 delivers infra only; #3912 still requires #3911 + RUNTIME-GO."""
+    header = SIGNAL_OVERRIDE.read_text(encoding="utf-8")
+    manifests_readme = MANIFESTS_README.read_text(encoding="utf-8")
+    joined = f"{header}\n{manifests_readme}".lower()
+    assert "#3911" in joined
+    assert "not ready" in joined
+
+
+def test_docker_compose_config_merge_is_valid(tmp_path: Path) -> None:
+    secrets_dir = _write_compose_secrets_stub(tmp_path / "compose-secrets")
+    env = {**os.environ, "SECRETS_PATH": str(secrets_dir)}
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            str(COMPOSE_RED),
+            "-f",
+            str(SIGNAL_OVERRIDE),
+            "config",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 and "docker" in (result.stderr or "").lower():
+        pytest.skip(f"docker compose unavailable: {result.stderr}")
+    assert result.returncode == 0, result.stderr
+    merged = yaml.safe_load(result.stdout)
+    assert "cdb_signal_pb1" in merged["services"]
+    assert "cdb_signal_donchian" in merged["services"]


### PR DESCRIPTION
## Summary

Closes #3909

Refs #3894
Refs #3910
Refs #3911
Refs #3912
Refs #3913

Adds a campaign-scoped Compose override for parallel natural-paper with two distinct `cdb_signal` instances (`primary_breakout_v1` + `donchian_breakout_v1`), contract tests, and manifest documentation. Configuration-only slice — no runtime start.

## Compose changes

- New `manifests/runtime_np_parallel_signal_compose_override.yml`
- Canonical `cdb_signal` gated behind `single-signal-default` profile
- New services: `cdb_signal_pb1` (port 8015) and `cdb_signal_donchian` (port 8016)
- Pairs with existing `manifests/runtime_np_parallel_allocation_compose_override.yml` (#3915)

## Bot-ID and strategy isolation

| Service | `SIGNAL_STRATEGY_ID` | `SIGNAL_BOT_ID` | `SIGNAL_PORT` |
|---------|----------------------|-----------------|---------------|
| `cdb_signal_pb1` | `primary_breakout_v1` | `np-pb1-parallel-01` | `8015` |
| `cdb_signal_donchian` | `donchian_breakout_v1` | `np-donchian-parallel-01` | `8016` |

Shared Redis topic `signals` / stream `stream.signals` remains — risk-side filter contract documented; ledger guards remain #3911.

## Validation

- `pytest -q tests/unit/arvp/test_arvp_np_parallel_signal_compose_contract_3909.py` (18 passed)
- `docker compose config` merge test (subprocess, secrets stub)
- `ruff check` on new test module
- `git diff --check`

## Non-goals

- No `docker compose up/down/restart`
- No parallel pilot (#3912)
- No RUNTIME-GO
- No risk-gate / allocation runtime changes
- No strategy logic changes
- #3893 untouched
- #205 untouched

## Safety Boundaries

- LR remains **NO-GO**
- No Live/Echtgeld authorization
- No productive DB writes
- No MCP mutations
- #3912 remains **NOT READY** until #3911 + alignment review + separate RUNTIME-GO
- #3893 remains untouched
