### PR TITLE
fix(arvp): correct parallel signal compose build context

### DIFF
--- a/manifests/runtime_np_parallel_signal_compose_override.yml
+++ b/manifests/runtime_np_parallel_signal_compose_override.yml
@@ -21,7 +21,7 @@ services:
 
   cdb_signal_pb1:
     build:
-      context: ..
+      context: ../..
       dockerfile: services/signal/Dockerfile
     container_name: cdb_signal_pb1
     restart: unless-stopped
@@ -69,7 +69,7 @@ services:
 
   cdb_signal_donchian:
     build:
-      context: ..
+      context: ../..
       dockerfile: services/signal/Dockerfile
     container_name: cdb_signal_donchian
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Fixes \cdb_signal_pb1\ / \cdb_signal_donchian\ image build when applying parallel compose override with base files under \infrastructure/compose/\. Relative \context: ..\ resolved to \infrastructure/\ instead of repo root.

## Validation

- \docker compose ... config\ shows context = repo root
- Execute #3912: both parallel signal containers built and healthy

Refs #3909 #3912

Made with [Cursor](https://cursor.com)