### PR TITLE
docs(arvp): re-verify telemetry preflight after #3971

### DIFF
--- a/docs/evidence/arvp_diag_telemetry_reverify_preflight_3973.md
+++ b/docs/evidence/arvp_diag_telemetry_reverify_preflight_3973.md
@@ -1,0 +1,126 @@
+# ARVP Diagnostic Telemetry Re-Verify — Preflight (#3973)
+
+Status Class: **PREFLIGHT_READY** — manifests/docs/tooling only; **no runtime executed**
+Issue: [#3973](https://github.com/jannekbuengener/Claire_de_Binare/issues/3973)
+Hypothesis: `HYP-ARVP-DIAG-TELEMETRY-REVERIFY-01`
+Prerequisites: [#3971](https://github.com/jannekbuengener/Claire_de_Binare/pull/3971) @ `251faf59d94f50bd77972c06b3a7cf23d6ecf401`
+Failed prior execute: [#3967](https://github.com/jannekbuengener/Claire_de_Binare/issues/3967) (`FAIL_FALSE_ZERO_EVENT_REPRODUCED`)
+Regression fix: [#3970](https://github.com/jannekbuengener/Claire_de_Binare/issues/3970) / PR [#3971](https://github.com/jannekbuengener/Claire_de_Binare/pull/3971)
+Live-Readiness: **NO-GO**
+Echtgeld: **not authorized**
+
+**Preflight verdict:** `READY_PENDING_RUNTIME_GO` — re-verify manifests, build-freshness guard,
+host-env mapping, and compose preflight complete; execution blocked until Jannek posts
+RUNTIME-GO on #3973.
+
+**No-run assertion:** This slice did **not** start any runtime observation.
+
+**#3971 not runtime-verified yet:** Code/tests merged; execute proof remains open.
+
+---
+
+## 1. Why re-verify
+
+#3967 showed Donchian signals in logs but supervisor/ledger **0/0** because all `signal_id`s
+collided with pre-#3956 historical ledger rows (likely **stale signal containers**).
+#3971 adds collision-safe ID propagation, ledger conflict visibility, and SHA freshness guard.
+
+---
+
+## 2. Expected source SHA (mandatory)
+
+| Field | Value |
+|-------|-------|
+| `expected_source_sha` | `251faf59d94f50bd77972c06b3a7cf23d6ecf401` |
+| `container_build_marker_env` | `CDB_SOURCE_SHA` |
+| PR | [#3971](https://github.com/jannekbuengener/Claire_de_Binare/pull/3971) |
+
+**Execute HOLD rule:** If `CDB_SOURCE_SHA` inside running containers cannot be proven equal to
+`expected_source_sha` **before** observation → terminal `FAIL_STALE_IMAGE_GUARD` (no supervisor start).
+
+---
+
+## 3. Re-verify campaign manifests
+
+| Lane | Manifest | `campaign_id` | `bot_id` | `strategy_id` |
+|------|----------|---------------|----------|---------------|
+| PB1 | `manifests/campaign_diag_reverify_pb1.yaml` | `arvp_diag_p0r_pb1_20260710t1600z` | `np-pb1-reverify-01` | `primary_breakout_v1` |
+| Donchian | `manifests/campaign_diag_reverify_donchian.yaml` | `arvp_diag_p0r_donchian_20260710t1600z` | `np-donchian-reverify-01` | `donchian_breakout_v1` |
+
+**Not reused:** #3967 IDs (`arvp_diag_p15_*`, `np-*-diag-01`).
+
+Compose override: `manifests/runtime_np_diag_reverify_signal_compose_override.yml`
+
+---
+
+## 4. Host env mapping (set before `docker compose build/up`)
+
+```powershell
+$env:CDB_CAMPAIGN_ID_PB1 = "arvp_diag_p0r_pb1_20260710t1600z"
+$env:CDB_CAMPAIGN_ID_DONCHIAN = "arvp_diag_p0r_donchian_20260710t1600z"
+$env:CDB_SOURCE_SHA = "251faf59d94f50bd77972c06b3a7cf23d6ecf401"
+```
+
+```bash
+export CDB_CAMPAIGN_ID_PB1="arvp_diag_p0r_pb1_20260710t1600z"
+export CDB_CAMPAIGN_ID_DONCHIAN="arvp_diag_p0r_donchian_20260710t1600z"
+export CDB_SOURCE_SHA="251faf59d94f50bd77972c06b3a7cf23d6ecf401"
+```
+
+Preflight tool: `python -m tools.arvp_diag_reverify_preflight --json`
+
+---
+
+## 5. Execute rebuild requirements (future RUNTIME-GO)
+
+1. Set host env (§4).
+2. Rebuild signal images (no cache):
+
+```powershell
+docker compose -f infrastructure/compose/compose.red.yml `
+  -f manifests/runtime_np_diag_reverify_signal_compose_override.yml `
+  build --no-cache cdb_signal_pb1 cdb_signal_donchian
+```
+
+3. Verify `CDB_SOURCE_SHA` in container env before observation:
+
+```powershell
+docker inspect cdb_signal_pb1 --format "{{range .Config.Env}}{{println .}}{{end}}" | findstr CDB_SOURCE_SHA
+docker inspect cdb_signal_donchian --format "{{range .Config.Env}}{{println .}}{{end}}" | findstr CDB_SOURCE_SHA
+```
+
+4. Only then start 2h observation window and supervisors.
+
+Safety: `MOCK_TRADING=true`, `DRY_RUN=true`, `MEXC_TESTNET=true`, `USE_REAL_BALANCE=false`.
+
+---
+
+## 6. Future terminal success / fail criteria
+
+| Verdict | Condition |
+|---------|-----------|
+| `PASS_TELEMETRY_REVERIFIED` | SHA proven; no historical ID reuse; ledger conflicts reported if any; lane counts non-ambiguous |
+| `FAIL_STALE_IMAGE_GUARD` | `CDB_SOURCE_SHA` != expected before observation |
+| `FAIL_SIGNAL_ID_COLLISION_REPRODUCED` | Runtime IDs match pre-fix historical ledger rows |
+| `FAIL_LEDGER_CONFLICT_SILENT` | Signals emitted but conflicts not visible in metrics/logs |
+| `FAIL_CAMPAIGN_ID_NOT_PROPAGATED` | Campaign window ledger rows lack diagnostic `campaign_id` |
+| `TIMEOUT_NO_SIGNAL_ACTIVITY` | True zero activity both lanes (no false-zero ambiguity) |
+| `HOLD_RUNTIME_BLOCKER` | Preflight/infra blocker before window |
+
+**Still unproven until execute:** `campaign_id_propagated_to_ledger`, `lane_campaign_evidence`.
+
+---
+
+## 7. RUNTIME-GO phrase (exact)
+
+```text
+RUNTIME-GO #3973: start 2h ARVP telemetry re-verify run after #3971 with rebuilt signal images, expected_source_sha=251faf59d94f50bd77972c06b3a7cf23d6ecf401, PB1 + Donchian, CDB_CAMPAIGN_ID_PB1 and CDB_CAMPAIGN_ID_DONCHIAN set from manifests, CDB_SOURCE_SHA verified in containers before observation, MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true, USE_REAL_BALANCE=false, no Live/Echtgeld.
+```
+
+---
+
+## 8. Boundaries
+
+- LR **NO-GO** unchanged
+- No Live/Echtgeld; no promotion claim
+- No runtime started in this preflight slice

--- a/manifests/campaign_diag_reverify_donchian.yaml
+++ b/manifests/campaign_diag_reverify_donchian.yaml
@@ -1,0 +1,84 @@
+schema_version: "1.0"
+campaign_id: arvp_diag_p0r_donchian_20260710t1600z
+hypothesis_id: HYP-ARVP-DIAG-TELEMETRY-REVERIFY-01
+parent_issue: 3973
+related_issues:
+  - 3967
+  - 3970
+  - 3971
+  - 3955
+  - 3960
+  - 3963
+symbol: BTCUSDT
+strategy_id: donchian_breakout_v1
+bot_id: np-donchian-reverify-01
+evidence_class: natural_paper_evidence
+expected_source_sha: "251faf59d94f50bd77972c06b3a7cf23d6ecf401"
+# Rewrite start_utc / timeout_utc at RUNTIME-GO execute (2h window recommended)
+start_utc: "TBD_AT_RUNTIME_GO"
+timeout_utc: "TBD_AT_RUNTIME_GO"
+max_duration_hours: 2.0
+start_criteria:
+  pre_documented: true
+  description: "Short ARVP telemetry re-verify lane B (Donchian) after #3971."
+  start_policy_ref: docs/evidence/arvp_diag_telemetry_reverify_preflight_3973.md
+  criteria_met: false
+  criteria_met_reason: "Awaiting RUNTIME-GO on #3973 with rebuilt signal images."
+signal_compose_override: manifests/runtime_np_diag_reverify_signal_compose_override.yml
+allocation_compose_override: manifests/runtime_np_parallel_allocation_compose_override.yml
+safety_flags:
+  mock_trading: true
+  use_real_balance: false
+  dry_run: true
+  mexc_testnet: true
+runtime_targets:
+  - cdb_ws
+  - cdb_market
+  - cdb_candles
+  - cdb_regime
+  - cdb_allocation
+  - cdb_signal_donchian
+  - cdb_risk
+  - cdb_execution
+  - cdb_db_writer
+  - cdb_paper_runner
+db_readonly_targets:
+  - public.correlation_ledger
+  - public.candles_1m
+evidence_doc: docs/evidence/arvp_diag_telemetry_reverify_run.md
+evidence_log_jsonl: artifacts/campaigns/arvp_diag_p0r_donchian_20260710t1600z/evidence_log.jsonl
+campaign_status_md: artifacts/campaigns/arvp_diag_p0r_donchian_20260710t1600z/campaign_status.md
+github_reporting:
+  post_on_issue_3973: true
+  issue_close_after_acceptance: false
+allowed_statuses:
+  - planned
+  - preflight_failed
+  - running
+  - pass_telemetry_reverified
+  - fail_stale_image_guard
+  - fail_signal_id_collision_reproduced
+  - fail_ledger_conflict_silent
+  - fail_campaign_id_not_propagated
+  - timeout_no_signal_activity
+  - hold_runtime_blocker
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_pr_open
+  - evidence_merged
+terminal_statuses:
+  - pass_telemetry_reverified
+  - fail_stale_image_guard
+  - fail_signal_id_collision_reproduced
+  - fail_ledger_conflict_silent
+  - fail_campaign_id_not_propagated
+  - timeout_no_signal_activity
+  - hold_runtime_blocker
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_merged
+  - preflight_failed
+campaign_status: planned
+gear_id: gear-donchian-breakout-v1-diag-reverify-btcusdt

--- a/manifests/campaign_diag_reverify_pb1.yaml
+++ b/manifests/campaign_diag_reverify_pb1.yaml
@@ -1,0 +1,84 @@
+schema_version: "1.0"
+campaign_id: arvp_diag_p0r_pb1_20260710t1600z
+hypothesis_id: HYP-ARVP-DIAG-TELEMETRY-REVERIFY-01
+parent_issue: 3973
+related_issues:
+  - 3967
+  - 3970
+  - 3971
+  - 3955
+  - 3960
+  - 3963
+symbol: BTCUSDT
+strategy_id: primary_breakout_v1
+bot_id: np-pb1-reverify-01
+evidence_class: natural_paper_evidence
+expected_source_sha: "251faf59d94f50bd77972c06b3a7cf23d6ecf401"
+# Rewrite start_utc / timeout_utc at RUNTIME-GO execute (2h window recommended)
+start_utc: "TBD_AT_RUNTIME_GO"
+timeout_utc: "TBD_AT_RUNTIME_GO"
+max_duration_hours: 2.0
+start_criteria:
+  pre_documented: true
+  description: "Short ARVP telemetry re-verify lane A (PB1) after #3971."
+  start_policy_ref: docs/evidence/arvp_diag_telemetry_reverify_preflight_3973.md
+  criteria_met: false
+  criteria_met_reason: "Awaiting RUNTIME-GO on #3973 with rebuilt signal images."
+signal_compose_override: manifests/runtime_np_diag_reverify_signal_compose_override.yml
+allocation_compose_override: manifests/runtime_np_parallel_allocation_compose_override.yml
+safety_flags:
+  mock_trading: true
+  use_real_balance: false
+  dry_run: true
+  mexc_testnet: true
+runtime_targets:
+  - cdb_ws
+  - cdb_market
+  - cdb_candles
+  - cdb_regime
+  - cdb_allocation
+  - cdb_signal_pb1
+  - cdb_risk
+  - cdb_execution
+  - cdb_db_writer
+  - cdb_paper_runner
+db_readonly_targets:
+  - public.correlation_ledger
+  - public.candles_1m
+evidence_doc: docs/evidence/arvp_diag_telemetry_reverify_run.md
+evidence_log_jsonl: artifacts/campaigns/arvp_diag_p0r_pb1_20260710t1600z/evidence_log.jsonl
+campaign_status_md: artifacts/campaigns/arvp_diag_p0r_pb1_20260710t1600z/campaign_status.md
+github_reporting:
+  post_on_issue_3973: true
+  issue_close_after_acceptance: false
+allowed_statuses:
+  - planned
+  - preflight_failed
+  - running
+  - pass_telemetry_reverified
+  - fail_stale_image_guard
+  - fail_signal_id_collision_reproduced
+  - fail_ledger_conflict_silent
+  - fail_campaign_id_not_propagated
+  - timeout_no_signal_activity
+  - hold_runtime_blocker
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_pr_open
+  - evidence_merged
+terminal_statuses:
+  - pass_telemetry_reverified
+  - fail_stale_image_guard
+  - fail_signal_id_collision_reproduced
+  - fail_ledger_conflict_silent
+  - fail_campaign_id_not_propagated
+  - timeout_no_signal_activity
+  - hold_runtime_blocker
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_merged
+  - preflight_failed
+campaign_status: planned
+gear_id: gear-primary-breakout-v1-diag-reverify-btcusdt

--- a/manifests/runtime_np_diag_reverify_signal_compose_override.yml
+++ b/manifests/runtime_np_diag_reverify_signal_compose_override.yml
@@ -1,0 +1,127 @@
+# Diagnostic telemetry re-verify compose override (#3973).
+# Post-#3971 short 2h parallel natural-paper re-verify (PB1 + Donchian).
+# Distinct re-verify bot IDs — do not reuse #3967 diagnostic IDs.
+# Requires rebuilt signal images with CDB_SOURCE_SHA before RUNTIME-GO.
+# Apply only after RUNTIME-GO on #3973; not canonical default.
+# Combine with manifests/runtime_np_parallel_allocation_compose_override.yml.
+# LR NO-GO — no Live/Echtgeld authorization from this manifest.
+#
+# Static validation (no runtime start):
+#   $env:CDB_CAMPAIGN_ID_PB1 = "<pb1 manifest campaign_id>"
+#   $env:CDB_CAMPAIGN_ID_DONCHIAN = "<donchian manifest campaign_id>"
+#   $env:CDB_SOURCE_SHA = "251faf59d94f50bd77972c06b3a7cf23d6ecf401"
+#   docker compose -f infrastructure/compose/compose.red.yml `
+#     -f manifests/runtime_np_diag_reverify_signal_compose_override.yml config
+#
+# Execute rebuild (required before observation):
+#   docker compose -f infrastructure/compose/compose.red.yml `
+#     -f manifests/runtime_np_diag_reverify_signal_compose_override.yml `
+#     build --no-cache cdb_signal_pb1 cdb_signal_donchian
+
+services:
+  cdb_signal:
+    profiles:
+      - single-signal-default
+
+  cdb_signal_pb1:
+    build:
+      context: ../..
+      dockerfile: services/signal/Dockerfile
+      args:
+        CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-251faf59d94f50bd77972c06b3a7cf23d6ecf401}
+    container_name: cdb_signal_pb1
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: primary_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-pb1-reverify-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_PB1:-}
+      CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-251faf59d94f50bd77972c06b3a7cf23d6ecf401}
+      SIGNAL_ENTRY_LOOKBACK_MIN: "240"
+      SIGNAL_EXIT_LOOKBACK_MIN: "120"
+      SIGNAL_BREAKOUT_BUFFER: "0.0005"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "60"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8015"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8015:8015"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8015/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network
+
+  cdb_signal_donchian:
+    build:
+      context: ../..
+      dockerfile: services/signal/Dockerfile
+      args:
+        CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-251faf59d94f50bd77972c06b3a7cf23d6ecf401}
+    container_name: cdb_signal_donchian
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: donchian_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-donchian-reverify-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_DONCHIAN:-}
+      CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-251faf59d94f50bd77972c06b3a7cf23d6ecf401}
+      SIGNAL_ENTRY_CHANNEL_BARS: "20"
+      SIGNAL_EXIT_CHANNEL_BARS: "10"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "30"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8016"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8016:8016"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8016/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
 
+ARG CDB_SOURCE_SHA=unknown
+ENV CDB_SOURCE_SHA=${CDB_SOURCE_SHA}
+
 WORKDIR /app
 
 # Security: upgrade OS packages with available Trixie security patches (#2289)

--- a/tests/unit/arvp/test_arvp_diag_reverify_preflight_3973.py
+++ b/tests/unit/arvp/test_arvp_diag_reverify_preflight_3973.py
@@ -1,0 +1,97 @@
+"""Re-verify diagnostic telemetry preflight contract tests (#3973)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.arvp_diag_reverify_preflight import (
+    EXPECTED_REVERIFY_SOURCE_SHA,
+    REVERIFY_DONCHIAN_MANIFEST,
+    REVERIFY_PB1_MANIFEST,
+    REVERIFY_SIGNAL_COMPOSE_OVERRIDE,
+    build_reverify_preflight_report,
+    load_reverify_compose_override,
+    load_reverify_manifests,
+    runtime_go_phrase,
+    validate_reverify_compose_alignment,
+    validate_reverify_manifest_pair,
+)
+from tools.arvp_parallel_lane_compose_contract import (
+    CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+    CAMPAIGN_ID_HOST_ENV_PB1,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PB1_CAMPAIGN_ID = "arvp_diag_p0r_pb1_20260710t1600z"
+DONCHIAN_CAMPAIGN_ID = "arvp_diag_p0r_donchian_20260710t1600z"
+
+
+def test_reverify_manifest_campaign_ids_are_distinct_and_not_3967() -> None:
+    pb1_manifest, donchian_manifest = load_reverify_manifests(REPO_ROOT)
+
+    assert pb1_manifest["campaign_id"] == PB1_CAMPAIGN_ID
+    assert donchian_manifest["campaign_id"] == DONCHIAN_CAMPAIGN_ID
+    assert PB1_CAMPAIGN_ID != DONCHIAN_CAMPAIGN_ID
+    assert "p15" not in PB1_CAMPAIGN_ID
+    assert "p15" not in DONCHIAN_CAMPAIGN_ID
+
+
+def test_reverify_bot_ids_are_distinct_from_3967() -> None:
+    pb1_manifest, donchian_manifest = load_reverify_manifests(REPO_ROOT)
+
+    assert pb1_manifest["bot_id"] == "np-pb1-reverify-01"
+    assert donchian_manifest["bot_id"] == "np-donchian-reverify-01"
+    assert pb1_manifest["bot_id"] != "np-pb1-diag-01"
+    assert donchian_manifest["bot_id"] != "np-donchian-diag-01"
+
+
+def test_reverify_manifests_pin_expected_source_sha() -> None:
+    pb1_manifest, donchian_manifest = load_reverify_manifests(REPO_ROOT)
+
+    assert pb1_manifest["expected_source_sha"] == EXPECTED_REVERIFY_SOURCE_SHA
+    assert donchian_manifest["expected_source_sha"] == EXPECTED_REVERIFY_SOURCE_SHA
+
+
+def test_reverify_host_env_maps_manifest_campaign_ids_and_sha() -> None:
+    pb1_manifest, donchian_manifest = load_reverify_manifests(REPO_ROOT)
+    host_env = validate_reverify_manifest_pair(pb1_manifest, donchian_manifest)
+
+    assert host_env[CAMPAIGN_ID_HOST_ENV_PB1] == PB1_CAMPAIGN_ID
+    assert host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN] == DONCHIAN_CAMPAIGN_ID
+
+
+def test_reverify_compose_override_aligns_with_host_env() -> None:
+    pb1_manifest, donchian_manifest = load_reverify_manifests(REPO_ROOT)
+    host_env = validate_reverify_manifest_pair(pb1_manifest, donchian_manifest)
+    compose_override = load_reverify_compose_override(REPO_ROOT)
+    validate_reverify_compose_alignment(host_env, compose_override)
+
+
+def test_reverify_preflight_report_is_ready_pending_runtime_go() -> None:
+    report = build_reverify_preflight_report(REPO_ROOT)
+
+    assert report["status"] == "READY_PENDING_RUNTIME_GO"
+    assert report["runtime_not_started"] is True
+    assert report["runtime_verified"] is False
+    assert report["lr_status"] == "NO-GO"
+    assert report["manifests"]["pb1"] == REVERIFY_PB1_MANIFEST
+    assert report["manifests"]["donchian"] == REVERIFY_DONCHIAN_MANIFEST
+    assert report["compose_override"] == REVERIFY_SIGNAL_COMPOSE_OVERRIDE
+    assert (
+        report["runtime_freshness"]["expected_source_sha"]
+        == EXPECTED_REVERIFY_SOURCE_SHA
+    )
+    assert "CDB_SOURCE_SHA" in report["host_env_exports"]["powershell"]
+
+
+def test_runtime_go_phrase_contains_required_tokens() -> None:
+    phrase = runtime_go_phrase()
+    assert "RUNTIME-GO #3973" in phrase
+    assert EXPECTED_REVERIFY_SOURCE_SHA in phrase
+    assert "CDB_SOURCE_SHA verified" in phrase
+    assert "no Live/Echtgeld" in phrase

--- a/tools/arvp_diag_reverify_preflight.py
+++ b/tools/arvp_diag_reverify_preflight.py
@@ -1,0 +1,270 @@
+"""ARVP diagnostic telemetry re-verify preflight (#3973).
+
+Prepares host-env exports, build-freshness guard, and compose alignment
+after #3971 regression fix — without starting runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from core.replay.correlation_ledger_attribution import CDB_CAMPAIGN_ID_ENV
+from tools.arvp_diag_telemetry_preflight import (
+    format_bash_exports,
+    format_powershell_exports,
+    resolve_repo_source_sha,
+)
+from tools.arvp_parallel_lane_compose_contract import (
+    CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+    CAMPAIGN_ID_HOST_ENV_PB1,
+    build_parallel_compose_host_env,
+    load_campaign_manifest,
+    manifest_campaign_id,
+)
+
+REVERIFY_PB1_MANIFEST = "manifests/campaign_diag_reverify_pb1.yaml"
+REVERIFY_DONCHIAN_MANIFEST = "manifests/campaign_diag_reverify_donchian.yaml"
+REVERIFY_SIGNAL_COMPOSE_OVERRIDE = (
+    "manifests/runtime_np_diag_reverify_signal_compose_override.yml"
+)
+
+EXPECTED_REVERIFY_SOURCE_SHA = "251faf59d94f50bd77972c06b3a7cf23d6ecf401"
+
+EXPECTED_REVERIFY_BOT_IDS = {
+    "cdb_signal_pb1": "np-pb1-reverify-01",
+    "cdb_signal_donchian": "np-donchian-reverify-01",
+}
+
+EXPECTED_STRATEGY_IDS = {
+    "cdb_signal_pb1": "primary_breakout_v1",
+    "cdb_signal_donchian": "donchian_breakout_v1",
+}
+
+FORBIDDEN_3967_BOT_IDS = {"np-pb1-diag-01", "np-donchian-diag-01"}
+FORBIDDEN_3967_CAMPAIGN_PREFIXES = (
+    "arvp_diag_p15_pb1_20260710t1100z",
+    "arvp_diag_p15_donchian_20260710t1100z",
+)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_reverify_manifests(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    pb1 = load_campaign_manifest(root / REVERIFY_PB1_MANIFEST)
+    donchian = load_campaign_manifest(root / REVERIFY_DONCHIAN_MANIFEST)
+    return pb1, donchian
+
+
+def load_reverify_compose_override(root: Path) -> dict[str, Any]:
+    path = root / REVERIFY_SIGNAL_COMPOSE_OVERRIDE
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("re-verify signal compose override must be a YAML object")
+    return raw
+
+
+def validate_reverify_manifest_pair(
+    pb1_manifest: dict[str, Any],
+    donchian_manifest: dict[str, Any],
+) -> dict[str, str]:
+    pb1_id = manifest_campaign_id(pb1_manifest)
+    donchian_id = manifest_campaign_id(donchian_manifest)
+    if pb1_id == donchian_id:
+        raise ValueError("re-verify lane campaign_id values must be distinct")
+    for manifest in (pb1_manifest, donchian_manifest):
+        bot_id = manifest.get("bot_id")
+        if bot_id in FORBIDDEN_3967_BOT_IDS:
+            raise ValueError(f"re-verify manifest must not reuse #3967 bot_id: {bot_id}")
+        campaign_id = manifest.get("campaign_id")
+        if campaign_id in FORBIDDEN_3967_CAMPAIGN_PREFIXES:
+            raise ValueError(
+                f"re-verify manifest must not reuse #3967 campaign_id: {campaign_id}"
+            )
+        expected_sha = manifest.get("expected_source_sha")
+        if expected_sha != EXPECTED_REVERIFY_SOURCE_SHA:
+            raise ValueError(
+                f"expected_source_sha mismatch: {expected_sha!r} != "
+                f"{EXPECTED_REVERIFY_SOURCE_SHA!r}"
+            )
+    return build_parallel_compose_host_env(pb1_manifest, donchian_manifest)
+
+
+def validate_reverify_compose_alignment(
+    host_env: dict[str, str],
+    compose_override: dict[str, Any],
+) -> None:
+    services = compose_override.get("services")
+    if not isinstance(services, dict):
+        raise ValueError("compose override services must be a mapping")
+
+    for service_name, expected_bot_id in EXPECTED_REVERIFY_BOT_IDS.items():
+        service = services.get(service_name)
+        if not isinstance(service, dict):
+            raise ValueError(f"missing compose service: {service_name}")
+        environment = service.get("environment")
+        if not isinstance(environment, dict):
+            raise ValueError(f"{service_name} environment must be a mapping")
+
+        expected_strategy = EXPECTED_STRATEGY_IDS[service_name]
+        if environment.get("SIGNAL_STRATEGY_ID") != expected_strategy:
+            raise ValueError(
+                f"{service_name} SIGNAL_STRATEGY_ID mismatch: "
+                f"{environment.get('SIGNAL_STRATEGY_ID')!r} != {expected_strategy!r}"
+            )
+        if environment.get("SIGNAL_BOT_ID") != expected_bot_id:
+            raise ValueError(
+                f"{service_name} SIGNAL_BOT_ID mismatch: "
+                f"{environment.get('SIGNAL_BOT_ID')!r} != {expected_bot_id!r}"
+            )
+
+        host_key = (
+            CAMPAIGN_ID_HOST_ENV_PB1
+            if service_name == "cdb_signal_pb1"
+            else CAMPAIGN_ID_HOST_ENV_DONCHIAN
+        )
+        expected_campaign = host_env[host_key]
+        substitution = f"${{{host_key}:-}}"
+        if environment.get(CDB_CAMPAIGN_ID_ENV) != substitution:
+            raise ValueError(
+                f"{service_name} {CDB_CAMPAIGN_ID_ENV} must use {substitution!r}"
+            )
+        if not expected_campaign:
+            raise ValueError(f"host env {host_key} must be non-empty")
+
+        cdb_source_sha = environment.get("CDB_SOURCE_SHA")
+        if not isinstance(cdb_source_sha, str) or "CDB_SOURCE_SHA" not in cdb_source_sha:
+            raise ValueError(f"{service_name} must declare CDB_SOURCE_SHA substitution")
+
+        build = service.get("build")
+        if not isinstance(build, dict):
+            raise ValueError(f"{service_name} must declare build args for freshness")
+        build_args = build.get("args")
+        if not isinstance(build_args, dict) or "CDB_SOURCE_SHA" not in build_args:
+            raise ValueError(f"{service_name} build.args must include CDB_SOURCE_SHA")
+
+
+def build_runtime_freshness_guard(root: Path) -> dict[str, Any]:
+    repo_sha = resolve_repo_source_sha(root)
+    return {
+        "expected_source_sha": EXPECTED_REVERIFY_SOURCE_SHA,
+        "repo_head_sha": repo_sha,
+        "repo_head_matches_expected": repo_sha == EXPECTED_REVERIFY_SOURCE_SHA,
+        "container_build_marker_env": "CDB_SOURCE_SHA",
+        "rebuild_required_before_execute": True,
+        "rebuild_services": ["cdb_signal_pb1", "cdb_signal_donchian"],
+        "execute_hold_if_unproven": (
+            "If container CDB_SOURCE_SHA != expected_source_sha before observation, "
+            "Execute must HOLD (FAIL_STALE_IMAGE_GUARD) — do not start supervisors."
+        ),
+        "verify_commands": [
+            "docker compose ... build --no-cache cdb_signal_pb1 cdb_signal_donchian",
+            "docker inspect cdb_signal_pb1 --format '{{range .Config.Env}}{{println .}}{{end}}' | findstr CDB_SOURCE_SHA",
+            "docker inspect cdb_signal_donchian --format '{{range .Config.Env}}{{println .}}{{end}}' | findstr CDB_SOURCE_SHA",
+            "curl -s http://127.0.0.1:8015/metrics | findstr correlation_ledger_insert_conflicts_total",
+            "curl -s http://127.0.0.1:8016/metrics | findstr correlation_ledger_insert_conflicts_total",
+        ],
+        "limitation": (
+            "This preflight slice does not run docker inspect or start containers."
+        ),
+    }
+
+
+def build_reverify_preflight_report(root: Path | None = None) -> dict[str, Any]:
+    base = root or repo_root()
+    pb1_manifest, donchian_manifest = load_reverify_manifests(base)
+    host_env = validate_reverify_manifest_pair(pb1_manifest, donchian_manifest)
+    compose_override = load_reverify_compose_override(base)
+    validate_reverify_compose_alignment(host_env, compose_override)
+
+    host_env_with_sha = {
+        **host_env,
+        "CDB_SOURCE_SHA": EXPECTED_REVERIFY_SOURCE_SHA,
+    }
+
+    return {
+        "status": "READY_PENDING_RUNTIME_GO",
+        "parent_issue": 3973,
+        "manifests": {
+            "pb1": REVERIFY_PB1_MANIFEST,
+            "donchian": REVERIFY_DONCHIAN_MANIFEST,
+        },
+        "compose_override": REVERIFY_SIGNAL_COMPOSE_OVERRIDE,
+        "campaign_ids": {
+            CAMPAIGN_ID_HOST_ENV_PB1: host_env[CAMPAIGN_ID_HOST_ENV_PB1],
+            CAMPAIGN_ID_HOST_ENV_DONCHIAN: host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN],
+        },
+        "bot_ids": {
+            "pb1": pb1_manifest["bot_id"],
+            "donchian": donchian_manifest["bot_id"],
+        },
+        "host_env_exports": {
+            "powershell": format_powershell_exports(host_env_with_sha),
+            "bash": format_bash_exports(host_env_with_sha),
+        },
+        "runtime_freshness": build_runtime_freshness_guard(base),
+        "runtime_not_started": True,
+        "runtime_verified": False,
+        "lr_status": "NO-GO",
+        "proof_gaps_remaining": [
+            "campaign_id_propagated_to_ledger",
+            "lane_campaign_evidence",
+            "#3971 fix runtime-verified",
+        ],
+    }
+
+
+def runtime_go_phrase(tracking_issue: int = 3973) -> str:
+    return (
+        f"RUNTIME-GO #{tracking_issue}: start 2h ARVP telemetry re-verify run after "
+        f"#3971 with rebuilt signal images, "
+        f"expected_source_sha={EXPECTED_REVERIFY_SOURCE_SHA}, "
+        f"PB1 + Donchian, CDB_CAMPAIGN_ID_PB1 and CDB_CAMPAIGN_ID_DONCHIAN set from "
+        f"manifests, CDB_SOURCE_SHA verified in containers before observation, "
+        f"MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true, USE_REAL_BALANCE=false, "
+        f"no Live/Echtgeld."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable preflight report on stdout",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_reverify_preflight_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    print("ARVP diagnostic telemetry re-verify preflight (#3973)")
+    print(f"Status: {report['status']}")
+    print()
+    print("Host env (PowerShell — set before docker compose build/up):")
+    print(report["host_env_exports"]["powershell"])
+    print()
+    print("Host env (bash):")
+    print(report["host_env_exports"]["bash"])
+    print()
+    print("RUNTIME-GO phrase (post on #3973 when ready):")
+    print(runtime_go_phrase())
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(f"preflight failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc


### PR DESCRIPTION
## Summary

Prepare ARVP telemetry **re-verify preflight** after #3971 regression fix. No runtime start.

## Delivered

- Fresh re-verify manifests (distinct campaign/bot IDs from #3967)
- Compose override with mandatory `CDB_SOURCE_SHA` build arg + env
- `tools/arvp_diag_reverify_preflight.py` + contract tests
- Evidence doc with `READY_PENDING_RUNTIME_GO` and exact RUNTIME-GO phrase
- Signal Dockerfile `ARG/ENV CDB_SOURCE_SHA` for container inspect proof

## Validation

- `pytest tests/unit/arvp/test_arvp_diag_reverify_preflight_3973.py` — 7 passed
- `docker compose ... config` — CDB_SOURCE_SHA / bot / campaign IDs verified
- `python -m tools.arvp_diag_reverify_preflight --json` — READY_PENDING_RUNTIME_GO

## Non-goals

- No runtime execution
- #3971 fix not runtime-verified yet
- LR NO-GO unchanged
- No promotion claim

Closes #3973
Refs #3967
Refs #3968
Refs #3970
Refs #3971
