### PR TITLE
docs(security): compress residual alert children

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_ALERT_COMPRESSION_3945-3954_2026-07-10.md
+++ b/docs/evidence/security/CDB_SECURITY_ALERT_COMPRESSION_3945-3954_2026-07-10.md
@@ -1,0 +1,89 @@
+# Security Alert Compression — Issues #3945–#3954
+
+**Stand:** 2026-07-10 (UTC+2)  
+**Mode:** Docs-only board compression — **not remediation**  
+**Parent meta:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513)  
+**Prior analysis:** [`CDB_SECURITY_RETRIAGE_2026-07-10.md`](CDB_SECURITY_RETRIAGE_2026-07-10.md)  
+**Runtime gate:** [#3982](https://github.com/jannekbuengener/Claire_de_Binare/issues/3982) OPEN during slice (docs-only; no runtime/image action)  
+**LR:** NO-GO (unchanged)
+
+---
+
+## Executive summary
+
+| Action | Result |
+|--------|--------|
+| Compress #3945–#3952 | Parent [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932) (perl-base / shared Trixie OS cluster) |
+| Compress #3953–#3954 | Parent [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803) (libacl1 CVE-2026-54369) |
+| Update #2513 index | Comment + this doc (includes [#3936](https://github.com/jannekbuengener/Claire_de_Binare/issues/3936) libcurl cluster) |
+| Code Scanning alerts | **Remain OPEN** — no dismissals |
+| Parent clusters | **Remain OPEN** — upstream-blocked |
+
+**Verdict:** `TRACKING_COMPRESSED` — GitHub issue dedupe only.
+
+---
+
+## Explicit boundaries
+
+- **Not remediated:** No Dockerfile, digest, dependency, or runtime change.
+- **Not fixed:** Code Scanning / Trivy alerts stay open until scan-verified upstream fix.
+- **Not dismissed:** No SARIF hiding, no alert dismissal, no Human-GO batch.
+- **PR #3755:** Remains **HOLD** (no security gain for Grafana CVE-2026-42504).
+
+---
+
+## Cluster A — CVE-2026-53615 → #2932
+
+**Parent:** [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932) — perl-base upstream-blocked CVEs across CDB service images  
+**Readout:** `2026-07-10T07:26:37Z`  
+**Package confidence:** **Likely** shared Debian Trixie OS layer under [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932) lineage (8/8 `library/cdb_*` services, same pattern as prior perl-base readouts). **No Trivy package probe in this slice** — do not treat `perl-base` as scan-proven for CVE-2026-53615.
+
+| Issue | Service | Fingerprint | Verdict |
+|-------|---------|-------------|---------|
+| [#3945](https://github.com/jannekbuengener/Claire_de_Binare/issues/3945) | `library/cdb_allocation` | `f53ad0318d81b41c` | Child → #2932 |
+| [#3946](https://github.com/jannekbuengener/Claire_de_Binare/issues/3946) | `library/cdb_db_writer` | `ef1b06eacef158d5` | Child → #2932 |
+| [#3947](https://github.com/jannekbuengener/Claire_de_Binare/issues/3947) | `library/cdb_execution` | `f53be0bb4e6d6fb6` | Child → #2932 |
+| [#3948](https://github.com/jannekbuengener/Claire_de_Binare/issues/3948) | `library/cdb_market` | `c779065ef9b964cf` | Child → #2932 |
+| [#3949](https://github.com/jannekbuengener/Claire_de_Binare/issues/3949) | `library/cdb_regime` | `47fe72960a14dc84` | Child → #2932 |
+| [#3950](https://github.com/jannekbuengener/Claire_de_Binare/issues/3950) | `library/cdb_risk` | `a9d1aa8a42124c96` | Child → #2932 |
+| [#3951](https://github.com/jannekbuengener/Claire_de_Binare/issues/3951) | `library/cdb_signal` | `b92d2761e79b057c` | Child → #2932 |
+| [#3952](https://github.com/jannekbuengener/Claire_de_Binare/issues/3952) | `library/cdb_ws` | `6a50fbdfdd8ba187` | Child → #2932 |
+
+**Operational tracking:** UPSTREAM_BLOCKED (inherits #2932). Re-triage when Trivy `FixedVersion` non-empty on representative `python:3.14-slim-trixie` service image.
+
+---
+
+## Cluster B — CVE-2026-54369 → #3803
+
+**Parent:** [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803) — Debian Trixie `libacl1` CVE-2026-54369  
+**Package confidence:** **High** — `libacl1@2.3.2-2+b1`, FixedVersion empty (evidence: [`CDB_SECURITY_OS_LAYER_3756-3765_CVE-41992_CVE-54369_VERIFY_2026-07-06.md`](CDB_SECURITY_OS_LAYER_3756-3765_CVE-41992_CVE-54369_VERIFY_2026-07-06.md))
+
+| Issue | Service | Fingerprint | Verdict |
+|-------|---------|-------------|---------|
+| [#3953](https://github.com/jannekbuengener/Claire_de_Binare/issues/3953) | `library/cdb_regime` | `693fcc81ad04225c` | Child → #3803 |
+| [#3954](https://github.com/jannekbuengener/Claire_de_Binare/issues/3954) | `library/cdb_risk` | `05c11356f8f3164c` | Child → #3803 |
+
+Prior compression in #3803: #3765, #3933–#3935. These two issues are additional readout deltas on the same OS layer.
+
+---
+
+## #2513 meta index (2026-07-10)
+
+Operational cluster units under parent [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513):
+
+| Cluster | Issue | CVE / package | Scope |
+|---------|-------|---------------|-------|
+| perl-base (+ readout deltas) | [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932) | multiple + **CVE-2026-53615** (#3945–#3952) | 8× `python:3.14-slim-trixie` |
+| Monitoring images | [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933) | Grafana/Prometheus/gosu/libxml2 | base images |
+| libsqlite3 | [#3705](https://github.com/jannekbuengener/Claire_de_Binare/issues/3705) | CVE-2026-11824 | 8× Trixie |
+| gzip | [#3802](https://github.com/jannekbuengener/Claire_de_Binare/issues/3802) | CVE-2026-41992 | 8× Trixie |
+| libacl1 | [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803) | CVE-2026-54369 (#3953–#3954 new) | all Trixie services |
+| libcurl4t64 | [#3936](https://github.com/jannekbuengener/Claire_de_Binare/issues/3936) | CVE-2026-12064 | 7× Trixie cdb (not postgres alpine) |
+
+**Open GitHub security tracking after this compression:** #2513 + **6 cluster parents** (no per-fingerprint child issues for #3945–#3954).
+
+---
+
+## Child closure rationale
+
+Issues #3945–#3954 closed as **duplicate/child tracking compressed into parent cluster** — same convention as prior compressions (#3756–#3763 → #3802, #3926–#3932 → #3936). Closure does **not** imply fix, dismiss, or LR change.

--- a/docs/evidence/security/CDB_SECURITY_META_2513_INDEX_2026-07-10.md
+++ b/docs/evidence/security/CDB_SECURITY_META_2513_INDEX_2026-07-10.md
@@ -1,0 +1,30 @@
+# #2513 Residual Cluster Index — 2026-07-10 Update
+
+**Parent:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513)  
+**Purpose:** Canonical cluster index for upstream-blocked Trivy residuals (issue-body supplement via comment + repo SSOT)  
+**LR:** NO-GO
+
+---
+
+## Active clusters (6)
+
+| # | Issue | Primary CVE(s) | Base / scope | Latest compression |
+|---|-------|----------------|--------------|-------------------|
+| 1 | [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932) | perl-base family + **CVE-2026-53615** | `python:3.14-slim-trixie` × 8 | #3945–#3952 → closed 2026-07-10 |
+| 2 | [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933) | Grafana/Prometheus/gosu/plugins | upstream images | #3764, #3694–#3695 prior |
+| 3 | [#3705](https://github.com/jannekbuengener/Claire_de_Binare/issues/3705) | CVE-2026-11824 / libsqlite3 | 8× Trixie | #3619–#3625 prior |
+| 4 | [#3802](https://github.com/jannekbuengener/Claire_de_Binare/issues/3802) | CVE-2026-41992 / gzip | 8× Trixie | #3756–#3763 prior |
+| 5 | [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803) | CVE-2026-54369 / libacl1 | all Trixie | #3953–#3954 → closed 2026-07-10 |
+| 6 | [#3936](https://github.com/jannekbuengener/Claire_de_Binare/issues/3936) | CVE-2026-12064 / libcurl4t64 | 7× Trixie cdb | #3926–#3932 prior |
+
+**Note:** Postgres alpine libcurl (same CVE id, different image) cleared by digest refresh PR #3921; Trixie cdb libcurl remains under #3936.
+
+---
+
+## Governance (unchanged)
+
+- All clusters: **UPSTREAM_BLOCKED** on current pins.
+- Code Scanning alerts: **OPEN** until scan-verified fix.
+- PR [#3755](https://github.com/jannekbuengener/Claire_de_Binare/pull/3755): **HOLD** — not a security remediation.
+
+Evidence: [`CDB_SECURITY_ALERT_COMPRESSION_3945-3954_2026-07-10.md`](CDB_SECURITY_ALERT_COMPRESSION_3945-3954_2026-07-10.md)

--- a/docs/evidence/security/CDB_SECURITY_RETRIAGE_2026-07-10.md
+++ b/docs/evidence/security/CDB_SECURITY_RETRIAGE_2026-07-10.md
@@ -1,0 +1,117 @@
+# Security Re-Triage — Open Residual Clusters & Alert Children
+
+**Stand:** 2026-07-10 (UTC+2)  
+**Mode:** Analysis (superseded for compression by [`CDB_SECURITY_ALERT_COMPRESSION_3945-3954_2026-07-10.md`](CDB_SECURITY_ALERT_COMPRESSION_3945-3954_2026-07-10.md))  
+**Parent meta:** [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513)  
+**Runtime gate:** [#3982](https://github.com/jannekbuengener/Claire_de_Binare/issues/3982) OPEN — 4h ARVP run active since `2026-07-10T17:20:00Z`  
+**LR:** NO-GO (unchanged)  
+**Main @ analysis:** `63d73734422652acd2c494c0823fa9a8281888e2`
+
+---
+
+## Executive verdict
+
+| Category | Count | Action |
+|----------|-------|--------|
+| Meta tracker | 1 (#2513) | Watch / index maintenance |
+| Residual cluster parents | 6 (#2932, #2933, #3705, #3802, #3803, #3936) | UPSTREAM_BLOCKED — watch Debian/upstream rebuilds |
+| Alert children #3945–#3954 | 10 | **Compressed** 2026-07-10 → #2932 / #3803 (see compression doc) |
+| Dependabot security PR | 1 (#3755) | HOLD — not a security fix |
+| CodeQL Python | 0 open | No action |
+| Actionable CDB fixes now | **0** | All open Trivy clusters upstream-blocked on current pins |
+
+**Status:** `ANALYSIS_READY_FOR_DECISION` → compression executed in follow-up slice (docs-only)
+
+---
+
+## Live snapshot (GitHub)
+
+- Open security issues (scoped): **17** (`type:security` + alert readout children)
+- Open security PRs: **1** (#3755 Grafana)
+- #3982: OPEN, RUNTIME-GO received, observation window until `2026-07-10T21:20:00Z`
+
+---
+
+## Cluster map
+
+```
+#2513 (meta index)
+├── #2932 perl-base CVEs (incl. new readout CVE-2026-53615 → #3945–#3952)
+├── #2933 Grafana / Prometheus / Postgres / gosu / bundled plugins
+├── #3705 libsqlite3 CVE-2026-11824 (8× python:3.14-slim-trixie)
+├── #3802 gzip CVE-2026-41992 (8× python:3.14-slim-trixie)
+├── #3803 libacl1 CVE-2026-54369 (all Trixie services; #3953–#3954 = new readout)
+└── #3936 libcurl4t64 CVE-2026-12064 (7× python:3.14-slim-trixie; NOT postgres alpine)
+```
+
+**Note:** Postgres alpine `libcurl` CVE-2026-12064 cleared by digest refresh PR #3921 (`384de27b`); GitHub alert delta pending next `security-scan.yml` on main. Trixie `libcurl4t64` is a **separate** cluster (#3936).
+
+---
+
+## Repo surface (static)
+
+| Surface | Pin / evidence |
+|---------|----------------|
+| 8 BLUE Trixie Dockerfiles | `python:3.14-slim-trixie@sha256:b877e50…` |
+| Grafana (main) | `grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41…` |
+| Postgres (main) | `postgres:18.4-alpine@sha256:ecafd342…` (post-#3921) |
+| Prometheus (main) | `prom/prometheus:v3.13.0@sha256:c6b27ea4…` |
+| CodeQL | 0 open alerts (cyclic-import fix #3940 merged) |
+
+---
+
+## PR #3755
+
+| Field | Value |
+|-------|-------|
+| Change | Grafana 13.0.3 → 13.1.0 in `compose.red.yml` |
+| CI | All required checks SUCCESS (2026-07-08) |
+| Security verdict | **HOLD** — CVE-2026-42504 still present on bundled ES plugin (Go stdlib 1.26.3) |
+| Merge as security fix | **NO** |
+| Covers | Optional semver hygiene only; does **not** close #2933 Grafana sub-clusters |
+
+Evidence: `docs/evidence/security/CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md`
+
+---
+
+## Recommended remediation batches (post-#3982)
+
+### Batch 1 — Docs-only alert compression (P0, low risk)
+
+- Link #3945–#3952 → #2932 (CVE-2026-53615; package probe recommended before close)
+- Link #3953–#3954 → #3803 (CVE-2026-54369)
+- Update #2513 cluster table to include #3936
+- No alert dismissals; Code Scanning stays open
+
+### Batch 2 — Digest-watch automation (P1, no action until upstream)
+
+- Single coordinated probe when Debian Trixie publishes fixes for gzip, libacl1, libsqlite3, libcurl4t64, perl-base
+- One digest pin refresh across 8 Dockerfiles + rebuild + Trivy/Code Scanning recheck
+
+### Batch 3 — Monitoring image watch (P2)
+
+- #2933: gosu, Grafana bundled plugins, Prometheus Go stdlib — upstream rebuild only
+- #3755: merge only under explicit non-security hygiene GO
+
+### Batch 4 — Human-GO dismissal batches (P3, not authorized)
+
+- Historical batches A–G2 per `docs/security/TRIAGE_RUNBOOK.md` — requires separate Human-GO
+
+---
+
+## Do-not-touch while #3982 runs
+
+- Docker build / image rebuild / digest refresh on BLUE services
+- `docker compose up|down|restart`
+- PR #3755 merge (RED/Grafana — avoid monitoring churn during ARVP window)
+- Any dependency bump or security remediation PR
+
+**Safe now:** read-only analysis, issue comments, evidence docs, label recommendations.
+
+---
+
+## Open questions
+
+1. **CVE-2026-53615 package:** No repo Trivy matrix yet — confirm `perl-base` via representative `cdb_risk` image probe after #3982.
+2. **Postgres libcurl alert delta:** Confirm GitHub Code Scanning clears after next weekly `security-scan.yml` (digest already on main).
+3. **#2513 drift:** Meta body lists 5 clusters; #3936 libcurl missing from index table.


### PR DESCRIPTION
## Summary

Docs-only security board compression for readout alert children #3945–#3954:

- **#3945–#3952** (CVE-2026-53615) → parent [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932) (likely perl-base / shared Trixie OS lineage; package not Trivy-proven in this slice)
- **#3953–#3954** (CVE-2026-54369) → parent [#3803](https://github.com/jannekbuengener/Claire_de_Binare/issues/3803) (libacl1, high confidence)
- **#2513** meta index updated to include [#3936](https://github.com/jannekbuengener/Claire_de_Binare/issues/3936) libcurl cluster

## Delivered

- `docs/evidence/security/CDB_SECURITY_ALERT_COMPRESSION_3945-3954_2026-07-10.md`
- `docs/evidence/security/CDB_SECURITY_META_2513_INDEX_2026-07-10.md`
- `docs/evidence/security/CDB_SECURITY_RETRIAGE_2026-07-10.md` (follow-up status)

## Boundaries

- **No remediation claim** — upstream-blocked OS-layer findings unchanged
- **No alert dismissal** — Code Scanning alerts remain OPEN
- **No Docker/runtime/dependency action** — #3982 runtime guard respected
- **PR #3755 not merged** — remains non-security HOLD
- **Parent clusters remain OPEN**
- **LR NO-GO unchanged**

## Test plan

- [x] Docs-only diff; no code/workflow changes
- [x] Compression doc distinguishes tracking dedupe from fix
- [ ] Parent issue comments after merge
- [ ] Child issues #3945–#3954 closed manually after merge (duplicate/child, not remediated)

Refs #2513
Refs #2932
Refs #3803
Refs #3936
Refs #3945
Refs #3946
Refs #3947
Refs #3948
Refs #3949
Refs #3950
Refs #3951
Refs #3952
Refs #3953
Refs #3954
