### PR TITLE
feat(arvp): wire campaign id per parallel lane

### DIFF
--- a/docs/evidence/arvp_p15_campaign_id_compose_contract_3963.md
+++ b/docs/evidence/arvp_p15_campaign_id_compose_contract_3963.md
@@ -1,0 +1,39 @@
+# ARVP P1.5 Campaign ID Runtime Compose Contract (#3963)
+
+Status Class: **ENGINEERING_FIX** — manifest/compose contract + tests only; no runtime rerun  
+Issue: [#3963](https://github.com/jannekbuengener/Claire_de_Binare/issues/3963)  
+Prerequisite: [#3960](https://github.com/jannekbuengener/Claire_de_Binare/issues/3960) / PR [#3961](https://github.com/jannekbuengener/Claire_de_Binare/pull/3961)  
+Root observation: [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912) (`TIMEOUT_NO_CHAIN`)  
+Live-Readiness: **NO-GO**  
+Echtgeld: **not authorized**
+
+## Problem
+
+P1 (#3961) added `CDB_CAMPAIGN_ID` propagation into correlation_ledger payloads, but
+parallel compose did not wire distinct campaign IDs into `cdb_signal_pb1` and
+`cdb_signal_donchian` runtime environments.
+
+## P1.5 Delivery
+
+| Item | Change |
+|------|--------|
+| P1.5-1 | `tools/arvp_parallel_lane_compose_contract.py` maps campaign manifest `campaign_id` → host env → container `CDB_CAMPAIGN_ID` per lane |
+| P1.5-2 | `manifests/runtime_np_parallel_signal_compose_override.yml` sets lane-specific substitution: `${CDB_CAMPAIGN_ID_PB1:-}` / `${CDB_CAMPAIGN_ID_DONCHIAN:-}` |
+| P1.5-3 | Contract tests in `tests/unit/arvp/test_arvp_p15_campaign_id_compose_contract.py` |
+
+## Execute contract (future parallel runs)
+
+1. Rewrite both campaign manifests (`campaign_id`, `start_utc`, `timeout_utc`).
+2. Export host env from manifests:
+   - `CDB_CAMPAIGN_ID_PB1=<pb1 manifest campaign_id>`
+   - `CDB_CAMPAIGN_ID_DONCHIAN=<donchian manifest campaign_id>`
+3. `docker compose up` with parallel signal override — each lane receives distinct `CDB_CAMPAIGN_ID`.
+
+`SIGNAL_BOT_ID` and `SIGNAL_STRATEGY_ID` behavior unchanged.
+
+## Non-goals
+
+- No runtime Docker execution in this slice
+- No risk semantic changes
+- No natural-paper promotion claim
+- LR **NO-GO** unchanged

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -53,6 +53,17 @@ docker compose `
 Rewrite `campaign_id`, `start_utc`, and `timeout_utc` at RUNTIME-GO execute (templates
 use `*_TEMPLATE` / `RUNTIME_GO_SET` placeholders).
 
+At RUNTIME-GO, export lane-specific host env from rewritten manifests before `docker compose up`:
+
+```text
+CDB_CAMPAIGN_ID_PB1=<pb1 manifest campaign_id>
+CDB_CAMPAIGN_ID_DONCHIAN=<donchian manifest campaign_id>
+```
+
+Helper: `tools.arvp_parallel_lane_compose_contract.build_parallel_compose_host_env()`.
+Each parallel signal service receives `CDB_CAMPAIGN_ID` via compose substitution (P1.5 / #3963).
+Values must be distinct.
+
 ### Risk-side filter contract (topic/stream isolation)
 
 Both parallel signal instances publish to the **shared** Redis pub/sub topic `signals`

--- a/manifests/runtime_np_parallel_signal_compose_override.yml
+++ b/manifests/runtime_np_parallel_signal_compose_override.yml
@@ -13,6 +13,11 @@
 # Risk-side filter contract (G3): both instances publish to shared Redis topic `signals`
 # and stream `stream.signals`. cdb_risk consumes the shared bus and routes by payload
 # `strategy_id` / `bot_id`. Ledger/evidence isolation guards are #3911 — not in this slice.
+#
+# Campaign ID contract (P1.5): set host env from rewritten campaign manifests at RUNTIME-GO:
+#   CDB_CAMPAIGN_ID_PB1=<pb1 manifest campaign_id>
+#   CDB_CAMPAIGN_ID_DONCHIAN=<donchian manifest campaign_id>
+# Each signal service receives CDB_CAMPAIGN_ID via lane-specific substitution (not shared).
 
 services:
   cdb_signal:
@@ -38,6 +43,7 @@ services:
       SIGNAL_SYMBOL: BTCUSDT
       SIGNAL_ADAPTER_ID: momentum_builtin
       SIGNAL_BOT_ID: np-pb1-parallel-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_PB1:-}
       SIGNAL_ENTRY_LOOKBACK_MIN: "240"
       SIGNAL_EXIT_LOOKBACK_MIN: "120"
       SIGNAL_BREAKOUT_BUFFER: "0.0005"
@@ -86,6 +92,7 @@ services:
       SIGNAL_SYMBOL: BTCUSDT
       SIGNAL_ADAPTER_ID: momentum_builtin
       SIGNAL_BOT_ID: np-donchian-parallel-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_DONCHIAN:-}
       SIGNAL_ENTRY_CHANNEL_BARS: "20"
       SIGNAL_EXIT_CHANNEL_BARS: "10"
       SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "30"

--- a/tests/unit/arvp/test_arvp_p15_campaign_id_compose_contract.py
+++ b/tests/unit/arvp/test_arvp_p15_campaign_id_compose_contract.py
@@ -1,0 +1,131 @@
+"""P1.5 parallel lane CDB_CAMPAIGN_ID compose contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.replay.correlation_ledger_attribution import CDB_CAMPAIGN_ID_ENV
+from tools.arvp_parallel_lane_compose_contract import (
+    CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+    CAMPAIGN_ID_HOST_ENV_PB1,
+    DONCHIAN_MANIFEST_PATH,
+    PB1_MANIFEST_PATH,
+    build_host_env_from_manifest,
+    build_parallel_compose_host_env,
+    compose_campaign_substitution,
+    load_campaign_manifest,
+    load_parallel_signal_compose_override,
+    resolve_lane_runtime_campaign_id,
+    validate_manifest_lane_alignment,
+    validate_parallel_manifest_pair,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PB1_CAMPAIGN_ID = "arvp_3912_np_parallel_pb1_20260709_1327"
+DONCHIAN_CAMPAIGN_ID = "arvp_3912_np_parallel_donchian_20260709_1327"
+
+
+def _rewritten_pb1_manifest() -> dict:
+    manifest = load_campaign_manifest(REPO_ROOT / PB1_MANIFEST_PATH)
+    manifest["campaign_id"] = PB1_CAMPAIGN_ID
+    manifest["start_utc"] = "2026-07-09T13:27:00Z"
+    manifest["timeout_utc"] = "2026-07-10T01:27:00Z"
+    return manifest
+
+
+def _rewritten_donchian_manifest() -> dict:
+    manifest = load_campaign_manifest(REPO_ROOT / DONCHIAN_MANIFEST_PATH)
+    manifest["campaign_id"] = DONCHIAN_CAMPAIGN_ID
+    manifest["start_utc"] = "2026-07-09T13:27:00Z"
+    manifest["timeout_utc"] = "2026-07-10T01:27:00Z"
+    return manifest
+
+
+def test_compose_override_declares_lane_specific_campaign_id_substitution() -> None:
+    override = load_parallel_signal_compose_override(REPO_ROOT)
+    pb1_env = override["services"]["cdb_signal_pb1"]["environment"]
+    donchian_env = override["services"]["cdb_signal_donchian"]["environment"]
+
+    assert pb1_env[CDB_CAMPAIGN_ID_ENV] == compose_campaign_substitution("cdb_signal_pb1")
+    assert donchian_env[CDB_CAMPAIGN_ID_ENV] == compose_campaign_substitution(
+        "cdb_signal_donchian"
+    )
+    assert pb1_env[CDB_CAMPAIGN_ID_ENV] != donchian_env[CDB_CAMPAIGN_ID_ENV]
+
+
+@pytest.mark.parametrize(
+    ("service_name", "expected_host_env", "expected_campaign_id"),
+    (
+        ("cdb_signal_pb1", CAMPAIGN_ID_HOST_ENV_PB1, PB1_CAMPAIGN_ID),
+        (
+            "cdb_signal_donchian",
+            CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+            DONCHIAN_CAMPAIGN_ID,
+        ),
+    ),
+)
+def test_manifest_maps_to_lane_host_env_and_runtime_campaign_id(
+    service_name: str,
+    expected_host_env: str,
+    expected_campaign_id: str,
+) -> None:
+    pb1_manifest = _rewritten_pb1_manifest()
+    donchian_manifest = _rewritten_donchian_manifest()
+    host_env = validate_parallel_manifest_pair(pb1_manifest, donchian_manifest)
+
+    assert host_env[expected_host_env] == expected_campaign_id
+    assert resolve_lane_runtime_campaign_id(service_name, host_env) == expected_campaign_id
+
+
+def test_parallel_lane_campaign_ids_are_distinct() -> None:
+    host_env = build_parallel_compose_host_env(
+        _rewritten_pb1_manifest(),
+        _rewritten_donchian_manifest(),
+    )
+    assert host_env[CAMPAIGN_ID_HOST_ENV_PB1] != host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN]
+
+
+def test_manifest_lane_alignment_matches_bot_id_and_strategy_id() -> None:
+    pb1_manifest = _rewritten_pb1_manifest()
+    donchian_manifest = _rewritten_donchian_manifest()
+
+    pb1_lane = validate_manifest_lane_alignment(pb1_manifest)
+    donchian_lane = validate_manifest_lane_alignment(donchian_manifest)
+
+    assert pb1_lane.service_name == "cdb_signal_pb1"
+    assert pb1_lane.strategy_id == pb1_manifest["strategy_id"]
+    assert pb1_lane.bot_id == pb1_manifest["bot_id"]
+
+    assert donchian_lane.service_name == "cdb_signal_donchian"
+    assert donchian_lane.strategy_id == donchian_manifest["strategy_id"]
+    assert donchian_lane.bot_id == donchian_manifest["bot_id"]
+
+
+def test_build_host_env_from_manifest_rejects_shared_campaign_id() -> None:
+    pb1_manifest = _rewritten_pb1_manifest()
+    donchian_manifest = _rewritten_donchian_manifest()
+    donchian_manifest["campaign_id"] = pb1_manifest["campaign_id"]
+
+    with pytest.raises(ValueError, match="distinct"):
+        build_parallel_compose_host_env(pb1_manifest, donchian_manifest)
+
+
+def test_compose_campaign_env_unchanged_for_signal_bot_and_strategy_ids() -> None:
+    override = load_parallel_signal_compose_override(REPO_ROOT)
+    pb1_env = override["services"]["cdb_signal_pb1"]["environment"]
+    donchian_env = override["services"]["cdb_signal_donchian"]["environment"]
+
+    assert pb1_env["SIGNAL_STRATEGY_ID"] == "primary_breakout_v1"
+    assert pb1_env["SIGNAL_BOT_ID"] == "np-pb1-parallel-01"
+    assert donchian_env["SIGNAL_STRATEGY_ID"] == "donchian_breakout_v1"
+    assert donchian_env["SIGNAL_BOT_ID"] == "np-donchian-parallel-01"
+
+
+def test_single_lane_host_env_builder() -> None:
+    host_env = build_host_env_from_manifest(_rewritten_pb1_manifest())
+    assert host_env == {CAMPAIGN_ID_HOST_ENV_PB1: PB1_CAMPAIGN_ID}

--- a/tests/unit/tools/test_arvp_parallel_lane_compose_contract.py
+++ b/tests/unit/tools/test_arvp_parallel_lane_compose_contract.py
@@ -1,0 +1,35 @@
+"""Unit tests for parallel lane compose contract helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.arvp_parallel_lane_compose_contract import (
+    build_host_env_from_manifest,
+    is_runtime_ready_campaign_id,
+    validate_manifest_lane_alignment,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_is_runtime_ready_campaign_id_rejects_template_placeholders() -> None:
+    assert is_runtime_ready_campaign_id("arvp_3912_np_parallel_pb1_20260709_1327")
+    assert not is_runtime_ready_campaign_id("arvp_3912_np_parallel_pb1_TEMPLATE")
+    assert not is_runtime_ready_campaign_id("RUNTIME_GO_SET")
+
+
+def test_validate_manifest_lane_alignment_rejects_bot_id_drift() -> None:
+    manifest = {
+        "strategy_id": "primary_breakout_v1",
+        "bot_id": "wrong-bot",
+        "runtime_targets": ["cdb_signal_pb1"],
+    }
+    with pytest.raises(ValueError, match="bot_id"):
+        validate_manifest_lane_alignment(manifest)
+
+
+def test_build_host_env_from_manifest_rejects_unknown_strategy() -> None:
+    manifest = {"strategy_id": "unknown_strategy", "campaign_id": "campaign_x"}
+    with pytest.raises(ValueError, match="parallel signal lane"):
+        build_host_env_from_manifest(manifest)

--- a/tools/arvp_parallel_lane_compose_contract.py
+++ b/tools/arvp_parallel_lane_compose_contract.py
@@ -1,0 +1,190 @@
+"""Parallel lane manifest ↔ compose campaign ID contract (ARVP P1.5)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from core.replay.correlation_ledger_attribution import CDB_CAMPAIGN_ID_ENV
+
+PARALLEL_SIGNAL_COMPOSE_OVERRIDE = (
+    "manifests/runtime_np_parallel_signal_compose_override.yml"
+)
+
+# Host-level substitution keys set at RUNTIME-GO from rewritten campaign manifests.
+CAMPAIGN_ID_HOST_ENV_PB1 = "CDB_CAMPAIGN_ID_PB1"
+CAMPAIGN_ID_HOST_ENV_DONCHIAN = "CDB_CAMPAIGN_ID_DONCHIAN"
+
+PB1_MANIFEST_PATH = "manifests/campaign_3912_np_parallel_pb1.yaml"
+DONCHIAN_MANIFEST_PATH = "manifests/campaign_3912_np_parallel_donchian.yaml"
+
+CAMPAIGN_ID_TEMPLATE_SUFFIX = "_TEMPLATE"
+RUNTIME_GO_PLACEHOLDER = "RUNTIME_GO_SET"
+
+
+@dataclass(frozen=True)
+class ParallelSignalLane:
+    service_name: str
+    strategy_id: str
+    bot_id: str
+    campaign_id_host_env: str
+    manifest_path: str
+
+
+PARALLEL_SIGNAL_LANES: tuple[ParallelSignalLane, ...] = (
+    ParallelSignalLane(
+        service_name="cdb_signal_pb1",
+        strategy_id="primary_breakout_v1",
+        bot_id="np-pb1-parallel-01",
+        campaign_id_host_env=CAMPAIGN_ID_HOST_ENV_PB1,
+        manifest_path=PB1_MANIFEST_PATH,
+    ),
+    ParallelSignalLane(
+        service_name="cdb_signal_donchian",
+        strategy_id="donchian_breakout_v1",
+        bot_id="np-donchian-parallel-01",
+        campaign_id_host_env=CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+        manifest_path=DONCHIAN_MANIFEST_PATH,
+    ),
+)
+
+LANE_BY_SERVICE: dict[str, ParallelSignalLane] = {
+    lane.service_name: lane for lane in PARALLEL_SIGNAL_LANES
+}
+
+
+def lane_for_service(service_name: str) -> ParallelSignalLane:
+    try:
+        return LANE_BY_SERVICE[service_name]
+    except KeyError as exc:
+        raise ValueError(f"unknown parallel signal service: {service_name}") from exc
+
+
+def load_campaign_manifest(path: str | Path) -> dict[str, Any]:
+    manifest_path = Path(path)
+    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"manifest must be a YAML object: {manifest_path}")
+    return raw
+
+
+def manifest_campaign_id(manifest: Mapping[str, Any]) -> str:
+    raw = manifest.get("campaign_id")
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError("manifest campaign_id must be a non-empty string")
+    return raw.strip()
+
+
+def is_runtime_ready_campaign_id(campaign_id: str) -> bool:
+    if campaign_id.endswith(CAMPAIGN_ID_TEMPLATE_SUFFIX):
+        return False
+    if campaign_id == RUNTIME_GO_PLACEHOLDER:
+        return False
+    return bool(campaign_id.strip())
+
+
+def compose_campaign_substitution(service_name: str) -> str:
+    lane = lane_for_service(service_name)
+    return f"${{{lane.campaign_id_host_env}:-}}"
+
+
+def compose_service_campaign_env(service_name: str) -> dict[str, str]:
+    return {CDB_CAMPAIGN_ID_ENV: compose_campaign_substitution(service_name)}
+
+
+def build_host_env_from_manifest(manifest: Mapping[str, Any]) -> dict[str, str]:
+    """Map one rewritten campaign manifest to its host compose substitution env."""
+    strategy_id = manifest.get("strategy_id")
+    lane = next(
+        (item for item in PARALLEL_SIGNAL_LANES if item.strategy_id == strategy_id),
+        None,
+    )
+    if lane is None:
+        raise ValueError(
+            f"manifest strategy_id {strategy_id!r} is not a parallel signal lane"
+        )
+    campaign_id = manifest_campaign_id(manifest)
+    return {lane.campaign_id_host_env: campaign_id}
+
+
+def build_parallel_compose_host_env(
+    pb1_manifest: Mapping[str, Any],
+    donchian_manifest: Mapping[str, Any],
+) -> dict[str, str]:
+    """Merge host env for both parallel lanes from rewritten manifests."""
+    host_env: dict[str, str] = {}
+    host_env.update(build_host_env_from_manifest(pb1_manifest))
+    host_env.update(build_host_env_from_manifest(donchian_manifest))
+    if (
+        host_env[CAMPAIGN_ID_HOST_ENV_PB1]
+        == host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN]
+    ):
+        raise ValueError("parallel lane campaign_id values must be distinct")
+    return host_env
+
+
+def resolve_lane_runtime_campaign_id(
+    service_name: str,
+    host_env: Mapping[str, str],
+) -> str | None:
+    """Resolve container CDB_CAMPAIGN_ID from host substitution env."""
+    lane = lane_for_service(service_name)
+    raw = host_env.get(lane.campaign_id_host_env, "").strip()
+    return raw or None
+
+
+def validate_manifest_lane_alignment(manifest: Mapping[str, Any]) -> ParallelSignalLane:
+    lane = lane_for_service(_runtime_target_signal_service(manifest))
+    if manifest.get("strategy_id") != lane.strategy_id:
+        raise ValueError(
+            f"manifest strategy_id {manifest.get('strategy_id')!r} "
+            f"does not match lane {lane.service_name} ({lane.strategy_id!r})"
+        )
+    bot_id = manifest.get("bot_id")
+    if bot_id != lane.bot_id:
+        raise ValueError(
+            f"manifest bot_id {bot_id!r} does not match lane "
+            f"{lane.service_name} ({lane.bot_id!r})"
+        )
+    return lane
+
+
+def validate_parallel_manifest_pair(
+    pb1_manifest: Mapping[str, Any],
+    donchian_manifest: Mapping[str, Any],
+) -> dict[str, str]:
+    pb1_lane = validate_manifest_lane_alignment(pb1_manifest)
+    donchian_lane = validate_manifest_lane_alignment(donchian_manifest)
+    if pb1_lane.service_name == donchian_lane.service_name:
+        raise ValueError("parallel manifests must target distinct signal services")
+    return build_parallel_compose_host_env(pb1_manifest, donchian_manifest)
+
+
+def load_parallel_signal_compose_override(
+    repo_root: str | Path | None = None,
+) -> dict[str, Any]:
+    root = Path(repo_root) if repo_root is not None else Path(__file__).resolve().parents[1]
+    path = root / PARALLEL_SIGNAL_COMPOSE_OVERRIDE
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("parallel signal compose override must be a YAML object")
+    return raw
+
+
+def _runtime_target_signal_service(manifest: Mapping[str, Any]) -> str:
+    targets = manifest.get("runtime_targets")
+    if not isinstance(targets, list):
+        raise ValueError("manifest runtime_targets must be a list")
+    signal_targets = [
+        target
+        for target in targets
+        if isinstance(target, str) and target in LANE_BY_SERVICE
+    ]
+    if len(signal_targets) != 1:
+        raise ValueError(
+            "manifest must declare exactly one parallel signal runtime target"
+        )
+    return signal_targets[0]


### PR DESCRIPTION
## Summary

Closes #3963

Refs #3912
Refs #3960
Refs #3961

- Campaign ID runtime contract: `tools/arvp_parallel_lane_compose_contract.py` maps rewritten campaign manifests to lane-specific host env (`CDB_CAMPAIGN_ID_PB1`, `CDB_CAMPAIGN_ID_DONCHIAN`) and container `CDB_CAMPAIGN_ID`.
- Parallel lane compose/env wiring: `manifests/runtime_np_parallel_signal_compose_override.yml` sets distinct `${CDB_CAMPAIGN_ID_PB1:-}` / `${CDB_CAMPAIGN_ID_DONCHIAN:-}` substitution per signal service.
- Contract tests for PB1/Donchian manifest alignment, distinct campaign IDs, and unchanged `SIGNAL_BOT_ID` / `SIGNAL_STRATEGY_ID`.

## Test plan

- [x] `pytest tests/unit/arvp/test_arvp_p15_campaign_id_compose_contract.py tests/unit/tools/test_arvp_parallel_lane_compose_contract.py -q`
- [x] `pytest tests/unit/arvp/test_arvp_np_parallel_signal_compose_contract_3909.py tests/unit/arvp/test_arvp_p1_campaign_block_evidence_3960.py -q`
- [x] `ruff check` on changed paths

## Safety boundaries

- LR **NO-GO** unchanged
- No runtime Docker execution
- No productive DB writes
- No risk bypass or risk semantic changes
- No strategy parameter tuning

## Non-goals

- No natural-paper promotion claim
- No runtime verification in this slice

## Remaining uncertainty

- Future parallel execute still requires operator to export host env from rewritten manifests before `docker compose up`; not automated by supervisor in this slice.
