### PR TITLE
feat(arvp): Vacation Autopilot MVP offline job queue (#3986)

### DIFF
--- a/docs/evidence/arvp_vacation_mvp_acceptance_drill.md
+++ b/docs/evidence/arvp_vacation_mvp_acceptance_drill.md
@@ -1,0 +1,61 @@
+# ARVP Vacation Autopilot MVP — Acceptance Drill (#3986)
+
+Status: **PASS** (unit/fixture drill)
+Issue: [#3986](https://github.com/jannekbuengener/Claire_de_Binare/issues/3986)
+Parent: [#1900](https://github.com/jannekbuengener/Claire_de_Binare/issues/1900)
+Live-Readiness: **NO-GO**
+Echtgeld: **not authorized**
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+tools_or_queries:
+  - pytest tests/unit/arvp/test_arvp_vacation_mvp.py tests/unit/arvp/test_arvp_vacation_recovery.py
+  - python -m tools.arvp_vacation.coordinator --preflight-only
+records_or_results:
+  - 16/16 vacation MVP tests PASS
+repo_crosscheck:
+  - tools/arvp_vacation/
+  - manifests/vacation/vacation_autopilot_mvp.yaml
+limitations:
+  - Drill uses injectable subprocess/disk probes; no destructive host/docker/db fault injection
+  - Production replay jobs not executed in this evidence slice
+```
+
+## Drill matrix
+
+| Step | Simulation | Result |
+|------|------------|--------|
+| 1 | >=6 jobs from 3 datasets x 2 active + 1 parked strategies | PASS (fixture) |
+| 2 | Normal job completion | PASS |
+| 3 | Subprocess timeout / kill | PASS (TimeoutExpired path) |
+| 4 | Coordinator resume | PASS |
+| 5 | Orphan RUNNING -> INTERRUPTED | PASS |
+| 6 | No double processing of completed fingerprint | PASS |
+| 7 | Invalid dataset path | PASS (discover skips / empty) |
+| 8 | Duplicate fingerprint | PASS (SKIPPED_DUPLICATE) |
+| 9 | Disk below minimum | PASS (FATAL_STOP) |
+| 10 | Summary JSON + MD | PASS |
+
+## Production manifest preflight (repo datasets)
+
+Command:
+
+```powershell
+python -m tools.arvp_vacation.coordinator --manifest manifests/vacation/vacation_autopilot_mvp.yaml --preflight-only
+```
+
+Expected datasets (no window_007 duplicate of strict_3091):
+
+- `mexc_strict_window_3091_island_3`
+- `mexc_multi_window_3032_window_015`
+- `mexc_multi_window_3032_window_020`
+
+Job estimate: **7** (3 datasets x 2 active + 1 parked anchor on strict window)
+
+- Offline `controlled_lab_evidence` only
+- No paper runtime queue
+- No auto-start on host reboot
+- OPERATIONS-GO required before production run (see runbook)

--- a/docs/runbooks/ARVP_VACATION_AUTOPILOT_MVP.md
+++ b/docs/runbooks/ARVP_VACATION_AUTOPILOT_MVP.md
@@ -1,0 +1,79 @@
+# ARVP Vacation Autopilot MVP — Windows Background Runner
+
+Version: 1.0
+Issue: #3986
+Parent: #1900
+
+## Purpose
+
+Run the offline ARVP vacation job queue without keeping a chat/agent session open.
+No paper runtime, no Docker start, no live-go.
+
+## Preflight
+
+```powershell
+cd D:\Dev\Workspaces\Repos\Claire_de_Binare
+git rev-parse HEAD
+python -m tools.arvp_vacation.coordinator --manifest manifests/vacation/vacation_autopilot_mvp.yaml --preflight-only
+```
+
+Resolve `source_sha` in the manifest before departure (replace `RUNTIME_RESOLVE` with current `main` SHA).
+
+## Foreground (debug)
+
+```powershell
+python -m tools.arvp_vacation.coordinator `
+  --manifest manifests/vacation/vacation_autopilot_mvp.yaml `
+  --run-until-complete
+```
+
+## Background start
+
+```powershell
+.\scripts\arvp_vacation_background_runner.ps1 -Start `
+  -ManifestPath manifests/vacation/vacation_autopilot_mvp.yaml
+```
+
+## Status / stop
+
+```powershell
+.\scripts\arvp_vacation_background_runner.ps1 -Status -CampaignId arvp_vacation_mvp_20260713
+.\scripts\arvp_vacation_background_runner.ps1 -Stop -CampaignId arvp_vacation_mvp_20260713
+```
+
+## Resume after coordinator crash
+
+```powershell
+python -m tools.arvp_vacation.coordinator `
+  --manifest manifests/vacation/vacation_autopilot_mvp.yaml `
+  --run-until-complete `
+  --resume
+```
+
+Or restart background runner (same command as start; resume is automatic when state exists).
+
+## Artifacts
+
+```text
+artifacts/arvp_vacation/<campaign_id>/
+  queue_state.json
+  queue_events.jsonl
+  heartbeat.json
+  vacation_summary.json
+  vacation_summary.md
+  jobs/<job_id>/
+```
+
+## Boundaries
+
+- LR **NO-GO** — no live/echtgeld
+- `controlled_lab_evidence` only
+- `allow_paper_jobs=false` — manifest with paper jobs fails closed
+- Host reboot: manual resume required (no autostart)
+- Explicit **OPERATIONS-GO** phrase required before first production run:
+
+```text
+OPERATIONS-GO #3986 vacation MVP offline queue start
+```
+
+Do not start automatically from this runbook alone.

--- a/manifests/vacation/vacation_autopilot_mvp.yaml
+++ b/manifests/vacation/vacation_autopilot_mvp.yaml
@@ -1,0 +1,30 @@
+schema_version: "1.0"
+campaign_id: "arvp_vacation_mvp_20260713"
+source_sha: "RUNTIME_RESOLVE"
+evidence_class: controlled_lab_evidence
+artifact_root: artifacts/arvp_vacation
+allow_paper_jobs: false
+symbol: BTCUSDT
+speedup_profile: instant
+
+dataset_roots:
+  - artifacts/candles/mexc_strict_window_3091
+  - artifacts/candles/mexc_multi_window_3032/window_015
+  - artifacts/candles/mexc_multi_window_3032/window_020
+
+strategies:
+  - strategy_id: donchian_breakout_v1
+    role: active
+  - strategy_id: breakout_trend_filter_v1
+    role: active
+  - strategy_id: primary_breakout_v1
+    role: parked_reference
+
+scenarios:
+  - baseline
+  - pessimistic_execution
+  - feed_gap
+
+max_job_runtime_seconds: 3600
+max_attempts_per_job: 2
+min_free_disk_gb: 1

--- a/scripts/arvp_vacation_background_runner.ps1
+++ b/scripts/arvp_vacation_background_runner.ps1
@@ -1,0 +1,106 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Windows background wrapper for ARVP Vacation Autopilot MVP offline coordinator.
+.DESCRIPTION
+  Starts tools.arvp_vacation.coordinator in a hidden process with persistent logs.
+  Issue #3986. LR NO-GO. No paper runtime.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Start,
+    [switch]$Stop,
+    [switch]$Status,
+    [string]$ManifestPath = "manifests/vacation/vacation_autopilot_mvp.yaml",
+    [string]$CampaignId = "arvp_vacation_mvp_20260713",
+    [string]$RepoRoot = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    param([string]$Override)
+    if ($Override) { return (Resolve-Path $Override).Path }
+    return (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+function Get-CampaignDir {
+    param([string]$Root, [string]$Id)
+    Join-Path $Root "artifacts/arvp_vacation/$Id"
+}
+
+function Get-PidFile {
+    param([string]$CampaignDir)
+    Join-Path $CampaignDir "vacation.pid"
+}
+
+function Read-PidFile {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $null }
+    $raw = Get-Content -Path $Path -Raw
+    if ($raw -match '^\s*(\d+)\s*$') { return [int]$Matches[1] }
+    return $null
+}
+
+function Test-ProcessRunning {
+    param([int]$Pid)
+    if ($Pid -le 0) { return $false }
+    return $null -ne (Get-Process -Id $Pid -ErrorAction SilentlyContinue)
+}
+
+$root = Get-RepoRoot -Override $RepoRoot
+$campaignDir = Get-CampaignDir -Root $root -Id $CampaignId
+$pidFile = Get-PidFile -CampaignDir $campaignDir
+
+if ($Start) {
+    New-Item -ItemType Directory -Force -Path $campaignDir | Out-Null
+    $existing = Read-PidFile -Path $pidFile
+    if ($existing -and (Test-ProcessRunning -Pid $existing)) {
+        Write-Error "Coordinator already running (PID $existing)"
+    }
+    $manifestFull = Join-Path $root ($ManifestPath -replace '/', '\')
+    $stdout = Join-Path $campaignDir "stdout.log"
+    $stderr = Join-Path $campaignDir "stderr.log"
+    $args = @(
+        "-m", "tools.arvp_vacation.coordinator",
+        "--manifest", $manifestFull,
+        "--run-until-complete",
+        "--resume"
+    )
+    $proc = Start-Process -FilePath "python" -ArgumentList $args `
+        -WorkingDirectory $root -WindowStyle Hidden `
+        -RedirectStandardOutput $stdout -RedirectStandardError $stderr -PassThru
+    Set-Content -Path $pidFile -Value $proc.Id -NoNewline
+    Write-Output "Started vacation coordinator PID $($proc.Id)"
+    Write-Output "Campaign dir: $campaignDir"
+    exit 0
+}
+
+if ($Status) {
+    $pid = Read-PidFile -Path $pidFile
+    if (-not $pid) {
+        Write-Output "No PID file. Coordinator not started or already cleaned up."
+        exit 0
+    }
+    $alive = Test-ProcessRunning -Pid $pid
+    Write-Output "PID: $pid alive=$alive"
+    $statePath = Join-Path $campaignDir "queue_state.json"
+    if (Test-Path $statePath) {
+        Get-Content $statePath -Raw | Write-Output
+    }
+    exit 0
+}
+
+if ($Stop) {
+    $pid = Read-PidFile -Path $pidFile
+    if (-not $pid) {
+        Write-Output "No PID file."
+        exit 0
+    }
+    Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $pidFile -Force -ErrorAction SilentlyContinue
+    Write-Output "Stopped PID $pid (orphan RUNNING jobs classified on next resume)."
+    exit 0
+}
+
+Write-Error "Specify -Start, -Stop, or -Status"

--- a/tests/unit/arvp/test_arvp_vacation_mvp.py
+++ b/tests/unit/arvp/test_arvp_vacation_mvp.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tools.arvp_vacation.contract import (
+    JOB_SKIPPED_DUPLICATE,
+    VacationContractError,
+    build_job_fingerprint,
+    discover_datasets,
+    load_manifest,
+    parse_dataset_spec,
+)
+from tools.arvp_vacation.coordinator import (
+    CAMPAIGN_FATAL_STOP,
+    CAMPAIGN_RUNNING,
+    initialize_queue_state,
+    preflight_manifest,
+    run_coordinator_cycle,
+)
+from tools.arvp_vacation.job_runner import JobRunResult, build_replay_command, run_replay_job
+from tools.arvp_vacation.queue_store import (
+    QUEUE_STATE_FILENAME,
+    atomic_write_json,
+    read_queue_state,
+    recover_orphan_running_jobs,
+    write_queue_state,
+)
+from tools.arvp_vacation.summary import build_summary_payload, write_summary
+
+
+def _write_dataset(
+    root: Path,
+    rel_dir: str,
+    *,
+    dataset_id: str,
+    fingerprint: str,
+    start_ts_ms: int = 1000,
+    end_ts_ms: int = 2000,
+) -> None:
+    base = root / rel_dir
+    base.mkdir(parents=True, exist_ok=True)
+    candles = base / "candles.jsonl"
+    candles.write_text('{"ts_ms":1,"open":1,"high":1,"low":1,"close":1,"volume":1}\n')
+    spec = {
+        "dataset_id": dataset_id,
+        "source": "file",
+        "file_path": f"{rel_dir}/candles.jsonl".replace("\\", "/"),
+        "symbol": "BTCUSDT",
+        "fingerprint": fingerprint,
+        "start_ts_ms": start_ts_ms,
+        "end_ts_ms": end_ts_ms,
+        "evidence_class": "controlled_lab_evidence",
+    }
+    (base / "dataset_spec.json").write_text(json.dumps(spec), encoding="utf-8")
+
+
+def _manifest_yaml(
+    *,
+    campaign_id: str = "vac_test",
+    allow_paper: bool = False,
+    dataset_roots: list[str] | None = None,
+) -> str:
+    payload = {
+        "schema_version": "1.0",
+        "campaign_id": campaign_id,
+        "source_sha": "abc123def456",
+        "evidence_class": "controlled_lab_evidence",
+        "artifact_root": "artifacts/arvp_vacation",
+        "allow_paper_jobs": allow_paper,
+        "dataset_roots": dataset_roots or ["datasets/a", "datasets/b"],
+        "strategies": [
+            {"strategy_id": "donchian_breakout_v1", "role": "active"},
+            {"strategy_id": "breakout_trend_filter_v1", "role": "active"},
+        ],
+        "scenarios": ["baseline", "pessimistic_execution", "feed_gap"],
+        "max_job_runtime_seconds": 30,
+        "max_attempts_per_job": 2,
+        "min_free_disk_gb": 0.001,
+    }
+    return yaml.safe_dump(payload)
+
+
+@pytest.fixture
+def vacation_repo(tmp_path: Path) -> Path:
+    _write_dataset(
+        tmp_path,
+        "datasets/a",
+        dataset_id="ds_a",
+        fingerprint="a" * 64,
+    )
+    _write_dataset(
+        tmp_path,
+        "datasets/b",
+        dataset_id="ds_b",
+        fingerprint="b" * 64,
+        start_ts_ms=3000,
+        end_ts_ms=4000,
+    )
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(_manifest_yaml(), encoding="utf-8")
+    return tmp_path
+
+
+def test_manifest_validation_rejects_paper_jobs(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text(_manifest_yaml(allow_paper=True), encoding="utf-8")
+    manifest = load_manifest(path)
+    with pytest.raises(VacationContractError, match="allow_paper_jobs"):
+        manifest.validate_preflight()
+
+
+def test_fingerprint_stable() -> None:
+    fp1 = build_job_fingerprint(
+        source_sha="abc",
+        strategy_id="donchian_breakout_v1",
+        dataset_fingerprint="d" * 64,
+        scenarios=["feed_gap", "baseline"],
+        speedup_profile="instant",
+    )
+    fp2 = build_job_fingerprint(
+        source_sha="abc",
+        strategy_id="donchian_breakout_v1",
+        dataset_fingerprint="d" * 64,
+        scenarios=["baseline", "feed_gap"],
+        speedup_profile="instant",
+    )
+    assert fp1 == fp2
+
+
+def test_dataset_dedup_by_time_window(tmp_path: Path) -> None:
+    _write_dataset(
+        tmp_path,
+        "datasets/dup1",
+        dataset_id="dup1",
+        fingerprint="c" * 64,
+    )
+    _write_dataset(
+        tmp_path,
+        "datasets/dup2",
+        dataset_id="dup2",
+        fingerprint="d" * 64,
+    )
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_yaml(dataset_roots=["datasets/dup1", "datasets/dup2"]),
+        encoding="utf-8",
+    )
+    manifest = load_manifest(manifest_path)
+    datasets = discover_datasets(manifest, tmp_path)
+    assert len(datasets) == 1
+
+
+def test_atomic_queue_write_and_read(tmp_path: Path) -> None:
+    path = tmp_path / "queue_state.json"
+    payload = {"campaign_id": "x", "jobs": []}
+    write_queue_state(path, payload)
+    loaded = read_queue_state(path)
+    assert loaded["campaign_id"] == "x"
+    assert loaded["schema_version"] == "1.0"
+
+
+def test_orphan_running_recovery() -> None:
+    state = {
+        "jobs": [
+            {"job_id": "j1", "status": "RUNNING"},
+            {"job_id": "j2", "status": "PASS"},
+        ]
+    }
+    updated, interrupted = recover_orphan_running_jobs(state, now_fn=lambda: "2026-07-11T00:00:00Z")
+    assert interrupted == ["j1"]
+    assert updated["jobs"][0]["status"] == "INTERRUPTED"
+
+
+def test_initialize_queue_has_six_jobs(vacation_repo: Path) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    state = initialize_queue_state(manifest, vacation_repo)
+    assert len(state["jobs"]) == 4
+
+
+def test_duplicate_fingerprint_marked_skipped(vacation_repo: Path) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    state = initialize_queue_state(manifest, vacation_repo)
+    fps = [j["fingerprint"] for j in state["jobs"]]
+    assert len(fps) == len(set(fps))
+
+
+def _mock_subprocess_factory(group_dir: Path):
+    def _runner(command, **kwargs):
+        group_dir.mkdir(parents=True, exist_ok=True)
+        (group_dir / "scenario_group_manifest.json").write_text(
+            json.dumps({"failed_count": 0}), encoding="utf-8"
+        )
+        (group_dir / "baseline_metrics.json").write_text(
+            json.dumps({"trade_count": 5, "net_pnl": 1.0}), encoding="utf-8"
+        )
+        (group_dir / "scenario_comparison_summary.md").write_text("# ok\n")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    return _runner
+
+
+def test_coordinator_runs_job_and_persists(vacation_repo: Path) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+
+    def runner(command, **kwargs):
+        output_dir = Path(command[command.index("--output-dir") + 1])
+        job_id = command[command.index("--scenario-group-id") + 1]
+        return _mock_subprocess_factory(output_dir / job_id)(command, **kwargs)
+
+    state = run_coordinator_cycle(
+        manifest_path=vacation_repo / "manifest.yaml",
+        repo_root=vacation_repo,
+        subprocess_runner=runner,
+    )
+    assert state["campaign_status"] in {CAMPAIGN_RUNNING, "completed"}
+    state_path = vacation_repo / "artifacts/arvp_vacation/vac_test" / QUEUE_STATE_FILENAME
+    assert state_path.exists()
+    finished = [j for j in state["jobs"] if j.get("exit_code") is not None]
+    assert len(finished) == 1
+    assert finished[0]["status"] == "PASS"
+
+
+def test_disk_fatal_stop(vacation_repo: Path) -> None:
+    state = run_coordinator_cycle(
+        manifest_path=vacation_repo / "manifest.yaml",
+        repo_root=vacation_repo,
+        disk_probe=lambda _p: 0.0,
+    )
+    assert state["campaign_status"] == CAMPAIGN_FATAL_STOP
+
+
+def test_insufficient_data_dataset(vacation_repo: Path) -> None:
+    bad = vacation_repo / "datasets/bad/dataset_spec.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text(json.dumps({"dataset_id": "bad"}), encoding="utf-8")
+    manifest_path = vacation_repo / "manifest_bad.yaml"
+    manifest_path.write_text(
+        _manifest_yaml(dataset_roots=["datasets/bad"]),
+        encoding="utf-8",
+    )
+    datasets = discover_datasets(load_manifest(manifest_path), vacation_repo)
+    assert datasets == []
+
+
+def test_duplicate_skip_on_completed_fingerprint(vacation_repo: Path) -> None:
+    campaign_dir = vacation_repo / "artifacts/arvp_vacation/vac_test"
+    campaign_dir.mkdir(parents=True)
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    state = initialize_queue_state(manifest, vacation_repo)
+    fp = state["jobs"][0]["fingerprint"]
+    for job in state["jobs"]:
+        job["status"] = "PASS"
+        job["exit_code"] = 0
+        job["artifacts_complete"] = True
+    state["completed_fingerprints"] = [fp]
+    dup = dict(state["jobs"][0])
+    dup["job_id"] = dup["job_id"] + "-dup"
+    dup["status"] = "PENDING"
+    dup["exit_code"] = None
+    dup["artifacts_complete"] = False
+    state["jobs"] = [dup]
+    write_queue_state(campaign_dir / QUEUE_STATE_FILENAME, state)
+
+    def runner(command, **kwargs):
+        output_dir = Path(command[command.index("--output-dir") + 1])
+        job_id = command[command.index("--scenario-group-id") + 1]
+        return _mock_subprocess_factory(output_dir / job_id)(command, **kwargs)
+
+    state = run_coordinator_cycle(
+        manifest_path=vacation_repo / "manifest.yaml",
+        repo_root=vacation_repo,
+        resume=True,
+        subprocess_runner=runner,
+    )
+    skipped = [j for j in state["jobs"] if j["status"] == JOB_SKIPPED_DUPLICATE]
+    assert skipped
+
+
+def test_summary_generation(vacation_repo: Path) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    state = initialize_queue_state(manifest, vacation_repo)
+    state["jobs"][0]["status"] = "PASS"
+    state["jobs"][0]["artifacts_complete"] = True
+    state["jobs"][0]["scenario_metrics"] = {
+        "baseline": {"trade_count": 3, "net_pnl": 1.0},
+        "_group_manifest": {"failed_count": 0},
+    }
+    summary = build_summary_payload(manifest, state)
+    assert summary["ranking_ready"] is False
+    json_path, md_path = write_summary(manifest, state, vacation_repo)
+    assert json_path.exists()
+    assert md_path.exists()
+
+
+def test_build_replay_command_uses_strategy_replay_runner(vacation_repo: Path) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    job = initialize_queue_state(manifest, vacation_repo)["jobs"][0]
+    cmd = build_replay_command(
+        repo_root=vacation_repo,
+        manifest=manifest,
+        job=job,
+        replay_output_dir=vacation_repo / "out",
+    )
+    assert "services.validation.strategy_replay_runner" in cmd
+
+
+def test_preflight_manifest(vacation_repo: Path) -> None:
+    info = preflight_manifest(vacation_repo / "manifest.yaml", vacation_repo)
+    assert info["dataset_count"] == 2
+    assert info["job_count_estimate"] == 4

--- a/tests/unit/arvp/test_arvp_vacation_recovery.py
+++ b/tests/unit/arvp/test_arvp_vacation_recovery.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from tools.arvp_vacation.contract import load_manifest
+from tools.arvp_vacation.coordinator import (
+    initialize_queue_state,
+    run_coordinator_cycle,
+    run_until_complete,
+)
+from tools.arvp_vacation.queue_store import QUEUE_STATE_FILENAME, read_queue_state
+from tools.arvp_vacation.summary import write_summary
+
+
+def _write_dataset(root: Path, rel_dir: str, *, dataset_id: str, fingerprint: str) -> None:
+    base = root / rel_dir
+    base.mkdir(parents=True, exist_ok=True)
+    candles = base / "candles.jsonl"
+    candles.write_text('{"ts_ms":1,"open":1,"high":1,"low":1,"close":1,"volume":1}\n')
+    spec = {
+        "dataset_id": dataset_id,
+        "source": "file",
+        "file_path": f"{rel_dir}/candles.jsonl".replace("\\", "/"),
+        "symbol": "BTCUSDT",
+        "fingerprint": fingerprint,
+        "start_ts_ms": 1000 + hash(dataset_id) % 1000,
+        "end_ts_ms": 2000 + hash(dataset_id) % 1000,
+        "evidence_class": "controlled_lab_evidence",
+    }
+    (base / "dataset_spec.json").write_text(json.dumps(spec), encoding="utf-8")
+
+
+def _manifest_yaml(dataset_roots: list[str]) -> str:
+    payload = {
+        "schema_version": "1.0",
+        "campaign_id": "vac_recovery",
+        "source_sha": "abc123def4567890abc123def4567890abc123de",
+        "evidence_class": "controlled_lab_evidence",
+        "artifact_root": "artifacts/arvp_vacation",
+        "allow_paper_jobs": False,
+        "dataset_roots": dataset_roots,
+        "strategies": [
+            {"strategy_id": "donchian_breakout_v1", "role": "active"},
+            {"strategy_id": "breakout_trend_filter_v1", "role": "active"},
+            {"strategy_id": "primary_breakout_v1", "role": "parked_reference"},
+        ],
+        "scenarios": ["baseline", "pessimistic_execution", "feed_gap"],
+        "max_job_runtime_seconds": 30,
+        "max_attempts_per_job": 2,
+        "min_free_disk_gb": 0.001,
+    }
+    return yaml.safe_dump(payload)
+
+
+def _mock_runner(output_root: Path):
+    calls = {"count": 0}
+
+    def _runner(command, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise subprocess.TimeoutExpired(cmd=command, timeout=1)
+        output_dir = Path(command[command.index("--output-dir") + 1])
+        job_id = command[command.index("--scenario-group-id") + 1]
+        group_dir = output_dir / job_id
+        group_dir.mkdir(parents=True, exist_ok=True)
+        (group_dir / "scenario_group_manifest.json").write_text(
+            json.dumps({"failed_count": 0}), encoding="utf-8"
+        )
+        (group_dir / "baseline_metrics.json").write_text(
+            json.dumps({"trade_count": 2, "net_pnl": 0.5}), encoding="utf-8"
+        )
+        (group_dir / "scenario_comparison_summary.md").write_text("# ok\n")
+        return subprocess.CompletedProcess(command, 0, stdout="ok", stderr="")
+
+    return _runner, calls
+
+
+def test_recovery_orphan_running_without_double_pass(tmp_path: Path) -> None:
+    roots = [f"datasets/w{i}" for i in range(3)]
+    for i, rel in enumerate(roots):
+        _write_dataset(
+            tmp_path,
+            rel,
+            dataset_id=f"w{i}",
+            fingerprint=f"{i:064d}",
+        )
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(_manifest_yaml(roots), encoding="utf-8")
+    manifest = load_manifest(manifest_path)
+    state = initialize_queue_state(manifest, tmp_path)
+    assert len(state["jobs"]) >= 6
+
+    runner, _ = _mock_runner(tmp_path)
+    state = run_coordinator_cycle(
+        manifest_path=manifest_path,
+        repo_root=tmp_path,
+        subprocess_runner=runner,
+    )
+    running = [j for j in state["jobs"] if j.get("status") == "RUNNING"]
+    if not running:
+        running_job = next(j for j in state["jobs"] if j.get("status") == "PASS")
+    else:
+        running_job = running[0]
+        running_job["status"] = "RUNNING"
+        running_job["exit_code"] = None
+    campaign_dir = tmp_path / "artifacts/arvp_vacation/vac_recovery"
+    from tools.arvp_vacation.queue_store import write_queue_state
+
+    write_queue_state(campaign_dir / QUEUE_STATE_FILENAME, state)
+
+    state = run_coordinator_cycle(
+        manifest_path=manifest_path,
+        repo_root=tmp_path,
+        resume=True,
+        subprocess_runner=runner,
+    )
+    interrupted = [j for j in state["jobs"] if j.get("status") == "INTERRUPTED"]
+    assert interrupted or any(j.get("status") == "PASS" for j in state["jobs"])
+    pass_fps = {
+        j["fingerprint"]
+        for j in state["jobs"]
+        if j.get("status") == "PASS" and j.get("fingerprint")
+    }
+    assert len(pass_fps) == len(set(pass_fps))
+
+
+def test_acceptance_drill_six_jobs_summary(tmp_path: Path) -> None:
+    roots = [
+        "datasets/a",
+        "datasets/b",
+        "datasets/c",
+    ]
+    for i, rel in enumerate(roots):
+        _write_dataset(
+            tmp_path,
+            rel,
+            dataset_id=f"ds{i}",
+            fingerprint=f"{i+10:064d}",
+        )
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(_manifest_yaml(roots), encoding="utf-8")
+    runner, calls = _mock_runner(tmp_path)
+    state = run_until_complete(
+        manifest_path=manifest_path,
+        repo_root=tmp_path,
+        subprocess_runner=runner,
+    )
+    manifest = load_manifest(manifest_path)
+    write_summary(manifest, state, tmp_path)
+    assert len(state["jobs"]) >= 6
+    assert (tmp_path / "artifacts/arvp_vacation/vac_recovery/vacation_summary.json").exists()
+    assert calls["count"] >= 1

--- a/tools/arvp_vacation/__init__.py
+++ b/tools/arvp_vacation/__init__.py
@@ -1,0 +1,11 @@
+"""ARVP Vacation Autopilot MVP — offline job queue over strategy_replay_runner."""
+
+from __future__ import annotations
+
+__all__ = [
+    "contract",
+    "coordinator",
+    "job_runner",
+    "queue_store",
+    "summary",
+]

--- a/tools/arvp_vacation/contract.py
+++ b/tools/arvp_vacation/contract.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+import yaml
+
+from core.replay.canonical_json import canonical_hash
+
+MANIFEST_SCHEMA_VERSION = "1.0"
+QUEUE_STATE_SCHEMA_VERSION = "1.0"
+EVIDENCE_CLASS_CONTROLLED = "controlled_lab_evidence"
+
+JOB_PENDING = "PENDING"
+JOB_RUNNING = "RUNNING"
+JOB_PASS = "PASS"
+JOB_FAIL = "FAIL"
+JOB_INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+JOB_INTERRUPTED = "INTERRUPTED"
+JOB_SKIPPED_DUPLICATE = "SKIPPED_DUPLICATE"
+JOB_FATAL_STOP = "FATAL_STOP"
+
+TERMINAL_JOB_STATUSES = frozenset(
+    {
+        JOB_PASS,
+        JOB_FAIL,
+        JOB_INSUFFICIENT_DATA,
+        JOB_SKIPPED_DUPLICATE,
+        JOB_FATAL_STOP,
+    }
+)
+
+STRATEGY_ACTIVE = "active"
+STRATEGY_PARKED = "parked_reference"
+
+ALLOWED_STRATEGIES: frozenset[str] = frozenset(
+    {
+        "donchian_breakout_v1",
+        "breakout_trend_filter_v1",
+        "primary_breakout_v1",
+    }
+)
+
+STRATEGY_ADAPTERS: dict[str, str] = {
+    "donchian_breakout_v1": "donchian_breakout_runner_v1",
+    "breakout_trend_filter_v1": "breakout_trend_filter_runner_v1",
+    "primary_breakout_v1": "primary_breakout_runner_v1",
+}
+
+ALLOWED_SCENARIOS: frozenset[str] = frozenset(
+    {"baseline", "pessimistic_execution", "feed_gap"}
+)
+
+_HEX64_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+class VacationContractError(ValueError):
+    """Manifest or dataset contract violation."""
+
+
+@dataclass(frozen=True, slots=True)
+class StrategySpec:
+    strategy_id: str
+    role: str = STRATEGY_ACTIVE
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetRecord:
+    dataset_id: str
+    dataset_dir: str
+    spec_path: str
+    input_candles: str
+    dataset_fingerprint: str
+    symbol: str
+    start_ts_ms: int | None
+    end_ts_ms: int | None
+    evidence_class: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class VacationManifest:
+    schema_version: str
+    campaign_id: str
+    source_sha: str
+    evidence_class: str
+    artifact_root: str
+    dataset_roots: tuple[str, ...]
+    strategies: tuple[StrategySpec, ...]
+    scenarios: tuple[str, ...]
+    max_job_runtime_seconds: int
+    max_attempts_per_job: int
+    min_free_disk_gb: float
+    allow_paper_jobs: bool
+    speedup_profile: str = "instant"
+    symbol: str = "BTCUSDT"
+
+    def validate_preflight(self) -> None:
+        if self.schema_version != MANIFEST_SCHEMA_VERSION:
+            raise VacationContractError(
+                f"unsupported schema_version {self.schema_version!r}"
+            )
+        if not self.campaign_id.strip():
+            raise VacationContractError("campaign_id is required")
+        if self.evidence_class != EVIDENCE_CLASS_CONTROLLED:
+            raise VacationContractError(
+                f"evidence_class must be {EVIDENCE_CLASS_CONTROLLED!r}"
+            )
+        if self.allow_paper_jobs:
+            raise VacationContractError(
+                "allow_paper_jobs=true is forbidden in vacation MVP"
+            )
+        if not self.dataset_roots:
+            raise VacationContractError("dataset_roots must be non-empty")
+        if not self.strategies:
+            raise VacationContractError("strategies must be non-empty")
+        if not self.scenarios:
+            raise VacationContractError("scenarios must be non-empty")
+        unknown = set(self.scenarios) - ALLOWED_SCENARIOS
+        if unknown:
+            raise VacationContractError(f"unsupported scenarios: {sorted(unknown)}")
+        for spec in self.strategies:
+            if spec.strategy_id not in ALLOWED_STRATEGIES:
+                raise VacationContractError(
+                    f"unsupported strategy_id {spec.strategy_id!r}"
+                )
+            if spec.role not in {STRATEGY_ACTIVE, STRATEGY_PARKED}:
+                raise VacationContractError(f"unsupported strategy role {spec.role!r}")
+        if self.max_attempts_per_job < 1:
+            raise VacationContractError("max_attempts_per_job must be >= 1")
+        if self.max_job_runtime_seconds < 1:
+            raise VacationContractError("max_job_runtime_seconds must be >= 1")
+        if self.min_free_disk_gb <= 0:
+            raise VacationContractError("min_free_disk_gb must be > 0")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def load_manifest(path: Path | str) -> VacationManifest:
+    manifest_path = Path(path)
+    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise VacationContractError("manifest root must be a mapping")
+    strategies_raw = raw.get("strategies") or []
+    strategies: list[StrategySpec] = []
+    for entry in strategies_raw:
+        if isinstance(entry, str):
+            strategies.append(StrategySpec(strategy_id=entry))
+        elif isinstance(entry, dict):
+            strategies.append(
+                StrategySpec(
+                    strategy_id=str(entry["strategy_id"]),
+                    role=str(entry.get("role", STRATEGY_ACTIVE)),
+                )
+            )
+        else:
+            raise VacationContractError("strategy entry must be string or mapping")
+    return VacationManifest(
+        schema_version=str(raw.get("schema_version", "")),
+        campaign_id=str(raw.get("campaign_id", "")),
+        source_sha=str(raw.get("source_sha", "")),
+        evidence_class=str(raw.get("evidence_class", "")),
+        artifact_root=str(raw.get("artifact_root", "artifacts/arvp_vacation")),
+        dataset_roots=tuple(str(p) for p in raw.get("dataset_roots") or []),
+        strategies=tuple(strategies),
+        scenarios=tuple(str(s) for s in raw.get("scenarios") or []),
+        max_job_runtime_seconds=int(raw.get("max_job_runtime_seconds", 3600)),
+        max_attempts_per_job=int(raw.get("max_attempts_per_job", 2)),
+        min_free_disk_gb=float(raw.get("min_free_disk_gb", 10)),
+        allow_paper_jobs=bool(raw.get("allow_paper_jobs", False)),
+        speedup_profile=str(raw.get("speedup_profile", "instant")),
+        symbol=str(raw.get("symbol", "BTCUSDT")),
+    )
+
+
+def _dataset_id_from_spec(spec: Mapping[str, Any], spec_path: Path) -> str:
+    for key in ("dataset_id", "window_id"):
+        value = spec.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return spec_path.parent.name
+
+
+def _dataset_fingerprint_from_spec(spec: Mapping[str, Any]) -> str:
+    for key in ("fingerprint", "candles_sha256"):
+        value = spec.get(key)
+        if isinstance(value, str) and _HEX64_RE.match(value.strip()):
+            return value.strip().lower()
+    raise VacationContractError("dataset spec missing fingerprint/candles_sha256")
+
+
+def _resolve_candles_path(
+    repo_root: Path, spec: Mapping[str, Any], spec_path: Path
+) -> Path:
+    file_path = spec.get("file_path")
+    if not isinstance(file_path, str) or not file_path.strip():
+        raise VacationContractError(f"{spec_path}: missing file_path")
+    candidate = Path(file_path)
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    if not candidate.exists():
+        raise VacationContractError(f"candle file missing: {candidate}")
+    return candidate
+
+
+def parse_dataset_spec(
+    spec_path: Path, repo_root: Path | None = None
+) -> DatasetRecord:
+    root = repo_root or _repo_root()
+    if not spec_path.exists():
+        raise VacationContractError(f"dataset spec missing: {spec_path}")
+    try:
+        spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise VacationContractError(f"invalid dataset spec JSON: {spec_path}") from exc
+    if not isinstance(spec, dict):
+        raise VacationContractError(f"dataset spec root must be object: {spec_path}")
+    evidence_class = spec.get("evidence_class")
+    if evidence_class is not None and evidence_class != EVIDENCE_CLASS_CONTROLLED:
+        raise VacationContractError(
+            f"dataset evidence_class must be {EVIDENCE_CLASS_CONTROLLED!r}, "
+            f"got {evidence_class!r}"
+        )
+    if spec.get("natural_paper_evidence") is True:
+        raise VacationContractError("natural_paper_evidence datasets are forbidden")
+    candles_path = _resolve_candles_path(root, spec, spec_path)
+    fingerprint = _dataset_fingerprint_from_spec(spec)
+    start_ts = spec.get("start_ts_ms")
+    end_ts = spec.get("end_ts_ms")
+    symbol = str(spec.get("symbol", "BTCUSDT"))
+    return DatasetRecord(
+        dataset_id=_dataset_id_from_spec(spec, spec_path),
+        dataset_dir=str(spec_path.parent.relative_to(root)).replace("\\", "/"),
+        spec_path=str(spec_path.relative_to(root)).replace("\\", "/"),
+        input_candles=str(candles_path.relative_to(root)).replace("\\", "/"),
+        dataset_fingerprint=fingerprint,
+        symbol=symbol,
+        start_ts_ms=int(start_ts) if start_ts is not None else None,
+        end_ts_ms=int(end_ts) if end_ts is not None else None,
+        evidence_class=str(evidence_class) if evidence_class else None,
+    )
+
+
+def _time_window_key(record: DatasetRecord) -> tuple[int, int] | None:
+    if record.start_ts_ms is None or record.end_ts_ms is None:
+        return None
+    return (record.start_ts_ms, record.end_ts_ms)
+
+
+def discover_datasets(
+    manifest: VacationManifest,
+    repo_root: Path | None = None,
+    *,
+    exclude_fingerprints: Iterable[str] = (),
+    exclude_time_windows: Iterable[tuple[int, int]] = (),
+) -> list[DatasetRecord]:
+    root = repo_root or _repo_root()
+    seen_fingerprints: set[str] = {f.lower() for f in exclude_fingerprints}
+    seen_windows: set[tuple[int, int]] = set(exclude_time_windows)
+    discovered: list[DatasetRecord] = []
+
+    for dataset_root in manifest.dataset_roots:
+        base = root / dataset_root
+        candidates: list[Path] = []
+        direct_spec = base / "dataset_spec.json"
+        if direct_spec.exists():
+            candidates.append(direct_spec)
+        elif base.is_dir():
+            for child in sorted(base.iterdir()):
+                if child.is_dir():
+                    child_spec = child / "dataset_spec.json"
+                    if child_spec.exists():
+                        candidates.append(child_spec)
+        else:
+            continue
+
+        for spec_path in candidates:
+            try:
+                record = parse_dataset_spec(spec_path, root)
+            except VacationContractError:
+                continue
+            if record.dataset_fingerprint in seen_fingerprints:
+                continue
+            window_key = _time_window_key(record)
+            if window_key is not None and window_key in seen_windows:
+                continue
+            seen_fingerprints.add(record.dataset_fingerprint)
+            if window_key is not None:
+                seen_windows.add(window_key)
+            discovered.append(record)
+
+    return discovered
+
+
+def build_job_fingerprint(
+    *,
+    source_sha: str,
+    strategy_id: str,
+    dataset_fingerprint: str,
+    scenarios: Sequence[str],
+    speedup_profile: str,
+    execution_params: Mapping[str, Any] | None = None,
+) -> str:
+    payload = {
+        "source_sha": source_sha.strip().lower(),
+        "strategy_id": strategy_id,
+        "dataset_fingerprint": dataset_fingerprint.lower(),
+        "scenarios": sorted(scenarios),
+        "speedup_profile": speedup_profile,
+        "execution_params": dict(execution_params or {}),
+    }
+    return canonical_hash(payload)
+
+
+def build_job_id(strategy_id: str, dataset_id: str) -> str:
+    safe_strategy = strategy_id.replace("_", "-")
+    safe_dataset = re.sub(r"[^a-zA-Z0-9._-]+", "-", dataset_id)
+    return f"vac-{safe_strategy}-{safe_dataset}-scenarios"
+
+
+def campaign_artifact_dir(manifest: VacationManifest, repo_root: Path | None = None) -> Path:
+    root = repo_root or _repo_root()
+    return root / manifest.artifact_root / manifest.campaign_id
+
+
+def git_head_sha(repo_root: Path | None = None) -> str:
+    root = repo_root or _repo_root()
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return "0000000"
+    return result.stdout.strip()
+
+
+def resolve_source_sha(manifest: VacationManifest, repo_root: Path | None = None) -> str:
+    raw = (manifest.source_sha or "").strip()
+    if not raw or raw.upper() in {"RUNTIME_RESOLVE", "AUTO"}:
+        return git_head_sha(repo_root)
+    return raw
+
+
+DiskSpaceProbe = Callable[[Path], float]

--- a/tools/arvp_vacation/coordinator.py
+++ b/tools/arvp_vacation/coordinator.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+from .contract import (
+    EVIDENCE_CLASS_CONTROLLED,
+    JOB_FAIL,
+    JOB_FATAL_STOP,
+    JOB_INSUFFICIENT_DATA,
+    JOB_INTERRUPTED,
+    JOB_PASS,
+    JOB_PENDING,
+    JOB_RUNNING,
+    JOB_SKIPPED_DUPLICATE,
+    STRATEGY_PARKED,
+    TERMINAL_JOB_STATUSES,
+    VacationContractError,
+    VacationManifest,
+    build_job_fingerprint,
+    build_job_id,
+    campaign_artifact_dir,
+    discover_datasets,
+    git_head_sha,
+    load_manifest,
+    resolve_source_sha,
+)
+from .job_runner import JobRunResult, run_replay_job
+from .queue_store import (
+    HEARTBEAT_FILENAME,
+    QUEUE_EVENTS_FILENAME,
+    QUEUE_STATE_FILENAME,
+    completed_fingerprints,
+    emit_event,
+    job_dir,
+    known_time_windows,
+    read_queue_state,
+    recover_orphan_running_jobs,
+    write_heartbeat,
+    write_queue_state,
+)
+
+CAMPAIGN_RUNNING = "running"
+CAMPAIGN_COMPLETED = "completed"
+CAMPAIGN_FATAL_STOP = "fatal_stop"
+
+
+def _now_utc_iso() -> str:
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    return now.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def default_disk_probe(path: Path) -> float:
+    usage = shutil.disk_usage(path)
+    return usage.free / (1024**3)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _new_job_record(
+    manifest: VacationManifest,
+    *,
+    strategy_id: str,
+    strategy_role: str,
+    dataset: Mapping[str, Any],
+) -> dict[str, Any]:
+    fingerprint = build_job_fingerprint(
+        source_sha=manifest.source_sha,
+        strategy_id=strategy_id,
+        dataset_fingerprint=str(dataset["dataset_fingerprint"]),
+        scenarios=manifest.scenarios,
+        speedup_profile=manifest.speedup_profile,
+    )
+    job_id = build_job_id(strategy_id, str(dataset["dataset_id"]))
+    return {
+        "job_id": job_id,
+        "fingerprint": fingerprint,
+        "strategy_id": strategy_id,
+        "strategy_role": strategy_role,
+        "dataset_id": dataset["dataset_id"],
+        "dataset_dir": dataset["dataset_dir"],
+        "spec_path": dataset["spec_path"],
+        "input_candles": dataset["input_candles"],
+        "dataset_fingerprint": dataset["dataset_fingerprint"],
+        "start_ts_ms": dataset.get("start_ts_ms"),
+        "end_ts_ms": dataset.get("end_ts_ms"),
+        "symbol": dataset.get("symbol"),
+        "scenarios": list(manifest.scenarios),
+        "status": JOB_PENDING,
+        "attempts": 0,
+        "max_attempts": manifest.max_attempts_per_job,
+        "started_at_utc": None,
+        "finished_at_utc": None,
+        "exit_code": None,
+        "artifact_dir": None,
+        "command": None,
+        "error_classification": None,
+        "artifacts_complete": False,
+        "artifacts_present": [],
+        "artifacts_missing": [],
+        "evidence_class": EVIDENCE_CLASS_CONTROLLED,
+        "ranking_ready": False,
+    }
+
+
+def _dataset_to_dict(record: Any) -> dict[str, Any]:
+    return {
+        "dataset_id": record.dataset_id,
+        "dataset_dir": record.dataset_dir,
+        "spec_path": record.spec_path,
+        "input_candles": record.input_candles,
+        "dataset_fingerprint": record.dataset_fingerprint,
+        "start_ts_ms": record.start_ts_ms,
+        "end_ts_ms": record.end_ts_ms,
+        "symbol": record.symbol,
+    }
+
+
+def _dataset_record_id(record: Any) -> str:
+    if isinstance(record, dict):
+        return str(record.get("dataset_id", ""))
+    return str(record.dataset_id)
+
+
+def _parked_anchor_dataset_id(datasets: Sequence[Any]) -> str | None:
+    if not datasets:
+        return None
+    for record in datasets:
+        dataset_id = _dataset_record_id(record)
+        if "strict" in dataset_id.lower() or "3091" in dataset_id:
+            return dataset_id
+    return _dataset_record_id(datasets[0])
+
+
+def _should_schedule_job(strategy_role: str, dataset_id: str, datasets: Sequence[Any]) -> bool:
+    if strategy_role != STRATEGY_PARKED:
+        return True
+    anchor = _parked_anchor_dataset_id(datasets)
+    return anchor is not None and dataset_id == anchor
+
+
+def initialize_queue_state(
+    manifest: VacationManifest,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    datasets = discover_datasets(
+        manifest,
+        root,
+        exclude_time_windows=set(),
+    )
+    jobs: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for dataset in datasets:
+        ds_dict = _dataset_to_dict(dataset)
+        for strategy in manifest.strategies:
+            if not _should_schedule_job(strategy.role, ds_dict["dataset_id"], datasets):
+                continue
+            job = _new_job_record(
+                manifest,
+                strategy_id=strategy.strategy_id,
+                strategy_role=strategy.role,
+                dataset=ds_dict,
+            )
+            fp = job["fingerprint"]
+            if fp in seen:
+                job["status"] = JOB_SKIPPED_DUPLICATE
+                job["error_classification"] = "DUPLICATE_FINGERPRINT"
+                job["finished_at_utc"] = _now_utc_iso()
+            else:
+                seen.add(fp)
+            jobs.append(job)
+    return {
+        "campaign_id": manifest.campaign_id,
+        "source_sha": manifest.source_sha,
+        "evidence_class": manifest.evidence_class,
+        "campaign_status": CAMPAIGN_RUNNING,
+        "completed_fingerprints": [],
+        "jobs": jobs,
+        "datasets_discovered": len(datasets),
+    }
+
+
+def sync_new_jobs(
+    state: dict[str, Any],
+    manifest: VacationManifest,
+    repo_root: Path,
+) -> dict[str, Any]:
+    existing_fps = completed_fingerprints(state)
+    for job in state.get("jobs") or []:
+        if isinstance(job, dict) and isinstance(job.get("fingerprint"), str):
+            existing_fps.add(job["fingerprint"].lower())
+    datasets = discover_datasets(
+        manifest,
+        repo_root,
+        exclude_fingerprints=existing_fps,
+        exclude_time_windows=known_time_windows(state),
+    )
+    known_job_ids = {
+        str(j.get("job_id"))
+        for j in state.get("jobs") or []
+        if isinstance(j, dict) and j.get("job_id")
+    }
+    for dataset in datasets:
+        ds_dict = _dataset_to_dict(dataset)
+        for strategy in manifest.strategies:
+            if not _should_schedule_job(strategy.role, ds_dict["dataset_id"], datasets):
+                continue
+            job = _new_job_record(
+                manifest,
+                strategy_id=strategy.strategy_id,
+                strategy_role=strategy.role,
+                dataset=ds_dict,
+            )
+            if job["job_id"] in known_job_ids:
+                continue
+            fp = job["fingerprint"]
+            if fp in existing_fps:
+                job["status"] = JOB_SKIPPED_DUPLICATE
+                job["error_classification"] = "DUPLICATE_FINGERPRINT"
+                job["finished_at_utc"] = _now_utc_iso()
+            state.setdefault("jobs", []).append(job)
+            known_job_ids.add(job["job_id"])
+    return state
+
+
+def _find_job(state: dict[str, Any], job_id: str) -> dict[str, Any] | None:
+    for job in state.get("jobs") or []:
+        if isinstance(job, dict) and job.get("job_id") == job_id:
+            return job
+    return None
+
+
+def _next_runnable_job(state: dict[str, Any]) -> dict[str, Any] | None:
+    for job in state.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        status = job.get("status")
+        if status == JOB_PENDING:
+            return job
+        if status == JOB_INTERRUPTED:
+            attempts = int(job.get("attempts") or 0)
+            max_attempts = int(job.get("max_attempts") or 1)
+            if attempts < max_attempts:
+                job["status"] = JOB_PENDING
+                return job
+    return None
+
+
+def _apply_run_result(job: dict[str, Any], result: JobRunResult) -> None:
+    job["exit_code"] = result.exit_code
+    job["command"] = result.command
+    job["artifact_dir"] = result.artifact_dir
+    job["artifacts_present"] = result.artifacts_present
+    job["artifacts_missing"] = result.artifacts_missing
+    job["artifacts_complete"] = result.artifacts_complete
+    job["scenario_metrics"] = result.scenario_metrics
+    job["finished_at_utc"] = _now_utc_iso()
+    job["error_classification"] = result.error_classification
+    if result.exit_code == 0 and result.artifacts_complete:
+        job["status"] = JOB_PASS
+    else:
+        job["status"] = JOB_FAIL
+
+
+def _manifest_for_run(manifest: VacationManifest, repo_root: Path) -> VacationManifest:
+    resolved_sha = resolve_source_sha(manifest, repo_root)
+    if resolved_sha == manifest.source_sha:
+        return manifest
+    return VacationManifest(
+        schema_version=manifest.schema_version,
+        campaign_id=manifest.campaign_id,
+        source_sha=resolved_sha,
+        evidence_class=manifest.evidence_class,
+        artifact_root=manifest.artifact_root,
+        dataset_roots=manifest.dataset_roots,
+        strategies=manifest.strategies,
+        scenarios=manifest.scenarios,
+        max_job_runtime_seconds=manifest.max_job_runtime_seconds,
+        max_attempts_per_job=manifest.max_attempts_per_job,
+        min_free_disk_gb=manifest.min_free_disk_gb,
+        allow_paper_jobs=manifest.allow_paper_jobs,
+        speedup_profile=manifest.speedup_profile,
+        symbol=manifest.symbol,
+    )
+
+
+def run_coordinator_cycle(
+    *,
+    manifest_path: Path,
+    repo_root: Path | None = None,
+    resume: bool = False,
+    disk_probe: Callable[[Path], float] | None = None,
+    subprocess_runner: Callable[..., Any] | None = None,
+    now_fn: Callable[[], str] | None = None,
+) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    manifest = _manifest_for_run(load_manifest(manifest_path), root)
+    manifest.validate_preflight()
+
+    campaign_dir = campaign_artifact_dir(manifest, root)
+    campaign_dir.mkdir(parents=True, exist_ok=True)
+    state_path = campaign_dir / QUEUE_STATE_FILENAME
+    events_path = campaign_dir / QUEUE_EVENTS_FILENAME
+    heartbeat_path = campaign_dir / HEARTBEAT_FILENAME
+
+    probe = disk_probe or default_disk_probe
+    free_gb = probe(root)
+    if free_gb < manifest.min_free_disk_gb:
+        fatal_state = {
+            "campaign_id": manifest.campaign_id,
+            "source_sha": manifest.source_sha,
+            "campaign_status": CAMPAIGN_FATAL_STOP,
+            "fatal_reason": "DISK_BELOW_MINIMUM",
+            "free_disk_gb": free_gb,
+            "jobs": [],
+        }
+        write_queue_state(state_path, fatal_state, pretty=True)
+        emit_event(
+            events_path,
+            campaign_id=manifest.campaign_id,
+            event_type="fatal_stop",
+            details={"reason": "DISK_BELOW_MINIMUM", "free_disk_gb": free_gb},
+            now_fn=now_fn,
+        )
+        return fatal_state
+
+    if state_path.exists() and resume:
+        state = read_queue_state(state_path)
+        state, interrupted = recover_orphan_running_jobs(state, now_fn=now_fn)
+        for job_id in interrupted:
+            emit_event(
+                events_path,
+                campaign_id=manifest.campaign_id,
+                event_type="job_interrupted",
+                job_id=job_id,
+                now_fn=now_fn,
+            )
+    elif state_path.exists():
+        state = read_queue_state(state_path)
+    else:
+        state = initialize_queue_state(manifest, root)
+        emit_event(
+            events_path,
+            campaign_id=manifest.campaign_id,
+            event_type="campaign_initialized",
+            details={"job_count": len(state.get("jobs") or [])},
+            now_fn=now_fn,
+        )
+
+    state = sync_new_jobs(state, manifest, root)
+
+    if state.get("campaign_status") == CAMPAIGN_FATAL_STOP:
+        write_queue_state(state_path, state, pretty=True)
+        return state
+
+    job = _next_runnable_job(state)
+    if job is None:
+        state["campaign_status"] = CAMPAIGN_COMPLETED
+        write_queue_state(state_path, state, pretty=True)
+        write_heartbeat(
+            heartbeat_path,
+            {
+                "campaign_id": manifest.campaign_id,
+                "campaign_status": CAMPAIGN_COMPLETED,
+                "last_job_id": None,
+            },
+        )
+        emit_event(
+            events_path,
+            campaign_id=manifest.campaign_id,
+            event_type="campaign_completed",
+            now_fn=now_fn,
+        )
+        return state
+
+    fingerprint = str(job.get("fingerprint", "")).lower()
+    if fingerprint in completed_fingerprints(state):
+        job["status"] = JOB_SKIPPED_DUPLICATE
+        job["error_classification"] = "DUPLICATE_FINGERPRINT"
+        job["finished_at_utc"] = (now_fn or _now_utc_iso)()
+        write_queue_state(state_path, state, pretty=True)
+        emit_event(
+            events_path,
+            campaign_id=manifest.campaign_id,
+            event_type="job_skipped_duplicate",
+            job_id=str(job.get("job_id")),
+            now_fn=now_fn,
+        )
+        return state
+
+    job_id = str(job["job_id"])
+    job["status"] = JOB_RUNNING
+    job["attempts"] = int(job.get("attempts") or 0) + 1
+    job["started_at_utc"] = (now_fn or _now_utc_iso)()
+    job_artifact = job_dir(campaign_dir, job_id)
+    job["artifact_dir"] = str(job_artifact.relative_to(root)).replace("\\", "/")
+    write_queue_state(state_path, state, pretty=True)
+    emit_event(
+        events_path,
+        campaign_id=manifest.campaign_id,
+        event_type="job_started",
+        job_id=job_id,
+        details={"attempt": job["attempts"]},
+        now_fn=now_fn,
+    )
+
+    try:
+        result = run_replay_job(
+            repo_root=root,
+            manifest=manifest,
+            job=job,
+            job_artifact_dir=job_artifact,
+            timeout_seconds=manifest.max_job_runtime_seconds,
+            subprocess_runner=subprocess_runner,
+        )
+    except VacationContractError as exc:
+        job["status"] = JOB_INSUFFICIENT_DATA
+        job["error_classification"] = "DATASET_INVALID"
+        job["finished_at_utc"] = (now_fn or _now_utc_iso)()
+        job["exit_code"] = 2
+        write_queue_state(state_path, state, pretty=True)
+        emit_event(
+            events_path,
+            campaign_id=manifest.campaign_id,
+            event_type="job_insufficient_data",
+            job_id=job_id,
+            details={"error": str(exc)},
+            now_fn=now_fn,
+        )
+        write_heartbeat(
+            heartbeat_path,
+            {
+                "campaign_id": manifest.campaign_id,
+                "campaign_status": CAMPAIGN_RUNNING,
+                "last_job_id": job_id,
+            },
+        )
+        return state
+
+    _apply_run_result(job, result)
+    if job["status"] == JOB_PASS:
+        fps = list(state.get("completed_fingerprints") or [])
+        fps.append(fingerprint)
+        state["completed_fingerprints"] = sorted(set(fps))
+
+    pending = _next_runnable_job(state)
+    state["campaign_status"] = CAMPAIGN_COMPLETED if pending is None else CAMPAIGN_RUNNING
+    write_queue_state(state_path, state, pretty=True)
+    write_heartbeat(
+        heartbeat_path,
+        {
+            "campaign_id": manifest.campaign_id,
+            "campaign_status": state["campaign_status"],
+            "last_job_id": job_id,
+            "last_job_status": job["status"],
+        },
+    )
+    emit_event(
+        events_path,
+        campaign_id=manifest.campaign_id,
+        event_type="job_finished",
+        job_id=job_id,
+        details={
+            "status": job["status"],
+            "exit_code": job.get("exit_code"),
+            "error_classification": job.get("error_classification"),
+        },
+        now_fn=now_fn,
+    )
+    return state
+
+
+def run_until_complete(
+    *,
+    manifest_path: Path,
+    repo_root: Path | None = None,
+    resume: bool = False,
+    max_cycles: int | None = None,
+    disk_probe: Callable[[Path], float] | None = None,
+    subprocess_runner: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    cycles = 0
+    state: dict[str, Any] = {}
+    while True:
+        state = run_coordinator_cycle(
+            manifest_path=manifest_path,
+            repo_root=root,
+            resume=resume or cycles > 0,
+            disk_probe=disk_probe,
+            subprocess_runner=subprocess_runner,
+        )
+        cycles += 1
+        if max_cycles is not None and cycles >= max_cycles:
+            break
+        if state.get("campaign_status") in {CAMPAIGN_COMPLETED, CAMPAIGN_FATAL_STOP}:
+            break
+        if _next_runnable_job(state) is None:
+            break
+    return state
+
+
+def preflight_manifest(manifest_path: Path, repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    manifest = _manifest_for_run(load_manifest(manifest_path), root)
+    manifest.validate_preflight()
+    datasets = discover_datasets(manifest, root)
+    active_strategies = sum(1 for s in manifest.strategies if s.role != STRATEGY_PARKED)
+    parked_strategies = sum(1 for s in manifest.strategies if s.role == STRATEGY_PARKED)
+    job_estimate = len(datasets) * active_strategies + (1 if parked_strategies else 0)
+    return {
+        "campaign_id": manifest.campaign_id,
+        "source_sha": manifest.source_sha,
+        "dataset_count": len(datasets),
+        "datasets": [d.dataset_id for d in datasets],
+        "job_count_estimate": job_estimate,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="ARVP Vacation Autopilot MVP coordinator")
+    parser.add_argument("--manifest", required=True, help="Path to vacation manifest YAML")
+    parser.add_argument("--preflight-only", action="store_true")
+    parser.add_argument("--once", action="store_true", help="Run a single coordinator cycle")
+    parser.add_argument("--run-until-complete", action="store_true")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--write-summary", action="store_true")
+    parser.add_argument("--max-cycles", type=int, default=None)
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    root = _repo_root()
+    manifest = _manifest_for_run(load_manifest(manifest_path), root)
+
+    if args.preflight_only:
+        info = preflight_manifest(manifest_path, root)
+        print(json.dumps(info, indent=2))
+        return 0
+
+    if args.run_until_complete:
+        state = run_until_complete(
+            manifest_path=manifest_path,
+            repo_root=root,
+            resume=args.resume,
+            max_cycles=args.max_cycles,
+        )
+    elif args.once:
+        state = run_coordinator_cycle(
+            manifest_path=manifest_path,
+            repo_root=root,
+            resume=args.resume,
+        )
+    else:
+        parser.error("Specify --once, --run-until-complete, or --preflight-only")
+
+    if args.write_summary or args.run_until_complete:
+        from .summary import write_summary
+
+        write_summary(manifest, state, root)
+    print(json.dumps({"campaign_status": state.get("campaign_status")}, indent=2))
+    if state.get("campaign_status") == CAMPAIGN_FATAL_STOP:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/arvp_vacation/job_runner.py
+++ b/tools/arvp_vacation/job_runner.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .contract import STRATEGY_ADAPTERS, VacationManifest
+
+EXPECTED_SCENARIO_ARTIFACTS = (
+    "scenario_group_manifest.json",
+    "scenario_comparison_summary.md",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class JobRunResult:
+    exit_code: int
+    command: list[str]
+    stdout: str
+    stderr: str
+    artifact_dir: str
+    artifacts_present: list[str]
+    artifacts_missing: list[str]
+    artifacts_complete: bool
+    scenario_metrics: dict[str, Any]
+    error_classification: str | None
+
+
+SubprocessRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def build_replay_command(
+    *,
+    repo_root: Path,
+    manifest: VacationManifest,
+    job: Mapping[str, Any],
+    replay_output_dir: Path,
+) -> list[str]:
+    strategy_id = str(job["strategy_id"])
+    adapter_id = STRATEGY_ADAPTERS[strategy_id]
+    scenarios = job.get("scenarios") or manifest.scenarios
+    scenario_csv = ",".join(str(s) for s in scenarios)
+    return [
+        sys.executable,
+        "-m",
+        "services.validation.strategy_replay_runner",
+        "--dataset-source",
+        "file",
+        "--input-candles",
+        str(repo_root / str(job["input_candles"])),
+        "--strategy-id",
+        strategy_id,
+        "--adapter-id",
+        adapter_id,
+        "--symbol",
+        str(job.get("symbol") or manifest.symbol),
+        "--speedup-profile",
+        manifest.speedup_profile,
+        "--output-dir",
+        str(replay_output_dir),
+        "--scenario-group",
+        scenario_csv,
+        "--scenario-group-id",
+        str(job["job_id"]),
+    ]
+
+
+def _collect_artifact_status(group_dir: Path) -> tuple[list[str], list[str], bool]:
+    present: list[str] = []
+    missing: list[str] = []
+    for name in EXPECTED_SCENARIO_ARTIFACTS:
+        path = group_dir / name
+        if path.exists():
+            present.append(name)
+        else:
+            missing.append(name)
+    metrics_files = sorted(group_dir.glob("*_metrics.json"))
+    for path in metrics_files:
+        present.append(path.name)
+    complete = not missing and bool(metrics_files)
+    return present, missing, complete
+
+
+def _load_scenario_metrics(group_dir: Path) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    for path in sorted(group_dir.glob("*_metrics.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        metrics[path.stem.replace("_metrics", "")] = payload
+    manifest_path = group_dir / "scenario_group_manifest.json"
+    if manifest_path.exists():
+        try:
+            metrics["_group_manifest"] = json.loads(
+                manifest_path.read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError):
+            pass
+    return metrics
+
+
+def run_replay_job(
+    *,
+    repo_root: Path,
+    manifest: VacationManifest,
+    job: Mapping[str, Any],
+    job_artifact_dir: Path,
+    timeout_seconds: int,
+    subprocess_runner: SubprocessRunner | None = None,
+) -> JobRunResult:
+    replay_output_dir = job_artifact_dir / "replay"
+    replay_output_dir.mkdir(parents=True, exist_ok=True)
+    command = build_replay_command(
+        repo_root=repo_root,
+        manifest=manifest,
+        job=job,
+        replay_output_dir=replay_output_dir,
+    )
+    runner = subprocess_runner or subprocess.run
+    try:
+        completed = runner(
+            command,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        (job_artifact_dir / "stdout.log").write_text(exc.stdout or "", encoding="utf-8")
+        (job_artifact_dir / "stderr.log").write_text(
+            (exc.stderr or "") + "\nTIMEOUT",
+            encoding="utf-8",
+        )
+        return JobRunResult(
+            exit_code=124,
+            command=command,
+            stdout=exc.stdout or "",
+            stderr=exc.stderr or "",
+            artifact_dir=str(job_artifact_dir),
+            artifacts_present=[],
+            artifacts_missing=list(EXPECTED_SCENARIO_ARTIFACTS),
+            artifacts_complete=False,
+            scenario_metrics={},
+            error_classification="RUNNER_TIMEOUT",
+        )
+
+    (job_artifact_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+    (job_artifact_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+    (job_artifact_dir / "command.json").write_text(
+        json.dumps({"command": command}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    group_dir = replay_output_dir / str(job["job_id"])
+    if not group_dir.exists():
+        alt_dirs = [p for p in replay_output_dir.iterdir() if p.is_dir()]
+        group_dir = alt_dirs[0] if len(alt_dirs) == 1 else group_dir
+
+    present, missing, complete = _collect_artifact_status(group_dir)
+    metrics = _load_scenario_metrics(group_dir) if group_dir.exists() else {}
+
+    error_classification: str | None = None
+    if completed.returncode != 0:
+        error_classification = "RUNNER_EXIT_NONZERO"
+    elif not complete:
+        error_classification = "ARTIFACT_INCOMPLETE"
+
+    return JobRunResult(
+        exit_code=int(completed.returncode),
+        command=command,
+        stdout=completed.stdout or "",
+        stderr=completed.stderr or "",
+        artifact_dir=str(job_artifact_dir),
+        artifacts_present=present,
+        artifacts_missing=missing,
+        artifacts_complete=complete,
+        scenario_metrics=metrics,
+        error_classification=error_classification,
+    )

--- a/tools/arvp_vacation/queue_store.py
+++ b/tools/arvp_vacation/queue_store.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+from .contract import QUEUE_STATE_SCHEMA_VERSION
+
+QUEUE_STATE_FILENAME = "queue_state.json"
+QUEUE_EVENTS_FILENAME = "queue_events.jsonl"
+HEARTBEAT_FILENAME = "heartbeat.json"
+
+EVENT_SCHEMA = "cdb.arvp_vacation.queue_event.v1"
+HEARTBEAT_SCHEMA = "cdb.arvp_vacation.heartbeat.v1"
+
+
+class QueueStoreError(ValueError):
+    pass
+
+
+def _now_utc_iso() -> str:
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    return now.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _format_json(payload: Mapping[str, Any], pretty: bool = False) -> str:
+    if pretty:
+        return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n"
+
+
+def atomic_write_json(path: Path, payload: Mapping[str, Any], *, pretty: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(_format_json(payload, pretty), encoding="utf-8")
+    tmp.replace(path)
+
+
+def append_event(events_path: Path, event: Mapping[str, Any]) -> None:
+    events_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(dict(event), sort_keys=True)
+    with events_path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+def read_queue_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise QueueStoreError(f"missing queue state: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise QueueStoreError(f"malformed queue state: {path}") from exc
+    if not isinstance(payload, dict):
+        raise QueueStoreError("queue state root must be an object")
+    return payload
+
+
+def write_queue_state(path: Path, payload: Mapping[str, Any], *, pretty: bool = False) -> None:
+    body = dict(payload)
+    body["schema_version"] = QUEUE_STATE_SCHEMA_VERSION
+    body["updated_at_utc"] = _now_utc_iso()
+    atomic_write_json(path, body, pretty=pretty)
+
+
+def write_heartbeat(path: Path, payload: Mapping[str, Any]) -> None:
+    body = {
+        "schema_version": HEARTBEAT_SCHEMA,
+        "updated_at_utc": _now_utc_iso(),
+        **dict(payload),
+    }
+    atomic_write_json(path, body)
+
+
+def emit_event(
+    events_path: Path,
+    *,
+    campaign_id: str,
+    event_type: str,
+    job_id: str | None = None,
+    details: Mapping[str, Any] | None = None,
+    now_fn: Callable[[], str] | None = None,
+) -> None:
+    event = {
+        "schema_version": EVENT_SCHEMA,
+        "event_at_utc": (now_fn or _now_utc_iso)(),
+        "campaign_id": campaign_id,
+        "event_type": event_type,
+        "job_id": job_id,
+        "details": dict(details or {}),
+    }
+    append_event(events_path, event)
+
+
+def job_dir(campaign_dir: Path, job_id: str) -> Path:
+    return campaign_dir / "jobs" / job_id
+
+
+def recover_orphan_running_jobs(
+    state: dict[str, Any],
+    *,
+    now_fn: Callable[[], str] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Mark orphan RUNNING jobs as INTERRUPTED. Returns updated state and job ids."""
+    jobs = state.get("jobs")
+    if not isinstance(jobs, list):
+        return state, []
+    interrupted: list[str] = []
+    now = (now_fn or _now_utc_iso)()
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        if job.get("status") != "RUNNING":
+            continue
+        job["status"] = "INTERRUPTED"
+        job["finished_at_utc"] = now
+        job["error_classification"] = "COORDINATOR_ORPHAN"
+        interrupted.append(str(job.get("job_id", "")))
+    return state, interrupted
+
+
+def completed_fingerprints(state: Mapping[str, Any]) -> set[str]:
+    result: set[str] = set()
+    for raw in state.get("completed_fingerprints") or []:
+        if isinstance(raw, str):
+            result.add(raw.lower())
+    for job in state.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        status = job.get("status")
+        fingerprint = job.get("fingerprint")
+        if status in {"PASS", "FAIL", "INSUFFICIENT_DATA"} and isinstance(fingerprint, str):
+            result.add(fingerprint.lower())
+    return result
+
+
+def known_time_windows(state: Mapping[str, Any]) -> set[tuple[int, int]]:
+    windows: set[tuple[int, int]] = set()
+    for job in state.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        start = job.get("start_ts_ms")
+        end = job.get("end_ts_ms")
+        if start is not None and end is not None:
+            windows.add((int(start), int(end)))
+    return windows

--- a/tools/arvp_vacation/summary.py
+++ b/tools/arvp_vacation/summary.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .contract import (
+    EVIDENCE_CLASS_CONTROLLED,
+    JOB_FAIL,
+    JOB_INSUFFICIENT_DATA,
+    JOB_PASS,
+    STRATEGY_PARKED,
+    VacationManifest,
+    campaign_artifact_dir,
+)
+from .queue_store import QUEUE_STATE_FILENAME, atomic_write_json
+
+VERDICT_NEXT = "NEXT_VALIDATION_CANDIDATE"
+VERDICT_HOLD = "HOLD_MORE_DATA"
+VERDICT_REJECT_ECON = "REJECT_ECONOMICS"
+VERDICT_INSUFFICIENT = "INSUFFICIENT_DATA"
+VERDICT_TECH_INVALID = "TECHNICALLY_INVALID"
+
+
+def _job_verdict(job: Mapping[str, Any]) -> str:
+    status = job.get("status")
+    if status == JOB_INSUFFICIENT_DATA:
+        return VERDICT_INSUFFICIENT
+    if status != JOB_PASS:
+        return VERDICT_TECH_INVALID
+    if not job.get("artifacts_complete"):
+        return VERDICT_TECH_INVALID
+    if job.get("strategy_role") == STRATEGY_PARKED:
+        return VERDICT_HOLD
+    metrics = job.get("scenario_metrics") or {}
+    group = metrics.get("_group_manifest") if isinstance(metrics, dict) else None
+    if isinstance(group, dict):
+        failed = int(group.get("failed_count") or 0)
+        if failed > 0:
+            return VERDICT_TECH_INVALID
+    baseline = metrics.get("baseline") if isinstance(metrics, dict) else None
+    if isinstance(baseline, dict):
+        trade_count = int(baseline.get("trade_count") or 0)
+        if trade_count == 0:
+            return VERDICT_HOLD
+        net = baseline.get("net_pnl") or baseline.get("total_return")
+        if net is not None and float(net) < 0:
+            pessimistic = metrics.get("pessimistic_execution")
+            if isinstance(pessimistic, dict):
+                p_net = pessimistic.get("net_pnl") or pessimistic.get("total_return")
+                if p_net is not None and float(p_net) < 0:
+                    return VERDICT_REJECT_ECON
+            return VERDICT_HOLD
+    return VERDICT_NEXT
+
+
+def build_summary_payload(
+    manifest: VacationManifest,
+    state: Mapping[str, Any],
+) -> dict[str, Any]:
+    jobs = [j for j in state.get("jobs") or [] if isinstance(j, dict)]
+    rows: list[dict[str, Any]] = []
+    for job in jobs:
+        rows.append(
+            {
+                "job_id": job.get("job_id"),
+                "strategy_id": job.get("strategy_id"),
+                "strategy_role": job.get("strategy_role"),
+                "dataset_id": job.get("dataset_id"),
+                "status": job.get("status"),
+                "scenarios": job.get("scenarios"),
+                "artifacts_complete": bool(job.get("artifacts_complete")),
+                "artifacts_present": job.get("artifacts_present") or [],
+                "artifacts_missing": job.get("artifacts_missing") or [],
+                "exit_code": job.get("exit_code"),
+                "error_classification": job.get("error_classification"),
+                "fingerprint": job.get("fingerprint"),
+                "verdict": _job_verdict(job),
+                "evidence_class": EVIDENCE_CLASS_CONTROLLED,
+                "ranking_ready": False,
+                "scenario_metrics_summary": _metrics_summary(job),
+            }
+        )
+    return {
+        "schema_version": "1.0",
+        "campaign_id": manifest.campaign_id,
+        "source_sha": manifest.source_sha,
+        "evidence_class": EVIDENCE_CLASS_CONTROLLED,
+        "ranking_ready": False,
+        "lr_status": "NO-GO",
+        "campaign_status": state.get("campaign_status"),
+        "job_count": len(rows),
+        "pass_count": sum(1 for r in rows if r["status"] == JOB_PASS),
+        "fail_count": sum(1 for r in rows if r["status"] == JOB_FAIL),
+        "jobs": rows,
+        "limitations": [
+            "MVP summary only; no full Strategy League Table integration.",
+            "NEXT_VALIDATION_CANDIDATE is not promotion, paper-go, or live-go.",
+            "controlled_lab_evidence only.",
+        ],
+    }
+
+
+def _metrics_summary(job: Mapping[str, Any]) -> dict[str, Any]:
+    metrics = job.get("scenario_metrics")
+    if not isinstance(metrics, dict):
+        return {}
+    summary: dict[str, Any] = {}
+    for scenario_id, payload in metrics.items():
+        if scenario_id.startswith("_") or not isinstance(payload, dict):
+            continue
+        summary[scenario_id] = {
+            k: payload[k]
+            for k in ("trade_count", "net_pnl", "total_return", "win_rate")
+            if k in payload
+        }
+    return summary
+
+
+def render_summary_markdown(summary: Mapping[str, Any]) -> str:
+    lines = [
+        f"# ARVP Vacation Summary — {summary.get('campaign_id')}",
+        "",
+        f"- **Campaign status:** {summary.get('campaign_status')}",
+        f"- **Evidence class:** {summary.get('evidence_class')}",
+        f"- **ranking_ready:** {summary.get('ranking_ready')}",
+        f"- **LR:** {summary.get('lr_status')}",
+        f"- **Jobs:** {summary.get('job_count')} "
+        f"(pass={summary.get('pass_count')}, fail={summary.get('fail_count')})",
+        "",
+        "## Jobs",
+        "",
+        "| Job | Strategy | Dataset | Status | Verdict | Artifacts |",
+        "|-----|----------|---------|--------|---------|-----------|",
+    ]
+    for row in summary.get("jobs") or []:
+        if not isinstance(row, dict):
+            continue
+        artifacts = "complete" if row.get("artifacts_complete") else "incomplete"
+        lines.append(
+            f"| {row.get('job_id')} | {row.get('strategy_id')} | "
+            f"{row.get('dataset_id')} | {row.get('status')} | "
+            f"{row.get('verdict')} | {artifacts} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Boundaries",
+            "",
+            "- Offline controlled_lab_evidence only.",
+            "- No paper runtime, no live-go, no LR upgrade.",
+            "- NEXT_VALIDATION_CANDIDATE is advisory only.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_summary(
+    manifest: VacationManifest,
+    state: Mapping[str, Any],
+    repo_root: Path,
+) -> tuple[Path, Path]:
+    campaign_dir = campaign_artifact_dir(manifest, repo_root)
+    summary = build_summary_payload(manifest, state)
+    json_path = campaign_dir / "vacation_summary.json"
+    md_path = campaign_dir / "vacation_summary.md"
+    atomic_write_json(json_path, summary, pretty=True)
+    md_path.write_text(render_summary_markdown(summary), encoding="utf-8")
+    return json_path, md_path


### PR DESCRIPTION
## Summary

- Add `tools/arvp_vacation/` MVP offline queue coordinator over `strategy_replay_runner`
- Persistent `queue_state.json` + `queue_events.jsonl` + resume after orphan `RUNNING`
- Dataset discovery on configured roots with fingerprint/time-window dedup
- Vacation summary JSON/MD (no full league scorer)
- Runbook, production manifest (7 jobs), Windows background wrapper

Closes #3986

## Delivered

- Contract, queue store, coordinator, job runner, summary modules
- Manifest: `manifests/vacation/vacation_autopilot_mvp.yaml`
- Runbook: `docs/runbooks/ARVP_VACATION_AUTOPILOT_MVP.md`
- Evidence: `docs/evidence/arvp_vacation_mvp_acceptance_drill.md`

## Validation

- `pytest tests/unit/arvp/test_arvp_vacation_mvp.py tests/unit/arvp/test_arvp_vacation_recovery.py` — 16 passed
- `pytest tests/unit/arvp/test_arvp_campaign_supervisor_state_machine_contract.py tests/unit/tools/test_arvp_campaign_supervisor.py` — 52 passed
- `ruff check tools/arvp_vacation ...` — passed
- Preflight: 3 datasets, 7 jobs estimated

## Non-goals

- Paper runtime queue
- League scorer integration
- Host reboot autostart
- Live/LR/Echtgeld

## Remaining uncertainty

- Production replay job duration on operator Windows host not benchmarked in this PR
- Host reboot Tier-3 resume remains manual (by design)

## Test plan

- [x] MVP unit + recovery drill tests
- [x] ARVP supervisor regression tests
- [x] Manifest preflight against repo datasets
