### PR TITLE
fix(security): refresh postgres alpine digest for libcurl alerts

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           - image: redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
             scan_name: redis
-          - image: postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
+          - image: postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
             scan_name: postgres
           - image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
             scan_name: prometheus
@@ -248,7 +248,7 @@ jobs:
       matrix:
         image:
           - redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
-          - postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
+          - postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
       fail-fast: false
 
     env:
@@ -408,5 +408,5 @@ jobs:
 #
 # 4. For manual scans:
 #    docker scout cves redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005 --only-severities critical,high
-#    docker scout cves postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa --only-severities critical,high
+#    docker scout cves postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda --only-severities critical,high
 

--- a/docs/evidence/security/CDB_SECURITY_POSTGRES_ALPINE_LIBCURL_REBUILD_2026-07-08.md
+++ b/docs/evidence/security/CDB_SECURITY_POSTGRES_ALPINE_LIBCURL_REBUILD_2026-07-08.md
@@ -1,0 +1,86 @@
+# Postgres 18.4-alpine Digest Refresh — libcurl CVE Cluster
+
+**Stand:** 2026-07-08 (UTC+2)  
+**Probe:** POSTGRES_ALPINE_REBUILD_PROBE  
+**Parent tracker:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513)  
+**Cluster tracker:** [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933)  
+**Scope guard:** Digest-only refresh. No alert dismissals. No runtime start. LR remains **NO-GO**.
+
+---
+
+## Executive summary
+
+| Item | Value |
+|------|-------|
+| Image tag | `postgres:18.4-alpine` (unchanged) |
+| Old index digest | `sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa` |
+| New index digest | `sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda` |
+| Upstream rebuild | `2026-07-07T17:43:40Z` (`docker-library/postgres` commit `4f9ced003ba58a854656ba150d146243d27ae3ac`) |
+| libcurl before | `8.20.0-r1` — **12 HIGH** Trivy findings |
+| libcurl after | **0** alpine-layer HIGH/CRITICAL findings |
+| FixedVersion target | `8.21.0-r0` (scan-verified) |
+| Residual on new pin | `usr/local/bin/gosu` — 14 HIGH/CRITICAL (upstream-blocked, out of scope) |
+
+**Verdict:** `FIX_VERIFIED_DIGEST_REFRESH` — narrow digest PR authorized.
+
+---
+
+## Probe method
+
+1. `docker buildx imagetools inspect postgres:18.4-alpine` — detected new index digest vs repo pin.
+2. `trivy image --severity HIGH,CRITICAL` on old and new digests (local Trivy `0.72.0`, DB `2026-07-06`).
+3. Repo pin convention: **OCI index digest** (same pattern as prior postgres digest-only PRs).
+
+---
+
+## Trivy evidence
+
+### Old pin (`1b1689b…`)
+
+| Target | HIGH | CRITICAL |
+|--------|------|----------|
+| alpine OS (`libcurl` cluster) | 12 | 0 |
+| `usr/local/bin/gosu` | 13 | 1 |
+
+libcurl CVEs (all `FixedVersion: 8.21.0-r0`): CVE-2026-11352, CVE-2026-11586, CVE-2026-12064, CVE-2026-8286, CVE-2026-8925, CVE-2026-8927, CVE-2026-8932, CVE-2026-9079, CVE-2026-9080, CVE-2026-9545, CVE-2026-9546, CVE-2026-9547.
+
+### New pin (`ecafd342…`)
+
+| Target | HIGH | CRITICAL |
+|--------|------|----------|
+| alpine OS | **0** | **0** |
+| `usr/local/bin/gosu` | 13 | 1 |
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `infrastructure/compose/base.yml` | Postgres digest refresh |
+| `infrastructure/compose/compose.blue.yml` | Postgres digest refresh |
+| `.github/workflows/security-scan.yml` | `trivy-scan-base` + `scan-base-images` matrix sync |
+
+---
+
+## Non-goals
+
+- No Grafana / Prometheus / Redis image changes.
+- No `cdb_*` service image changes.
+- No alert dismissals or SARIF suppression.
+- No gosu upstream-blocked remediation (tracked under #2933).
+- No runtime `docker compose up` or DB migration in this slice.
+
+---
+
+## Expected GitHub Code Scanning impact
+
+After merge + next `security-scan.yml` run, **12** `library/postgres` libcurl HIGH alerts should clear on scan-verified digest. gosu residuals remain open until upstream rebuild.
+
+---
+
+## References
+
+- Read-only triage: `knowledge/logs/sessions/2026-07-08-security-retriage-readonly-report.md`
+- Prior gosu residual doc: `docs/evidence/security/CDB_SECURITY_RESIDUALS_3694-3695_2026-07-03.md`
+- Runbook: `docs/security/TRIAGE_RUNBOOK.md`

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -31,7 +31,7 @@ services:
       - cdb_network
 
   cdb_postgres:
-    image: postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
+    image: postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
     container_name: cdb_postgres
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.blue.yml
+++ b/infrastructure/compose/compose.blue.yml
@@ -17,7 +17,7 @@ services:
   # ==================== DATA LAYER ====================
 
   cdb_postgres:
-    image: postgres:18.4-alpine@sha256:1b1689b20d16a014a3d195653381cf2caa75a41a92d93b255a9d6ea29fd353aa
+    image: postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
     container_name: cdb_postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

Trivy-verified digest-only refresh of `postgres:18.4-alpine` clears **12 libcurl HIGH** CVEs after upstream rebuild (`libcurl 8.21.0-r0`, index digest `ecafd342…`, built 2026-07-07).

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- tools_or_queries: `docker buildx imagetools inspect`, `trivy image`, `gh issue view`, repo compose/security-scan refs
- records_or_results: old pin `1b1689b…` → 12 libcurl HIGH; new pin `ecafd342…` → 0 alpine HIGH/CRITICAL
- repo_crosscheck: `infrastructure/compose/base.yml`, `compose.blue.yml`, `.github/workflows/security-scan.yml`
- impact_on_plan: digest refresh authorized; gosu residual unchanged (upstream-blocked)
- limitations: GitHub Code Scanning alert closure requires post-merge `security-scan.yml` run

## Delivered

- Postgres index digest refresh in compose (`base.yml`, `compose.blue.yml`)
- `security-scan.yml` matrix sync (trivy-scan-base + scan-base-images)
- Evidence doc: `docs/evidence/security/CDB_SECURITY_POSTGRES_ALPINE_LIBCURL_REBUILD_2026-07-08.md`

## Validation

- `trivy image --severity HIGH,CRITICAL` old vs new digest (local Trivy 0.72.0)
- `git diff --check` clean
- `pytest -q tests/unit/infra/test_compose_blue_red_stack_contract.py tests/unit/infra/test_stack_lifecycle_script_contract.py` — 47 passed

## Safety Boundaries

- No alert dismissals
- No runtime / `docker compose up`
- No DB writes / MCP mutations
- LR remains NO-GO
- PR #3755 untouched (Grafana HOLD)

## Non-goals

- Grafana / Prometheus / Redis image changes
- `cdb_*` service image changes
- gosu upstream-blocked remediation (#2933)
- Runtime postgres migration (digest-only pin)

## Remaining uncertainty

- GitHub Trivy open-count delta (~12 alerts) confirmed only after next scheduled/security workflow scan post-merge

Refs #2933 #2513

Made with [Cursor](https://cursor.com)