### PR TITLE
feat(arvp): add campaign attribution and block reason evidence

### DIFF
--- a/core/replay/correlation_ledger_attribution.py
+++ b/core/replay/correlation_ledger_attribution.py
@@ -1,0 +1,220 @@
+"""Correlation ledger campaign/lane attribution helpers (ARVP P1 telemetry)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+
+CDB_CAMPAIGN_ID_ENV = "CDB_CAMPAIGN_ID"
+
+DECISION_BLOCK = "BLOCK"
+DECISION_ALLOW = "ALLOW"
+
+NO_CHAIN_REASON_NO_SIGNALS = "NO_SIGNALS_OR_GATE_IDLE"
+NO_CHAIN_REASON_RISK_BLOCKED = "RISK_BLOCKED_NO_PROMOTABLE_CHAIN"
+
+
+def resolve_campaign_id() -> str | None:
+    raw = os.getenv(CDB_CAMPAIGN_ID_ENV, "").strip()
+    return raw or None
+
+
+def _payload_config_hash(payload: Mapping[str, Any]) -> str | None:
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        raw = metadata.get("config_hash")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+    raw_top = payload.get("config_hash")
+    if isinstance(raw_top, str) and raw_top.strip():
+        return raw_top.strip()
+    return None
+
+
+def _payload_bot_id(payload: Mapping[str, Any]) -> str | None:
+    raw = payload.get("bot_id")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        raw_meta = metadata.get("bot_id")
+        if isinstance(raw_meta, str) and raw_meta.strip():
+            return raw_meta.strip()
+    return None
+
+
+def _payload_strategy_id(payload: Mapping[str, Any]) -> str | None:
+    raw = payload.get("strategy_id")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        snapshot = metadata.get("config_snapshot")
+        if isinstance(snapshot, dict):
+            raw_snap = snapshot.get("strategy_id")
+            if isinstance(raw_snap, str) and raw_snap.strip():
+                return raw_snap.strip()
+    return None
+
+
+def _payload_campaign_id(payload: Mapping[str, Any]) -> str | None:
+    raw = payload.get("campaign_id")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        raw_meta = metadata.get("campaign_id")
+        if isinstance(raw_meta, str) and raw_meta.strip():
+            return raw_meta.strip()
+    return None
+
+
+def build_signal_ledger_payload(signal_payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return correlation_ledger payload for SIGNAL with campaign attribution."""
+    payload = dict(signal_payload)
+    campaign_id = resolve_campaign_id()
+    if campaign_id:
+        payload["campaign_id"] = campaign_id
+    return payload
+
+
+def build_decision_ledger_payload(
+    evidence: Mapping[str, Any],
+    *,
+    signal: Any,
+    decision: str,
+    reason_code: str | None,
+) -> dict[str, Any]:
+    """Return correlation_ledger payload for DECISION with lane attribution."""
+    payload = dict(evidence)
+    payload["decision"] = decision
+    if reason_code is not None:
+        payload["reason_code"] = reason_code
+    strategy_id = getattr(signal, "strategy_id", None)
+    bot_id = getattr(signal, "bot_id", None)
+    if strategy_id:
+        payload["strategy_id"] = strategy_id
+    if bot_id:
+        payload["bot_id"] = bot_id
+    metadata = getattr(signal, "metadata", None)
+    if isinstance(metadata, dict):
+        config_hash = metadata.get("config_hash")
+        if isinstance(config_hash, str) and config_hash.strip():
+            payload.setdefault("metadata", {})
+            if isinstance(payload["metadata"], dict):
+                payload["metadata"]["config_hash"] = config_hash.strip()
+    campaign_id = resolve_campaign_id()
+    if campaign_id:
+        payload["campaign_id"] = campaign_id
+    return payload
+
+
+def _row_matches_lane(
+    row: Mapping[str, Any],
+    *,
+    bot_id: str | None,
+    strategy_id: str | None,
+    campaign_id: str | None,
+    config_hash: str | None,
+) -> bool:
+    payload = row.get("payload")
+    if not isinstance(payload, dict):
+        payload = {}
+    if bot_id and _payload_bot_id(payload) != bot_id:
+        return False
+    if strategy_id and _payload_strategy_id(payload) != strategy_id:
+        return False
+    if campaign_id and _payload_campaign_id(payload) != campaign_id:
+        return False
+    if config_hash and _payload_config_hash(payload) != config_hash:
+        return False
+    return True
+
+
+def derive_no_chain_reason(summary: Mapping[str, Any]) -> str | None:
+    signals = int(summary.get("signals_emitted") or 0)
+    orders = int(summary.get("orders") or 0)
+    fills = int(summary.get("fills") or 0)
+    blocks_total = int(summary.get("blocks_total") or 0)
+
+    if signals == 0:
+        return NO_CHAIN_REASON_NO_SIGNALS
+    if fills > 0 or orders > 0:
+        return None
+    if blocks_total > 0:
+        return NO_CHAIN_REASON_RISK_BLOCKED
+    return None
+
+
+def aggregate_lane_campaign_evidence(
+    rows: list[Mapping[str, Any]],
+    *,
+    bot_id: str | None = None,
+    strategy_id: str | None = None,
+    campaign_id: str | None = None,
+    config_hash: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate per-lane campaign evidence from correlation_ledger rows."""
+    filtered = [
+        row
+        for row in rows
+        if _row_matches_lane(
+            row,
+            bot_id=bot_id,
+            strategy_id=strategy_id,
+            campaign_id=campaign_id,
+            config_hash=config_hash,
+        )
+    ]
+
+    signals_emitted = 0
+    decisions_total = 0
+    approvals = 0
+    blocks_total = 0
+    blocks_by_reason: dict[str, int] = {}
+    orders = 0
+    fills = 0
+
+    for row in filtered:
+        event_type = str(row.get("event_type") or "").upper()
+        payload = row.get("payload")
+        if not isinstance(payload, dict):
+            payload = {}
+
+        if event_type == "SIGNAL":
+            signals_emitted += 1
+            continue
+        if event_type == "DECISION":
+            decisions_total += 1
+            decision = str(payload.get("decision") or "").upper()
+            reason_code = payload.get("reason_code")
+            if decision == DECISION_BLOCK:
+                blocks_total += 1
+                if isinstance(reason_code, str) and reason_code.strip():
+                    code = reason_code.strip()
+                    blocks_by_reason[code] = blocks_by_reason.get(code, 0) + 1
+            elif decision == DECISION_ALLOW:
+                approvals += 1
+            continue
+        if event_type == "ORDER":
+            orders += 1
+            continue
+        if event_type == "FILL":
+            fills += 1
+
+    summary: dict[str, Any] = {
+        "campaign_id": campaign_id,
+        "bot_id": bot_id,
+        "strategy_id": strategy_id,
+        "config_hash": config_hash,
+        "signals_emitted": signals_emitted,
+        "decisions_total": decisions_total,
+        "approvals": approvals,
+        "blocks_total": blocks_total,
+        "blocks_by_reason": blocks_by_reason,
+        "orders": orders,
+        "fills": fills,
+        "no_chain_reason": None,
+    }
+    summary["no_chain_reason"] = derive_no_chain_reason(summary)
+    return summary

--- a/docs/evidence/arvp_p1_campaign_block_evidence_3960.md
+++ b/docs/evidence/arvp_p1_campaign_block_evidence_3960.md
@@ -1,0 +1,49 @@
+# ARVP P1 Campaign Attribution + Block-Reason Evidence (#3960)
+
+Status Class: **ENGINEERING_FIX** — code/tests only; no runtime rerun  
+Issue: [#3960](https://github.com/jannekbuengener/Claire_de_Binare/issues/3960)  
+Root observation: [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912) (`TIMEOUT_NO_CHAIN`)  
+P0 prerequisite: [#3955](https://github.com/jannekbuengener/Claire_de_Binare/issues/3955) / PR [#3956](https://github.com/jannekbuengener/Claire_de_Binare/pull/3956)  
+Live-Readiness: **NO-GO**  
+Echtgeld: **not authorized**
+
+## Problem
+
+P0 fixed false global zero-event telemetry (#3955) but parallel runs still could not
+attribute ledger rows to a campaign or explain lane-level `TIMEOUT_NO_CHAIN` with
+risk block codes (e.g. Donchian 50× `RC_001` under `HIGH_VOL_CHAOTIC`).
+
+## P1 Delivery
+
+| Item | Change |
+|------|--------|
+| P1-1 | `CDB_CAMPAIGN_ID` propagated into `correlation_ledger` SIGNAL/DECISION payloads via `core/replay/correlation_ledger_attribution.py` |
+| P1-2 | `aggregate_lane_campaign_evidence()` reports per-lane `signals_emitted`, `decisions_total`, `approvals`, `blocks_total`, `blocks_by_reason`, `orders`, `fills`, `no_chain_reason` |
+| P1-3 | `probe_ledger` + supervisor cycle JSONL expose `lane_campaign_evidence` and `no_chain_reason` (P0 `ledger_counts` preserved) |
+
+## Evidence shape (lane)
+
+```json
+{
+  "campaign_id": "arvp_3912_np_parallel_donchian_20260709_1327",
+  "bot_id": "np-donchian-parallel-01",
+  "strategy_id": "donchian_breakout_v1",
+  "signals_emitted": 50,
+  "decisions_total": 50,
+  "approvals": 0,
+  "blocks_total": 50,
+  "blocks_by_reason": {"RC_001": 50},
+  "orders": 0,
+  "fills": 0,
+  "no_chain_reason": "RISK_BLOCKED_NO_PROMOTABLE_CHAIN"
+}
+```
+
+Idle lane example (`primary_breakout_v1`): `signals_emitted=0`, `no_chain_reason=NO_SIGNALS_OR_GATE_IDLE`.
+
+## Non-goals
+
+- No change to RC_001 / risk semantics
+- No natural-paper promotion claim
+- No runtime Docker execution in this slice
+- LR **NO-GO** unchanged

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -58,6 +58,7 @@ from core.replay.policy_snapshot import (
     build_policy_snapshot,
     policy_snapshot_binding_enabled,
 )
+from core.replay.correlation_ledger_attribution import build_decision_ledger_payload
 from core.contracts.decision_contract_v1 import (
     DecisionContractError,
     build_decision_contract_v1_bundle,
@@ -1676,7 +1677,12 @@ class RiskManager:
                     symbol=signal.symbol,
                     timestamp_ms=now_ms,
                     decision_id=decision_id,
-                    payload=evidence,
+                    payload=build_decision_ledger_payload(
+                        evidence,
+                        signal=signal,
+                        decision=decision,
+                        reason_code=reason_code,
+                    ),
                 ):
                     logger.warning(
                         f"⚠️ correlation_ledger DECISION write failed (evidence debt)"

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -30,6 +30,7 @@ import psycopg2
 import psycopg2.extensions
 
 from core.replay.canonical_json import canonical_hash
+from core.replay.correlation_ledger_attribution import build_signal_ledger_payload
 from core.utils.clock import utcnow
 from core.utils.redis_payload import sanitize_signal
 from core.utils.uuid_gen import (
@@ -508,7 +509,7 @@ class SignalEngine:
                     event_type,
                     signal.symbol,
                     signal.ts_ms,
-                    json.dumps(signal.to_dict()),
+                    json.dumps(build_signal_ledger_payload(signal.to_dict())),
                 ),
             )
             logger.debug(f"📊 correlation_ledger SIGNAL: {signal.signal_id}")

--- a/tests/unit/arvp/test_arvp_p1_campaign_block_evidence_3960.py
+++ b/tests/unit/arvp/test_arvp_p1_campaign_block_evidence_3960.py
@@ -1,0 +1,147 @@
+"""P1 campaign attribution + block-reason evidence contract tests (#3960)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.arvp_campaign_supervisor import _build_cycle_entry
+
+_PB1_MANIFEST = {
+    "campaign_id": "arvp_3912_np_parallel_pb1_20260709_1327",
+    "bot_id": "np-pb1-parallel-01",
+    "strategy_id": "primary_breakout_v1",
+}
+
+_DONCHIAN_MANIFEST = {
+    "campaign_id": "arvp_3912_np_parallel_donchian_20260709_1327",
+    "bot_id": "np-donchian-parallel-01",
+    "strategy_id": "donchian_breakout_v1",
+}
+
+
+def _ledger_probe(
+    *,
+    global_count: int,
+    bot_count: int,
+    strategy_count: int,
+    lane_campaign_evidence: dict | None = None,
+    bot_id: str,
+    strategy_id: str,
+) -> dict:
+    return {
+        "probe": "correlation_ledger",
+        "status": "ok",
+        "limitations": [],
+        "evidence": {
+            "events_since_campaign_start": global_count,
+            "events_since_campaign_start_global": global_count,
+            "events_since_campaign_start_bot_id": bot_count,
+            "events_since_campaign_start_strategy_id": strategy_count,
+            "ledger_attribution": {
+                "bot_id": bot_id,
+                "strategy_id": strategy_id,
+                "campaign_id_propagated_to_ledger": True,
+            },
+            "lane_campaign_evidence": lane_campaign_evidence,
+        },
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.contract
+def test_mixed_lane_supervisor_keeps_global_lane_and_block_reason_separate() -> None:
+    donchian_lane_evidence = {
+        "signals_emitted": 50,
+        "decisions_total": 50,
+        "approvals": 0,
+        "blocks_total": 50,
+        "blocks_by_reason": {"RC_001": 50},
+        "orders": 0,
+        "fills": 0,
+        "no_chain_reason": "RISK_BLOCKED_NO_PROMOTABLE_CHAIN",
+    }
+    pb1_lane_evidence = {
+        "signals_emitted": 0,
+        "decisions_total": 0,
+        "approvals": 0,
+        "blocks_total": 0,
+        "blocks_by_reason": {},
+        "orders": 0,
+        "fills": 0,
+        "no_chain_reason": "NO_SIGNALS_OR_GATE_IDLE",
+    }
+
+    donchian_entry = _build_cycle_entry(
+        1,
+        [
+            _ledger_probe(
+                global_count=0,
+                bot_count=50,
+                strategy_count=50,
+                lane_campaign_evidence=donchian_lane_evidence,
+                bot_id=_DONCHIAN_MANIFEST["bot_id"],
+                strategy_id=_DONCHIAN_MANIFEST["strategy_id"],
+            )
+        ],
+        "TIMEOUT_NO_CHAIN",
+        _DONCHIAN_MANIFEST,
+    )
+    pb1_entry = _build_cycle_entry(
+        1,
+        [
+            _ledger_probe(
+                global_count=0,
+                bot_count=0,
+                strategy_count=0,
+                lane_campaign_evidence=pb1_lane_evidence,
+                bot_id=_PB1_MANIFEST["bot_id"],
+                strategy_id=_PB1_MANIFEST["strategy_id"],
+            )
+        ],
+        "TIMEOUT_NO_CHAIN",
+        _PB1_MANIFEST,
+    )
+
+    assert donchian_entry["event_count_since_start"] == 0
+    assert donchian_entry["event_count_since_start_lane"] == 50
+    assert donchian_entry["lane_campaign_evidence"]["blocks_by_reason"]["RC_001"] == 50
+    assert donchian_entry["no_chain_reason"] == "RISK_BLOCKED_NO_PROMOTABLE_CHAIN"
+
+    assert pb1_entry["event_count_since_start_lane"] == 0
+    assert pb1_entry["lane_campaign_evidence"]["signals_emitted"] == 0
+    assert pb1_entry["no_chain_reason"] == "NO_SIGNALS_OR_GATE_IDLE"
+
+
+@pytest.mark.unit
+@pytest.mark.contract
+def test_supervisor_exposes_lane_campaign_evidence_shape() -> None:
+    lane_evidence = {
+        "campaign_id": _DONCHIAN_MANIFEST["campaign_id"],
+        "bot_id": _DONCHIAN_MANIFEST["bot_id"],
+        "strategy_id": _DONCHIAN_MANIFEST["strategy_id"],
+        "signals_emitted": 50,
+        "decisions_total": 50,
+        "approvals": 0,
+        "blocks_total": 50,
+        "blocks_by_reason": {"RC_001": 50},
+        "orders": 0,
+        "fills": 0,
+        "no_chain_reason": "RISK_BLOCKED_NO_PROMOTABLE_CHAIN",
+    }
+    entry = _build_cycle_entry(
+        1,
+        [
+            _ledger_probe(
+                global_count=0,
+                bot_count=50,
+                strategy_count=50,
+                lane_campaign_evidence=lane_evidence,
+                bot_id=_DONCHIAN_MANIFEST["bot_id"],
+                strategy_id=_DONCHIAN_MANIFEST["strategy_id"],
+            )
+        ],
+        "TIMEOUT_NO_CHAIN",
+        _DONCHIAN_MANIFEST,
+    )
+    assert entry["lane_campaign_evidence"]["signals_emitted"] == 50
+    assert entry["ledger_counts"]["lane_effective_since_start"] == 50

--- a/tests/unit/replay/test_correlation_ledger_attribution.py
+++ b/tests/unit/replay/test_correlation_ledger_attribution.py
@@ -1,0 +1,138 @@
+"""Unit tests for correlation ledger campaign/lane attribution (#3960)."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.replay.correlation_ledger_attribution import (
+    NO_CHAIN_REASON_NO_SIGNALS,
+    NO_CHAIN_REASON_RISK_BLOCKED,
+    aggregate_lane_campaign_evidence,
+    build_decision_ledger_payload,
+    build_signal_ledger_payload,
+    resolve_campaign_id,
+)
+
+
+def _donchian_blocked_rows(count: int = 50) -> list[dict]:
+    rows: list[dict] = []
+    for idx in range(count):
+        signal_id = f"sig-don-{idx:03d}"
+        rows.append(
+            {
+                "event_type": "SIGNAL",
+                "payload": {
+                    "signal_id": signal_id,
+                    "strategy_id": "donchian_breakout_v1",
+                    "bot_id": "np-donchian-parallel-01",
+                    "campaign_id": "arvp_3912_np_parallel_donchian_20260709_1327",
+                    "metadata": {"config_hash": "cfg-donchian-parallel-v1"},
+                },
+            }
+        )
+        rows.append(
+            {
+                "event_type": "DECISION",
+                "payload": {
+                    "signal_id": signal_id,
+                    "strategy_id": "donchian_breakout_v1",
+                    "bot_id": "np-donchian-parallel-01",
+                    "campaign_id": "arvp_3912_np_parallel_donchian_20260709_1327",
+                    "decision": "BLOCK",
+                    "reason_code": "RC_001",
+                    "metadata": {"config_hash": "cfg-donchian-parallel-v1"},
+                },
+            }
+        )
+    return rows
+
+
+@pytest.mark.unit
+def test_build_signal_ledger_payload_includes_campaign_id(monkeypatch) -> None:
+    monkeypatch.setenv("CDB_CAMPAIGN_ID", "arvp_test_campaign")
+    payload = build_signal_ledger_payload(
+        {
+            "signal_id": "sig-1",
+            "strategy_id": "donchian_breakout_v1",
+            "bot_id": "np-donchian-parallel-01",
+            "metadata": {"config_hash": "cfg-1"},
+        }
+    )
+    assert payload["campaign_id"] == "arvp_test_campaign"
+    assert payload["strategy_id"] == "donchian_breakout_v1"
+
+
+@pytest.mark.unit
+def test_build_decision_ledger_payload_includes_block_reason(monkeypatch) -> None:
+    monkeypatch.setenv("CDB_CAMPAIGN_ID", "arvp_test_campaign")
+    signal = MagicMock()
+    signal.strategy_id = "donchian_breakout_v1"
+    signal.bot_id = "np-donchian-parallel-01"
+    signal.metadata = {"config_hash": "cfg-1"}
+    payload = build_decision_ledger_payload(
+        {"signal_id": "sig-1", "decision_id": "dec-1"},
+        signal=signal,
+        decision="BLOCK",
+        reason_code="RC_001",
+    )
+    assert payload["decision"] == "BLOCK"
+    assert payload["reason_code"] == "RC_001"
+    assert payload["campaign_id"] == "arvp_test_campaign"
+    assert payload["metadata"]["config_hash"] == "cfg-1"
+
+
+@pytest.mark.unit
+def test_donchian_fixture_blocks_by_reason_rc_001() -> None:
+    summary = aggregate_lane_campaign_evidence(
+        _donchian_blocked_rows(50),
+        bot_id="np-donchian-parallel-01",
+        strategy_id="donchian_breakout_v1",
+        campaign_id="arvp_3912_np_parallel_donchian_20260709_1327",
+    )
+    assert summary["signals_emitted"] == 50
+    assert summary["decisions_total"] == 50
+    assert summary["blocks_total"] == 50
+    assert summary["blocks_by_reason"]["RC_001"] == 50
+    assert summary["no_chain_reason"] == NO_CHAIN_REASON_RISK_BLOCKED
+
+
+@pytest.mark.unit
+def test_pb1_zero_signals_reports_idle_reason() -> None:
+    summary = aggregate_lane_campaign_evidence(
+        [],
+        bot_id="np-pb1-parallel-01",
+        strategy_id="primary_breakout_v1",
+        campaign_id="arvp_3912_np_parallel_pb1_20260709_1327",
+    )
+    assert summary["signals_emitted"] == 0
+    assert summary["no_chain_reason"] == NO_CHAIN_REASON_NO_SIGNALS
+
+
+@pytest.mark.unit
+def test_resolve_campaign_id_empty_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("CDB_CAMPAIGN_ID", raising=False)
+    assert resolve_campaign_id() is None
+
+
+@pytest.mark.unit
+def test_signal_service_persist_payload_json_includes_campaign_id(monkeypatch) -> None:
+    monkeypatch.setenv("CDB_CAMPAIGN_ID", "arvp_signal_campaign")
+    from services.signal.models import Signal
+
+    payload = build_signal_ledger_payload(
+        Signal(
+            signal_id="sig-test",
+            strategy_id="donchian_breakout_v1",
+            bot_id="np-donchian-parallel-01",
+            symbol="BTCUSDT",
+            side="BUY",
+            ts_ms=1_783_603_620_000,
+            metadata={"config_hash": "cfg-1"},
+        ).to_dict()
+    )
+    decoded = json.loads(json.dumps(payload))
+    assert decoded["campaign_id"] == "arvp_signal_campaign"

--- a/tests/unit/tools/test_arvp_probe_layer.py
+++ b/tests/unit/tools/test_arvp_probe_layer.py
@@ -483,6 +483,67 @@ class TestProbeLedger:
             for item in result["limitations"]
         )
 
+    def test_lane_campaign_evidence_aggregated(self, monkeypatch):
+        monkeypatch.setattr("importlib.util.find_spec", lambda _: True)
+
+        lane_rows = []
+        for idx in range(2):
+            lane_rows.append(
+                (
+                    "SIGNAL",
+                    {
+                        "strategy_id": "donchian_breakout_v1",
+                        "bot_id": "np-donchian-parallel-01",
+                        "campaign_id": "arvp_3912_np_parallel_donchian_20260709_1327",
+                        "metadata": {"config_hash": "cfg-donchian-parallel-v1"},
+                    },
+                )
+            )
+            lane_rows.append(
+                (
+                    "DECISION",
+                    {
+                        "strategy_id": "donchian_breakout_v1",
+                        "bot_id": "np-donchian-parallel-01",
+                        "campaign_id": "arvp_3912_np_parallel_donchian_20260709_1327",
+                        "decision": "BLOCK",
+                        "reason_code": "RC_001",
+                    },
+                )
+            )
+
+        def fake_run_sql(host, port, dbname, user, query, container=None):
+            if "SELECT event_type, payload" in query:
+                return lane_rows
+            if "GROUP BY" in query:
+                return [("SIGNAL", 2), ("DECISION", 2)]
+            if "ORDER BY timestamp_ms DESC LIMIT 1" in query:
+                return [(1_783_603_620_000, "SIGNAL", "corr-1")]
+            if "payload->>'bot_id'" in query and "np-donchian-parallel-01" in query:
+                return [(4,)]
+            if "payload->>'strategy_id'" in query:
+                return [(4,)]
+            if "payload->>'campaign_id'" in query:
+                return [(4,)]
+            if "COUNT(*)" in query:
+                return [(4,)]
+            return []
+
+        monkeypatch.setattr("tools.arvp_probe_layer._run_sql", fake_run_sql)
+
+        result = probe_ledger(
+            campaign_start_utc="2026-07-09T13:27:00Z",
+            bot_id="np-donchian-parallel-01",
+            strategy_id="donchian_breakout_v1",
+            campaign_id="arvp_3912_np_parallel_donchian_20260709_1327",
+        )
+        lane_evidence = result["evidence"]["lane_campaign_evidence"]
+        assert lane_evidence["signals_emitted"] == 2
+        assert lane_evidence["blocks_by_reason"]["RC_001"] == 2
+        assert result["evidence"]["ledger_attribution"][
+            "campaign_id_propagated_to_ledger"
+        ] is True
+
 
 # ---------------------------------------------------------------------------
 # 7. Regime probe tests

--- a/tools/arvp_campaign_supervisor.py
+++ b/tools/arvp_campaign_supervisor.py
@@ -131,6 +131,7 @@ def run_all_probes(manifest: dict[str, Any]) -> list[dict[str, Any]]:
                 bot_id=manifest.get("bot_id"),
                 strategy_id=manifest.get("strategy_id"),
                 campaign_id=manifest.get("campaign_id"),
+                config_hash=manifest.get("config_hash"),
             ),
         }
     )
@@ -278,6 +279,9 @@ def _build_cycle_entry(
             "lane_effective_since_start": lane_count,
             "attribution": ev.get("ledger_attribution"),
         }
+        lane_campaign_evidence = ev.get("lane_campaign_evidence")
+    else:
+        lane_campaign_evidence = None
 
     probe_statuses = {p["probe"]: p.get("status") for p in probes}
 
@@ -294,6 +298,12 @@ def _build_cycle_entry(
             "lane_effective_since_start"
         ),
         "ledger_counts": ledger_counts,
+        "lane_campaign_evidence": lane_campaign_evidence,
+        "no_chain_reason": (
+            lane_campaign_evidence.get("no_chain_reason")
+            if isinstance(lane_campaign_evidence, dict)
+            else None
+        ),
         "chain_detected": state == STATE_CHAIN_FOUND,
         "no_mutation": True,
         "limitations": list(ledger.get("limitations", [])) if ledger else [],
@@ -351,7 +361,23 @@ def write_status_md(path: str, entry: dict[str, Any], manifest: dict[str, Any]) 
         f"- **Event count since start (global):** {entry.get('event_count_since_start', '-')}",
         f"- **Event count since start (lane):** {entry.get('event_count_since_start_lane', '-')}",
         f"- **Chain detected:** {entry.get('chain_detected', False)}",
+        f"- **No-chain reason:** {entry.get('no_chain_reason', '-')}",
         "",
+    ]
+    lane_evidence = entry.get("lane_campaign_evidence")
+    if isinstance(lane_evidence, dict):
+        lines += [
+            "## Lane Campaign Evidence",
+            f"- **Signals emitted:** {lane_evidence.get('signals_emitted', '-')}",
+            f"- **Decisions total:** {lane_evidence.get('decisions_total', '-')}",
+            f"- **Approvals:** {lane_evidence.get('approvals', '-')}",
+            f"- **Blocks total:** {lane_evidence.get('blocks_total', '-')}",
+            f"- **Blocks by reason:** {lane_evidence.get('blocks_by_reason', {})}",
+            f"- **Orders:** {lane_evidence.get('orders', '-')}",
+            f"- **Fills:** {lane_evidence.get('fills', '-')}",
+            "",
+        ]
+    lines += [
         "## Safety Flags",
     ]
     for flag, val in safety.items():

--- a/tools/arvp_probe_layer.py
+++ b/tools/arvp_probe_layer.py
@@ -11,6 +11,8 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from core.replay.correlation_ledger_attribution import aggregate_lane_campaign_evidence
+
 logger = logging.getLogger(__name__)
 
 ProbeResult = dict[str, Any]
@@ -770,6 +772,53 @@ def _ledger_count_since_start(
     return int(rows[0][0]) if rows else 0
 
 
+def _ledger_events_since_start(
+    host: str,
+    port: int,
+    dbname: str,
+    user: str,
+    campaign_start_utc: str,
+    *,
+    bot_id: str | None = None,
+    strategy_id: str | None = None,
+    campaign_id: str | None = None,
+    config_hash: str | None = None,
+) -> list[dict[str, Any]]:
+    start_expr = _campaign_start_ms_expr(campaign_start_utc)
+    clauses = [f"timestamp_ms >= {start_expr}"]
+    if bot_id:
+        clauses.append(f"payload->>'bot_id' = '{bot_id}'")
+    if strategy_id:
+        clauses.append(f"payload->>'strategy_id' = '{strategy_id}'")
+    if campaign_id:
+        clauses.append(f"payload->>'campaign_id' = '{campaign_id}'")
+    if config_hash:
+        clauses.append(
+            f"COALESCE(payload->'metadata'->>'config_hash', '') = '{config_hash}'"
+        )
+    where = " AND ".join(clauses)
+    rows = _run_sql(
+        host,
+        port,
+        dbname,
+        user,
+        "SELECT event_type, payload "
+        f"FROM correlation_ledger WHERE {where} ORDER BY timestamp_ms ASC",
+    ) or []
+    events: list[dict[str, Any]] = []
+    for row in rows:
+        payload = row[1]
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except json.JSONDecodeError:
+                payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+        events.append({"event_type": row[0], "payload": payload})
+    return events
+
+
 def probe_ledger(
     campaign_start_utc: str | None = None,
     host: str = DB_DEFAULTS["host"],
@@ -905,13 +954,43 @@ def probe_ledger(
         if campaign_id and count_campaign_id == 0:
             limitations.append(
                 "campaign_id filter returned 0 rows; campaign_id is not "
-                "propagated to correlation_ledger payload today"
+                "propagated to correlation_ledger payload yet"
             )
             evidence["ledger_attribution"]["campaign_id_propagated_to_ledger"] = False
+        elif campaign_id and count_campaign_id and count_campaign_id > 0:
+            evidence["ledger_attribution"]["campaign_id_propagated_to_ledger"] = True
         if bot_id is None and strategy_id is None:
             limitations.append(
                 "no bot_id/strategy_id filter supplied; only global ledger count available"
             )
+
+        if campaign_start_utc and (bot_id or strategy_id):
+            try:
+                lane_rows = _ledger_events_since_start(
+                    host,
+                    port,
+                    dbname,
+                    user,
+                    campaign_start_utc,
+                    bot_id=bot_id,
+                    strategy_id=strategy_id,
+                    campaign_id=campaign_id,
+                    config_hash=config_hash,
+                )
+                evidence["lane_campaign_evidence"] = aggregate_lane_campaign_evidence(
+                    lane_rows,
+                    bot_id=bot_id,
+                    strategy_id=strategy_id,
+                    campaign_id=campaign_id,
+                    config_hash=config_hash,
+                )
+                evidence["queries"].append(
+                    "SELECT event_type, payload FROM correlation_ledger "
+                    "WHERE timestamp_ms >= ... [lane filters]"
+                )
+            except Exception as exc:
+                logger.warning("lane campaign evidence query failed: %s", exc)
+                evidence["lane_campaign_evidence_error"] = str(exc)
 
         events_raw: list[dict] | None = None
         if include_events:


### PR DESCRIPTION
## Summary

- Propagate `CDB_CAMPAIGN_ID` into `correlation_ledger` SIGNAL/DECISION payloads (`core/replay/correlation_ledger_attribution.py`)
- Add per-lane campaign evidence aggregation: `signals_emitted`, `decisions_total`, `approvals`, `blocks_total`, `blocks_by_reason`, `orders`, `fills`, `no_chain_reason`
- Extend `probe_ledger` + supervisor cycle JSONL/status with `lane_campaign_evidence` (P0 `ledger_counts` preserved)

Closes #3960
Refs #3912
Refs #3955
Refs #3956

## Campaign attribution path

- Signal service: `build_signal_ledger_payload()` adds `campaign_id` from `CDB_CAMPAIGN_ID`
- Risk service: `build_decision_ledger_payload()` adds `campaign_id`, lane IDs, `decision`, `reason_code`

## Block-reason evidence shape

Supervisor/probe now surfaces lane-level block reasons so `TIMEOUT_NO_CHAIN` can be explained without hiding active blocked signals (e.g. Donchian 50× `RC_001`).

## Tests

- `pytest tests/unit/tools tests/unit/arvp tests/unit/replay/test_correlation_ledger_attribution.py tests/unit/test_uuid_gen.py -q` → 2210 passed
- `ruff check` on touched files → clean

## Safety boundaries

- LR **NO-GO** unchanged
- No runtime execution
- No productive DB writes
- No risk semantic changes / no risk bypass
- No natural-paper promotion claim

## Non-goals

- No ARVP re-run
- No change to #3912 terminal verdict

## Remaining uncertainty

- Runtime compose must set `CDB_CAMPAIGN_ID` per lane at execute time for live campaign_id filter counts (code path ready; not exercised in this slice)
