### PR TITLE
fix(arvp): prevent false zero-event campaign telemetry

### DIFF
--- a/core/utils/uuid_gen.py
+++ b/core/utils/uuid_gen.py
@@ -65,6 +65,25 @@ def generate_uuid_hex(
     return uuid.UUID(value).hex[:length]
 
 
+def generate_runtime_signal_id_hex(length: int = 32) -> str:
+    """Generate a collision-safe runtime signal id fragment (UUID4-based).
+
+    Use for live natural-paper/runtime paths. Do **not** use the module-global
+    deterministic counter here: container restarts would reuse ids and suppress
+    correlation_ledger inserts via ON CONFLICT DO NOTHING.
+
+    For replay/fixtures, keep using ``generate_uuid_hex(name=..., seed=...)``.
+    """
+    if length < 1 or length > 32:
+        raise ValueError("runtime signal id length must be between 1 and 32")
+    return uuid.uuid4().hex[:length]
+
+
+def format_runtime_signal_id(length: int = 32) -> str:
+    """Return a runtime ``sig-`` prefixed signal id safe across restarts."""
+    return f"sig-{generate_runtime_signal_id_hex(length=length)}"
+
+
 # Namespace for decision_pk (Phase 8B)
 DECISION_PK_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
 

--- a/docs/evidence/arvp_3912_zero_event_telemetry_fix_3955.md
+++ b/docs/evidence/arvp_3912_zero_event_telemetry_fix_3955.md
@@ -1,0 +1,39 @@
+# ARVP #3912 False Zero-Event Telemetry Fix (#3955)
+
+Status Class: **ENGINEERING_FIX** — code/tests only; no runtime rerun  
+Issue: [#3955](https://github.com/jannekbuengener/Claire_de_Binare/issues/3955)  
+Parent observation: [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912)  
+Live-Readiness: **NO-GO**  
+Echtgeld: **not authorized**
+
+## Problem
+
+Parallel natural-paper run #3912 reported `events_since_start=0` on both lanes at
+terminal evaluation, although Donchian emitted **50** runtime signals.
+
+Root causes:
+
+1. **Runtime `signal_id` collision** — `generate_uuid_hex()` without an explicit
+   `name` used a module-global deterministic counter that resets on container
+   restart. Reused IDs hit `correlation_ledger` `ON CONFLICT DO NOTHING`, so no
+   new rows appeared in the observation window.
+2. **Supervisor global-only ledger count** — `probe_ledger` counted all ledger
+   rows since `start_utc` without `bot_id` / `strategy_id` lane filters.
+
+`TIMEOUT_NO_CHAIN` remains valid when no promotable SIGNAL→DECISION→ORDER→FILL
+chain exists (e.g. 50× RC_001 under `HIGH_VOL_CHAOTIC`). Telemetry must still
+surface lane activity separately from chain verdict.
+
+## Fix (P0)
+
+| Item | Change |
+|------|--------|
+| P0-1 | `format_runtime_signal_id()` / `generate_runtime_signal_id_hex()` (UUID4) for live runtime paths; deterministic IDs kept for stimulus/replay |
+| P0-2 | `probe_ledger` exposes global + `bot_id` / `strategy_id` / `campaign_id` / `config_hash` scoped counts; supervisor cycle adds `event_count_since_start_lane` + `ledger_counts` |
+
+## Non-goals
+
+- No change to RC_001 / risk semantics
+- No natural-paper promotion claim
+- No runtime Docker execution in this slice
+- LR **NO-GO** unchanged

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -33,6 +33,7 @@ from core.replay.canonical_json import canonical_hash
 from core.utils.clock import utcnow
 from core.utils.redis_payload import sanitize_signal
 from core.utils.uuid_gen import (
+    format_runtime_signal_id,
     generate_uuid_hex,
     compute_correlation_id,
     compute_event_pk,
@@ -294,8 +295,13 @@ class SignalEngine:
                         f"stimulus:{stimulus_run_id}:{candidate.symbol}:"
                         f"{candidate.side}:{market_data.timestamp}"
                     )
+        signal_id = (
+            f"sig-{generate_uuid_hex(name=signal_id_name, length=32)}"
+            if signal_id_name
+            else format_runtime_signal_id(length=32)
+        )
         signal = Signal(
-            signal_id=f"sig-{generate_uuid_hex(name=signal_id_name, length=32)}",
+            signal_id=signal_id,
             symbol=candidate.symbol,
             side=candidate.side,
             reason=candidate.reason,
@@ -648,7 +654,7 @@ class SignalEngine:
             and close_now < lower_level
         ):
             result_signal = Signal(
-                signal_id=f"sig-{generate_uuid_hex(length=32)}",
+                signal_id=format_runtime_signal_id(length=32),
                 symbol=symbol,
                 side="SELL",
                 reason="donchian_lower_break",
@@ -690,7 +696,7 @@ class SignalEngine:
             )
         ):
             result_signal = Signal(
-                signal_id=f"sig-{generate_uuid_hex(length=32)}",
+                signal_id=format_runtime_signal_id(length=32),
                 symbol=symbol,
                 side="BUY",
                 reason="donchian_upper_break",
@@ -816,7 +822,7 @@ class SignalEngine:
             and close_now < lowest_low
         ):
             result_signal = Signal(
-                signal_id=f"sig-{generate_uuid_hex(length=32)}",
+                signal_id=format_runtime_signal_id(length=32),
                 symbol=symbol,
                 side="SELL",
                 reason="channel_exit",
@@ -861,7 +867,7 @@ class SignalEngine:
             )
             if entry_ready:
                 result_signal = Signal(
-                    signal_id=f"sig-{generate_uuid_hex(length=32)}",
+                    signal_id=format_runtime_signal_id(length=32),
                     symbol=symbol,
                     side="BUY",
                     reason="breakout_entry",

--- a/tests/unit/arvp/test_arvp_parallel_ledger_telemetry_contract_3955.py
+++ b/tests/unit/arvp/test_arvp_parallel_ledger_telemetry_contract_3955.py
@@ -1,0 +1,93 @@
+"""Contract tests for parallel campaign ledger telemetry (#3955 / #3912)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.arvp_campaign_supervisor import _build_cycle_entry, _ledger_activity_count
+
+
+_PB1_MANIFEST = {
+    "campaign_id": "arvp_3912_np_parallel_pb1_20260709_1327",
+    "bot_id": "np-pb1-parallel-01",
+    "strategy_id": "primary_breakout_v1",
+}
+
+_DONCHIAN_MANIFEST = {
+    "campaign_id": "arvp_3912_np_parallel_donchian_20260709_1327",
+    "bot_id": "np-donchian-parallel-01",
+    "strategy_id": "donchian_breakout_v1",
+}
+
+
+def _ledger_probe(
+  *,
+  global_count: int,
+  bot_count: int,
+  strategy_count: int,
+  bot_id: str,
+  strategy_id: str,
+) -> dict:
+    return {
+        "probe": "correlation_ledger",
+        "status": "ok",
+        "limitations": [],
+        "evidence": {
+            "events_since_campaign_start": global_count,
+            "events_since_campaign_start_global": global_count,
+            "events_since_campaign_start_bot_id": bot_count,
+            "events_since_campaign_start_strategy_id": strategy_count,
+            "ledger_attribution": {
+                "bot_id": bot_id,
+                "strategy_id": strategy_id,
+                "campaign_id_propagated_to_ledger": False,
+            },
+        },
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.contract
+def test_lane_effective_count_prefers_bot_id_over_global_zero() -> None:
+    evidence = _ledger_probe(
+        global_count=0,
+        bot_count=50,
+        strategy_count=50,
+        bot_id=_DONCHIAN_MANIFEST["bot_id"],
+        strategy_id=_DONCHIAN_MANIFEST["strategy_id"],
+    )["evidence"]
+    assert _ledger_activity_count(evidence, _DONCHIAN_MANIFEST) == 50
+
+
+@pytest.mark.unit
+@pytest.mark.contract
+def test_supervisor_cycle_entry_exposes_lane_count_for_donchian() -> None:
+    probes = [
+        _ledger_probe(
+            global_count=0,
+            bot_count=50,
+            strategy_count=50,
+            bot_id=_DONCHIAN_MANIFEST["bot_id"],
+            strategy_id=_DONCHIAN_MANIFEST["strategy_id"],
+        )
+    ]
+    entry = _build_cycle_entry(1, probes, "CAMPAIGN_RUNNING", _DONCHIAN_MANIFEST)
+    assert entry["event_count_since_start"] == 0
+    assert entry["event_count_since_start_lane"] == 50
+    assert entry["ledger_counts"]["bot_id_since_start"] == 50
+
+
+@pytest.mark.unit
+@pytest.mark.contract
+def test_supervisor_cycle_entry_lane_zero_for_pb1_when_no_signals() -> None:
+    probes = [
+        _ledger_probe(
+            global_count=0,
+            bot_count=0,
+            strategy_count=0,
+            bot_id=_PB1_MANIFEST["bot_id"],
+            strategy_id=_PB1_MANIFEST["strategy_id"],
+        )
+    ]
+    entry = _build_cycle_entry(1, probes, "CAMPAIGN_RUNNING", _PB1_MANIFEST)
+    assert entry["event_count_since_start_lane"] == 0

--- a/tests/unit/test_uuid_gen.py
+++ b/tests/unit/test_uuid_gen.py
@@ -1,7 +1,13 @@
 import pytest
 """Unit tests for core.utils.uuid_gen module."""
 
-from core.utils.uuid_gen import generate_uuid, generate_uuid_hex
+from core.utils.uuid_gen import (
+    DeterministicUUIDGenerator,
+    format_runtime_signal_id,
+    generate_runtime_signal_id_hex,
+    generate_uuid,
+    generate_uuid_hex,
+)
 
 
 @pytest.mark.unit
@@ -33,3 +39,21 @@ def test_generate_uuid_hex_length():
     """Test deterministic UUID hex generation length."""
     short_hex = generate_uuid_hex(name="hex-test", length=12)
     assert len(short_hex) == 12
+
+
+@pytest.mark.unit
+def test_runtime_signal_ids_unique_across_simulated_restarts():
+    """Deterministic counter restarts collide; runtime UUID4 ids must not."""
+    gen_restart_a = DeterministicUUIDGenerator(seed=0)
+    gen_restart_b = DeterministicUUIDGenerator(seed=0)
+    assert str(gen_restart_a.generate()) == str(gen_restart_b.generate())
+
+    restart_ids = {format_runtime_signal_id(length=32) for _ in range(32)}
+    assert len(restart_ids) == 32
+
+
+@pytest.mark.unit
+def test_runtime_signal_id_hex_is_uuid4_fragment():
+    runtime_hex = generate_runtime_signal_id_hex(length=32)
+    assert len(runtime_hex) == 32
+    assert runtime_hex.isalnum()

--- a/tests/unit/tools/test_arvp_campaign_supervisor.py
+++ b/tests/unit/tools/test_arvp_campaign_supervisor.py
@@ -578,7 +578,7 @@ class TestRunAllProbes:
         )
         monkeypatch.setattr(
             "tools.arvp_campaign_supervisor.probe_ledger",
-            lambda campaign_start_utc=None, include_events=False: _ok(
+            lambda campaign_start_utc=None, include_events=False, **kwargs: _ok(
                 "correlation_ledger"
             ),
         )

--- a/tests/unit/tools/test_arvp_probe_layer.py
+++ b/tests/unit/tools/test_arvp_probe_layer.py
@@ -446,6 +446,43 @@ class TestProbeLedger:
         result = probe_ledger()
         assert result["status"] == "blocked"
 
+    def test_lane_scoped_counts_exposed(self, monkeypatch):
+        monkeypatch.setattr("importlib.util.find_spec", lambda _: True)
+
+        def fake_run_sql(host, port, dbname, user, query, container=None):
+            if "GROUP BY" in query:
+                return [("SIGNAL", 50)]
+            if "ORDER BY timestamp_ms DESC LIMIT 1" in query:
+                return [(1_783_603_620_000, "SIGNAL", "corr-1")]
+            if "payload->>'bot_id'" in query and "np-donchian-parallel-01" in query:
+                return [(50,)]
+            if "payload->>'strategy_id'" in query:
+                return [(50,)]
+            if "payload->>'campaign_id'" in query:
+                return [(0,)]
+            if "COUNT(*)" in query:
+                return [(0,)]
+            return []
+
+        monkeypatch.setattr("tools.arvp_probe_layer._run_sql", fake_run_sql)
+
+        result = probe_ledger(
+            campaign_start_utc="2026-07-09T13:27:00Z",
+            bot_id="np-donchian-parallel-01",
+            strategy_id="donchian_breakout_v1",
+            campaign_id="arvp_3912_np_parallel_donchian_20260709_1327",
+        )
+        evidence = result["evidence"]
+        assert result["status"] == "ok"
+        assert evidence["events_since_campaign_start_global"] == 0
+        assert evidence["events_since_campaign_start_bot_id"] == 50
+        assert evidence["events_since_campaign_start_strategy_id"] == 50
+        assert evidence["events_since_campaign_start_campaign_id"] == 0
+        assert any(
+            "campaign_id is not propagated" in item
+            for item in result["limitations"]
+        )
+
 
 # ---------------------------------------------------------------------------
 # 7. Regime probe tests

--- a/tools/arvp_campaign_supervisor.py
+++ b/tools/arvp_campaign_supervisor.py
@@ -125,7 +125,13 @@ def run_all_probes(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     results.append(
         {
             "probe": "correlation_ledger",
-            **probe_ledger(campaign_start_utc=start_utc, include_events=True),
+            **probe_ledger(
+                campaign_start_utc=start_utc,
+                include_events=True,
+                bot_id=manifest.get("bot_id"),
+                strategy_id=manifest.get("strategy_id"),
+                campaign_id=manifest.get("campaign_id"),
+            ),
         }
     )
     results.append({"probe": "regime", **probe_regime()})
@@ -145,13 +151,31 @@ def _check_blocked(probes: list[dict[str, Any]], name: str) -> bool:
     return p is not None and p.get("status") in ("blocked",)
 
 
-def detect_chain(probes: list[dict[str, Any]]) -> dict[str, Any] | None:
+def _ledger_activity_count(
+    evidence: dict[str, Any], manifest: dict[str, Any]
+) -> int | None:
+    """Prefer lane-scoped ledger count when manifest supplies bot_id."""
+    global_count = evidence.get("events_since_campaign_start")
+    bot_count = evidence.get("events_since_campaign_start_bot_id")
+    strategy_count = evidence.get("events_since_campaign_start_strategy_id")
+    if manifest.get("bot_id") and bot_count is not None:
+        return bot_count
+    if manifest.get("strategy_id") and strategy_count is not None:
+        return strategy_count
+    return global_count
+
+
+def detect_chain(
+    probes: list[dict[str, Any]], manifest: dict[str, Any] | None = None
+) -> dict[str, Any] | None:
     ledger = _find_probe(probes, "correlation_ledger")
     if ledger is None or ledger.get("status") != "ok":
         return None
 
     evidence = ledger.get("evidence", {})
     count_since = evidence.get("events_since_campaign_start")
+    if manifest is not None:
+        count_since = _ledger_activity_count(evidence, manifest)
     if count_since is not None and count_since <= 0:
         return None
 
@@ -203,7 +227,7 @@ def evaluate_state(
     if safety is not None and safety.get("status") == "blocked":
         return STATE_BLOCKED_GOVERNANCE
 
-    chain_result = detect_chain(probes)
+    chain_result = detect_chain(probes, manifest)
     if (
         chain_result is not None
         and chain_result.get("chain_status") == "complete_chain"
@@ -234,13 +258,30 @@ def _build_cycle_entry(
 ) -> dict[str, Any]:
     ledger = _find_probe(probes, "correlation_ledger")
     event_count = None
+    ledger_counts: dict[str, Any] = {}
     if ledger is not None:
         ev = ledger.get("evidence", {})
         event_count = ev.get("events_since_campaign_start")
+        lane_count = _ledger_activity_count(ev, manifest)
+        ledger_counts = {
+            "global_since_start": ev.get("events_since_campaign_start_global"),
+            "bot_id_since_start": ev.get("events_since_campaign_start_bot_id"),
+            "strategy_id_since_start": ev.get(
+                "events_since_campaign_start_strategy_id"
+            ),
+            "campaign_id_since_start": ev.get(
+                "events_since_campaign_start_campaign_id"
+            ),
+            "config_hash_since_start": ev.get(
+                "events_since_campaign_start_config_hash"
+            ),
+            "lane_effective_since_start": lane_count,
+            "attribution": ev.get("ledger_attribution"),
+        }
 
     probe_statuses = {p["probe"]: p.get("status") for p in probes}
 
-    chain_details = detect_chain(probes)
+    chain_details = detect_chain(probes, manifest)
 
     entry: dict[str, Any] = {
         "observed_at_utc": _utcnow(),
@@ -249,9 +290,13 @@ def _build_cycle_entry(
         "state": state,
         "probe_statuses": probe_statuses,
         "event_count_since_start": event_count,
+        "event_count_since_start_lane": ledger_counts.get(
+            "lane_effective_since_start"
+        ),
+        "ledger_counts": ledger_counts,
         "chain_detected": state == STATE_CHAIN_FOUND,
         "no_mutation": True,
-        "limitations": [],
+        "limitations": list(ledger.get("limitations", [])) if ledger else [],
     }
 
     if chain_details is not None:
@@ -303,7 +348,8 @@ def write_status_md(path: str, entry: dict[str, Any], manifest: dict[str, Any]) 
         f"- **Strategy:** {manifest.get('strategy_id', '-')}",
         f"- **Start (UTC):** {manifest.get('start_utc', '-')}",
         f"- **Timeout (UTC):** {manifest.get('timeout_utc', '-')}",
-        f"- **Event count since start:** {entry.get('event_count_since_start', '-')}",
+        f"- **Event count since start (global):** {entry.get('event_count_since_start', '-')}",
+        f"- **Event count since start (lane):** {entry.get('event_count_since_start_lane', '-')}",
         f"- **Chain detected:** {entry.get('chain_detected', False)}",
         "",
         "## Safety Flags",

--- a/tools/arvp_probe_layer.py
+++ b/tools/arvp_probe_layer.py
@@ -729,6 +729,47 @@ def probe_candles(
 # ---------------------------------------------------------------------------
 
 
+def _campaign_start_ms_expr(campaign_start_utc: str) -> str:
+    return (
+        f"EXTRACT(EPOCH FROM '{campaign_start_utc}'::timestamptz)::bigint * 1000"
+    )
+
+
+def _ledger_count_since_start(
+    host: str,
+    port: int,
+    dbname: str,
+    user: str,
+    campaign_start_utc: str,
+    *,
+    bot_id: str | None = None,
+    strategy_id: str | None = None,
+    campaign_id: str | None = None,
+    config_hash: str | None = None,
+) -> int | None:
+    start_expr = _campaign_start_ms_expr(campaign_start_utc)
+    clauses = [f"timestamp_ms >= {start_expr}"]
+    if bot_id:
+        clauses.append(f"payload->>'bot_id' = '{bot_id}'")
+    if strategy_id:
+        clauses.append(f"payload->>'strategy_id' = '{strategy_id}'")
+    if campaign_id:
+        clauses.append(f"payload->>'campaign_id' = '{campaign_id}'")
+    if config_hash:
+        clauses.append(
+            f"COALESCE(payload->'metadata'->>'config_hash', '') = '{config_hash}'"
+        )
+    where = " AND ".join(clauses)
+    rows = _run_sql(
+        host,
+        port,
+        dbname,
+        user,
+        f"SELECT COUNT(*) FROM correlation_ledger WHERE {where}",
+    )
+    return int(rows[0][0]) if rows else 0
+
+
 def probe_ledger(
     campaign_start_utc: str | None = None,
     host: str = DB_DEFAULTS["host"],
@@ -736,6 +777,10 @@ def probe_ledger(
     dbname: str = DB_DEFAULTS["dbname"],
     user: str = DB_DEFAULTS["user"],
     include_events: bool = False,
+    bot_id: str | None = None,
+    strategy_id: str | None = None,
+    campaign_id: str | None = None,
+    config_hash: str | None = None,
 ) -> ProbeResult:
     import importlib
 
@@ -767,17 +812,50 @@ def probe_ledger(
             }
 
         count_since_start: int | None = None
+        count_bot_id: int | None = None
+        count_strategy_id: int | None = None
+        count_campaign_id: int | None = None
+        count_config_hash: int | None = None
         if campaign_start_utc:
-            count_rows = _run_sql(
-                host,
-                port,
-                dbname,
-                user,
-                f"SELECT COUNT(*) FROM correlation_ledger "
-                f"WHERE timestamp_ms >= "
-                f"EXTRACT(EPOCH FROM '{campaign_start_utc}'::timestamptz)::bigint * 1000",
+            count_since_start = _ledger_count_since_start(
+                host, port, dbname, user, campaign_start_utc
             )
-            count_since_start = int(count_rows[0][0]) if count_rows else 0
+            if bot_id:
+                count_bot_id = _ledger_count_since_start(
+                    host,
+                    port,
+                    dbname,
+                    user,
+                    campaign_start_utc,
+                    bot_id=bot_id,
+                )
+            if strategy_id:
+                count_strategy_id = _ledger_count_since_start(
+                    host,
+                    port,
+                    dbname,
+                    user,
+                    campaign_start_utc,
+                    strategy_id=strategy_id,
+                )
+            if campaign_id:
+                count_campaign_id = _ledger_count_since_start(
+                    host,
+                    port,
+                    dbname,
+                    user,
+                    campaign_start_utc,
+                    campaign_id=campaign_id,
+                )
+            if config_hash:
+                count_config_hash = _ledger_count_since_start(
+                    host,
+                    port,
+                    dbname,
+                    user,
+                    campaign_start_utc,
+                    config_hash=config_hash,
+                )
 
         grouped = _run_sql(
             host,
@@ -800,14 +878,40 @@ def probe_ledger(
         evidence: dict[str, Any] = {
             "latest_event": latest_event,
             "events_since_campaign_start": count_since_start,
+            "events_since_campaign_start_global": count_since_start,
+            "events_since_campaign_start_bot_id": count_bot_id,
+            "events_since_campaign_start_strategy_id": count_strategy_id,
+            "events_since_campaign_start_campaign_id": count_campaign_id,
+            "events_since_campaign_start_config_hash": count_config_hash,
             "events_by_type_status": events_by_type,
             "campaign_start_utc": campaign_start_utc,
+            "ledger_attribution": {
+                "bot_id": bot_id,
+                "strategy_id": strategy_id,
+                "campaign_id": campaign_id,
+                "config_hash": config_hash,
+                "campaign_id_propagated_to_ledger": False,
+                "config_hash_path": "payload.metadata.config_hash",
+            },
             "queries": [
                 "SELECT ... FROM correlation_ledger ORDER BY timestamp_ms DESC LIMIT 1",
                 "SELECT COUNT(*) FROM correlation_ledger WHERE timestamp_ms >= ...",
+                "SELECT COUNT(*) FROM correlation_ledger WHERE timestamp_ms >= ... AND payload->>'bot_id' = ...",
+                "SELECT COUNT(*) FROM correlation_ledger WHERE timestamp_ms >= ... AND payload->>'strategy_id' = ...",
                 "SELECT event_type, COUNT(*) FROM correlation_ledger GROUP BY ...",
             ],
         }
+        limitations: list[str] = []
+        if campaign_id and count_campaign_id == 0:
+            limitations.append(
+                "campaign_id filter returned 0 rows; campaign_id is not "
+                "propagated to correlation_ledger payload today"
+            )
+            evidence["ledger_attribution"]["campaign_id_propagated_to_ledger"] = False
+        if bot_id is None and strategy_id is None:
+            limitations.append(
+                "no bot_id/strategy_id filter supplied; only global ledger count available"
+            )
 
         events_raw: list[dict] | None = None
         if include_events:
@@ -843,7 +947,13 @@ def probe_ledger(
                 logger.warning("events query failed: %s", exc)
                 evidence["events_error"] = str(exc)
 
-        return _ok(evidence)
+        return {
+            "status": "ok",
+            "evidence": evidence,
+            "observed_at_utc": _utcnow(),
+            "limitations": limitations,
+            "no_mutation": True,
+        }
     except Exception as exc:
         return _blocked(
             {"error": str(exc)},
@@ -949,6 +1059,16 @@ def main() -> None:
         "--campaign-start",
         help="Campaign start UTC (ISO-8601) for ledger probe",
     )
+    parser.add_argument("--bot-id", help="Lane bot_id filter for ledger probe")
+    parser.add_argument(
+        "--strategy-id", help="Lane strategy_id filter for ledger probe"
+    )
+    parser.add_argument(
+        "--campaign-id", help="Campaign id filter for ledger probe (optional)"
+    )
+    parser.add_argument(
+        "--config-hash", help="Config hash filter for ledger probe (optional)"
+    )
     parser.add_argument(
         "--docker-targets",
         nargs="*",
@@ -989,7 +1109,13 @@ def main() -> None:
         results.append(
             {
                 "probe": "correlation_ledger",
-                **probe_ledger(campaign_start_utc=args.campaign_start),
+                **probe_ledger(
+                    campaign_start_utc=args.campaign_start,
+                    bot_id=args.bot_id,
+                    strategy_id=args.strategy_id,
+                    campaign_id=args.campaign_id,
+                    config_hash=args.config_hash,
+                ),
             }
         )
     if args.all or args.regime:


### PR DESCRIPTION
## Summary

Refs #3912, Closes #3955

### Root cause
- Natural-paper parallel campaign #3912 showed `events_since_start=0` for an active Donchian lane despite 50 emitted signals.
- Runtime `signal_id` values were generated via module-global deterministic counter (`generate_uuid_hex()` without namespace), which resets on container restart and collides with prior ledger rows.
- `correlation_ledger` uses `ON CONFLICT DO NOTHING` on `signal_id`, so colliding inserts were silently dropped while logs still reported writes.
- Supervisor/probe counted only global ledger rows since campaign start, with no `bot_id` / `strategy_id` lane attribution.

### Fix (P0-1): collision-safe runtime signal IDs
- Add `generate_runtime_signal_id_hex()` / `format_runtime_signal_id()` in `core/utils/uuid_gen.py` (UUID4-based).
- Use runtime IDs for live signal emission in `services/signal/service.py`; keep deterministic IDs only for stimulus/fixture/replay paths.

### Fix (P0-2): raw/global vs lane-scoped supervisor counts
- Extend `tools/arvp_probe_layer.py` with global and filtered counts (`bot_id`, `strategy_id`, `campaign_id`, `config_hash`) plus explicit `ledger_attribution` / `limitations`.
- Extend `tools/arvp_campaign_supervisor.py` cycle output with `event_count_since_start_lane`, `ledger_counts`, and lane-effective count selection.

## Test plan
- [x] `tests/unit/test_uuid_gen.py` — runtime ID uniqueness + restart collision regression
- [x] `tests/unit/tools/test_arvp_probe_layer.py` — lane-scoped counts
- [x] `tests/unit/arvp/test_arvp_parallel_ledger_telemetry_contract_3955.py` — Donchian/PB1 parallel contract
- [x] `tests/unit/tools/test_arvp_campaign_supervisor.py` — supervisor cycle fields
- [x] `tests/unit/signal/*` (except numpy-only classifier) + `tests/replay/test_deterministic_replay.py`

## Safety boundaries
- LR remains **NO-GO**; no live/echtgeld implication.
- No runtime execution, Docker mutations, or DB writes in this slice.
- No RC_001 / risk-gate semantics changed.
- No strategy parameter tuning or natural-paper promotion claim.

## Non-goals
- Block-reason evidence shape (P1) deferred.
- Manifest terminal drift in main worktree left untouched.

## Remaining uncertainty
- `campaign_id` is not yet propagated into `correlation_ledger` payload; probe reports this explicitly via `ledger_attribution.campaign_id_propagated_to_ledger: false`.
