### PR TITLE
fix(security): break CodeQL cyclic import in context evidence tools

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_CODEQL_CYCLIC_IMPORT_3939_2026-07-09.md
+++ b/docs/evidence/security/CDB_SECURITY_CODEQL_CYCLIC_IMPORT_3939_2026-07-09.md
@@ -1,0 +1,70 @@
+# CodeQL Cyclic-Import Fix — Issue #3939
+
+**Date:** 2026-07-09 (UTC+2)  
+**Scope:** Break `py/cyclic-import` between context harness and evidence JSON  
+**Issue:** [#3939](https://github.com/jannekbuengener/Claire_de_Binare/issues/3939)  
+**Parent:** [#3924](https://github.com/jannekbuengener/Claire_de_Binare/issues/3924) quality batch  
+**LR:** NO-GO (unchanged)
+
+---
+
+## Brain Evidence
+
+| Feld | Wert |
+|------|------|
+| brain_source | repo-only |
+| brain_status | not-used |
+| context_brain_attempted | true |
+| repo_fallback_used | true |
+| repo_fallback_reason | insufficient_evidence |
+| tools_or_queries | `gh api code-scanning/alerts`, repo import graph, targeted pytest |
+| records_or_results | Alerts #4616, #4617 (`py/cyclic-import`) on harness ↔ evidence_json |
+| impact_on_plan | Module split at shared types; no CodeQL suppression |
+
+---
+
+## Root Cause
+
+- `context_invocation_evidence_json` imported `context_live_invocation_harness` at module level for `HarnessReport` / `MatrixRow`.
+- `context_live_invocation_harness.format_report()` lazy-imported `serialize_invocation_evidence` from evidence_json for `--format json`.
+- CodeQL `py/cyclic-import` flags the module-level cycle (#4616, #4617).
+
+## Fix
+
+Extracted shared dataclasses and constants to `tools/surrealdb/context_invocation_harness_types.py`:
+
+- `MatrixRow`, `HarnessReport`, `MatrixStatus`, `FinalVerdict`, `InvocationProfile`
+- `ISSUE_REF`, `RATIFICATION_DOC`
+
+Import graph after fix:
+
+```
+context_invocation_harness_types  (no surrealdb siblings)
+        ↑                ↑
+        |                |
+evidence_json      live_invocation_harness ──lazy──► evidence_json (json format only)
+```
+
+No top-level cycle: evidence_json no longer imports harness.
+
+## Validation
+
+```bash
+ruff check tools/surrealdb/context_invocation_harness_types.py \
+  tools/surrealdb/context_invocation_evidence_json.py \
+  tools/surrealdb/context_live_invocation_harness.py
+pytest -q tests/unit/surrealdb/test_context_invocation_evidence_json.py \
+  tests/unit/surrealdb/test_context_live_invocation_harness.py
+```
+
+## Restunsicherheit
+
+GitHub CodeQL alert closure (#4616, #4617) is measurable only after Default Setup rescan on `main`. No alert dismissals performed.
+
+## Safety Boundaries
+
+- No alert dismissals
+- #3755 Grafana HOLD untouched
+- #3936 libcurl residual untouched
+- No Trivy/image/runtime changes
+- LR remains NO-GO

--- a/docs/evidence/security/CDB_SECURITY_CODEQL_QUALITY_BATCH_2026-07-08.md
+++ b/docs/evidence/security/CDB_SECURITY_CODEQL_QUALITY_BATCH_2026-07-08.md
@@ -43,7 +43,7 @@
 | `py/import-and-import-from` | 2 | **Fixed** — single import style in tests |
 | `py/implicit-string-concatenation-in-list` | 1 | **Fixed** — explicit concatenation in scanner |
 | `py/uninitialized-local-variable` | 1 | **Deferred** — .codex plugin-creator (already has `= None` on main; scan lag) |
-| `py/cyclic-import` | 2 | **Deferred** — harness ↔ evidence_json refactor slice |
+| cyclic-import | 2 | **Fixed** in #3939 — shared types extracted to `context_invocation_harness_types.py` |
 | `py/file-not-closed` | 1 | **Deferred** — paper stimulus test fixture lifecycle |
 | `py/polluting-import` | 1 | **Deferred** — local test helper import semantics |
 
@@ -65,7 +65,7 @@
 
 | Cluster | Alerts | Rationale | Follow-up |
 |---------|--------|-----------|-----------|
-| cyclic-import | 2 | `context_invocation_evidence_json` ↔ `context_live_invocation_harness` needs module split / lazy import design | Separate refactor slice if no existing issue |
+| cyclic-import | 2 | `context_invocation_evidence_json` ↔ `context_live_invocation_harness` — fixed in #3939 via `context_invocation_harness_types.py` | #3939 (closed) |
 | file-not-closed | 1 | `test_paper_runtime_stimulus_runner.py` — fixture lifecycle semantics | Document only |
 | polluting-import | 1 | `memory_db_proof_helpers.py` — test-local import pattern | Document only |
 

--- a/tests/unit/surrealdb/test_context_invocation_evidence_json.py
+++ b/tests/unit/surrealdb/test_context_invocation_evidence_json.py
@@ -16,6 +16,22 @@ from tools.surrealdb.db_record_evidence_contract import (
 
 pytestmark = pytest.mark.unit
 
+
+def test_modules_import_without_cyclic_dependency() -> None:
+    """Regression guard for CodeQL py/cyclic-import (#3939)."""
+    import importlib
+    import sys
+
+    for name in (
+        "tools.surrealdb.context_invocation_harness_types",
+        "tools.surrealdb.context_invocation_evidence_json",
+        "tools.surrealdb.context_live_invocation_harness",
+    ):
+        sys.modules.pop(name, None)
+    importlib.import_module("tools.surrealdb.context_invocation_evidence_json")
+    importlib.import_module("tools.surrealdb.context_live_invocation_harness")
+
+
 _REQUIRED_TOP_LEVEL = frozenset(
     {
         "schema_version",

--- a/tools/surrealdb/context_invocation_evidence_json.py
+++ b/tools/surrealdb/context_invocation_evidence_json.py
@@ -10,7 +10,7 @@ import json
 from typing import Any, Mapping
 
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
-from tools.surrealdb import context_live_invocation_harness as harness
+from tools.surrealdb import context_invocation_harness_types as harness_types
 from tools.surrealdb.negative_controls import negative_control_matrix_summary
 from tools.surrealdb.db_record_evidence_contract import (
     ACCEPTED_LIMITATION_CODES,
@@ -49,7 +49,7 @@ def _stable_run_id(profile: str, git_sha: str) -> str:
     return f"context-live-invoke-{profile}-{sha}"
 
 
-def derive_evidence_final_verdict(report: harness.HarnessReport) -> str:
+def derive_evidence_final_verdict(report: harness_types.HarnessReport) -> str:
     """Map harness outcome to machine-readable final_verdict for JSON evidence."""
     if report.final_verdict == "fail":
         return "FAIL"
@@ -60,7 +60,7 @@ def derive_evidence_final_verdict(report: harness.HarnessReport) -> str:
 
 
 def _build_accepted_limitation_claim(
-    row: harness.MatrixRow,
+    row: harness_types.MatrixRow,
     *,
     profile: str,
     git_sha: str,
@@ -86,7 +86,7 @@ def _build_accepted_limitation_claim(
         record_hashes_or_content_fingerprints=[],
         record_timestamps_or_freshness_signal="not_applicable",
         repo_crosscheck={
-            "path": harness.RATIFICATION_DOC,
+            "path": harness_types.RATIFICATION_DOC,
             "symbol": "PASS_WITH_LIMITS_ERROR_CODES",
             "commit": (git_sha or "unknown")[:8],
         },
@@ -105,7 +105,9 @@ def _build_accepted_limitation_claim(
     return claim
 
 
-def _tool_invocation_row(row: harness.MatrixRow, *, profile: str) -> dict[str, Any]:
+def _tool_invocation_row(
+    row: harness_types.MatrixRow, *, profile: str
+) -> dict[str, Any]:
     return {
         "tool_name": row.tool_name,
         "invocation_id": _invocation_fingerprint(row.tool_name, row.call, profile),
@@ -121,7 +123,7 @@ def _tool_invocation_row(row: harness.MatrixRow, *, profile: str) -> dict[str, A
 
 
 def _accepted_limitations_list(
-    rows: list[harness.MatrixRow],
+    rows: list[harness_types.MatrixRow],
 ) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for row in rows:
@@ -140,7 +142,7 @@ def _accepted_limitations_list(
     return sorted(out, key=lambda item: item["tool_name"])
 
 
-def _missing_evidence_codes(rows: list[harness.MatrixRow]) -> list[str]:
+def _missing_evidence_codes(rows: list[harness_types.MatrixRow]) -> list[str]:
     codes: set[str] = set()
     for row in rows:
         if row.status == "PASS_WITH_LIMITS" and row.error_code:
@@ -148,7 +150,7 @@ def _missing_evidence_codes(rows: list[harness.MatrixRow]) -> list[str]:
     return sorted(codes)
 
 
-def _limits_block(report: harness.HarnessReport) -> list[dict[str, str]]:
+def _limits_block(report: harness_types.HarnessReport) -> list[dict[str, str]]:
     items = [
         {"code": "bridge_only", "description": GLOBAL_LIMITATIONS[0]},
         {"code": "safety_gates_default_off", "description": GLOBAL_LIMITATIONS[1]},
@@ -177,7 +179,9 @@ def compute_aggregate_determinism_hash(document: Mapping[str, Any]) -> str:
     return canonical_hash(hash_payload_for_determinism(document))
 
 
-def build_invocation_evidence(report: harness.HarnessReport) -> dict[str, Any]:
+def build_invocation_evidence(
+    report: harness_types.HarnessReport,
+) -> dict[str, Any]:
     """Build the #2850 machine-readable evidence document from a harness report."""
     limit_rows = [r for r in report.matrix if r.status == "PASS_WITH_LIMITS"]
     evidence_claims = [
@@ -209,7 +213,7 @@ def build_invocation_evidence(report: harness.HarnessReport) -> dict[str, Any]:
         "redaction_summary": "no sensitive values present; bridge benchmark payloads only",
         "limitations": list(GLOBAL_LIMITATIONS),
         "issue_ref": ISSUE_REF,
-        "parent_issue_ref": harness.ISSUE_REF,
+        "parent_issue_ref": harness_types.ISSUE_REF,
         "ratification_doc": report.ratification_doc,
         "claim_schema_version": CLAIM_SCHEMA_VERSION,
         "git_sha": report.git_sha,
@@ -225,7 +229,7 @@ def build_invocation_evidence(report: harness.HarnessReport) -> dict[str, Any]:
 
 
 def serialize_invocation_evidence(
-    report: harness.HarnessReport,
+    report: harness_types.HarnessReport,
     *,
     indent: int | None = 2,
 ) -> str:

--- a/tools/surrealdb/context_invocation_harness_types.py
+++ b/tools/surrealdb/context_invocation_harness_types.py
@@ -1,0 +1,91 @@
+"""Shared types for context live invocation harness and JSON evidence (#3939).
+
+Extracted to break the CodeQL cyclic-import between
+``context_live_invocation_harness`` and ``context_invocation_evidence_json``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+MatrixStatus = Literal["PASS", "PASS_WITH_LIMITS", "FAIL", "BLOCKED_SAFETY"]
+FinalVerdict = Literal["pass", "fail"]
+InvocationProfile = Literal["minimal", "full"]
+
+ISSUE_REF = "#2849"
+RATIFICATION_DOC = (
+    "docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md"
+)
+
+
+@dataclass
+class MatrixRow:
+    tool_name: str
+    call: dict[str, Any]
+    expected: str
+    actual: str
+    status: MatrixStatus
+    handler_status: str | None = None
+    error_code: str | None = None
+    limitation: str | None = None
+    invocation_path: str = "bridge"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "call": self.call,
+            "expected": self.expected,
+            "actual": self.actual,
+            "status": self.status,
+            "handler_status": self.handler_status,
+            "error_code": self.error_code,
+            "limitation": self.limitation,
+            "invocation_path": self.invocation_path,
+        }
+
+
+@dataclass
+class HarnessReport:
+    timestamp: str
+    git_sha: str
+    branch: str
+    worktree_clean: bool
+    tool_count: int
+    expected_tool_count: int
+    matrix: list[MatrixRow] = field(default_factory=list)
+    summary: dict[str, int] = field(default_factory=dict)
+    safety_flags: dict[str, bool] = field(default_factory=dict)
+    lr_note: str = "NO-GO"
+    final_verdict: FinalVerdict = "pass"
+    issue_ref: str = ISSUE_REF
+    profile: InvocationProfile = "minimal"
+    ratification_doc: str = RATIFICATION_DOC
+    manifest_tool_names: list[str] = field(default_factory=list)
+    registry_tool_names: list[str] = field(default_factory=list)
+    missing_from_manifest: list[str] = field(default_factory=list)
+    extra_in_manifest: list[str] = field(default_factory=list)
+    root_inventory: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "git_sha": self.git_sha,
+            "branch": self.branch,
+            "worktree_clean": self.worktree_clean,
+            "tool_count": self.tool_count,
+            "expected_tool_count": self.expected_tool_count,
+            "matrix": [row.to_dict() for row in self.matrix],
+            "summary": self.summary,
+            "safety_flags": self.safety_flags,
+            "lr_note": self.lr_note,
+            "final_verdict": self.final_verdict,
+            "issue_ref": self.issue_ref,
+            "profile": self.profile,
+            "ratification_doc": self.ratification_doc,
+            "manifest_tool_names": self.manifest_tool_names,
+            "registry_tool_names": self.registry_tool_names,
+            "missing_from_manifest": self.missing_from_manifest,
+            "extra_in_manifest": self.extra_in_manifest,
+            "root_inventory": self.root_inventory,
+        }

--- a/tools/surrealdb/context_live_invocation_harness.py
+++ b/tools/surrealdb/context_live_invocation_harness.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
@@ -33,17 +32,19 @@ from core.utils.clock import utcnow
 from tools.mcp.context_bridge import create_bridge
 from tools.mcp.memory_write_intent_tools import MUTATION_ALLOWED
 from tools.surrealdb import memory_write_gate
+from tools.surrealdb.context_invocation_harness_types import (
+    ISSUE_REF,
+    RATIFICATION_DOC,
+    FinalVerdict,
+    HarnessReport,
+    InvocationProfile,
+    MatrixRow,
+    MatrixStatus,
+)
 
-MatrixStatus = Literal["PASS", "PASS_WITH_LIMITS", "FAIL", "BLOCKED_SAFETY"]
-FinalVerdict = Literal["pass", "fail"]
 OutputFormat = Literal["text", "json", "markdown"]
 
 EXPECTED_TOOL_COUNT = 27
-ISSUE_REF = "#2849"
-RATIFICATION_DOC = (
-    "docs/evidence/context_tooling/CDB_PASS_WITH_LIMITS_RATIFICATION_2026-06-03.md"
-)
-InvocationProfile = Literal["minimal", "full"]
 
 _BENCH_SCOPE = "bench-2852"
 _BENCH_EVIDENCE: list[dict[str, Any]] = [
@@ -352,78 +353,6 @@ def classify_tool_result(
         return "FAIL"
 
     return "FAIL"
-
-
-@dataclass
-class MatrixRow:
-    tool_name: str
-    call: dict[str, Any]
-    expected: str
-    actual: str
-    status: MatrixStatus
-    handler_status: str | None = None
-    error_code: str | None = None
-    limitation: str | None = None
-    invocation_path: str = "bridge"
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "tool_name": self.tool_name,
-            "call": self.call,
-            "expected": self.expected,
-            "actual": self.actual,
-            "status": self.status,
-            "handler_status": self.handler_status,
-            "error_code": self.error_code,
-            "limitation": self.limitation,
-            "invocation_path": self.invocation_path,
-        }
-
-
-@dataclass
-class HarnessReport:
-    timestamp: str
-    git_sha: str
-    branch: str
-    worktree_clean: bool
-    tool_count: int
-    expected_tool_count: int
-    matrix: list[MatrixRow] = field(default_factory=list)
-    summary: dict[str, int] = field(default_factory=dict)
-    safety_flags: dict[str, bool] = field(default_factory=dict)
-    lr_note: str = "NO-GO"
-    final_verdict: FinalVerdict = "pass"
-    issue_ref: str = ISSUE_REF
-    profile: InvocationProfile = "minimal"
-    ratification_doc: str = RATIFICATION_DOC
-    manifest_tool_names: list[str] = field(default_factory=list)
-    registry_tool_names: list[str] = field(default_factory=list)
-    missing_from_manifest: list[str] = field(default_factory=list)
-    extra_in_manifest: list[str] = field(default_factory=list)
-    root_inventory: dict[str, Any] = field(default_factory=dict)
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "timestamp": self.timestamp,
-            "git_sha": self.git_sha,
-            "branch": self.branch,
-            "worktree_clean": self.worktree_clean,
-            "tool_count": self.tool_count,
-            "expected_tool_count": self.expected_tool_count,
-            "matrix": [row.to_dict() for row in self.matrix],
-            "summary": self.summary,
-            "safety_flags": self.safety_flags,
-            "lr_note": self.lr_note,
-            "final_verdict": self.final_verdict,
-            "issue_ref": self.issue_ref,
-            "profile": self.profile,
-            "ratification_doc": self.ratification_doc,
-            "manifest_tool_names": self.manifest_tool_names,
-            "registry_tool_names": self.registry_tool_names,
-            "missing_from_manifest": self.missing_from_manifest,
-            "extra_in_manifest": self.extra_in_manifest,
-            "root_inventory": self.root_inventory,
-        }
 
 
 def _safety_flags() -> dict[str, bool]:


### PR DESCRIPTION
## Summary

Closes #3939

Refs #3924

Breaks the CodeQL `py/cyclic-import` cluster between `context_live_invocation_harness` and `context_invocation_evidence_json` by extracting shared types to `context_invocation_harness_types.py`.

## Delivered

- New module `tools/surrealdb/context_invocation_harness_types.py` with `HarnessReport`, `MatrixRow`, and shared constants
- `context_invocation_evidence_json` imports types module instead of harness (no module-level cycle)
- `context_live_invocation_harness` keeps lazy JSON serialization import (unchanged CLI behavior)
- Regression test `test_modules_import_without_cyclic_dependency`
- Evidence: `docs/evidence/security/CDB_SECURITY_CODEQL_CYCLIC_IMPORT_3939_2026-07-09.md`

## Brain Evidence

| Feld | Wert |
|------|------|
| brain_source | repo-only |
| brain_status | not-used |
| context_brain_attempted | true |
| repo_fallback_used | true |
| repo_fallback_reason | insufficient_evidence |
| tools_or_queries | gh code-scanning alerts API, repo import graph |
| records_or_results | Alerts #4616, #4617 (py/cyclic-import) |

## Validation

- `ruff check` on touched files
- `pytest` 14 tests in `test_context_invocation_evidence_json` + `test_context_live_invocation_harness`

## Non-goals

- No alert dismissals
- #3755 Grafana HOLD untouched
- #3936 libcurl residual untouched
- No Trivy/image/runtime changes
- No unrelated CodeQL quality fixes

## Safety Boundaries

- LR remains NO-GO
- No MCP/DB mutations
- No BLUE/RED runtime changes

## Restunsicherheiten

GitHub CodeQL alert closure (#4616, #4617) measurable only after Default Setup rescan on `main`.

Made with [Cursor](https://cursor.com)