### PR TITLE
docs(arvp): preflight PB1+Donchian parallel NP after telemetry PASS (#3980)

### DIFF
--- a/docs/evidence/arvp_np_parallel_after_telemetry_pass_preflight.md
+++ b/docs/evidence/arvp_np_parallel_after_telemetry_pass_preflight.md
@@ -1,0 +1,137 @@
+# ARVP Parallel Natural-Paper After Telemetry PASS — Preflight (#3980)
+
+Status Class: **PREFLIGHT_READY** — docs/manifests only; **no runtime executed**
+Issue: [#3980](https://github.com/jannekbuengener/Claire_de_Binare/issues/3980)
+Hypothesis: `HYP-NP-PARALLEL-2S-01`
+Parent: [#1900](https://github.com/jannekbuengener/Claire_de_Binare/issues/1900)
+Telemetry chain: [#3977](https://github.com/jannekbuengener/Claire_de_Binare/issues/3977) `PASS_TELEMETRY_REVERIFIED` / PR [#3978](https://github.com/jannekbuengener/Claire_de_Binare/pull/3978) / PR [#3979](https://github.com/jannekbuengener/Claire_de_Binare/pull/3979)
+Prior pilot: [#3912](https://github.com/jannekbuengener/Claire_de_Binare/issues/3912) (CLOSED `TIMEOUT_NO_CHAIN`)
+Live-Readiness: **NO-GO**
+Echtgeld: **not authorized**
+
+**Preflight verdict:** `READY_PENDING_RUNTIME_GO` — strategy validation run prepared;
+execution blocked until Jannek posts RUNTIME-GO on #3980.
+
+**No-run assertion:** This slice did **not** start parallel natural-paper observation.
+
+---
+
+## 1. Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+context_tool_status: available
+context_trust_level: none
+records_found: none
+```
+
+---
+
+## 2. Prerequisites checklist
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| #3977 telemetry re-verify | PASS | `PASS_TELEMETRY_REVERIFIED`; `docs/evidence/arvp_diag_telemetry_reverify_run.md` |
+| #3971 collision-safe signal IDs | PASS | merged @ `251faf59` |
+| #3911 ledger isolation | PASS | PR #3941 @ `0f273b15` |
+| Fresh campaign manifests | PASS | `manifests/campaign_np_telemetry_pass_pb1.yaml`, `..._donchian.yaml` |
+| Compose lane wiring | PASS | `manifests/runtime_np_telemetry_pass_signal_compose_override.yml` |
+| `CDB_SOURCE_SHA` pinned | PASS | `441fb9d6d0731f2111142899a1b8be828a4a046a` (`origin/main` @ #3979) |
+| RUNTIME-GO on #3980 | **PENDING** | Human gate |
+
+---
+
+## 3. Prepared run
+
+| Lane | `strategy_id` | `bot_id` | `campaign_id` |
+|------|---------------|----------|---------------|
+| PB1 | `primary_breakout_v1` | `np-pb1-telemetry-pass-01` | `arvp_np_pb1_after_telemetry_pass_20260710t1700z` |
+| Donchian | `donchian_breakout_v1` | `np-donchian-telemetry-pass-01` | `arvp_np_donchian_after_telemetry_pass_20260710t1700z` |
+
+| Parameter | Value |
+|-----------|-------|
+| Window | **4h first** (not 12h) |
+| Symbol | BTCUSDT |
+| Supervisors | 2× `tools.arvp_campaign_supervisor` (one per manifest) |
+| Execute evidence doc | `docs/evidence/arvp_np_parallel_after_telemetry_pass_run.md` (opened at execute) |
+
+**Not reused:** #3912 pilot IDs, #3967 diagnostic IDs, #3977 re-verify IDs.
+
+---
+
+## 4. Host env mapping
+
+Preflight tool: `python -m tools.arvp_np_telemetry_pass_preflight --json`
+
+```powershell
+$env:CDB_CAMPAIGN_ID_PB1 = "arvp_np_pb1_after_telemetry_pass_20260710t1700z"
+$env:CDB_CAMPAIGN_ID_DONCHIAN = "arvp_np_donchian_after_telemetry_pass_20260710t1700z"
+$env:CDB_SOURCE_SHA = "441fb9d6d0731f2111142899a1b8be828a4a046a"
+```
+
+```bash
+export CDB_CAMPAIGN_ID_PB1="arvp_np_pb1_after_telemetry_pass_20260710t1700z"
+export CDB_CAMPAIGN_ID_DONCHIAN="arvp_np_donchian_after_telemetry_pass_20260710t1700z"
+export CDB_SOURCE_SHA="441fb9d6d0731f2111142899a1b8be828a4a046a"
+```
+
+---
+
+## 5. Telemetry gates (mandatory at execute)
+
+| Gate | Observable via |
+|------|----------------|
+| `lane_campaign_evidence` | `tools.arvp_campaign_supervisor` / probe layer |
+| `correlation_ledger_insert_conflicts_total` | `:8015` / `:8016` metrics |
+| `campaign_id` propagation | lane ledger rows + supervisor evidence |
+| No false-zero | container log signal count == supervisor ledger count |
+
+Execute **must HOLD** if `CDB_SOURCE_SHA` in running containers ≠ expected SHA.
+
+---
+
+## 6. Static validation (2026-07-10)
+
+```text
+pytest -q tests/unit/arvp tests/unit/tools tests/unit/replay -k "np_telemetry_pass or arvp"
+ruff check core services tools tests
+python -m tools.arvp_np_telemetry_pass_preflight --json
+docker compose -f infrastructure/compose/compose.blue.yml
+  -f infrastructure/compose/compose.red.yml
+  -f manifests/runtime_np_telemetry_pass_signal_compose_override.yml
+  -f manifests/runtime_np_parallel_allocation_compose_override.yml config
+```
+
+Note: `infrastructure/compose/docker-compose.yml` is not present in this repo;
+canonical static validation uses `compose.blue.yml` + `compose.red.yml` + overrides.
+
+---
+
+## 7. RUNTIME-GO phrase (Jannek — copy/paste on #3980)
+
+```text
+RUNTIME-GO #3980: start 4h ARVP PB1 + Donchian parallel natural-paper run after telemetry PASS, CDB_CAMPAIGN_ID_PB1 and CDB_CAMPAIGN_ID_DONCHIAN set from manifests, CDB_SOURCE_SHA verified in containers before observation, MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true, USE_REAL_BALANCE=false, no Live/Echtgeld.
+```
+
+Before supervisor start: rewrite `start_utc` and `timeout_utc` in both manifests
+(replace `RUNTIME_GO_SET` placeholders).
+
+---
+
+## 8. Boundaries
+
+- LR **NO-GO** unchanged
+- No Live/Echtgeld authorization from this preflight
+- No strategy parameter tuning
+- No promotion claim
+- Shared risk/execution — conservative per-strategy allocation caps apply
+
+---
+
+*Preflight recorded 2026-07-10 on `docs/arvp-parallel-after-telemetry-pass-preflight`.*

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -94,6 +94,21 @@ Preflight: `docs/evidence/arvp_diag_telemetry_verification_preflight.md`.
 Helper: `python -m tools.arvp_diag_telemetry_preflight`.
 **Pending Jannek RUNTIME-GO on #3965.**
 
+### Parallel natural-paper after telemetry PASS (#3980)
+
+Strategy validation run after #3977 `PASS_TELEMETRY_REVERIFIED`. **4h first window**
+(recommended; not 12h).
+
+| Artifact | Lane |
+|----------|------|
+| `campaign_np_telemetry_pass_pb1.yaml` | `primary_breakout_v1` / `np-pb1-telemetry-pass-01` |
+| `campaign_np_telemetry_pass_donchian.yaml` | `donchian_breakout_v1` / `np-donchian-telemetry-pass-01` |
+| `runtime_np_telemetry_pass_signal_compose_override.yml` | Telemetry-pass bot IDs + P1.5 `CDB_CAMPAIGN_ID` + `CDB_SOURCE_SHA` wiring |
+
+Preflight: `docs/evidence/arvp_np_parallel_after_telemetry_pass_preflight.md`.
+Helper: `python -m tools.arvp_np_telemetry_pass_preflight`.
+**Pending Jannek RUNTIME-GO on #3980.**
+
 ## Single-strategy prior art
 
 | Artifact | Purpose |

--- a/manifests/campaign_np_telemetry_pass_donchian.yaml
+++ b/manifests/campaign_np_telemetry_pass_donchian.yaml
@@ -1,0 +1,78 @@
+schema_version: "1.0"
+campaign_id: arvp_np_donchian_after_telemetry_pass_20260710t1700z
+hypothesis_id: HYP-NP-PARALLEL-2S-01
+parent_issue: 3980
+related_issues:
+  - 1900
+  - 3912
+  - 3977
+  - 3978
+  - 3979
+  - 3742
+symbol: BTCUSDT
+strategy_id: donchian_breakout_v1
+bot_id: np-donchian-telemetry-pass-01
+evidence_class: natural_paper_evidence
+expected_source_sha: "441fb9d6d0731f2111142899a1b8be828a4a046a"
+# Rewrite start_utc / timeout_utc at RUNTIME-GO execute (4h window recommended)
+start_utc: "RUNTIME_GO_SET"
+timeout_utc: "RUNTIME_GO_SET"
+max_duration_hours: 4.0
+start_criteria:
+  pre_documented: true
+  description: "Parallel natural-paper lane B (Donchian) after telemetry PASS per #3980."
+  start_policy_ref: docs/evidence/arvp_np_parallel_after_telemetry_pass_preflight.md
+  criteria_met: false
+  criteria_met_reason: "Preflight READY_PENDING_RUNTIME_GO; awaiting RUNTIME-GO on #3980."
+signal_compose_override: manifests/runtime_np_telemetry_pass_signal_compose_override.yml
+allocation_compose_override: manifests/runtime_np_parallel_allocation_compose_override.yml
+safety_flags:
+  mock_trading: true
+  use_real_balance: false
+  dry_run: true
+  mexc_testnet: true
+runtime_targets:
+  - cdb_ws
+  - cdb_market
+  - cdb_candles
+  - cdb_regime
+  - cdb_allocation
+  - cdb_signal_donchian
+  - cdb_risk
+  - cdb_execution
+  - cdb_db_writer
+  - cdb_paper_runner
+db_readonly_targets:
+  - public.correlation_ledger
+  - public.candles_1m
+evidence_doc: docs/evidence/arvp_np_parallel_after_telemetry_pass_run.md
+evidence_log_jsonl: artifacts/campaigns/arvp_np_donchian_after_telemetry_pass_20260710t1700z/evidence_log.jsonl
+campaign_status_md: artifacts/campaigns/arvp_np_donchian_after_telemetry_pass_20260710t1700z/campaign_status.md
+github_reporting:
+  post_on_issue_3980: true
+  post_on_issue_3742: true
+  post_on_issue_1900: false
+  issue_close_after_acceptance: false
+allowed_statuses:
+  - planned
+  - preflight_failed
+  - running
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_pr_open
+  - evidence_merged
+terminal_statuses:
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_merged
+  - preflight_failed
+campaign_status: planned
+gear_id: gear-donchian-breakout-v1-np-telemetry-pass-btcusdt

--- a/manifests/campaign_np_telemetry_pass_pb1.yaml
+++ b/manifests/campaign_np_telemetry_pass_pb1.yaml
@@ -1,0 +1,78 @@
+schema_version: "1.0"
+campaign_id: arvp_np_pb1_after_telemetry_pass_20260710t1700z
+hypothesis_id: HYP-NP-PARALLEL-2S-01
+parent_issue: 3980
+related_issues:
+  - 1900
+  - 3912
+  - 3977
+  - 3978
+  - 3979
+  - 3742
+symbol: BTCUSDT
+strategy_id: primary_breakout_v1
+bot_id: np-pb1-telemetry-pass-01
+evidence_class: natural_paper_evidence
+expected_source_sha: "441fb9d6d0731f2111142899a1b8be828a4a046a"
+# Rewrite start_utc / timeout_utc at RUNTIME-GO execute (4h window recommended)
+start_utc: "RUNTIME_GO_SET"
+timeout_utc: "RUNTIME_GO_SET"
+max_duration_hours: 4.0
+start_criteria:
+  pre_documented: true
+  description: "Parallel natural-paper lane A (PB1) after telemetry PASS per #3980."
+  start_policy_ref: docs/evidence/arvp_np_parallel_after_telemetry_pass_preflight.md
+  criteria_met: false
+  criteria_met_reason: "Preflight READY_PENDING_RUNTIME_GO; awaiting RUNTIME-GO on #3980."
+signal_compose_override: manifests/runtime_np_telemetry_pass_signal_compose_override.yml
+allocation_compose_override: manifests/runtime_np_parallel_allocation_compose_override.yml
+safety_flags:
+  mock_trading: true
+  use_real_balance: false
+  dry_run: true
+  mexc_testnet: true
+runtime_targets:
+  - cdb_ws
+  - cdb_market
+  - cdb_candles
+  - cdb_regime
+  - cdb_allocation
+  - cdb_signal_pb1
+  - cdb_risk
+  - cdb_execution
+  - cdb_db_writer
+  - cdb_paper_runner
+db_readonly_targets:
+  - public.correlation_ledger
+  - public.candles_1m
+evidence_doc: docs/evidence/arvp_np_parallel_after_telemetry_pass_run.md
+evidence_log_jsonl: artifacts/campaigns/arvp_np_pb1_after_telemetry_pass_20260710t1700z/evidence_log.jsonl
+campaign_status_md: artifacts/campaigns/arvp_np_pb1_after_telemetry_pass_20260710t1700z/campaign_status.md
+github_reporting:
+  post_on_issue_3980: true
+  post_on_issue_3742: true
+  post_on_issue_1900: false
+  issue_close_after_acceptance: false
+allowed_statuses:
+  - planned
+  - preflight_failed
+  - running
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_pr_open
+  - evidence_merged
+terminal_statuses:
+  - chain_found
+  - timeout_no_chain
+  - interrupted
+  - blocked_runtime
+  - blocked_db_readonly
+  - blocked_governance
+  - evidence_merged
+  - preflight_failed
+campaign_status: planned
+gear_id: gear-primary-breakout-v1-np-telemetry-pass-btcusdt

--- a/manifests/runtime_np_telemetry_pass_signal_compose_override.yml
+++ b/manifests/runtime_np_telemetry_pass_signal_compose_override.yml
@@ -1,0 +1,129 @@
+# Parallel natural-paper compose override after telemetry PASS (#3980).
+# Post-#3977 strategy validation run (PB1 + Donchian, 4h first window).
+# Distinct telemetry-pass bot IDs — do not reuse #3912 / #3967 / #3977 IDs.
+# Requires signal images with CDB_SOURCE_SHA before RUNTIME-GO.
+# Apply only after RUNTIME-GO on #3980; not canonical default.
+# Combine with manifests/runtime_np_parallel_allocation_compose_override.yml.
+# LR NO-GO — no Live/Echtgeld authorization from this manifest.
+#
+# Static validation (no runtime start):
+#   $env:CDB_CAMPAIGN_ID_PB1 = "<pb1 manifest campaign_id>"
+#   $env:CDB_CAMPAIGN_ID_DONCHIAN = "<donchian manifest campaign_id>"
+#   $env:CDB_SOURCE_SHA = "441fb9d6d0731f2111142899a1b8be828a4a046a"
+#   docker compose -f infrastructure/compose/compose.blue.yml `
+#     -f infrastructure/compose/compose.red.yml `
+#     -f manifests/runtime_np_telemetry_pass_signal_compose_override.yml `
+#     -f manifests/runtime_np_parallel_allocation_compose_override.yml config
+#
+# Execute rebuild (recommended before observation):
+#   docker compose -f infrastructure/compose/compose.red.yml `
+#     -f manifests/runtime_np_telemetry_pass_signal_compose_override.yml `
+#     build --no-cache cdb_signal_pb1 cdb_signal_donchian
+
+services:
+  cdb_signal:
+    profiles:
+      - single-signal-default
+
+  cdb_signal_pb1:
+    build:
+      context: ../..
+      dockerfile: services/signal/Dockerfile
+      args:
+        CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-441fb9d6d0731f2111142899a1b8be828a4a046a}
+    container_name: cdb_signal_pb1
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: primary_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-pb1-telemetry-pass-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_PB1:-}
+      CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-441fb9d6d0731f2111142899a1b8be828a4a046a}
+      SIGNAL_ENTRY_LOOKBACK_MIN: "240"
+      SIGNAL_EXIT_LOOKBACK_MIN: "120"
+      SIGNAL_BREAKOUT_BUFFER: "0.0005"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "60"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8015"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8015:8015"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8015/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network
+
+  cdb_signal_donchian:
+    build:
+      context: ../..
+      dockerfile: services/signal/Dockerfile
+      args:
+        CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-441fb9d6d0731f2111142899a1b8be828a4a046a}
+    container_name: cdb_signal_donchian
+    restart: unless-stopped
+    secrets:
+      - redis_password
+      - postgres_password
+    environment:
+      ENV: "development"
+      LOG_LEVEL: "DEBUG"
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      SIGNAL_STRATEGY_ID: donchian_breakout_v1
+      SIGNAL_SYMBOL: BTCUSDT
+      SIGNAL_ADAPTER_ID: momentum_builtin
+      SIGNAL_BOT_ID: np-donchian-telemetry-pass-01
+      CDB_CAMPAIGN_ID: ${CDB_CAMPAIGN_ID_DONCHIAN:-}
+      CDB_SOURCE_SHA: ${CDB_SOURCE_SHA:-441fb9d6d0731f2111142899a1b8be828a4a046a}
+      SIGNAL_ENTRY_CHANNEL_BARS: "20"
+      SIGNAL_EXIT_CHANNEL_BARS: "10"
+      SIGNAL_MIN_MINUTES_BETWEEN_ENTRIES: "30"
+      SIGNAL_TRADE_SIDE_MODE: long_only
+      SIGNAL_PORT: "8016"
+      SIGNAL_THRESHOLD_PCT: "0.005"
+      SIGNAL_MIN_VOLUME: "0"
+    entrypoint:
+      [
+        "sh",
+        "-c",
+        "export REDIS_PASSWORD=$(cat /run/secrets/redis_password) && export POSTGRES_PASSWORD=$(cat /run/secrets/postgres_password) && exec python -m services.signal.service",
+      ]
+    ports:
+      - "127.0.0.1:8016:8016"
+    volumes:
+      - ../logs:/app/logs
+    depends_on:
+      cdb_ws:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8016/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - cdb_network

--- a/tests/unit/arvp/test_arvp_np_telemetry_pass_preflight_3980.py
+++ b/tests/unit/arvp/test_arvp_np_telemetry_pass_preflight_3980.py
@@ -1,0 +1,98 @@
+"""Parallel natural-paper preflight after telemetry PASS contract tests (#3980)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.arvp_np_telemetry_pass_preflight import (
+    EXPECTED_SOURCE_SHA,
+    NP_DONCHIAN_MANIFEST,
+    NP_PB1_MANIFEST,
+    NP_SIGNAL_COMPOSE_OVERRIDE,
+    build_np_preflight_report,
+    load_np_compose_override,
+    load_np_manifests,
+    runtime_go_phrase,
+    validate_np_compose_alignment,
+    validate_np_manifest_pair,
+)
+from tools.arvp_parallel_lane_compose_contract import (
+    CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+    CAMPAIGN_ID_HOST_ENV_PB1,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PB1_CAMPAIGN_ID = "arvp_np_pb1_after_telemetry_pass_20260710t1700z"
+DONCHIAN_CAMPAIGN_ID = "arvp_np_donchian_after_telemetry_pass_20260710t1700z"
+
+
+def test_np_manifest_campaign_ids_are_distinct_and_fresh() -> None:
+    pb1_manifest, donchian_manifest = load_np_manifests(REPO_ROOT)
+
+    assert pb1_manifest["campaign_id"] == PB1_CAMPAIGN_ID
+    assert donchian_manifest["campaign_id"] == DONCHIAN_CAMPAIGN_ID
+    assert PB1_CAMPAIGN_ID != DONCHIAN_CAMPAIGN_ID
+    assert "3912" not in PB1_CAMPAIGN_ID
+    assert "p15" not in PB1_CAMPAIGN_ID
+    assert "p0r" not in PB1_CAMPAIGN_ID
+
+
+def test_np_bot_ids_are_distinct_from_prior_runs() -> None:
+    pb1_manifest, donchian_manifest = load_np_manifests(REPO_ROOT)
+
+    assert pb1_manifest["bot_id"] == "np-pb1-telemetry-pass-01"
+    assert donchian_manifest["bot_id"] == "np-donchian-telemetry-pass-01"
+    assert pb1_manifest["bot_id"] != "np-pb1-parallel-01"
+    assert donchian_manifest["bot_id"] != "np-donchian-parallel-01"
+    assert pb1_manifest["bot_id"] != "np-pb1-reverify-01"
+
+
+def test_np_manifests_pin_expected_source_sha() -> None:
+    pb1_manifest, donchian_manifest = load_np_manifests(REPO_ROOT)
+
+    assert pb1_manifest["expected_source_sha"] == EXPECTED_SOURCE_SHA
+    assert donchian_manifest["expected_source_sha"] == EXPECTED_SOURCE_SHA
+
+
+def test_np_host_env_maps_manifest_campaign_ids_and_sha() -> None:
+    pb1_manifest, donchian_manifest = load_np_manifests(REPO_ROOT)
+    host_env = validate_np_manifest_pair(pb1_manifest, donchian_manifest)
+
+    assert host_env[CAMPAIGN_ID_HOST_ENV_PB1] == PB1_CAMPAIGN_ID
+    assert host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN] == DONCHIAN_CAMPAIGN_ID
+
+
+def test_np_compose_override_aligns_with_host_env() -> None:
+    pb1_manifest, donchian_manifest = load_np_manifests(REPO_ROOT)
+    host_env = validate_np_manifest_pair(pb1_manifest, donchian_manifest)
+    compose_override = load_np_compose_override(REPO_ROOT)
+    validate_np_compose_alignment(host_env, compose_override)
+
+
+def test_np_preflight_report_is_ready_pending_runtime_go() -> None:
+    report = build_np_preflight_report(REPO_ROOT)
+
+    assert report["status"] == "READY_PENDING_RUNTIME_GO"
+    assert report["runtime_not_started"] is True
+    assert report["runtime_verified"] is False
+    assert report["lr_status"] == "NO-GO"
+    assert report["recommended_window_hours"] == 4.0
+    assert report["manifests"]["pb1"] == NP_PB1_MANIFEST
+    assert report["manifests"]["donchian"] == NP_DONCHIAN_MANIFEST
+    assert report["compose_override"] == NP_SIGNAL_COMPOSE_OVERRIDE
+    assert report["runtime_freshness"]["expected_source_sha"] == EXPECTED_SOURCE_SHA
+    assert "CDB_SOURCE_SHA" in report["host_env_exports"]["powershell"]
+
+
+def test_runtime_go_phrase_contains_required_tokens() -> None:
+    phrase = runtime_go_phrase()
+    assert "RUNTIME-GO #3980" in phrase
+    assert "4h ARVP PB1 + Donchian parallel natural-paper run after telemetry PASS" in phrase
+    assert "CDB_CAMPAIGN_ID_PB1 and CDB_CAMPAIGN_ID_DONCHIAN set from manifests" in phrase
+    assert "CDB_SOURCE_SHA verified in containers before observation" in phrase
+    assert "no Live/Echtgeld" in phrase

--- a/tools/arvp_np_telemetry_pass_preflight.py
+++ b/tools/arvp_np_telemetry_pass_preflight.py
@@ -1,0 +1,286 @@
+"""ARVP parallel natural-paper preflight after telemetry PASS (#3980).
+
+Prepares host-env exports, compose alignment, and telemetry gate checklist
+after #3977 PASS_TELEMETRY_REVERIFIED — without starting runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from core.replay.correlation_ledger_attribution import CDB_CAMPAIGN_ID_ENV
+from tools.arvp_diag_telemetry_preflight import (
+    format_bash_exports,
+    format_powershell_exports,
+    resolve_repo_source_sha,
+)
+from tools.arvp_parallel_lane_compose_contract import (
+    CAMPAIGN_ID_HOST_ENV_DONCHIAN,
+    CAMPAIGN_ID_HOST_ENV_PB1,
+    build_parallel_compose_host_env,
+    load_campaign_manifest,
+    manifest_campaign_id,
+)
+
+NP_PB1_MANIFEST = "manifests/campaign_np_telemetry_pass_pb1.yaml"
+NP_DONCHIAN_MANIFEST = "manifests/campaign_np_telemetry_pass_donchian.yaml"
+NP_SIGNAL_COMPOSE_OVERRIDE = (
+    "manifests/runtime_np_telemetry_pass_signal_compose_override.yml"
+)
+
+EXPECTED_SOURCE_SHA = "441fb9d6d0731f2111142899a1b8be828a4a046a"
+
+EXPECTED_BOT_IDS = {
+    "cdb_signal_pb1": "np-pb1-telemetry-pass-01",
+    "cdb_signal_donchian": "np-donchian-telemetry-pass-01",
+}
+
+EXPECTED_STRATEGY_IDS = {
+    "cdb_signal_pb1": "primary_breakout_v1",
+    "cdb_signal_donchian": "donchian_breakout_v1",
+}
+
+FORBIDDEN_PRIOR_BOT_IDS = {
+    "np-pb1-parallel-01",
+    "np-donchian-parallel-01",
+    "np-pb1-diag-01",
+    "np-donchian-diag-01",
+    "np-pb1-reverify-01",
+    "np-donchian-reverify-01",
+}
+
+FORBIDDEN_PRIOR_CAMPAIGN_IDS = {
+    "arvp_3912_np_parallel_pb1_20260709_1327",
+    "arvp_3912_np_parallel_donchian_20260709_1327",
+    "arvp_diag_p15_pb1_20260710t1100z",
+    "arvp_diag_p15_donchian_20260710t1100z",
+    "arvp_diag_p0r_pb1_20260710t1600z",
+    "arvp_diag_p0r_donchian_20260710t1600z",
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_np_manifests(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    pb1 = load_campaign_manifest(root / NP_PB1_MANIFEST)
+    donchian = load_campaign_manifest(root / NP_DONCHIAN_MANIFEST)
+    return pb1, donchian
+
+
+def load_np_compose_override(root: Path) -> dict[str, Any]:
+    path = root / NP_SIGNAL_COMPOSE_OVERRIDE
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("telemetry-pass signal compose override must be a YAML object")
+    return raw
+
+
+def validate_np_manifest_pair(
+    pb1_manifest: dict[str, Any],
+    donchian_manifest: dict[str, Any],
+) -> dict[str, str]:
+    pb1_id = manifest_campaign_id(pb1_manifest)
+    donchian_id = manifest_campaign_id(donchian_manifest)
+    if pb1_id == donchian_id:
+        raise ValueError("parallel lane campaign_id values must be distinct")
+    for manifest in (pb1_manifest, donchian_manifest):
+        bot_id = manifest.get("bot_id")
+        if bot_id in FORBIDDEN_PRIOR_BOT_IDS:
+            raise ValueError(
+                f"manifest must not reuse prior diagnostic/pilot bot_id: {bot_id}"
+            )
+        campaign_id = manifest.get("campaign_id")
+        if campaign_id in FORBIDDEN_PRIOR_CAMPAIGN_IDS:
+            raise ValueError(
+                f"manifest must not reuse prior campaign_id: {campaign_id}"
+            )
+        expected_sha = manifest.get("expected_source_sha")
+        if expected_sha != EXPECTED_SOURCE_SHA:
+            raise ValueError(
+                f"expected_source_sha mismatch: {expected_sha!r} != "
+                f"{EXPECTED_SOURCE_SHA!r}"
+            )
+    return build_parallel_compose_host_env(pb1_manifest, donchian_manifest)
+
+
+def validate_np_compose_alignment(
+    host_env: dict[str, str],
+    compose_override: dict[str, Any],
+) -> None:
+    services = compose_override.get("services")
+    if not isinstance(services, dict):
+        raise ValueError("compose override services must be a mapping")
+
+    for service_name, expected_bot_id in EXPECTED_BOT_IDS.items():
+        service = services.get(service_name)
+        if not isinstance(service, dict):
+            raise ValueError(f"missing compose service: {service_name}")
+        environment = service.get("environment")
+        if not isinstance(environment, dict):
+            raise ValueError(f"{service_name} environment must be a mapping")
+
+        expected_strategy = EXPECTED_STRATEGY_IDS[service_name]
+        if environment.get("SIGNAL_STRATEGY_ID") != expected_strategy:
+            raise ValueError(
+                f"{service_name} SIGNAL_STRATEGY_ID mismatch: "
+                f"{environment.get('SIGNAL_STRATEGY_ID')!r} != {expected_strategy!r}"
+            )
+        if environment.get("SIGNAL_BOT_ID") != expected_bot_id:
+            raise ValueError(
+                f"{service_name} SIGNAL_BOT_ID mismatch: "
+                f"{environment.get('SIGNAL_BOT_ID')!r} != {expected_bot_id!r}"
+            )
+
+        host_key = (
+            CAMPAIGN_ID_HOST_ENV_PB1
+            if service_name == "cdb_signal_pb1"
+            else CAMPAIGN_ID_HOST_ENV_DONCHIAN
+        )
+        expected_campaign = host_env[host_key]
+        substitution = f"${{{host_key}:-}}"
+        if environment.get(CDB_CAMPAIGN_ID_ENV) != substitution:
+            raise ValueError(
+                f"{service_name} {CDB_CAMPAIGN_ID_ENV} must use {substitution!r}"
+            )
+        if not expected_campaign:
+            raise ValueError(f"host env {host_key} must be non-empty")
+
+        cdb_source_sha = environment.get("CDB_SOURCE_SHA")
+        if not isinstance(cdb_source_sha, str) or "CDB_SOURCE_SHA" not in cdb_source_sha:
+            raise ValueError(f"{service_name} must declare CDB_SOURCE_SHA substitution")
+
+        build = service.get("build")
+        if not isinstance(build, dict):
+            raise ValueError(f"{service_name} must declare build args for freshness")
+        build_args = build.get("args")
+        if not isinstance(build_args, dict) or "CDB_SOURCE_SHA" not in build_args:
+            raise ValueError(f"{service_name} build.args must include CDB_SOURCE_SHA")
+
+
+def build_runtime_freshness_guard(root: Path) -> dict[str, Any]:
+    repo_sha = resolve_repo_source_sha(root)
+    return {
+        "expected_source_sha": EXPECTED_SOURCE_SHA,
+        "repo_head_sha": repo_sha,
+        "repo_head_matches_expected": repo_sha == EXPECTED_SOURCE_SHA,
+        "container_build_marker_env": "CDB_SOURCE_SHA",
+        "rebuild_recommended_before_execute": True,
+        "rebuild_services": ["cdb_signal_pb1", "cdb_signal_donchian"],
+        "execute_hold_if_unproven": (
+            "If container CDB_SOURCE_SHA != expected_source_sha before observation, "
+            "Execute must HOLD (FAIL_STALE_IMAGE_GUARD) — do not start supervisors."
+        ),
+        "telemetry_gates": [
+            "lane_campaign_evidence observable via supervisor/probe",
+            "correlation_ledger_insert_conflicts_total observable on :8015/:8016",
+            "campaign_id propagated to lane ledger rows",
+            "no false-zero supervisor count mismatch",
+        ],
+        "limitation": (
+            "This preflight slice does not run docker inspect or start containers."
+        ),
+    }
+
+
+def build_np_preflight_report(root: Path | None = None) -> dict[str, Any]:
+    base = root or repo_root()
+    pb1_manifest, donchian_manifest = load_np_manifests(base)
+    host_env = validate_np_manifest_pair(pb1_manifest, donchian_manifest)
+    compose_override = load_np_compose_override(base)
+    validate_np_compose_alignment(host_env, compose_override)
+
+    host_env_with_sha = {
+        **host_env,
+        "CDB_SOURCE_SHA": EXPECTED_SOURCE_SHA,
+    }
+
+    return {
+        "status": "READY_PENDING_RUNTIME_GO",
+        "parent_issue": 3980,
+        "recommended_window_hours": 4.0,
+        "manifests": {
+            "pb1": NP_PB1_MANIFEST,
+            "donchian": NP_DONCHIAN_MANIFEST,
+        },
+        "compose_override": NP_SIGNAL_COMPOSE_OVERRIDE,
+        "allocation_compose_override": (
+            "manifests/runtime_np_parallel_allocation_compose_override.yml"
+        ),
+        "campaign_ids": {
+            CAMPAIGN_ID_HOST_ENV_PB1: host_env[CAMPAIGN_ID_HOST_ENV_PB1],
+            CAMPAIGN_ID_HOST_ENV_DONCHIAN: host_env[CAMPAIGN_ID_HOST_ENV_DONCHIAN],
+        },
+        "bot_ids": {
+            "pb1": pb1_manifest["bot_id"],
+            "donchian": donchian_manifest["bot_id"],
+        },
+        "host_env_exports": {
+            "powershell": format_powershell_exports(host_env_with_sha),
+            "bash": format_bash_exports(host_env_with_sha),
+        },
+        "runtime_freshness": build_runtime_freshness_guard(base),
+        "runtime_not_started": True,
+        "runtime_verified": False,
+        "lr_status": "NO-GO",
+        "strategy_validation_focus": True,
+        "proof_gaps_remaining": [
+            "per-lane chain evidence (orders/fills) unproven until execute",
+            "PB1 regime-idle vs true chain distinction at strategy window",
+            "Donchian RC_001 block rate under shared risk pool",
+        ],
+    }
+
+
+def runtime_go_phrase(tracking_issue: int = 3980) -> str:
+    return (
+        f"RUNTIME-GO #{tracking_issue}: start 4h ARVP PB1 + Donchian parallel "
+        f"natural-paper run after telemetry PASS, "
+        f"CDB_CAMPAIGN_ID_PB1 and CDB_CAMPAIGN_ID_DONCHIAN set from manifests, "
+        f"CDB_SOURCE_SHA verified in containers before observation, "
+        f"MOCK_TRADING=true, DRY_RUN=true, MEXC_TESTNET=true, USE_REAL_BALANCE=false, "
+        f"no Live/Echtgeld."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable preflight report on stdout",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_np_preflight_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    print("ARVP parallel natural-paper preflight after telemetry PASS (#3980)")
+    print(f"Status: {report['status']}")
+    print()
+    print("Host env (PowerShell — set before docker compose build/up):")
+    print(report["host_env_exports"]["powershell"])
+    print()
+    print("Host env (bash):")
+    print(report["host_env_exports"]["bash"])
+    print()
+    print("RUNTIME-GO phrase (post on #3980 when ready):")
+    print(runtime_go_phrase())
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(f"preflight failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc


### PR DESCRIPTION
## Summary

Prepare the next ARVP PB1 + Donchian parallel natural-paper **strategy validation** run after #3977 `PASS_TELEMETRY_REVERIFIED`.

- Fresh campaign manifests with distinct bot/campaign IDs (not reused from #3912 / #3967 / #3977)
- Compose override with lane `CDB_CAMPAIGN_ID` wiring and pinned `CDB_SOURCE_SHA`
- Preflight tool + contract tests + evidence doc
- **Stops at `READY_PENDING_RUNTIME_GO`** — no runtime started

Closes #3980

Refs #3977
Refs #3978
Refs #3979
Refs #3912

## Delivered

- `manifests/campaign_np_telemetry_pass_pb1.yaml` / `campaign_np_telemetry_pass_donchian.yaml`
- `manifests/runtime_np_telemetry_pass_signal_compose_override.yml`
- `tools/arvp_np_telemetry_pass_preflight.py`
- `docs/evidence/arvp_np_parallel_after_telemetry_pass_preflight.md`

## Validation

- `pytest -q tests/unit/arvp/test_arvp_np_telemetry_pass_preflight_3980.py` — 7 passed
- `python -m tools.arvp_np_telemetry_pass_preflight --json` — READY_PENDING_RUNTIME_GO
- `docker compose ... config` — lane env distinct and correct
- `ruff check` on new Python files — pass

## Non-goals

- No runtime start / docker compose up
- No strategy parameter tuning
- No promotion claim

## Remaining uncertainty

- Per-lane chain evidence (orders/fills) unproven until RUNTIME-GO execute
- PB1 regime-idle vs true chain at 4h window
- Donchian RC_001 block rate under shared risk pool

## Test plan

- [x] Contract tests for manifest ↔ compose alignment
- [x] Preflight JSON report READY_PENDING_RUNTIME_GO
- [x] Compose config resolves distinct campaign IDs per lane
