### PR TITLE
docs(arvp): diagnostic telemetry verification preflight (#3965)

### DIFF
--- a/docs/evidence/arvp_diag_telemetry_verification_preflight.md
+++ b/docs/evidence/arvp_diag_telemetry_verification_preflight.md
@@ -1,0 +1,143 @@
+# ARVP Diagnostic Telemetry Verification — Preflight (#3965)
+
+Status Class: **PREFLIGHT_READY** — manifests/docs/tooling only; **no runtime executed**
+Issue: [#3965](https://github.com/jannekbuengener/Claire_de_Binare/issues/3965)
+Hypothesis: `HYP-ARVP-DIAG-TELEMETRY-01`
+Prerequisites: [#3956](https://github.com/jannekbuengener/Claire_de_Binare/pull/3956), [#3961](https://github.com/jannekbuengener/Claire_de_Binare/pull/3961), [#3964](https://github.com/jannekbuengener/Claire_de_Binare/pull/3964)
+Root observation: [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912) (`TIMEOUT_NO_CHAIN`)
+Live-Readiness: **NO-GO**
+Echtgeld: **not authorized**
+
+**Preflight verdict:** `READY_PENDING_RUNTIME_GO` — diagnostic manifests, host-env mapping,
+and compose preflight complete; execution blocked until Jannek posts RUNTIME-GO on #3965.
+
+**No-run assertion:** This slice did **not** start any runtime observation.
+
+---
+
+## 1. Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+context_tool_status: available
+context_trust_level: none
+records_found: none
+```
+
+---
+
+## 2. What the future run will prove
+
+After RUNTIME-GO on #3965, a **2h** parallel natural-paper diagnostic run (PB1 + Donchian,
+`BTCUSDT`) should demonstrate post-#3964 telemetry repairs:
+
+| Proof target | Source slice | Runtime signal |
+|--------------|--------------|----------------|
+| Collision-safe `signal_id` | #3955 / #3956 | No duplicate runtime signal IDs across lanes |
+| Global + lane-scoped Supervisor counts | #3955 / #3956 | Supervisor reports both scopes |
+| `campaign_id` per parallel lane | #3963 / #3964 | Container `CDB_CAMPAIGN_ID` matches manifest |
+| `lane_campaign_evidence` | #3960 / #3961 | Probe/supervisor payload per lane |
+| `blocks_by_reason` | #3960 / #3961 | Visible when Risk blocks |
+| `campaign_id_propagated_to_ledger` | #3960 / #3961 | **Not proven until runtime** |
+
+**Not claimed in this preflight:** `campaign_id_propagated_to_ledger` — requires runtime evidence.
+
+---
+
+## 3. Diagnostic campaign manifests
+
+| Lane | Manifest | `campaign_id` | `bot_id` | `strategy_id` |
+|------|----------|---------------|----------|---------------|
+| PB1 | `manifests/campaign_diag_telemetry_pb1.yaml` | `arvp_diag_p15_pb1_20260710t1100z` | `np-pb1-diag-01` | `primary_breakout_v1` |
+| Donchian | `manifests/campaign_diag_telemetry_donchian.yaml` | `arvp_diag_p15_donchian_20260710t1100z` | `np-donchian-diag-01` | `donchian_breakout_v1` |
+
+Distinct from #3912 (`np-pb1-parallel-01`, `np-donchian-parallel-01`, `arvp_3912_*` IDs).
+
+Compose override: `manifests/runtime_np_diag_telemetry_signal_compose_override.yml`
+Allocation override: `manifests/runtime_np_parallel_allocation_compose_override.yml` (unchanged)
+
+---
+
+## 4. Host env mapping (set before `docker compose up`)
+
+Export from manifests via `tools.arvp_diag_telemetry_preflight`:
+
+```powershell
+$env:CDB_CAMPAIGN_ID_PB1 = "arvp_diag_p15_pb1_20260710t1100z"
+$env:CDB_CAMPAIGN_ID_DONCHIAN = "arvp_diag_p15_donchian_20260710t1100z"
+```
+
+```bash
+export CDB_CAMPAIGN_ID_PB1="arvp_diag_p15_pb1_20260710t1100z"
+export CDB_CAMPAIGN_ID_DONCHIAN="arvp_diag_p15_donchian_20260710t1100z"
+```
+
+Helper:
+
+```powershell
+python -m tools.arvp_diag_telemetry_preflight
+python -m tools.arvp_diag_telemetry_preflight --json
+```
+
+At RUNTIME-GO execute: rewrite `start_utc` and `timeout_utc` in both manifests
+(replace `RUNTIME_GO_SET`).
+
+---
+
+## 5. Static validation (2026-07-10)
+
+```powershell
+pytest -q tests/unit/arvp tests/unit/tools -k "diag_telemetry or p15_campaign"
+ruff check tools services core tests
+$env:CDB_CAMPAIGN_ID_PB1 = "arvp_diag_p15_pb1_20260710t1100z"
+$env:CDB_CAMPAIGN_ID_DONCHIAN = "arvp_diag_p15_donchian_20260710t1100z"
+docker compose `
+  -f infrastructure/compose/compose.blue.yml `
+  -f infrastructure/compose/compose.red.yml `
+  -f manifests/runtime_np_diag_telemetry_signal_compose_override.yml `
+  -f manifests/runtime_np_parallel_allocation_compose_override.yml `
+  config
+```
+
+`docker compose config` only — no `up`, `restart`, or container start.
+
+---
+
+## 6. Execute parameters (at RUNTIME-GO)
+
+| Parameter | Value |
+|-----------|-------|
+| Window | 2h (recommended) |
+| Symbol | BTCUSDT |
+| PB1 `strategy_id` / `bot_id` | `primary_breakout_v1` / `np-pb1-diag-01` |
+| Donchian `strategy_id` / `bot_id` | `donchian_breakout_v1` / `np-donchian-diag-01` |
+| Supervisors | 2× `tools.arvp_campaign_supervisor` (one per manifest) |
+| Terminal evidence | `docs/evidence/arvp_diag_telemetry_verification_run.md` (opened at execute) |
+| Safety | `MOCK_TRADING=true`, `DRY_RUN=true`, `MEXC_TESTNET=true`, `USE_REAL_BALANCE=false` |
+
+---
+
+## 7. RUNTIME-GO phrase (Jannek — copy/paste on #3965)
+
+```text
+RUNTIME-GO #3965: start 2h ARVP telemetry diagnostic run with PB1 + Donchian, CDB_CAMPAIGN_ID_PB1 and CDB_CAMPAIGN_ID_DONCHIAN set from manifests, MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true, USE_REAL_BALANCE=false, no Live/Echtgeld.
+```
+
+---
+
+## 8. Boundaries
+
+- LR **NO-GO** unchanged
+- No Live/Echtgeld authorization from this preflight
+- No runtime started in this slice
+- `campaign_id_propagated_to_ledger` unproven until runtime execute
+
+---
+
+*Preflight recorded 2026-07-10 on `main` @ `0eb19e46` (#3964).*

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -79,6 +79,21 @@ ledger/evidence isolation is guarded by contract tests in
 Gearbox alignment: `docs/evidence/arvp_parallel_pilot_gearbox_alignment_3912.md`.
 **#3912** still requires explicit **RUNTIME-GO** before execute.
 
+### Diagnostic telemetry verification (#3965)
+
+Short 2h parallel run to prove post-#3964 telemetry (collision-safe `signal_id`,
+lane-scoped counts, `campaign_id` propagation, block-reason evidence).
+
+| Artifact | Lane |
+|----------|------|
+| `campaign_diag_telemetry_pb1.yaml` | `primary_breakout_v1` / `np-pb1-diag-01` |
+| `campaign_diag_telemetry_donchian.yaml` | `donchian_breakout_v1` / `np-donchian-diag-01` |
+| `runtime_np_diag_telemetry_signal_compose_override.yml` | Diagnostic bot IDs + P1.5 `CDB_CAMPAIGN_ID` wiring |
+
+Preflight: `docs/evidence/arvp_diag_telemetry_verification_preflight.md`.
+Helper: `python -m tools.arvp_diag_telemetry_preflight`.
+**Pending Jannek RUNTIME-GO on #3965.**
+
 ## Single-strategy prior art
 
 | Artifact | Purpose |

--- a/manifests/campaign_diag_telemetry_donchian.yaml
+++ b/manifests/campaign_diag_telemetry_donchian.yaml
@@ -1,0 +1,73 @@
+schema_version: "1.0"
+campaign_id: arvp_diag_p15_donchian_20260710t1100z
+hypothesis_id: HYP-ARVP-DIAG-TELEMETRY-01
+parent_issue: 3965
+related_issues:
+  - 3912
+  - 3955
+  - 3960
+  - 3963
+symbol: BTCUSDT
+strategy_id: donchian_breakout_v1
+bot_id: np-donchian-diag-01
+evidence_class: natural_paper_evidence
+# Rewrite start_utc / timeout_utc at RUNTIME-GO execute (2h window recommended)
+start_utc: "RUNTIME_GO_SET"
+timeout_utc: "RUNTIME_GO_SET"
+max_duration_hours: 2.0
+start_criteria:
+  pre_documented: true
+  description: "Short ARVP telemetry diagnostic lane B (Donchian) after #3964."
+  start_policy_ref: docs/evidence/arvp_diag_telemetry_verification_preflight.md
+  criteria_met: false
+  criteria_met_reason: "Awaiting Jannek RUNTIME-GO on #3965."
+signal_compose_override: manifests/runtime_np_diag_telemetry_signal_compose_override.yml
+allocation_compose_override: manifests/runtime_np_parallel_allocation_compose_override.yml
+safety_flags:
+  mock_trading: true
+  use_real_balance: false
+  dry_run: true
+  mexc_testnet: true
+runtime_targets:
+  - cdb_ws
+  - cdb_market
+  - cdb_candles
+  - cdb_regime
+  - cdb_allocation
+  - cdb_signal_donchian
+  - cdb_risk
+  - cdb_execution
+  - cdb_db_writer
+  - cdb_paper_runner
+db_readonly_targets:
+  - public.correlation_ledger
+  - public.candles_1m
+evidence_doc: docs/evidence/arvp_diag_telemetry_verification_run.md
+evidence_log_jsonl: artifacts/campaigns/arvp_diag_p15_donchian_20260710t1100z/evidence_log.jsonl
+campaign_status_md: artifacts/campaigns/arvp_diag_p15_donchian_20260710t1100z/campaign_status.md
+github_reporting:
+  post_on_issue_3965: true
+  issue_close_after_acceptance: false
+allowed_statuses:
+  - planned
+  - preflight_failed
+  - running
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_pr_open
+  - evidence_merged
+terminal_statuses:
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_merged
+  - preflight_failed
+campaign_status: planned
+gear_id: gear-donchian-breakout-v1-diag-telemetry-btcusdt

--- a/manifests/campaign_diag_telemetry_pb1.yaml
+++ b/manifests/campaign_diag_telemetry_pb1.yaml
@@ -1,0 +1,73 @@
+schema_version: "1.0"
+campaign_id: arvp_diag_p15_pb1_20260710t1100z
+hypothesis_id: HYP-ARVP-DIAG-TELEMETRY-01
+parent_issue: 3965
+related_issues:
+  - 3912
+  - 3955
+  - 3960
+  - 3963
+symbol: BTCUSDT
+strategy_id: primary_breakout_v1
+bot_id: np-pb1-diag-01
+evidence_class: natural_paper_evidence
+# Rewrite start_utc / timeout_utc at RUNTIME-GO execute (2h window recommended)
+start_utc: "RUNTIME_GO_SET"
+timeout_utc: "RUNTIME_GO_SET"
+max_duration_hours: 2.0
+start_criteria:
+  pre_documented: true
+  description: "Short ARVP telemetry diagnostic lane A (PB1) after #3964."
+  start_policy_ref: docs/evidence/arvp_diag_telemetry_verification_preflight.md
+  criteria_met: false
+  criteria_met_reason: "Awaiting Jannek RUNTIME-GO on #3965."
+signal_compose_override: manifests/runtime_np_diag_telemetry_signal_compose_override.yml
+allocation_compose_override: manifests/runtime_np_parallel_allocation_compose_override.yml
+safety_flags:
+  mock_trading: true
+  use_real_balance: false
+  dry_run: true
+  mexc_testnet: true
+runtime_targets:
+  - cdb_ws
+  - cdb_market
+  - cdb_candles
+  - cdb_regime
+  - cdb_allocation
+  - cdb_signal_pb1
+  - cdb_risk
+  - cdb_execution
+  - cdb_db_writer
+  - cdb_paper_runner
+db_readonly_targets:
+  - public.correlation_ledger
+  - public.candles_1m
+evidence_doc: docs/evidence/arvp_diag_telemetry_verification_run.md
+evidence_log_jsonl: artifacts/campaigns/arvp_diag_p15_pb1_20260710t1100z/evidence_log.jsonl
+campaign_status_md: artifacts/campaigns/arvp_diag_p15_pb1_20260710t1100z/campaign_status.md
+github_reporting:
+  post_on_issue_3965: true
+  issue_close_after_acceptance: false
+allowed_statuses:
+  - planned
+  - preflight_failed
+  - running
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_pr_open
+  - evidence_merged
+terminal_statuses:
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_merged
+  - preflight_failed
+campaign_status: planned
+gear_id: gear-primary-breakout-v1-diag-telemetry-btcusdt

--- a/manifests/runtime_np_diag_telemetry_signal_compose_override.yml
+++ b/manifests/runtime_np_diag_telemetry_signal_compose_override.yml
@@ -1,0 +1,118 @@
+# Diagnostic telemetry verification compose override (#3965).
+# Short 2h parallel natural-paper run to prove post-#3964 telemetry wiring.
+# Distinct diagnostic bot IDs — do not reuse #3912 campaign or bot IDs.
+# Apply only after RUNTIME-GO on #3965; not canonical default.
+# Combine with manifests/runtime_np_parallel_allocation_compose_override.yml.
+# LR NO-GO — no Live/Echtgeld authorization from this manifest.
+#
+# Static validation (no runtime start):
+#   $env:CDB_CAMPAIGN_ID_PB1 = "<pb1 manifest campaign_id>"
+#   $env:CDB_CAMPAIGN_ID_DONCHIAN = "<donchian manifest campaign_id>"
+#   docker compose -f infrastructure/compose/compose.red.yml `
+#     -f manifests/runtime_np_diag_telemetry_signal_compose_override.yml config
+#
+# Host env contract (P1.5): export before compose up:
+#   CDB_CAMPAIGN_ID_PB1=<pb1 manifest campaign_id>
+#   CDB_CAMPAIGN_ID_DONCHIAN=<donchian manifest campaign_id>
+
+services:
+  cdb_signal:
+    profiles:
+      - single-signal-default
+
+  cdb_signal_pb1:
+    build:
+      context: ../..
+      dockerfile: services/signal/Dockerfile
+    container_name: cdb_signal_pb1
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: primary_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-pb1-diag-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_PB1:-}
+      SIGNAL_ENTRY_LOOKBACK_MIN: "240"
+      SIGNAL_EXIT_LOOKBACK_MIN: "120"
+      SIGNAL_BREAKOUT_BUFFER: "0.0005"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "60"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8015"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8015:8015"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8015/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network
+
+  cdb_signal_donchian:
+    build:
+      context: ../..
+      dockerfile: services/signal/Dockerfile
+    container_name: cdb_signal_donchian
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: donchian_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-donchian-diag-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_DONCHIAN:-}
+      SIGNAL_ENTRY_CHANNEL_BARS: "20"
+      SIGNAL_EXIT_CHANNEL_BARS: "10"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "30"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8016"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8016:8016"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8016/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network

--- a/tests/unit/arvp/test_arvp_diag_telemetry_preflight_3965.py
+++ b/tests/unit/arvp/test_arvp_diag_telemetry_preflight_3965.py
@@ -1,0 +1,75 @@
+"""Diagnostic telemetry preflight contract tests (#3965)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.arvp_diag_telemetry_preflight import (
+    DIAG_DONCHIAN_MANIFEST,
+    DIAG_PB1_MANIFEST,
+    DIAG_SIGNAL_COMPOSE_OVERRIDE,
+    build_preflight_report,
+    load_diag_manifests,
+    validate_diag_compose_alignment,
+    validate_diag_manifest_pair,
+)
+from tools.arvp_parallel_lane_compose_contract import (
+    CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+    CAMPAIGN_ID_HOST_ENV_PB1,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PB1_CAMPAIGN_ID = "arvp_diag_p15_pb1_20260710t1100z"
+DONCHIAN_CAMPAIGN_ID = "arvp_diag_p15_donchian_20260710t1100z"
+
+
+def test_diag_manifest_campaign_ids_are_distinct_and_not_3912() -> None:
+    pb1_manifest, donchian_manifest = load_diag_manifests(REPO_ROOT)
+
+    assert pb1_manifest["campaign_id"] == PB1_CAMPAIGN_ID
+    assert donchian_manifest["campaign_id"] == DONCHIAN_CAMPAIGN_ID
+    assert PB1_CAMPAIGN_ID != DONCHIAN_CAMPAIGN_ID
+    assert "3912" not in PB1_CAMPAIGN_ID
+    assert "3912" not in DONCHIAN_CAMPAIGN_ID
+
+
+def test_diag_bot_ids_are_distinct_from_3912() -> None:
+    pb1_manifest, donchian_manifest = load_diag_manifests(REPO_ROOT)
+
+    assert pb1_manifest["bot_id"] == "np-pb1-diag-01"
+    assert donchian_manifest["bot_id"] == "np-donchian-diag-01"
+    assert pb1_manifest["bot_id"] != "np-pb1-parallel-01"
+    assert donchian_manifest["bot_id"] != "np-donchian-parallel-01"
+
+
+def test_diag_host_env_maps_manifest_campaign_ids() -> None:
+    pb1_manifest, donchian_manifest = load_diag_manifests(REPO_ROOT)
+    host_env = validate_diag_manifest_pair(pb1_manifest, donchian_manifest)
+
+    assert host_env[CAMPAIGN_ID_HOST_ENV_PB1] == PB1_CAMPAIGN_ID
+    assert host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN] == DONCHIAN_CAMPAIGN_ID
+
+
+def test_diag_compose_override_aligns_with_host_env() -> None:
+    pb1_manifest, donchian_manifest = load_diag_manifests(REPO_ROOT)
+    host_env = validate_diag_manifest_pair(pb1_manifest, donchian_manifest)
+    from tools.arvp_diag_telemetry_preflight import load_diag_compose_override
+
+    compose_override = load_diag_compose_override(REPO_ROOT)
+    validate_diag_compose_alignment(host_env, compose_override)
+
+
+def test_preflight_report_is_ready_pending_runtime_go() -> None:
+    report = build_preflight_report(REPO_ROOT)
+
+    assert report["status"] == "READY_PENDING_RUNTIME_GO"
+    assert report["runtime_not_started"] is True
+    assert report["lr_status"] == "NO-GO"
+    assert report["manifests"]["pb1"] == DIAG_PB1_MANIFEST
+    assert report["manifests"]["donchian"] == DIAG_DONCHIAN_MANIFEST
+    assert report["compose_override"] == DIAG_SIGNAL_COMPOSE_OVERRIDE

--- a/tools/arvp_diag_telemetry_preflight.py
+++ b/tools/arvp_diag_telemetry_preflight.py
@@ -1,0 +1,194 @@
+"""ARVP diagnostic telemetry verification preflight (#3965).
+
+Prepares host-env export instructions and validates manifest ↔ compose alignment
+without starting runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from core.replay.correlation_ledger_attribution import CDB_CAMPAIGN_ID_ENV
+from tools.arvp_parallel_lane_compose_contract import (
+    CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+    CAMPAIGN_ID_HOST_ENV_PB1,
+    build_parallel_compose_host_env,
+    load_campaign_manifest,
+    manifest_campaign_id,
+)
+
+DIAG_PB1_MANIFEST = "manifests/campaign_diag_telemetry_pb1.yaml"
+DIAG_DONCHIAN_MANIFEST = "manifests/campaign_diag_telemetry_donchian.yaml"
+DIAG_SIGNAL_COMPOSE_OVERRIDE = (
+    "manifests/runtime_np_diag_telemetry_signal_compose_override.yml"
+)
+
+EXPECTED_DIAG_BOT_IDS = {
+    "cdb_signal_pb1": "np-pb1-diag-01",
+    "cdb_signal_donchian": "np-donchian-diag-01",
+}
+
+EXPECTED_STRATEGY_IDS = {
+    "cdb_signal_pb1": "primary_breakout_v1",
+    "cdb_signal_donchian": "donchian_breakout_v1",
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_diag_manifests(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    pb1 = load_campaign_manifest(root / DIAG_PB1_MANIFEST)
+    donchian = load_campaign_manifest(root / DIAG_DONCHIAN_MANIFEST)
+    return pb1, donchian
+
+
+def load_diag_compose_override(root: Path) -> dict[str, Any]:
+    path = root / DIAG_SIGNAL_COMPOSE_OVERRIDE
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("diagnostic signal compose override must be a YAML object")
+    return raw
+
+
+def validate_diag_manifest_pair(
+    pb1_manifest: dict[str, Any],
+    donchian_manifest: dict[str, Any],
+) -> dict[str, str]:
+    pb1_id = manifest_campaign_id(pb1_manifest)
+    donchian_id = manifest_campaign_id(donchian_manifest)
+    if pb1_id == donchian_id:
+        raise ValueError("diagnostic lane campaign_id values must be distinct")
+    if pb1_manifest.get("bot_id") == "np-pb1-parallel-01":
+        raise ValueError("diagnostic PB1 manifest must not reuse #3912 bot_id")
+    if donchian_manifest.get("bot_id") == "np-donchian-parallel-01":
+        raise ValueError("diagnostic Donchian manifest must not reuse #3912 bot_id")
+    return build_parallel_compose_host_env(pb1_manifest, donchian_manifest)
+
+
+def validate_diag_compose_alignment(
+    host_env: dict[str, str],
+    compose_override: dict[str, Any],
+) -> None:
+    services = compose_override.get("services")
+    if not isinstance(services, dict):
+        raise ValueError("compose override services must be a mapping")
+
+    for service_name, expected_bot_id in EXPECTED_DIAG_BOT_IDS.items():
+        service = services.get(service_name)
+        if not isinstance(service, dict):
+            raise ValueError(f"missing compose service: {service_name}")
+        environment = service.get("environment")
+        if not isinstance(environment, dict):
+            raise ValueError(f"{service_name} environment must be a mapping")
+
+        expected_strategy = EXPECTED_STRATEGY_IDS[service_name]
+        if environment.get("SIGNAL_STRATEGY_ID") != expected_strategy:
+            raise ValueError(
+                f"{service_name} SIGNAL_STRATEGY_ID mismatch: "
+                f"{environment.get('SIGNAL_STRATEGY_ID')!r} != {expected_strategy!r}"
+            )
+        if environment.get("SIGNAL_BOT_ID") != expected_bot_id:
+            raise ValueError(
+                f"{service_name} SIGNAL_BOT_ID mismatch: "
+                f"{environment.get('SIGNAL_BOT_ID')!r} != {expected_bot_id!r}"
+            )
+
+        host_key = (
+            CAMPAIGN_ID_HOST_ENV_PB1
+            if service_name == "cdb_signal_pb1"
+            else CAMPAIGN_ID_HOST_ENV_DONCHIAN
+        )
+        expected_campaign = host_env[host_key]
+        substitution = f"${{{host_key}:-}}"
+        if environment.get(CDB_CAMPAIGN_ID_ENV) != substitution:
+            raise ValueError(
+                f"{service_name} {CDB_CAMPAIGN_ID_ENV} must use {substitution!r}"
+            )
+        if not expected_campaign:
+            raise ValueError(f"host env {host_key} must be non-empty")
+
+
+def format_powershell_exports(host_env: dict[str, str]) -> str:
+    lines = [
+        f'$env:{key} = "{value}"'
+        for key, value in sorted(host_env.items())
+    ]
+    return "\n".join(lines)
+
+
+def format_bash_exports(host_env: dict[str, str]) -> str:
+    lines = [f'export {key}="{value}"' for key, value in sorted(host_env.items())]
+    return "\n".join(lines)
+
+
+def build_preflight_report(root: Path | None = None) -> dict[str, Any]:
+    base = root or repo_root()
+    pb1_manifest, donchian_manifest = load_diag_manifests(base)
+    host_env = validate_diag_manifest_pair(pb1_manifest, donchian_manifest)
+    compose_override = load_diag_compose_override(base)
+    validate_diag_compose_alignment(host_env, compose_override)
+
+    return {
+        "status": "READY_PENDING_RUNTIME_GO",
+        "parent_issue": 3965,
+        "manifests": {
+            "pb1": DIAG_PB1_MANIFEST,
+            "donchian": DIAG_DONCHIAN_MANIFEST,
+        },
+        "compose_override": DIAG_SIGNAL_COMPOSE_OVERRIDE,
+        "campaign_ids": {
+            CAMPAIGN_ID_HOST_ENV_PB1: host_env[CAMPAIGN_ID_HOST_ENV_PB1],
+            CAMPAIGN_ID_HOST_ENV_DONCHIAN: host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN],
+        },
+        "bot_ids": {
+            "pb1": pb1_manifest["bot_id"],
+            "donchian": donchian_manifest["bot_id"],
+        },
+        "host_env_exports": {
+            "powershell": format_powershell_exports(host_env),
+            "bash": format_bash_exports(host_env),
+        },
+        "runtime_not_started": True,
+        "lr_status": "NO-GO",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable preflight report on stdout",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_preflight_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    print("ARVP diagnostic telemetry preflight (#3965)")
+    print(f"Status: {report['status']}")
+    print()
+    print("Host env (PowerShell — set before docker compose up):")
+    print(report["host_env_exports"]["powershell"])
+    print()
+    print("Host env (bash):")
+    print(report["host_env_exports"]["bash"])
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(f"preflight failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc


### PR DESCRIPTION
## Summary

Prepares a short 2h ARVP telemetry diagnostic run after #3964 without starting runtime.

- Diagnostic campaign manifests for PB1 + Donchian with distinct `campaign_id` and diagnostic `bot_id` values (not reusing #3912 IDs)
- Diagnostic compose override wiring `CDB_CAMPAIGN_ID_PB1` / `CDB_CAMPAIGN_ID_DONCHIAN` per lane
- `tools/arvp_diag_telemetry_preflight` helper for host-env export + manifest/compose alignment checks
- Preflight evidence doc at `READY_PENDING_RUNTIME_GO`

## Test plan

- [x] `pytest -q tests/unit/arvp/test_arvp_diag_telemetry_preflight_3965.py`
- [x] `pytest -q tests/unit/arvp tests/unit/tools`
- [x] `ruff check` on new Python files
- [x] `docker compose ... config` (no `up`) with host env set — `CDB_CAMPAIGN_ID`, `SIGNAL_BOT_ID`, `SIGNAL_STRATEGY_ID` verified

## Delivered

- Manifests: `campaign_diag_telemetry_pb1.yaml`, `campaign_diag_telemetry_donchian.yaml`
- Compose: `runtime_np_diag_telemetry_signal_compose_override.yml`
- Tool: `tools/arvp_diag_telemetry_preflight.py`
- Evidence: `docs/evidence/arvp_diag_telemetry_verification_preflight.md`

## Validation

- 2214 unit tests passed (`tests/unit/arvp`, `tests/unit/tools`)
- Compose config resolves lane-specific campaign IDs and diagnostic bot IDs

## Non-goals

- No runtime start (`docker compose up` not executed)
- No `campaign_id_propagated_to_ledger` claim
- LR remains **NO-GO**

## Remaining uncertainty

- Runtime telemetry proof deferred until Jannek RUNTIME-GO on #3965

Closes #3965
Refs #3912, #3955, #3956, #3960, #3961, #3963, #3964
