### PR TITLE
fix(arvp): separate vacation scenario_group_id from readable job_id (#3988)

### DIFF
--- a/tests/unit/arvp/test_arvp_vacation_mvp.py
+++ b/tests/unit/arvp/test_arvp_vacation_mvp.py
@@ -9,11 +9,16 @@ import yaml
 
 from tools.arvp_vacation.contract import (
     JOB_SKIPPED_DUPLICATE,
+    SCENARIO_GROUP_ID_RE,
     VacationContractError,
+    backfill_scenario_group_ids,
     build_job_fingerprint,
+    build_job_id,
+    build_scenario_group_id,
     discover_datasets,
     load_manifest,
     parse_dataset_spec,
+    resolve_scenario_group_id,
 )
 from tools.arvp_vacation.coordinator import (
     CAMPAIGN_FATAL_STOP,
@@ -22,7 +27,11 @@ from tools.arvp_vacation.coordinator import (
     preflight_manifest,
     run_coordinator_cycle,
 )
-from tools.arvp_vacation.job_runner import JobRunResult, build_replay_command, run_replay_job
+from tools.arvp_vacation.job_runner import (
+    JobRunResult,
+    build_replay_command,
+    run_replay_job,
+)
 from tools.arvp_vacation.queue_store import (
     QUEUE_STATE_FILENAME,
     atomic_write_json,
@@ -205,13 +214,17 @@ def _mock_subprocess_factory(group_dir: Path):
     return _runner
 
 
+def _scenario_group_id_from_command(command: list[str]) -> str:
+    return command[command.index("--scenario-group-id") + 1]
+
+
 def test_coordinator_runs_job_and_persists(vacation_repo: Path) -> None:
     manifest = load_manifest(vacation_repo / "manifest.yaml")
 
     def runner(command, **kwargs):
         output_dir = Path(command[command.index("--output-dir") + 1])
-        job_id = command[command.index("--scenario-group-id") + 1]
-        return _mock_subprocess_factory(output_dir / job_id)(command, **kwargs)
+        group_id = _scenario_group_id_from_command(command)
+        return _mock_subprocess_factory(output_dir / group_id)(command, **kwargs)
 
     state = run_coordinator_cycle(
         manifest_path=vacation_repo / "manifest.yaml",
@@ -269,8 +282,8 @@ def test_duplicate_skip_on_completed_fingerprint(vacation_repo: Path) -> None:
 
     def runner(command, **kwargs):
         output_dir = Path(command[command.index("--output-dir") + 1])
-        job_id = command[command.index("--scenario-group-id") + 1]
-        return _mock_subprocess_factory(output_dir / job_id)(command, **kwargs)
+        group_id = _scenario_group_id_from_command(command)
+        return _mock_subprocess_factory(output_dir / group_id)(command, **kwargs)
 
     state = run_coordinator_cycle(
         manifest_path=vacation_repo / "manifest.yaml",
@@ -314,3 +327,118 @@ def test_preflight_manifest(vacation_repo: Path) -> None:
     info = preflight_manifest(vacation_repo / "manifest.yaml", vacation_repo)
     assert info["dataset_count"] == 2
     assert info["job_count_estimate"] == 4
+
+
+def _realistic_job_fingerprint() -> str:
+    return build_job_fingerprint(
+        source_sha="bde716af52d662010edb5871afb1df9f9326b7f3",
+        strategy_id="breakout_trend_filter_v1",
+        dataset_fingerprint="618064a3ec6f2f4e51f9f3a8a5ba4ccfe30c30d60685e17794d49c11a78b4586",
+        scenarios=["baseline", "pessimistic_execution", "feed_gap"],
+        speedup_profile="instant",
+    )
+
+
+def test_scenario_group_id_valid_for_real_long_job_names() -> None:
+    strategy_id = "breakout_trend_filter_v1"
+    dataset_id = "mexc_strict_window_3091_island_3"
+    fingerprint = _realistic_job_fingerprint()
+    job_id = build_job_id(strategy_id, dataset_id)
+    group_id = build_scenario_group_id(strategy_id, fingerprint)
+    assert len(job_id) > 64
+    assert len(group_id) <= 64
+    assert SCENARIO_GROUP_ID_RE.fullmatch(group_id)
+    assert group_id.startswith("vac_btf_")
+
+
+def test_scenario_group_id_stable_and_unique() -> None:
+    fp = _realistic_job_fingerprint()
+    gid1 = build_scenario_group_id("donchian_breakout_v1", fp)
+    gid2 = build_scenario_group_id("donchian_breakout_v1", fp)
+    other = build_scenario_group_id(
+        "donchian_breakout_v1",
+        build_job_fingerprint(
+            source_sha="bde716af52d662010edb5871afb1df9f9326b7f3",
+            strategy_id="donchian_breakout_v1",
+            dataset_fingerprint="a" * 64,
+            scenarios=["baseline"],
+            speedup_profile="instant",
+        ),
+    )
+    assert gid1 == gid2
+    assert gid1 != other
+
+
+def test_build_replay_command_passes_scenario_group_id_not_job_id(
+    vacation_repo: Path,
+) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    job = initialize_queue_state(manifest, vacation_repo)["jobs"][0]
+    cmd = build_replay_command(
+        repo_root=vacation_repo,
+        manifest=manifest,
+        job=job,
+        replay_output_dir=vacation_repo / "out",
+    )
+    group_id = cmd[cmd.index("--scenario-group-id") + 1]
+    assert group_id == job["scenario_group_id"]
+    assert group_id != job["job_id"]
+    assert len(group_id) <= 64
+
+
+def test_artifact_resolution_uses_scenario_group_dir(vacation_repo: Path) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    job = initialize_queue_state(manifest, vacation_repo)["jobs"][0]
+    job_dir = vacation_repo / "job-artifacts"
+    replay_dir = job_dir / "replay"
+    group_dir = replay_dir / job["scenario_group_id"]
+    group_dir.mkdir(parents=True)
+    (group_dir / "scenario_group_manifest.json").write_text("{}", encoding="utf-8")
+    (group_dir / "baseline_metrics.json").write_text("{}", encoding="utf-8")
+    (group_dir / "scenario_comparison_summary.md").write_text("# ok\n")
+
+    def runner(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    result = run_replay_job(
+        repo_root=vacation_repo,
+        manifest=manifest,
+        job=job,
+        job_artifact_dir=job_dir,
+        timeout_seconds=30,
+        subprocess_runner=runner,
+    )
+    assert result.artifacts_complete is True
+    assert "scenario_group_manifest.json" in result.artifacts_present
+
+
+def test_legacy_queue_state_backfills_scenario_group_id(vacation_repo: Path) -> None:
+    manifest = load_manifest(vacation_repo / "manifest.yaml")
+    state = initialize_queue_state(manifest, vacation_repo)
+    legacy_job = dict(state["jobs"][0])
+    legacy_job.pop("scenario_group_id", None)
+    backfilled = backfill_scenario_group_ids({"jobs": [legacy_job]})
+    job = backfilled["jobs"][0]
+    assert job["scenario_group_id"] == resolve_scenario_group_id(job)
+    assert len(job["scenario_group_id"]) <= 64
+
+
+def test_harness_accepts_generated_scenario_group_id(tmp_path: Path) -> None:
+    from core.replay.scenario_harness import ScenarioSpec, run_scenario_group
+
+    fingerprint = _realistic_job_fingerprint()
+    group_id = build_scenario_group_id("donchian_breakout_v1", fingerprint)
+
+    def _run_fn(spec: ScenarioSpec):
+        from core.replay.scenario_harness import ScenarioRunResult
+
+        return ScenarioRunResult(scenario_id=spec.scenario_id, exit_code=0)
+
+    manifest = run_scenario_group(
+        [ScenarioSpec("baseline", "baseline", {})],
+        run_fn=_run_fn,
+        output_dir=tmp_path,
+        group_id=group_id,
+    )
+    assert manifest.group_id == group_id
+    assert (tmp_path / group_id / "scenario_group_manifest.json").exists()

--- a/tests/unit/arvp/test_arvp_vacation_recovery.py
+++ b/tests/unit/arvp/test_arvp_vacation_recovery.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import yaml
 
-from tools.arvp_vacation.contract import load_manifest
+from tools.arvp_vacation.contract import backfill_scenario_group_ids, load_manifest
 from tools.arvp_vacation.coordinator import (
     initialize_queue_state,
     run_coordinator_cycle,
@@ -64,8 +64,8 @@ def _mock_runner(output_root: Path):
         if calls["count"] == 2:
             raise subprocess.TimeoutExpired(cmd=command, timeout=1)
         output_dir = Path(command[command.index("--output-dir") + 1])
-        job_id = command[command.index("--scenario-group-id") + 1]
-        group_dir = output_dir / job_id
+        group_id = command[command.index("--scenario-group-id") + 1]
+        group_dir = output_dir / group_id
         group_dir.mkdir(parents=True, exist_ok=True)
         (group_dir / "scenario_group_manifest.json").write_text(
             json.dumps({"failed_count": 0}), encoding="utf-8"
@@ -154,3 +154,24 @@ def test_acceptance_drill_six_jobs_summary(tmp_path: Path) -> None:
     assert len(state["jobs"]) >= 6
     assert (tmp_path / "artifacts/arvp_vacation/vac_recovery/vacation_summary.json").exists()
     assert calls["count"] >= 1
+
+
+def test_recovery_preserves_scenario_group_id(tmp_path: Path) -> None:
+    roots = ["datasets/a", "datasets/b"]
+    for i, rel in enumerate(roots):
+        _write_dataset(
+            tmp_path,
+            rel,
+            dataset_id=f"w{i}",
+            fingerprint=f"{i+20:064d}",
+        )
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(_manifest_yaml(roots), encoding="utf-8")
+    manifest = load_manifest(manifest_path)
+    state = initialize_queue_state(manifest, tmp_path)
+    original = state["jobs"][0]["scenario_group_id"]
+    legacy = dict(state["jobs"][0])
+    legacy.pop("scenario_group_id", None)
+    state["jobs"][0] = legacy
+    backfilled = backfill_scenario_group_ids(state)
+    assert backfilled["jobs"][0]["scenario_group_id"] == original

--- a/tools/arvp_vacation/contract.py
+++ b/tools/arvp_vacation/contract.py
@@ -55,6 +55,13 @@ ALLOWED_SCENARIOS: frozenset[str] = frozenset(
 )
 
 _HEX64_RE = re.compile(r"^[a-f0-9]{64}$")
+SCENARIO_GROUP_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,64}$")
+_SCENARIO_GROUP_FINGERPRINT_CHARS = 16
+_STRATEGY_SLUGS: dict[str, str] = {
+    "donchian_breakout_v1": "donchian",
+    "breakout_trend_filter_v1": "btf",
+    "primary_breakout_v1": "pbo",
+}
 
 
 class VacationContractError(ValueError):
@@ -320,6 +327,67 @@ def build_job_id(strategy_id: str, dataset_id: str) -> str:
     safe_strategy = strategy_id.replace("_", "-")
     safe_dataset = re.sub(r"[^a-zA-Z0-9._-]+", "-", dataset_id)
     return f"vac-{safe_strategy}-{safe_dataset}-scenarios"
+
+
+def _strategy_slug(strategy_id: str) -> str:
+    if strategy_id in _STRATEGY_SLUGS:
+        return _STRATEGY_SLUGS[strategy_id]
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", strategy_id).strip("_").lower()
+    if slug.endswith("_v1"):
+        slug = slug[:-3]
+    return slug[:24] or "strategy"
+
+
+def build_scenario_group_id(strategy_id: str, job_fingerprint: str) -> str:
+    """Derive a harness-safe scenario group id from strategy + job fingerprint."""
+    fp = job_fingerprint.strip().lower()
+    if not _HEX64_RE.match(fp):
+        raise VacationContractError(
+            "job_fingerprint must be a 64-char lowercase hex string"
+        )
+    slug = _strategy_slug(strategy_id)
+    prefix = fp[:_SCENARIO_GROUP_FINGERPRINT_CHARS]
+    group_id = f"vac_{slug}_{prefix}"
+    if len(group_id) > 64 or not SCENARIO_GROUP_ID_RE.match(group_id):
+        raise VacationContractError(
+            f"derived scenario_group_id invalid: {group_id!r}"
+        )
+    return group_id
+
+
+def resolve_scenario_group_id(job: Mapping[str, Any]) -> str:
+    """Return persisted scenario_group_id or derive deterministically from the job."""
+    stored = job.get("scenario_group_id")
+    if isinstance(stored, str) and stored.strip():
+        group_id = stored.strip()
+        if not SCENARIO_GROUP_ID_RE.match(group_id):
+            raise VacationContractError(
+                f"invalid stored scenario_group_id: {group_id!r}"
+            )
+        return group_id
+    strategy_id = job.get("strategy_id")
+    fingerprint = job.get("fingerprint")
+    if not isinstance(strategy_id, str) or not isinstance(fingerprint, str):
+        raise VacationContractError(
+            "job record missing strategy_id/fingerprint; "
+            "cannot derive scenario_group_id"
+        )
+    return build_scenario_group_id(strategy_id, fingerprint)
+
+
+def backfill_scenario_group_ids(state: Mapping[str, Any]) -> dict[str, Any]:
+    """Ensure every job record carries a deterministic scenario_group_id."""
+    updated = dict(state)
+    jobs: list[dict[str, Any]] = []
+    for raw in updated.get("jobs") or []:
+        if not isinstance(raw, dict):
+            continue
+        job = dict(raw)
+        if not job.get("scenario_group_id"):
+            job["scenario_group_id"] = resolve_scenario_group_id(job)
+        jobs.append(job)
+    updated["jobs"] = jobs
+    return updated
 
 
 def campaign_artifact_dir(manifest: VacationManifest, repo_root: Path | None = None) -> Path:

--- a/tools/arvp_vacation/coordinator.py
+++ b/tools/arvp_vacation/coordinator.py
@@ -24,6 +24,8 @@ from .contract import (
     VacationManifest,
     build_job_fingerprint,
     build_job_id,
+    build_scenario_group_id,
+    backfill_scenario_group_ids,
     campaign_artifact_dir,
     discover_datasets,
     git_head_sha,
@@ -81,8 +83,10 @@ def _new_job_record(
         speedup_profile=manifest.speedup_profile,
     )
     job_id = build_job_id(strategy_id, str(dataset["dataset_id"]))
+    scenario_group_id = build_scenario_group_id(strategy_id, fingerprint)
     return {
         "job_id": job_id,
+        "scenario_group_id": scenario_group_id,
         "fingerprint": fingerprint,
         "strategy_id": strategy_id,
         "strategy_role": strategy_role,
@@ -335,7 +339,7 @@ def run_coordinator_cycle(
         return fatal_state
 
     if state_path.exists() and resume:
-        state = read_queue_state(state_path)
+        state = backfill_scenario_group_ids(read_queue_state(state_path))
         state, interrupted = recover_orphan_running_jobs(state, now_fn=now_fn)
         for job_id in interrupted:
             emit_event(
@@ -346,7 +350,7 @@ def run_coordinator_cycle(
                 now_fn=now_fn,
             )
     elif state_path.exists():
-        state = read_queue_state(state_path)
+        state = backfill_scenario_group_ids(read_queue_state(state_path))
     else:
         state = initialize_queue_state(manifest, root)
         emit_event(

--- a/tools/arvp_vacation/job_runner.py
+++ b/tools/arvp_vacation/job_runner.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
-from .contract import STRATEGY_ADAPTERS, VacationManifest
+from .contract import (
+    STRATEGY_ADAPTERS,
+    VacationContractError,
+    VacationManifest,
+    resolve_scenario_group_id,
+)
 
 EXPECTED_SCENARIO_ARTIFACTS = (
     "scenario_group_manifest.json",
@@ -43,6 +48,7 @@ def build_replay_command(
     adapter_id = STRATEGY_ADAPTERS[strategy_id]
     scenarios = job.get("scenarios") or manifest.scenarios
     scenario_csv = ",".join(str(s) for s in scenarios)
+    scenario_group_id = resolve_scenario_group_id(job)
     return [
         sys.executable,
         "-m",
@@ -64,7 +70,7 @@ def build_replay_command(
         "--scenario-group",
         scenario_csv,
         "--scenario-group-id",
-        str(job["job_id"]),
+        scenario_group_id,
     ]
 
 
@@ -101,6 +107,21 @@ def _load_scenario_metrics(group_dir: Path) -> dict[str, Any]:
         except (OSError, json.JSONDecodeError):
             pass
     return metrics
+
+
+def resolve_replay_group_dir(
+    replay_output_dir: Path, scenario_group_id: str
+) -> Path:
+    """Resolve scenario artifacts under replay_output_dir / scenario_group_id."""
+    primary = replay_output_dir / scenario_group_id
+    if primary.is_dir():
+        return primary
+    if not replay_output_dir.is_dir():
+        return primary
+    alt_dirs = [p for p in replay_output_dir.iterdir() if p.is_dir()]
+    if len(alt_dirs) == 1 and not primary.exists():
+        return alt_dirs[0]
+    return primary
 
 
 def run_replay_job(
@@ -152,14 +173,21 @@ def run_replay_job(
     (job_artifact_dir / "stdout.log").write_text(completed.stdout or "", encoding="utf-8")
     (job_artifact_dir / "stderr.log").write_text(completed.stderr or "", encoding="utf-8")
     (job_artifact_dir / "command.json").write_text(
-        json.dumps({"command": command}, indent=2) + "\n",
+        json.dumps(
+            {
+                "command": command,
+                "job_id": job.get("job_id"),
+                "scenario_group_id": resolve_scenario_group_id(job),
+                "fingerprint": job.get("fingerprint"),
+            },
+            indent=2,
+        )
+        + "\n",
         encoding="utf-8",
     )
 
-    group_dir = replay_output_dir / str(job["job_id"])
-    if not group_dir.exists():
-        alt_dirs = [p for p in replay_output_dir.iterdir() if p.is_dir()]
-        group_dir = alt_dirs[0] if len(alt_dirs) == 1 else group_dir
+    scenario_group_id = resolve_scenario_group_id(job)
+    group_dir = resolve_replay_group_dir(replay_output_dir, scenario_group_id)
 
     present, missing, complete = _collect_artifact_status(group_dir)
     metrics = _load_scenario_metrics(group_dir) if group_dir.exists() else {}


### PR DESCRIPTION
## Summary

- **Root cause:** `build_replay_command()` passed the readable `job_id` (67–72 chars) as `--scenario-group-id`. `core/replay/scenario_harness.py` enforces `^[a-zA-Z0-9_-]{1,64}$`, so all 7 real foreground benchmark jobs failed with exit code 2.
- **Design:** `job_id` remains the human-readable queue/directory identifier; a new deterministic `scenario_group_id` (`vac_<strategy_slug>_<fingerprint_prefix>`) is stored on each job record and passed to the replay runner.
- **Test gap closed:** Added real `run_scenario_group()` harness acceptance test plus contract tests for length, charset, stability, artifact path, legacy backfill, and recovery.

## Changed files

- `tools/arvp_vacation/contract.py` — `build_scenario_group_id`, `resolve_scenario_group_id`, `backfill_scenario_group_ids`
- `tools/arvp_vacation/coordinator.py` — persist `scenario_group_id`; backfill on resume
- `tools/arvp_vacation/job_runner.py` — use short id for CLI + artifact resolution
- `tests/unit/arvp/test_arvp_vacation_mvp.py`
- `tests/unit/arvp/test_arvp_vacation_recovery.py`

## Validation

```text
pytest tests/unit/arvp/test_arvp_vacation_mvp.py -q          → 20 passed
pytest tests/unit/arvp/test_arvp_vacation_recovery.py -q      → 3 passed
pytest tests/unit/tools/test_arvp_campaign_supervisor.py -q    → 30 passed
pytest tests/unit/tools/test_arvp_supervisor_failure_simulation.py -q → 60 passed
pytest tests/unit/replay/test_scenario_harness.py -q           → 37 passed
ruff check tools/arvp_vacation tests/unit/arvp               → PASS
```

Max observed `scenario_group_id` length: **29** chars (limit 64).

## Non-goals / boundaries

- No new foreground benchmark executed in this PR
- No queue extension, harvester wiring, paper/docker/live changes
- LR remains **NO-GO**

Closes #3988
