### PR TITLE
fix(arvp): prevent runtime signal id collision regression

### DIFF
--- a/core/contracts/external_adapter_contracts.py
+++ b/core/contracts/external_adapter_contracts.py
@@ -52,6 +52,7 @@ class StrategySignalCandidate:
     confidence: float | None = None
     price: float | None = None
     pct_change: float | None = None
+    signal_id: str | None = None
     metadata: Mapping[str, Any] | None = None
 
 

--- a/core/replay/correlation_ledger_insert.py
+++ b/core/replay/correlation_ledger_insert.py
@@ -1,0 +1,65 @@
+"""Correlation ledger insert result classification (#3970 / #3956 regression)."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+class CorrelationLedgerInsertResult(str, Enum):
+    INSERTED = "inserted"
+    CONFLICT = "conflict"
+    SKIPPED = "skipped"
+    ERROR = "error"
+
+
+def classify_insert_rowcount(rowcount: int) -> CorrelationLedgerInsertResult:
+    """Map psycopg2 rowcount after INSERT ... ON CONFLICT DO NOTHING."""
+    if rowcount == 1:
+        return CorrelationLedgerInsertResult.INSERTED
+    if rowcount == 0:
+        return CorrelationLedgerInsertResult.CONFLICT
+    return CorrelationLedgerInsertResult.ERROR
+
+
+def evaluate_false_zero_event_risk(
+    *,
+    ledger_lane_count: int | None,
+    insert_conflicts_total: int | None,
+    signals_generated_total: int | None,
+) -> dict[str, Any]:
+    """Distinguish true zero activity from conflict-suppressed ledger rows."""
+    lane = ledger_lane_count if ledger_lane_count is not None else 0
+    conflicts = insert_conflicts_total or 0
+    signals = signals_generated_total or 0
+    false_zero_risk = lane <= 0 and (conflicts > 0 or signals > 0)
+    return {
+        "false_zero_event_risk": false_zero_risk,
+        "ledger_lane_count": ledger_lane_count,
+        "insert_conflicts_total": insert_conflicts_total,
+        "signals_generated_total": signals_generated_total,
+        "interpretation": (
+            "ledger_insert_conflict_or_signal_without_ledger_row"
+            if false_zero_risk
+            else "no_false_zero_risk_detected"
+        ),
+    }
+
+
+def parse_prometheus_counter(metrics_body: str, metric_name: str) -> int | None:
+    """Parse a counter value from Prometheus text exposition."""
+    total = 0
+    found = False
+    prefix = metric_name
+    for line in metrics_body.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        if line.startswith(prefix):
+            found = True
+            parts = line.rsplit(" ", 1)
+            if len(parts) == 2:
+                try:
+                    total += int(float(parts[1]))
+                except ValueError:
+                    continue
+    return total if found else None

--- a/docs/evidence/arvp_runtime_signal_id_collision_regression_3970.md
+++ b/docs/evidence/arvp_runtime_signal_id_collision_regression_3970.md
@@ -1,0 +1,49 @@
+# ARVP Runtime signal_id Collision Regression Fix (#3970)
+
+Status Class: **ENGINEERING_FIX** — code/tests only; no runtime rerun  
+Issue: [#3970](https://github.com/jannekbuengener/Claire_de_Binare/issues/3970)  
+Failed diagnostic: [#3967](https://github.com/jannekbuengener/Claire_de_Binare/issues/3967) / PR [#3968](https://github.com/jannekbuengener/Claire_de_Binare/pull/3968)  
+Prior P0 fix: [#3955](https://github.com/jannekbuengener/Claire_de_Binare/issues/3955) / PR [#3956](https://github.com/jannekbuengener/Claire_de_Binare/pull/3956)  
+Live-Readiness: **NO-GO**  
+Echtgeld: **not authorized**
+
+## Problem (#3967)
+
+Donchian emitted **10** runtime signals (container logs) but supervisor/ledger reported **0/0**.
+All 10 `signal_id` values already existed in `correlation_ledger` (first_seen `2026-02-15`).
+`INSERT … ON CONFLICT (event_pk) DO NOTHING` suppressed rows silently; telemetry read as zero activity.
+
+## Root cause (evidence-based)
+
+| Factor | Finding |
+|--------|---------|
+| Code path on `main` post-#3956 | Donchian/PB1 use `format_runtime_signal_id()` (UUID4) |
+| Pre-#3956 runtime path | `generate_uuid_hex(length=32)` without `name` → deterministic counter reuse after restart |
+| #3967 timing | #3956 merged `2026-07-10T10:04:51Z`; execute window `11:30Z` — **likely stale signal containers** not rebuilt |
+| Secondary gap | `_persist_correlation_event` treated `ON CONFLICT` as success (`return True`) |
+| ID discard gap | Strategy adapter dropped pre-assigned `signal_id` from Donchian/PB1 before publish |
+
+## Fix (P0 regression)
+
+| ID | Change |
+|----|--------|
+| P0R-1 | Preserve `signal_id` on `StrategySignalCandidate`; `_signal_from_candidate` keeps strategy-assigned runtime IDs |
+| P0R-2 | `CorrelationLedgerInsertResult`; conflict on `rowcount==0`; Prometheus `correlation_ledger_insert_conflicts_total`; supervisor `ledger_telemetry_risk` via `probe_signal_metrics` |
+| P0R-3 | Preflight `runtime_freshness.expected_source_sha` + rebuild note (`CDB_SOURCE_SHA` marker env) |
+
+## Validation (this slice)
+
+- `pytest tests/unit/arvp/test_arvp_runtime_signal_id_collision_regression_3970.py`
+- `pytest tests/unit/replay/test_correlation_ledger_insert.py`
+- No runtime execution; no productive DB writes
+
+## Non-goals
+
+- Does not change #3967 verdict
+- No strategy/risk semantics change
+- No promotion claim
+- LR **NO-GO** unchanged
+
+## Remaining uncertainty
+
+Runtime re-verification requires a future execute slice with **rebuilt signal images** matching post-#3970 `expected_source_sha`.

--- a/services/signal/service.py
+++ b/services/signal/service.py
@@ -31,6 +31,10 @@ import psycopg2.extensions
 
 from core.replay.canonical_json import canonical_hash
 from core.replay.correlation_ledger_attribution import build_signal_ledger_payload
+from core.replay.correlation_ledger_insert import (
+    CorrelationLedgerInsertResult,
+    classify_insert_rowcount,
+)
 from core.utils.clock import utcnow
 from core.utils.redis_payload import sanitize_signal
 from core.utils.uuid_gen import (
@@ -99,6 +103,7 @@ stats = {
     "latency_count": 0,  # Number of processed messages
     "errors_total": 0,  # Total errors
     "errors_by_type": {},  # Errors grouped by error type
+    "ledger_insert_conflicts": 0,  # ON CONFLICT DO NOTHING suppressions
 }
 
 
@@ -297,9 +302,13 @@ class SignalEngine:
                         f"{candidate.side}:{market_data.timestamp}"
                     )
         signal_id = (
-            f"sig-{generate_uuid_hex(name=signal_id_name, length=32)}"
-            if signal_id_name
-            else format_runtime_signal_id(length=32)
+            candidate.signal_id
+            if candidate.signal_id
+            else (
+                f"sig-{generate_uuid_hex(name=signal_id_name, length=32)}"
+                if signal_id_name
+                else format_runtime_signal_id(length=32)
+            )
         )
         signal = Signal(
             signal_id=signal_id,
@@ -367,6 +376,7 @@ class SignalEngine:
                         confidence=breakout_signal.confidence,
                         price=breakout_signal.price,
                         pct_change=breakout_signal.pct_change,
+                        signal_id=breakout_signal.signal_id,
                         metadata={
                             "adapter_id": adapter_id,
                             "signal_metadata": breakout_signal.metadata or {},
@@ -401,6 +411,7 @@ class SignalEngine:
                         confidence=donchian_signal.confidence,
                         price=donchian_signal.price,
                         pct_change=donchian_signal.pct_change,
+                        signal_id=donchian_signal.signal_id,
                         metadata={
                             "adapter_id": adapter_id,
                             "signal_metadata": donchian_signal.metadata or {},
@@ -468,12 +479,15 @@ class SignalEngine:
             self._pg_conn = None
             return None
 
-    def _persist_correlation_event(self, signal: "Signal", *, event_type: str) -> bool:
+    def _persist_correlation_event(
+        self, signal: "Signal", *, event_type: str
+    ) -> CorrelationLedgerInsertResult:
         """
         Persist SIGNAL event to correlation_ledger (Phase 8C).
 
         Fail-closed: If signal_id missing, raises ValueError.
-        ON CONFLICT (event_pk) DO NOTHING for idempotent writes.
+        ON CONFLICT (event_pk) DO NOTHING for idempotent writes; conflicts are
+        surfaced as CorrelationLedgerInsertResult.CONFLICT (not silent success).
         """
         if not signal.signal_id:
             raise ValueError(
@@ -487,7 +501,7 @@ class SignalEngine:
             conn = self._get_postgres_conn()
             if conn is None:
                 logger.warning("⚠️ correlation_ledger write skipped (no DB connection)")
-                return False
+                return CorrelationLedgerInsertResult.SKIPPED
 
             cursor = conn.cursor()
             cursor.execute("SET LOCAL statement_timeout = '250ms'")
@@ -512,11 +526,27 @@ class SignalEngine:
                     json.dumps(build_signal_ledger_payload(signal.to_dict())),
                 ),
             )
-            logger.debug(f"📊 correlation_ledger SIGNAL: {signal.signal_id}")
-            return True
+            result = classify_insert_rowcount(cursor.rowcount)
+            if result == CorrelationLedgerInsertResult.INSERTED:
+                logger.debug(f"📊 correlation_ledger SIGNAL: {signal.signal_id}")
+            elif result == CorrelationLedgerInsertResult.CONFLICT:
+                stats["ledger_insert_conflicts"] += 1
+                logger.warning(
+                    "⚠️ correlation_ledger SIGNAL insert conflict "
+                    "(event_pk collision, row suppressed): signal_id=%s event_pk=%s",
+                    signal.signal_id,
+                    event_pk,
+                )
+            else:
+                logger.error(
+                    "❌ correlation_ledger SIGNAL unexpected rowcount=%s signal_id=%s",
+                    cursor.rowcount,
+                    signal.signal_id,
+                )
+            return result
         except Exception as e:
             logger.error(f"❌ correlation_ledger write failed: {e}")
-            return False
+            return CorrelationLedgerInsertResult.ERROR
 
     def connect_redis(self):
         """Verbindung zu Redis herstellen"""
@@ -1004,9 +1034,16 @@ class SignalEngine:
             # Phase 8C: Persist SIGNAL event to correlation_ledger
             # ValueError (missing signal_id) = fail-closed (bubble up)
             # DB errors = warn-only (evidence debt, don't block trading)
-            if not self._persist_correlation_event(signal, event_type="SIGNAL"):
+            insert_result = self._persist_correlation_event(signal, event_type="SIGNAL")
+            if insert_result == CorrelationLedgerInsertResult.CONFLICT:
+                self._record_error("ledger_insert_conflict")
+            elif insert_result in (
+                CorrelationLedgerInsertResult.SKIPPED,
+                CorrelationLedgerInsertResult.ERROR,
+            ):
                 logger.warning(
-                    f"⚠️ correlation_ledger write failed for {signal.signal_id} (evidence debt)"
+                    f"⚠️ correlation_ledger write failed for {signal.signal_id} "
+                    f"(evidence debt, result={insert_result.value})"
                 )
 
             # Sanitize payload (Issue #349: None-filtering + contract v1.0 enforcement)
@@ -1168,6 +1205,11 @@ if _FLASK_AVAILABLE:
             "# HELP signals_generated_total Anzahl generierter Signale\n"
             "# TYPE signals_generated_total counter\n"
             f"signals_generated_total {stats['signals_generated']}\n\n"
+            "# HELP correlation_ledger_insert_conflicts_total "
+            "SIGNAL rows suppressed by event_pk ON CONFLICT DO NOTHING\n"
+            "# TYPE correlation_ledger_insert_conflicts_total counter\n"
+            f"correlation_ledger_insert_conflicts_total "
+            f"{stats['ledger_insert_conflicts']}\n\n"
             "# HELP signal_engine_status Service Status (1=running, 0=stopped)\n"
             "# TYPE signal_engine_status gauge\n"
             f"signal_engine_status {1 if stats['status'] == 'running' else 0}\n\n"

--- a/tests/unit/arvp/test_arvp_runtime_signal_id_collision_regression_3970.py
+++ b/tests/unit/arvp/test_arvp_runtime_signal_id_collision_regression_3970.py
@@ -1,0 +1,183 @@
+"""Regression tests: runtime signal_id collision path (#3970 / #3967)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.contracts.external_adapter_contracts import StrategySignalCandidate
+from core.replay.correlation_ledger_insert import CorrelationLedgerInsertResult
+from core.utils.uuid_gen import DeterministicUUIDGenerator, generate_uuid_hex
+
+_services_signal = Path(__file__).resolve().parents[3] / "services" / "signal"
+if str(_services_signal) not in sys.path:
+    sys.path.insert(0, str(_services_signal))
+
+from config import SignalConfig  # noqa: E402
+from models import MarketData  # noqa: E402
+from service import SignalEngine  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def _donchian_config() -> SignalConfig:
+    return SignalConfig(
+        strategy_id="donchian_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100.0,
+        entry_channel_bars=3,
+        exit_channel_bars=2,
+        min_minutes_between_entries=0,
+        trade_side_mode="long_only",
+        bot_id="np-donchian-diag-01",
+    )
+
+
+def _pb1_config() -> SignalConfig:
+    return SignalConfig(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        min_volume=100.0,
+        entry_lookback_minutes=5,
+        exit_lookback_minutes=3,
+        breakout_buffer=0.01,
+        min_minutes_between_entries=0,
+        trade_side_mode="long_only",
+        bot_id="np-pb1-diag-01",
+    )
+
+
+def _tick_donchian_buy(engine: SignalEngine, ts: int, price: float) -> object | None:
+    for idx, row in enumerate(
+        (
+            {"price": 100.0, "high": 100.0, "low": 99.0},
+            {"price": 101.0, "high": 101.0, "low": 100.0},
+            {"price": 102.0, "high": 102.0, "low": 101.0},
+        )
+    ):
+        engine.process_market_data(
+            {
+                "symbol": "BTCUSDT",
+                "timestamp": ts - (2 - idx) * 60_000,
+                "price": row["price"],
+                "close": row["price"],
+                "high": row["high"],
+                "low": row["low"],
+                "volume": 200_000.0,
+                "pct_change": 5.0,
+            }
+        )
+    return engine.process_market_data(
+        {
+            "symbol": "BTCUSDT",
+            "timestamp": ts,
+            "price": price,
+            "close": price,
+            "high": price,
+            "low": price - 1,
+            "volume": 200_000.0,
+            "pct_change": 5.0,
+        }
+    )
+
+
+@pytest.mark.unit
+def test_donchian_runtime_emission_preserves_strategy_signal_id() -> None:
+    with patch("service.config", _donchian_config()):
+        engine = SignalEngine()
+    with patch(
+        "service.format_runtime_signal_id",
+        side_effect=lambda length=32: f"sig-{'a' * length}",
+    ) as runtime_id:
+        signal = _tick_donchian_buy(engine, 1_700_000_000_000, 110.0)
+    assert signal is not None
+    assert runtime_id.called
+    assert signal.signal_id == f"sig-{'a' * 32}"
+    assert signal.signal_id != f"sig-{generate_uuid_hex(length=32)}"
+
+
+@pytest.mark.unit
+def test_pb1_runtime_emission_uses_collision_safe_id_not_deterministic_counter() -> None:
+    with patch("service.config", _pb1_config()):
+        engine = SignalEngine()
+    candidate = StrategySignalCandidate(
+        strategy_id="primary_breakout_v1",
+        symbol="BTCUSDT",
+        side="BUY",
+        reason="breakout_entry",
+        signal_id="sig-runtime-preserved-pb1",
+    )
+    market_data = MarketData(
+        symbol="BTCUSDT",
+        price=50000.0,
+        timestamp=1_700_000_000_000,
+        pct_change=2.0,
+        volume=500_000.0,
+    )
+    signal = engine._signal_from_candidate(candidate, market_data)
+    assert signal.signal_id == "sig-runtime-preserved-pb1"
+    deterministic = f"sig-{generate_uuid_hex(length=32)}"
+    assert signal.signal_id != deterministic or signal.signal_id.startswith("sig-runtime")
+
+
+@pytest.mark.unit
+def test_restart_simulation_runtime_ids_do_not_reuse_deterministic_counter() -> None:
+    gen_restart_a = DeterministicUUIDGenerator(seed=0)
+    gen_restart_b = DeterministicUUIDGenerator(seed=0)
+    deterministic_restart = f"sig-{gen_restart_a.generate().hex[:32]}"
+    assert deterministic_restart == f"sig-{gen_restart_b.generate().hex[:32]}"
+
+    with patch("service.config", _donchian_config()):
+        engine_a = SignalEngine()
+        engine_b = SignalEngine()
+    with patch(
+        "service.format_runtime_signal_id",
+        side_effect=[f"sig-{'b' * 32}", f"sig-{'c' * 32}"],
+    ):
+        sig_a = _tick_donchian_buy(engine_a, 1_700_000_100_000, 110.0)
+        sig_b = _tick_donchian_buy(engine_b, 1_700_000_200_000, 110.0)
+    assert sig_a is not None and sig_b is not None
+    assert sig_a.signal_id != sig_b.signal_id
+    assert sig_a.signal_id != deterministic_restart
+
+
+@pytest.mark.unit
+def test_persist_correlation_event_reports_conflict_not_success() -> None:
+    with patch("service.config", _donchian_config()):
+        engine = SignalEngine()
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.rowcount = 0
+    mock_conn.cursor.return_value = mock_cursor
+
+    from models import Signal
+
+    signal = Signal(
+        signal_id="sig-collision-test",
+        symbol="BTCUSDT",
+        side="BUY",
+        reason="test",
+        timestamp=1,
+        ts_ms=1_700_000_000_000,
+        price=1.0,
+        strategy_id="donchian_breakout_v1",
+        bot_id="np-donchian-diag-01",
+    )
+    with patch.object(engine, "_get_postgres_conn", return_value=mock_conn):
+        result = engine._persist_correlation_event(signal, event_type="SIGNAL")
+    assert result == CorrelationLedgerInsertResult.CONFLICT
+
+
+@pytest.mark.unit
+def test_supervisor_false_zero_risk_when_metrics_show_conflicts() -> None:
+    from core.replay.correlation_ledger_insert import evaluate_false_zero_event_risk
+
+    risk = evaluate_false_zero_event_risk(
+        ledger_lane_count=0,
+        insert_conflicts_total=4,
+        signals_generated_total=10,
+    )
+    assert risk["false_zero_event_risk"] is True

--- a/tests/unit/replay/test_correlation_ledger_insert.py
+++ b/tests/unit/replay/test_correlation_ledger_insert.py
@@ -1,0 +1,51 @@
+"""Unit tests for correlation ledger insert classification (#3970)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.correlation_ledger_insert import (
+    CorrelationLedgerInsertResult,
+    classify_insert_rowcount,
+    evaluate_false_zero_event_risk,
+    parse_prometheus_counter,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_classify_insert_rowcount_inserted() -> None:
+    assert classify_insert_rowcount(1) == CorrelationLedgerInsertResult.INSERTED
+
+
+def test_classify_insert_rowcount_conflict_on_zero() -> None:
+    assert classify_insert_rowcount(0) == CorrelationLedgerInsertResult.CONFLICT
+
+
+def test_evaluate_false_zero_event_risk_when_conflicts_without_ledger_rows() -> None:
+    result = evaluate_false_zero_event_risk(
+        ledger_lane_count=0,
+        insert_conflicts_total=3,
+        signals_generated_total=10,
+    )
+    assert result["false_zero_event_risk"] is True
+    assert result["interpretation"] == "ledger_insert_conflict_or_signal_without_ledger_row"
+
+
+def test_evaluate_false_zero_event_risk_clear_when_ledger_has_rows() -> None:
+    result = evaluate_false_zero_event_risk(
+        ledger_lane_count=5,
+        insert_conflicts_total=0,
+        signals_generated_total=5,
+    )
+    assert result["false_zero_event_risk"] is False
+
+
+def test_parse_prometheus_counter_sums_labeled_series() -> None:
+    body = (
+        "# HELP correlation_ledger_insert_conflicts_total conflicts\n"
+        "# TYPE correlation_ledger_insert_conflicts_total counter\n"
+        'correlation_ledger_insert_conflicts_total{error_type="ledger_insert_conflict"} 2\n'
+        "correlation_ledger_insert_conflicts_total 5\n"
+    )
+    assert parse_prometheus_counter(body, "correlation_ledger_insert_conflicts_total") == 7

--- a/tests/unit/tools/test_arvp_campaign_supervisor.py
+++ b/tests/unit/tools/test_arvp_campaign_supervisor.py
@@ -582,11 +582,16 @@ class TestRunAllProbes:
                 "correlation_ledger"
             ),
         )
+        monkeypatch.setattr(
+            "tools.arvp_campaign_supervisor.probe_signal_metrics",
+            lambda metrics_url: _ok("signal_metrics"),
+        )
 
         manifest = _minimal_manifest()
         results = run_all_probes(manifest)
-        assert len(results) == 7
+        assert len(results) == 8
         assert all(r["status"] == "ok" for r in results)
+        assert any(r["probe"] == "signal_metrics" for r in results)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/arvp_campaign_supervisor.py
+++ b/tools/arvp_campaign_supervisor.py
@@ -18,7 +18,10 @@ from tools.arvp_probe_layer import (
     probe_ledger,
     probe_regime,
     probe_safety,
+    probe_signal_metrics,
+    resolve_signal_metrics_url,
 )
+from core.replay.correlation_ledger_insert import evaluate_false_zero_event_risk
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +139,12 @@ def run_all_probes(manifest: dict[str, Any]) -> list[dict[str, Any]]:
         }
     )
     results.append({"probe": "regime", **probe_regime()})
+
+    metrics_url = resolve_signal_metrics_url(manifest)
+    if metrics_url:
+        results.append(
+            {"probe": "signal_metrics", **probe_signal_metrics(metrics_url)}
+        )
 
     return results
 
@@ -258,8 +267,10 @@ def _build_cycle_entry(
     manifest: dict[str, Any],
 ) -> dict[str, Any]:
     ledger = _find_probe(probes, "correlation_ledger")
+    signal_metrics = _find_probe(probes, "signal_metrics")
     event_count = None
     ledger_counts: dict[str, Any] = {}
+    ledger_telemetry_risk: dict[str, Any] | None = None
     if ledger is not None:
         ev = ledger.get("evidence", {})
         event_count = ev.get("events_since_campaign_start")
@@ -280,6 +291,18 @@ def _build_cycle_entry(
             "attribution": ev.get("ledger_attribution"),
         }
         lane_campaign_evidence = ev.get("lane_campaign_evidence")
+        sm_evidence = (
+            signal_metrics.get("evidence", {})
+            if signal_metrics is not None
+            else {}
+        )
+        ledger_telemetry_risk = evaluate_false_zero_event_risk(
+            ledger_lane_count=lane_count,
+            insert_conflicts_total=sm_evidence.get(
+                "correlation_ledger_insert_conflicts_total"
+            ),
+            signals_generated_total=sm_evidence.get("signals_generated_total"),
+        )
     else:
         lane_campaign_evidence = None
 
@@ -299,6 +322,7 @@ def _build_cycle_entry(
         ),
         "ledger_counts": ledger_counts,
         "lane_campaign_evidence": lane_campaign_evidence,
+        "ledger_telemetry_risk": ledger_telemetry_risk,
         "no_chain_reason": (
             lane_campaign_evidence.get("no_chain_reason")
             if isinstance(lane_campaign_evidence, dict)

--- a/tools/arvp_diag_telemetry_preflight.py
+++ b/tools/arvp_diag_telemetry_preflight.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -116,6 +117,36 @@ def validate_diag_compose_alignment(
             raise ValueError(f"host env {host_key} must be non-empty")
 
 
+def resolve_repo_source_sha(root: Path) -> str | None:
+    """Return current git HEAD for runtime image freshness checks."""
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        sha = proc.stdout.strip()
+        return sha or None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def build_runtime_freshness_guard(root: Path) -> dict[str, Any]:
+    sha = resolve_repo_source_sha(root)
+    return {
+        "expected_source_sha": sha,
+        "container_build_marker_env": "CDB_SOURCE_SHA",
+        "rebuild_required_after_telemetry_fix": True,
+        "limitation": (
+            "Preflight cannot verify running container image SHA without docker inspect; "
+            "operator must rebuild signal services after P0 telemetry merges."
+        ),
+    }
+
+
 def format_powershell_exports(host_env: dict[str, str]) -> str:
     lines = [
         f'$env:{key} = "{value}"'
@@ -156,6 +187,7 @@ def build_preflight_report(root: Path | None = None) -> dict[str, Any]:
             "powershell": format_powershell_exports(host_env),
             "bash": format_bash_exports(host_env),
         },
+        "runtime_freshness": build_runtime_freshness_guard(base),
         "runtime_not_started": True,
         "lr_status": "NO-GO",
     }

--- a/tools/arvp_probe_layer.py
+++ b/tools/arvp_probe_layer.py
@@ -12,6 +12,10 @@ from datetime import datetime, timezone
 from typing import Any
 
 from core.replay.correlation_ledger_attribution import aggregate_lane_campaign_evidence
+from core.replay.correlation_ledger_insert import (
+    evaluate_false_zero_event_risk,
+    parse_prometheus_counter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -817,6 +821,52 @@ def _ledger_events_since_start(
             payload = {}
         events.append({"event_type": row[0], "payload": payload})
     return events
+
+
+def resolve_signal_metrics_url(manifest: dict[str, Any]) -> str | None:
+    """Derive lane signal /metrics URL from manifest (optional explicit override)."""
+    explicit = manifest.get("signal_metrics_url")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    strategy_id = manifest.get("strategy_id")
+    host = manifest.get("signal_metrics_host", "127.0.0.1")
+    if strategy_id == "donchian_breakout_v1":
+        return f"http://{host}:8016/metrics"
+    if strategy_id == "primary_breakout_v1":
+        return f"http://{host}:8015/metrics"
+    return None
+
+
+def probe_signal_metrics(metrics_url: str) -> ProbeResult:
+    """Read-only signal engine Prometheus metrics (insert conflict visibility)."""
+    import urllib.error
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(metrics_url, timeout=5) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return _blocked(
+            {"metrics_url": metrics_url, "error": str(exc)},
+            ["signal metrics endpoint unreachable"],
+        )
+
+    conflicts = parse_prometheus_counter(
+        body, "correlation_ledger_insert_conflicts_total"
+    )
+    signals = parse_prometheus_counter(body, "signals_generated_total")
+    return _ok(
+        {
+            "metrics_url": metrics_url,
+            "correlation_ledger_insert_conflicts_total": conflicts,
+            "signals_generated_total": signals,
+        },
+        limitations=(
+            ["counter totals are process-lifetime since last container start"]
+            if conflicts is None and signals is None
+            else []
+        ),
+    )
 
 
 def probe_ledger(


### PR DESCRIPTION
## Summary

Fix P0 regression where #3967 reproduced false zero-event telemetry despite #3956.

## Root cause

- Pre-#3956 runtime used `generate_uuid_hex(length=32)` (deterministic counter) → historical `signal_id` collisions on container restart.
- #3956 merged before #3967 execute, but **likely stale signal containers** still ran pre-fix code (all 10 Donchian IDs matched `2026-02-15` ledger rows).
- Secondary gaps: strategy adapter discarded pre-assigned runtime IDs; ledger `ON CONFLICT DO NOTHING` returned success silently.

## Fix

- Preserve `signal_id` on `StrategySignalCandidate` through publish path (Donchian/PB1).
- `CorrelationLedgerInsertResult` + Prometheus `correlation_ledger_insert_conflicts_total`.
- Supervisor `probe_signal_metrics` + `ledger_telemetry_risk` false-zero detection.
- Preflight `runtime_freshness.expected_source_sha` rebuild guard.

## Regression tests

- `tests/unit/arvp/test_arvp_runtime_signal_id_collision_regression_3970.py`
- `tests/unit/replay/test_correlation_ledger_insert.py`

## Safety boundaries

- LR **NO-GO** unchanged
- No runtime execution in this slice
- No productive DB writes
- No strategy/risk semantics change
- No promotion claim

Closes #3970
Refs #3967
Refs #3968
Refs #3955
Refs #3956
