### PR TITLE
feat(arvp): vacation 14d MEXC data capture prep (#3990)

### DIFF
--- a/docs/runbooks/ARVP_VACATION_DATA_CAPTURE_14D.md
+++ b/docs/runbooks/ARVP_VACATION_DATA_CAPTURE_14D.md
@@ -173,7 +173,7 @@ No DB writes. No large artifact commits.
 - No signal/strategy execution, paper trading, orders, live-go, LR upgrade
 - No deletion/overwrite of existing candles
 - No compose `down -v`
-- No secrets in evidence artifacts
+- No credentials in evidence artifacts
 
 ## Verdicts
 

--- a/docs/runbooks/ARVP_VACATION_DATA_CAPTURE_14D.md
+++ b/docs/runbooks/ARVP_VACATION_DATA_CAPTURE_14D.md
@@ -1,0 +1,186 @@
+# ARVP Vacation Data Capture — 14-Day MEXC BTCUSDT 1m (No Trading)
+
+Version: 1.0  
+Issue: #3990  
+Parent: #1900  
+Related: #3091 (capture path), #3986/#3988 (offline vacation queue — post-capture consumer)
+
+## Purpose
+
+Collect **new, provenance-valid MEXC BTCUSDT 1m candles** into `public.candles_1m` during operator absence.
+This is a **data-capture campaign**, not paper trading, not signal execution, not live-go.
+
+Static replay expansion improves evidence breadth but cannot provide two-week runtime capacity.
+The vacation workload is a no-trading MEXC candle capture campaign. Replays consume the resulting windows after capture.
+
+LR remains **NO-GO**. No paper, live, or Echtgeld scope.
+
+## Verified minimal service set
+
+Evidence chain (repo, #3091):
+
+```text
+MEXC WebSocket (cdb_ws)
+  → Redis pub/sub market_data
+  → Candle service (cdb_candles)
+  → stream.candles_1m
+  → DB Writer (cdb_db_writer)
+  → public.candles_1m
+```
+
+| Service | Role | Compose file |
+|---------|------|--------------|
+| `cdb_postgres` | Candle persistence | `compose.blue.yml` |
+| `cdb_redis` | Message bus | `compose.blue.yml` |
+| `cdb_ws` | MEXC market input | `compose.red.yml` |
+| `cdb_candles` | 1m aggregation | `compose.blue.yml` |
+| `cdb_db_writer` | Stream → Postgres | `compose.blue.yml` |
+
+**Explicitly excluded** (must not run): `cdb_signal`, `cdb_risk`, `cdb_allocation`, `cdb_execution`, `cdb_paper_runner`, vacation replay queue coordinator, any order/paper path.
+
+**Not required for raw capture:** `cdb_market`, `cdb_regime` (regime enrichment is a post-export offline step).
+
+## Artifacts
+
+```text
+manifests/vacation/vacation_data_capture_14d.yaml
+scripts/arvp_vacation_data_capture.ps1
+artifacts/arvp_vacation/data_capture/<campaign_id>/
+  campaign_state.json
+  campaign_events.jsonl
+  heartbeat.json
+  service_inventory.json
+  coverage_snapshots.jsonl
+  final_capture_summary.json   (after stop / return)
+  final_capture_summary.md
+```
+
+## Preflight (before GO)
+
+```powershell
+cd D:\Dev\Workspaces\Repos\Claire_de_Binare
+git rev-parse HEAD
+git status
+.\scripts\arvp_vacation_data_capture.ps1 -Preflight -Json
+```
+
+Preflight checks (14 items):
+
+1. Git HEAD matches manifest `source_sha` (or `RUNTIME_RESOLVE` at GO)
+2. Working tree clean
+3. Docker reachable
+4. Free disk ≥ manifest minimum (default 5 GB)
+5. Postgres/Redis start path available (compose files present)
+6. No forbidden trading/paper services running
+7. No productive exchange credentials used for orders (forbidden services off)
+8. Candle stream / DB-writer contract unchanged (allowed set only)
+9. `public.candles_1m` coverage probe via `POSTGRES_READONLY_PASSWORD_DSN` when set
+10. Campaign ID unused (no prior `campaign_state.json`)
+11. No volume/data deletion (`stop` never uses `down -v`)
+12. UTC timestamps enforced at runtime window resolution
+13. Planned end = start + exactly 14 days (validated at Start)
+14. Safety flags: `allow_signal/execution/paper/live_trading=false`
+
+Pin `source_sha` in the manifest before departure if you require a fixed commit pin instead of `RUNTIME_RESOLVE`.
+
+## Human gate (Start / Resume)
+
+Start and Resume are blocked unless the exact phrase is supplied:
+
+```text
+DATA-CAPTURE-GO #3990 vacation 14d preflight and acceptance drill
+```
+
+```powershell
+$go = "DATA-CAPTURE-GO #3990 vacation 14d preflight and acceptance drill"
+.\scripts\arvp_vacation_data_capture.ps1 -Start -GoPhrase $go
+.\scripts\arvp_vacation_data_capture.ps1 -Status -Json
+.\scripts\arvp_vacation_data_capture.ps1 -Stop
+.\scripts\arvp_vacation_data_capture.ps1 -Resume -GoPhrase $go
+```
+
+## Acceptance drill (before 14-day run)
+
+Use a **separate campaign ID** (copy manifest, set `drill_campaign_id` pattern, `max_duration_days` unchanged but stop manually after ~15 minutes).
+
+Drill must prove:
+
+1. Only allowed services start
+2. No signal/execution/paper services run
+3. New MEXC candles reach `cdb_candles` (Redis stream growth)
+4. New rows appear in `public.candles_1m`
+5. Timestamps monotonic in drill window
+6. No duplicates/gaps in drill window (readonly gap script post-drill)
+7. Status coverage correct
+8. Stop ends capture services cleanly
+9. Data retained after stop
+10. Resume works or is documented as manual-only
+
+Suggested drill flow:
+
+```powershell
+# 1. Preflight
+.\scripts\arvp_vacation_data_capture.ps1 -Preflight -Json
+
+# 2. Start with GO phrase (drill manifest copy if isolated campaign_id desired)
+$go = "DATA-CAPTURE-GO #3990 vacation 14d preflight and acceptance drill"
+.\scripts\arvp_vacation_data_capture.ps1 -Start -GoPhrase $go
+
+# 3. Wait >= drill_duration_minutes (default 15) — observe Status every few minutes
+.\scripts\arvp_vacation_data_capture.ps1 -Status -Json
+
+# 4. Stop (no volume delete)
+.\scripts\arvp_vacation_data_capture.ps1 -Stop
+```
+
+## 14-day operation
+
+Expected candle volume: **20 160** rows (14 × 24 × 60), plus warmup overlap negligible.
+
+Disk estimate (Postgres candles row ~200–400 B): **~8–15 MB** raw table growth for BTCUSDT 1m only; allow headroom for WAL/logs (manifest default 5 GB free minimum).
+
+Status polling: heartbeat every `heartbeat_interval_seconds` (300 s); stale if no new candle > `stale_threshold_seconds` (180 s) while campaign running.
+
+## Host reboot / auto-resume
+
+**Not enabled.** Tier-3 Evidence Harvester supervisor (#3733/#3738) targets the harvester coordinator, not this Docker capture set.
+Trading-adjacent services are forbidden; unproven Windows Task Scheduler install is out of scope.
+
+After host reboot: **manual Resume** with GO phrase, respecting `max_restart_budget` (default 3) and `planned_end_utc`.
+
+## Post-return export (read-only)
+
+No DB writes. No large artifact commits.
+
+1. **Inventory** (readonly DSN):
+
+   ```powershell
+   python scripts/arvp_3742_natural_paper_window_inventory.py
+   ```
+
+   Or scoped SELECT on `public.candles_1m` for `[start_ts_ms, end_ts_ms]` from `campaign_state.json`.
+
+2. **Gap / continuity**: reuse patterns from `docs/evidence/mexc_future_capture_3091.md` and `scripts/profitability/build_mexc_multi_window_evidence_3032.py` (island detection, 1m step checks).
+
+3. **File-backed dataset**: export JSONL + `dataset_spec.json` + `provenance_manifest.json` under `artifacts/candles/<campaign_window_id>/` (readonly principal `cdb_readonly`).
+
+4. **Regime-enriched variant** (optional, offline): `assign_regime_calibrate_3032_expansion` pipeline on exported file — not required for capture campaign.
+
+5. **Vacation queue**: add new dataset roots to a **generated** vacation manifest (do not edit tracked MVP manifest in-place). Offline replays consume windows after capture.
+
+## Boundaries
+
+- No signal/strategy execution, paper trading, orders, live-go, LR upgrade
+- No deletion/overwrite of existing candles
+- No compose `down -v`
+- No secrets in evidence artifacts
+
+## Verdicts
+
+| Verdict | Meaning |
+|---------|---------|
+| `VACATION_DATA_CAPTURE_READY_FOR_DRILL` | Preflight tooling merged; drill not yet run |
+| `VACATION_DATA_CAPTURE_PARTIAL` | Drill partial or resume unproven |
+| `VACATION_DATA_CAPTURE_NO_GO` | Safety/preflight blocker |
+
+This preparation slice targets **READY_FOR_DRILL** without runtime start.

--- a/manifests/vacation/vacation_data_capture_14d.yaml
+++ b/manifests/vacation/vacation_data_capture_14d.yaml
@@ -1,0 +1,36 @@
+schema_version: "1.0"
+campaign_id: "arvp_vacation_data_capture_14d_20260711"
+source_sha: "RUNTIME_RESOLVE"
+evidence_class: controlled_lab_evidence
+symbol: BTCUSDT
+venue: MEXC
+timeframe: 1m
+start_utc: "RUNTIME_RESOLVE"
+planned_end_utc: "RUNTIME_RESOLVE"
+max_duration_days: 14
+allowed_services:
+  - cdb_postgres
+  - cdb_redis
+  - cdb_ws
+  - cdb_candles
+  - cdb_db_writer
+forbidden_services:
+  - cdb_signal
+  - cdb_risk
+  - cdb_allocation
+  - cdb_execution
+  - cdb_paper_runner
+database_target: public.candles_1m
+heartbeat_interval_seconds: 300
+stale_threshold_seconds: 180
+min_free_disk_gb: 5
+max_restart_budget: 3
+evidence_dir: artifacts/arvp_vacation/data_capture
+allow_signal: false
+allow_execution: false
+allow_paper: false
+allow_live_trading: false
+compose_blue: infrastructure/compose/compose.blue.yml
+compose_red: infrastructure/compose/compose.red.yml
+drill_duration_minutes: 15
+drill_campaign_id: "arvp_vacation_data_capture_drill_20260711"

--- a/scripts/arvp_vacation_data_capture.ps1
+++ b/scripts/arvp_vacation_data_capture.ps1
@@ -1,0 +1,97 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  ARVP 14-day vacation MEXC candle data capture (no trading).
+.DESCRIPTION
+  Wraps tools.arvp_vacation.data_capture for preflight, start, status, stop, resume.
+  Issue #3990. LR NO-GO. No paper, signal, execution, or live trading.
+  Start/Resume require the exact DATA-CAPTURE-GO phrase.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Preflight,
+    [switch]$Start,
+    [switch]$Status,
+    [switch]$Stop,
+    [switch]$Resume,
+    [string]$ManifestPath = "manifests/vacation/vacation_data_capture_14d.yaml",
+    [string]$GoPhrase = "",
+    [string]$RepoRoot = "",
+    [switch]$Json
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    param([string]$Override)
+    if ($Override) { return (Resolve-Path $Override).Path }
+    return (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+}
+
+$root = Get-RepoRoot -Override $RepoRoot
+$manifestFull = Join-Path $root ($ManifestPath -replace '/', '\')
+$pyArgs = @("-m", "tools.arvp_vacation.data_capture", "--manifest", $manifestFull)
+if ($Json) { $pyArgs += "--json" }
+
+if ($Preflight) {
+    $pyArgs += "--preflight-only"
+    Push-Location $root
+    try {
+        & python @pyArgs
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+if ($Status) {
+    $pyArgs += "--status"
+    Push-Location $root
+    try {
+        & python @pyArgs
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+if ($Start) {
+    if (-not $GoPhrase) {
+        Write-Error "Start requires -GoPhrase with exact DATA-CAPTURE-GO phrase"
+    }
+    $pyArgs += @("--start", "--go-phrase", $GoPhrase)
+    Push-Location $root
+    try {
+        & python @pyArgs
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+if ($Stop) {
+    $pyArgs += "--stop"
+    Push-Location $root
+    try {
+        & python @pyArgs
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+if ($Resume) {
+    if (-not $GoPhrase) {
+        Write-Error "Resume requires -GoPhrase with exact DATA-CAPTURE-GO phrase"
+    }
+    $pyArgs += @("--resume", "--go-phrase", $GoPhrase)
+    Push-Location $root
+    try {
+        & python @pyArgs
+        exit $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+}
+
+Write-Error "Specify -Preflight, -Start, -Status, -Stop, or -Resume"

--- a/tests/unit/arvp/test_arvp_vacation_data_capture.py
+++ b/tests/unit/arvp/test_arvp_vacation_data_capture.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tools.arvp_vacation.data_capture import (
+    CAMPAIGN_STATE_FILENAME,
+    DataCaptureError,
+    build_preflight_report,
+    start_campaign,
+    stop_campaign,
+    verify_go_phrase,
+)
+from tools.arvp_vacation.data_capture_contract import (
+    DATA_CAPTURE_GO_PHRASE,
+    DataCaptureContractError,
+    classify_running_services,
+    load_data_capture_manifest,
+    resolve_planned_end_utc,
+    resolve_runtime_window,
+    validate_end_matches_start,
+)
+
+
+@pytest.fixture()
+def manifest_path(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    manifest = {
+        "schema_version": "1.0",
+        "campaign_id": "arvp_vacation_data_capture_test",
+        "source_sha": "RUNTIME_RESOLVE",
+        "symbol": "BTCUSDT",
+        "venue": "MEXC",
+        "timeframe": "1m",
+        "start_utc": "2026-07-11T12:00:00Z",
+        "planned_end_utc": "2026-07-25T12:00:00Z",
+        "max_duration_days": 14,
+        "database_target": "public.candles_1m",
+        "heartbeat_interval_seconds": 300,
+        "stale_threshold_seconds": 180,
+        "min_free_disk_gb": 1,
+        "max_restart_budget": 3,
+        "evidence_dir": "artifacts/arvp_vacation/data_capture",
+        "allow_signal": False,
+        "allow_execution": False,
+        "allow_paper": False,
+        "allow_live_trading": False,
+    }
+    path = repo / "manifest.yaml"
+    path.write_text(yaml.dump(manifest), encoding="utf-8")
+    return path
+
+
+@pytest.mark.unit
+def test_load_manifest_validates_14_day_window(manifest_path: Path) -> None:
+    manifest = load_data_capture_manifest(manifest_path)
+    validate_end_matches_start(
+        manifest.start_utc, manifest.planned_end_utc, manifest.max_duration_days
+    )
+
+
+@pytest.mark.unit
+def test_planned_end_exactly_14_days() -> None:
+    start = "2026-07-11T12:00:00Z"
+    end = resolve_planned_end_utc(start, 14)
+    assert end == "2026-07-25T12:00:00Z"
+
+
+@pytest.mark.unit
+def test_reject_paper_flags(manifest_path: Path) -> None:
+    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    raw["allow_paper"] = True
+    manifest_path.write_text(yaml.dump(raw), encoding="utf-8")
+    with pytest.raises(DataCaptureContractError, match="allow_paper"):
+        load_data_capture_manifest(manifest_path)
+
+
+@pytest.mark.unit
+def test_classify_forbidden_services() -> None:
+    result = classify_running_services(
+        ["cdb_postgres", "cdb_signal", "cdb_candles"],
+        allowed=["cdb_postgres", "cdb_candles", "cdb_redis", "cdb_ws", "cdb_db_writer"],
+        forbidden=["cdb_signal", "cdb_risk"],
+    )
+    assert result["running_forbidden"] == ["cdb_signal"]
+    assert "cdb_postgres" in result["running_allowed"]
+
+
+@pytest.mark.unit
+def test_go_phrase_gate() -> None:
+    verify_go_phrase(DATA_CAPTURE_GO_PHRASE)
+    with pytest.raises(DataCaptureError, match="DATA-CAPTURE-GO"):
+        verify_go_phrase("wrong phrase")
+
+
+@pytest.mark.unit
+def test_preflight_passes_with_mocks(manifest_path: Path, tmp_path: Path) -> None:
+    repo = manifest_path.parent
+
+    def fake_git(_: Path) -> str:
+        return "clean"
+
+    def fake_disk(_: Path) -> float:
+        return 10.0
+
+    def fake_coverage(_: Path, __: str, ___: int | None) -> dict:
+        return {"available": True, "candle_count": 100}
+
+    def fake_docker(args, cwd: Path):
+        import subprocess
+
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    def fake_containers() -> list[str]:
+        return ["cdb_postgres"]
+
+    manifest = load_data_capture_manifest(manifest_path)
+    report = build_preflight_report(
+        manifest,
+        repo_root=repo,
+        docker_runner=fake_docker,
+        container_lister=fake_containers,
+        git_status_probe=fake_git,
+        disk_probe=fake_disk,
+        coverage_probe=fake_coverage,
+        skip_docker=False,
+    )
+    assert report["passed"] is True
+    assert report["verdict"] == "PREFLIGHT_PASS"
+
+
+@pytest.mark.unit
+def test_preflight_fails_on_forbidden_running(manifest_path: Path) -> None:
+    repo = manifest_path.parent
+    manifest = load_data_capture_manifest(manifest_path)
+
+    def fake_containers() -> list[str]:
+        return ["cdb_signal"]
+
+    def fake_docker(args, cwd: Path):
+        import subprocess
+
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    report = build_preflight_report(
+        manifest,
+        repo_root=repo,
+        docker_runner=fake_docker,
+        container_lister=fake_containers,
+        git_status_probe=lambda _: "clean",
+        disk_probe=lambda _: 10.0,
+        coverage_probe=lambda *_: {"available": True},
+    )
+    assert report["passed"] is False
+    assert "no_forbidden_services_running" in report["failed_checks"]
+
+
+@pytest.mark.unit
+def test_start_stop_with_skip_docker(manifest_path: Path) -> None:
+    repo = manifest_path.parent
+    manifest = load_data_capture_manifest(manifest_path)
+    started = start_campaign(
+        manifest,
+        repo_root=repo,
+        go_phrase=DATA_CAPTURE_GO_PHRASE,
+        skip_docker=True,
+        git_status_probe=lambda _: "clean",
+        disk_probe=lambda _: 10.0,
+        coverage_probe=lambda *_: {"available": True, "candle_count": 0},
+    )
+    assert started["status"] == "running"
+    state_path = (
+        repo
+        / "artifacts/arvp_vacation/data_capture"
+        / manifest.campaign_id
+        / CAMPAIGN_STATE_FILENAME
+    )
+    assert state_path.exists()
+    stopped = stop_campaign(manifest, repo_root=repo, skip_docker=True)
+    assert stopped["status"] == "stopped"
+
+
+@pytest.mark.unit
+def test_runtime_window_resolution(manifest_path: Path) -> None:
+    manifest = load_data_capture_manifest(manifest_path)
+    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    raw["start_utc"] = "RUNTIME_RESOLVE"
+    raw["planned_end_utc"] = "RUNTIME_RESOLVE"
+    manifest_path.write_text(yaml.dump(raw), encoding="utf-8")
+    manifest = load_data_capture_manifest(manifest_path)
+    fixed = datetime(2026, 7, 11, 12, 0, 0, tzinfo=UTC)
+    start, end = resolve_runtime_window(manifest, now=fixed)
+    assert start == "2026-07-11T12:00:00Z"
+    assert end == "2026-07-25T12:00:00Z"

--- a/tools/arvp_vacation/data_capture.py
+++ b/tools/arvp_vacation/data_capture.py
@@ -387,7 +387,7 @@ def build_status_report(
     )
     start_ts_ms = state.get("start_ts_ms")
     coverage = coverage_probe(root, manifest.symbol, start_ts_ms)
-    now_ms = int(datetime.now(tz=UTC).timestamp() * 1000)
+    now_ms = int(cdb_utcnow().timestamp() * 1000)
     stale = False
     last_ts = coverage.get("max_ts_ms")
     if last_ts is not None and state.get("status") == CAMPAIGN_RUNNING:
@@ -563,7 +563,10 @@ def resume_campaign(
     planned_end = state.get("planned_end_utc", "")
     if planned_end:
         end_dt = datetime.fromisoformat(planned_end.replace("Z", "+00:00"))
-        if datetime.now(tz=UTC) >= end_dt.astimezone(UTC):
+        now = cdb_utcnow()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=UTC)
+        if now.astimezone(UTC) >= end_dt.astimezone(UTC):
             raise DataCaptureError("campaign planned_end_utc has passed")
 
     running = container_lister() if not skip_docker else []

--- a/tools/arvp_vacation/data_capture.py
+++ b/tools/arvp_vacation/data_capture.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from core.utils.clock import utcnow as cdb_utcnow
+
+from .contract import git_head_sha
+from .data_capture_contract import (
+    DATA_CAPTURE_GO_PHRASE,
+    RUNTIME_RESOLVE,
+    DataCaptureContractError,
+    DataCaptureManifest,
+    classify_running_services,
+    load_data_capture_manifest,
+    resolve_runtime_window,
+    resolve_source_sha,
+    validate_end_matches_start,
+)
+
+CAMPAIGN_STATE_FILENAME = "campaign_state.json"
+CAMPAIGN_EVENTS_FILENAME = "campaign_events.jsonl"
+HEARTBEAT_FILENAME = "heartbeat.json"
+SERVICE_INVENTORY_FILENAME = "service_inventory.json"
+COVERAGE_SNAPSHOTS_FILENAME = "coverage_snapshots.jsonl"
+
+CAMPAIGN_PLANNED = "planned"
+CAMPAIGN_RUNNING = "running"
+CAMPAIGN_STOPPED = "stopped"
+CAMPAIGN_COMPLETED = "completed"
+CAMPAIGN_BLOCKED = "blocked"
+
+DockerRunner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+ContainerLister = Callable[[], list[str]]
+CoverageProbe = Callable[[Path, str, int | None], dict[str, Any]]
+GitStatusProbe = Callable[[Path], str]
+DiskProbe = Callable[[Path], float]
+
+
+class DataCaptureError(RuntimeError):
+    pass
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _now_utc_iso() -> str:
+    now = cdb_utcnow()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    return now.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def default_disk_probe(path: Path) -> float:
+    usage = shutil.disk_usage(path)
+    return usage.free / (1024**3)
+
+
+def default_docker_runner(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def default_container_lister() -> list[str]:
+    result = default_docker_runner(
+        ["docker", "ps", "--format", "{{.Names}}"],
+        _repo_root(),
+    )
+    if result.returncode != 0:
+        raise DataCaptureError(result.stderr.strip() or "docker ps failed")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def default_git_status_probe(repo_root: Path) -> str:
+    result = default_docker_runner(["git", "status", "--porcelain"], repo_root)
+    if result.returncode != 0:
+        return "unknown"
+    return "clean" if not result.stdout.strip() else "dirty"
+
+
+def default_coverage_probe(
+    repo_root: Path, symbol: str, start_ts_ms: int | None
+) -> dict[str, Any]:
+    dsn = os.environ.get("POSTGRES_READONLY_PASSWORD_DSN", "").strip()
+    if not dsn:
+        return {
+            "available": False,
+            "reason": "POSTGRES_READONLY_PASSWORD_DSN not set",
+        }
+    try:
+        import psycopg2
+
+        with psycopg2.connect(dsn) as conn:
+            with conn.cursor() as cur:
+                if start_ts_ms is not None:
+                    cur.execute(
+                        """
+                        SELECT COUNT(*), MIN(ts_ms), MAX(ts_ms)
+                        FROM public.candles_1m
+                        WHERE symbol = %s AND ts_ms >= %s
+                        """,
+                        (symbol, start_ts_ms),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        SELECT COUNT(*), MIN(ts_ms), MAX(ts_ms)
+                        FROM public.candles_1m
+                        WHERE symbol = %s
+                        """,
+                        (symbol,),
+                    )
+                count, min_ts, max_ts = cur.fetchone()
+        return {
+            "available": True,
+            "candle_count": int(count or 0),
+            "min_ts_ms": int(min_ts) if min_ts is not None else None,
+            "max_ts_ms": int(max_ts) if max_ts is not None else None,
+        }
+    except Exception as exc:  # noqa: BLE001 — probe must not crash status
+        return {"available": False, "reason": str(exc)}
+
+
+def _campaign_dir(manifest: DataCaptureManifest, repo_root: Path) -> Path:
+    return manifest.campaign_artifact_dir(repo_root)
+
+
+def _append_event(campaign_dir: Path, event_type: str, payload: Mapping[str, Any]) -> None:
+    campaign_dir.mkdir(parents=True, exist_ok=True)
+    record = {"ts_utc": _now_utc_iso(), "event_type": event_type, **dict(payload)}
+    path = campaign_dir / CAMPAIGN_EVENTS_FILENAME
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_campaign_state(campaign_dir: Path) -> dict[str, Any] | None:
+    path = campaign_dir / CAMPAIGN_STATE_FILENAME
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verify_go_phrase(provided: str | None) -> None:
+    expected = DATA_CAPTURE_GO_PHRASE
+    actual = (provided or os.environ.get("CDB_DATA_CAPTURE_GO", "")).strip()
+    if actual != expected:
+        raise DataCaptureError(
+            "Start blocked: exact DATA-CAPTURE-GO phrase required. "
+            f"Expected: {expected!r}"
+        )
+
+
+def build_preflight_report(
+    manifest: DataCaptureManifest,
+    *,
+    repo_root: Path | None = None,
+    docker_runner: DockerRunner = default_docker_runner,
+    container_lister: ContainerLister = default_container_lister,
+    git_status_probe: GitStatusProbe = default_git_status_probe,
+    disk_probe: DiskProbe = default_disk_probe,
+    coverage_probe: CoverageProbe = default_coverage_probe,
+    skip_docker: bool = False,
+) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    manifest.validate_preflight()
+    head = git_head_sha(root)
+    resolved_sha = resolve_source_sha(manifest, root)
+    checks: list[dict[str, Any]] = []
+
+    def add(name: str, ok: bool, detail: str) -> None:
+        checks.append({"check": name, "ok": ok, "detail": detail})
+
+    pinned = (manifest.source_sha or "").strip().upper()
+    if pinned in {RUNTIME_RESOLVE, "AUTO", ""}:
+        add(
+            "git_head_matches_manifest",
+            True,
+            f"HEAD={head} (RUNTIME_RESOLVE at GO)",
+        )
+    else:
+        add(
+            "git_head_matches_manifest",
+            head == manifest.source_sha.strip(),
+            f"HEAD={head} manifest.source_sha={manifest.source_sha}",
+        )
+    wt = git_status_probe(root)
+    add("working_tree_clean", wt == "clean", f"working_tree={wt}")
+    free_gb = disk_probe(root)
+    add(
+        "disk_space",
+        free_gb >= manifest.min_free_disk_gb,
+        f"free_gb={free_gb:.2f} required={manifest.min_free_disk_gb}",
+    )
+    add(
+        "campaign_id_unique",
+        not (manifest.campaign_artifact_dir(root).exists()
+             and (manifest.campaign_artifact_dir(root) / CAMPAIGN_STATE_FILENAME).exists()),
+        f"campaign_dir={manifest.campaign_artifact_dir(root)}",
+    )
+    add("allow_signal_false", not manifest.allow_signal, "ok")
+    add("allow_execution_false", not manifest.allow_execution, "ok")
+    add("allow_paper_false", not manifest.allow_paper, "ok")
+    add("allow_live_trading_false", not manifest.allow_live_trading, "ok")
+
+    if manifest.start_utc.upper() not in {"RUNTIME_RESOLVE", "AUTO", ""}:
+        try:
+            validate_end_matches_start(
+                manifest.start_utc,
+                manifest.planned_end_utc,
+                manifest.max_duration_days,
+            )
+            add("planned_end_exact_14d", True, "start/end window validated")
+        except DataCaptureContractError as exc:
+            add("planned_end_exact_14d", False, str(exc))
+    else:
+        add("planned_end_exact_14d", True, "deferred until runtime GO")
+
+    docker_ok = False
+    docker_detail = "skipped"
+    forbidden_running: list[str] = []
+    if not skip_docker:
+        ping = docker_runner(["docker", "info"], root)
+        docker_ok = ping.returncode == 0
+        docker_detail = "reachable" if docker_ok else (ping.stderr.strip() or "unreachable")
+        if docker_ok:
+            try:
+                running = container_lister()
+                classified = classify_running_services(
+                    running,
+                    allowed=manifest.allowed_services,
+                    forbidden=manifest.forbidden_services,
+                )
+                forbidden_running = classified["running_forbidden"]
+                add(
+                    "no_forbidden_services_running",
+                    not forbidden_running,
+                    f"forbidden={forbidden_running}",
+                )
+            except DataCaptureError as exc:
+                add("no_forbidden_services_running", False, str(exc))
+    add("docker_reachable", docker_ok or skip_docker, docker_detail)
+
+    coverage = coverage_probe(root, manifest.symbol, None)
+    add(
+        "coverage_probe_available",
+        coverage.get("available", False) or skip_docker,
+        coverage.get("reason", "ok"),
+    )
+
+    failed = [c for c in checks if not c["ok"]]
+    return {
+        "campaign_id": manifest.campaign_id,
+        "source_sha": resolved_sha,
+        "checks": checks,
+        "passed": not failed,
+        "failed_checks": [c["check"] for c in failed],
+        "forbidden_services_running": forbidden_running,
+        "coverage_probe": coverage,
+        "verdict": "PREFLIGHT_PASS" if not failed else "PREFLIGHT_FAIL",
+    }
+
+
+def compose_up_allowed(
+    manifest: DataCaptureManifest,
+    repo_root: Path,
+    *,
+    docker_runner: DockerRunner = default_docker_runner,
+) -> dict[str, Any]:
+    blue = repo_root / manifest.compose_blue
+    red = repo_root / manifest.compose_red
+    blue_services = [s for s in manifest.allowed_services if s != "cdb_ws"]
+    red_services = [s for s in manifest.allowed_services if s == "cdb_ws"]
+    results: list[dict[str, Any]] = []
+    if blue_services:
+        cmd = [
+            "docker",
+            "compose",
+            "-f",
+            str(blue.relative_to(repo_root)).replace("\\", "/"),
+            "up",
+            "-d",
+            *blue_services,
+        ]
+        proc = docker_runner(cmd, repo_root)
+        results.append(
+            {
+                "compose": str(blue),
+                "services": blue_services,
+                "returncode": proc.returncode,
+                "stderr": proc.stderr.strip(),
+            }
+        )
+        if proc.returncode != 0:
+            raise DataCaptureError(proc.stderr.strip() or "blue compose up failed")
+    if red_services:
+        cmd = [
+            "docker",
+            "compose",
+            "-f",
+            str(red.relative_to(repo_root)).replace("\\", "/"),
+            "up",
+            "-d",
+            *red_services,
+        ]
+        proc = docker_runner(cmd, repo_root)
+        results.append(
+            {
+                "compose": str(red),
+                "services": red_services,
+                "returncode": proc.returncode,
+                "stderr": proc.stderr.strip(),
+            }
+        )
+        if proc.returncode != 0:
+            raise DataCaptureError(proc.stderr.strip() or "red compose up failed")
+    return {"compose_results": results}
+
+
+def compose_stop_allowed(
+    manifest: DataCaptureManifest,
+    repo_root: Path,
+    *,
+    docker_runner: DockerRunner = default_docker_runner,
+) -> dict[str, Any]:
+    blue = repo_root / manifest.compose_blue
+    red = repo_root / manifest.compose_red
+    results: list[dict[str, Any]] = []
+    for compose_path, services in (
+        (red, [s for s in manifest.allowed_services if s == "cdb_ws"]),
+        (blue, [s for s in manifest.allowed_services if s != "cdb_ws"]),
+    ):
+        if not services:
+            continue
+        cmd = [
+            "docker",
+            "compose",
+            "-f",
+            str(compose_path.relative_to(repo_root)).replace("\\", "/"),
+            "stop",
+            *services,
+        ]
+        proc = docker_runner(cmd, repo_root)
+        results.append(
+            {
+                "compose": str(compose_path),
+                "services": services,
+                "returncode": proc.returncode,
+                "stderr": proc.stderr.strip(),
+            }
+        )
+    return {"compose_results": results}
+
+
+def build_status_report(
+    manifest: DataCaptureManifest,
+    *,
+    repo_root: Path | None = None,
+    container_lister: ContainerLister = default_container_lister,
+    disk_probe: DiskProbe = default_disk_probe,
+    coverage_probe: CoverageProbe = default_coverage_probe,
+) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    campaign_dir = _campaign_dir(manifest, root)
+    state = read_campaign_state(campaign_dir) or {}
+    running = container_lister()
+    classified = classify_running_services(
+        running,
+        allowed=manifest.allowed_services,
+        forbidden=manifest.forbidden_services,
+    )
+    start_ts_ms = state.get("start_ts_ms")
+    coverage = coverage_probe(root, manifest.symbol, start_ts_ms)
+    now_ms = int(datetime.now(tz=UTC).timestamp() * 1000)
+    stale = False
+    last_ts = coverage.get("max_ts_ms")
+    if last_ts is not None and state.get("status") == CAMPAIGN_RUNNING:
+        stale = (now_ms - int(last_ts)) > manifest.stale_threshold_seconds * 1000
+
+    verdict = state.get("status", CAMPAIGN_PLANNED)
+    if classified["running_forbidden"]:
+        verdict = CAMPAIGN_BLOCKED
+    elif stale and state.get("status") == CAMPAIGN_RUNNING:
+        verdict = "stale"
+
+    return {
+        "campaign_id": manifest.campaign_id,
+        "start_utc": state.get("start_utc"),
+        "planned_end_utc": state.get("planned_end_utc"),
+        "status": state.get("status", CAMPAIGN_PLANNED),
+        "running_allowed_services": classified["running_allowed"],
+        "running_forbidden_services": classified["running_forbidden"],
+        "running_unexpected_services": classified["running_unexpected"],
+        "last_candle_ts_ms": last_ts,
+        "new_candles_since_start": coverage.get("candle_count"),
+        "gap_stale_status": "stale" if stale else "ok",
+        "db_writer_running": "cdb_db_writer" in classified["running_allowed"],
+        "free_disk_gb": round(disk_probe(root), 2),
+        "restart_count": state.get("restart_count", 0),
+        "campaign_verdict": verdict,
+        "coverage_probe": coverage,
+    }
+
+
+def start_campaign(
+    manifest: DataCaptureManifest,
+    *,
+    repo_root: Path | None = None,
+    go_phrase: str | None = None,
+    docker_runner: DockerRunner = default_docker_runner,
+    container_lister: ContainerLister = default_container_lister,
+    git_status_probe: GitStatusProbe = default_git_status_probe,
+    disk_probe: DiskProbe = default_disk_probe,
+    coverage_probe: CoverageProbe = default_coverage_probe,
+    skip_docker: bool = False,
+) -> dict[str, Any]:
+    verify_go_phrase(go_phrase)
+    root = repo_root or _repo_root()
+    preflight = build_preflight_report(
+        manifest,
+        repo_root=root,
+        docker_runner=docker_runner,
+        container_lister=container_lister,
+        git_status_probe=git_status_probe,
+        disk_probe=disk_probe,
+        coverage_probe=coverage_probe,
+        skip_docker=skip_docker,
+    )
+    if not preflight["passed"]:
+        raise DataCaptureError(
+            f"preflight failed: {preflight['failed_checks']}"
+        )
+
+    start_utc, planned_end_utc = resolve_runtime_window(manifest)
+    validate_end_matches_start(start_utc, planned_end_utc, manifest.max_duration_days)
+    start_dt = datetime.fromisoformat(start_utc.replace("Z", "+00:00"))
+    start_ts_ms = int(start_dt.timestamp() * 1000)
+
+    campaign_dir = _campaign_dir(manifest, root)
+    compose_result: dict[str, Any] = {}
+    if not skip_docker:
+        compose_result = compose_up_allowed(manifest, root, docker_runner=docker_runner)
+        running = container_lister()
+        classified = classify_running_services(
+            running,
+            allowed=manifest.allowed_services,
+            forbidden=manifest.forbidden_services,
+        )
+        if classified["running_forbidden"]:
+            raise DataCaptureError(
+                f"forbidden services running after start: {classified['running_forbidden']}"
+            )
+
+    state = {
+        "schema_version": "1.0",
+        "campaign_id": manifest.campaign_id,
+        "source_sha": resolve_source_sha(manifest, root),
+        "status": CAMPAIGN_RUNNING,
+        "start_utc": start_utc,
+        "planned_end_utc": planned_end_utc,
+        "start_ts_ms": start_ts_ms,
+        "restart_count": 0,
+        "allowed_services": list(manifest.allowed_services),
+        "forbidden_services": list(manifest.forbidden_services),
+    }
+    _write_json(campaign_dir / CAMPAIGN_STATE_FILENAME, state)
+    _write_json(
+        campaign_dir / SERVICE_INVENTORY_FILENAME,
+        classify_running_services(
+            container_lister() if not skip_docker else [],
+            allowed=manifest.allowed_services,
+            forbidden=manifest.forbidden_services,
+        ),
+    )
+    _append_event(campaign_dir, "campaign_start", {"state": state})
+    if compose_result:
+        _append_event(campaign_dir, "services_started", compose_result)
+
+    coverage = coverage_probe(root, manifest.symbol, start_ts_ms)
+    _write_json(
+        campaign_dir / HEARTBEAT_FILENAME,
+        {
+            "ts_utc": _now_utc_iso(),
+            "coverage": coverage,
+            "free_disk_gb": round(disk_probe(root), 2),
+        },
+    )
+    with (campaign_dir / COVERAGE_SNAPSHOTS_FILENAME).open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {"ts_utc": _now_utc_iso(), "coverage": coverage}, sort_keys=True
+            )
+            + "\n"
+        )
+
+    return {
+        "status": CAMPAIGN_RUNNING,
+        "campaign_dir": str(campaign_dir),
+        "start_utc": start_utc,
+        "planned_end_utc": planned_end_utc,
+        "compose": compose_result,
+    }
+
+
+def stop_campaign(
+    manifest: DataCaptureManifest,
+    *,
+    repo_root: Path | None = None,
+    docker_runner: DockerRunner = default_docker_runner,
+    skip_docker: bool = False,
+) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    campaign_dir = _campaign_dir(manifest, root)
+    state = read_campaign_state(campaign_dir) or {}
+    compose_result: dict[str, Any] = {}
+    if not skip_docker:
+        compose_result = compose_stop_allowed(manifest, root, docker_runner=docker_runner)
+    state["status"] = CAMPAIGN_STOPPED
+    state["stopped_utc"] = _now_utc_iso()
+    _write_json(campaign_dir / CAMPAIGN_STATE_FILENAME, state)
+    _append_event(campaign_dir, "campaign_stop", {"compose": compose_result})
+    return {"status": CAMPAIGN_STOPPED, "compose": compose_result}
+
+
+def resume_campaign(
+    manifest: DataCaptureManifest,
+    *,
+    repo_root: Path | None = None,
+    go_phrase: str | None = None,
+    docker_runner: DockerRunner = default_docker_runner,
+    container_lister: ContainerLister = default_container_lister,
+    skip_docker: bool = False,
+) -> dict[str, Any]:
+    verify_go_phrase(go_phrase)
+    root = repo_root or _repo_root()
+    campaign_dir = _campaign_dir(manifest, root)
+    state = read_campaign_state(campaign_dir)
+    if not state:
+        raise DataCaptureError("no campaign state; use Start first")
+    if state.get("status") == CAMPAIGN_COMPLETED:
+        raise DataCaptureError("campaign already completed")
+    restart_count = int(state.get("restart_count", 0)) + 1
+    if restart_count > manifest.max_restart_budget:
+        raise DataCaptureError(
+            f"restart budget exhausted ({restart_count}>{manifest.max_restart_budget})"
+        )
+    planned_end = state.get("planned_end_utc", "")
+    if planned_end:
+        end_dt = datetime.fromisoformat(planned_end.replace("Z", "+00:00"))
+        if datetime.now(tz=UTC) >= end_dt.astimezone(UTC):
+            raise DataCaptureError("campaign planned_end_utc has passed")
+
+    running = container_lister() if not skip_docker else []
+    classified = classify_running_services(
+        running,
+        allowed=manifest.allowed_services,
+        forbidden=manifest.forbidden_services,
+    )
+    if classified["running_forbidden"]:
+        raise DataCaptureError(
+            f"forbidden services running: {classified['running_forbidden']}"
+        )
+
+    compose_result: dict[str, Any] = {}
+    if not skip_docker:
+        compose_result = compose_up_allowed(manifest, root, docker_runner=docker_runner)
+
+    state["status"] = CAMPAIGN_RUNNING
+    state["restart_count"] = restart_count
+    state["last_resume_utc"] = _now_utc_iso()
+    _write_json(campaign_dir / CAMPAIGN_STATE_FILENAME, state)
+    _append_event(
+        campaign_dir,
+        "campaign_resume",
+        {"restart_count": restart_count, "compose": compose_result},
+    )
+    return {
+        "status": CAMPAIGN_RUNNING,
+        "restart_count": restart_count,
+        "compose": compose_result,
+    }
+
+
+def preflight_manifest(manifest_path: Path, repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root or _repo_root()
+    manifest = load_data_capture_manifest(manifest_path)
+    return build_preflight_report(manifest, repo_root=root)
+
+
+def _main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="ARVP vacation data capture (#3990)")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--preflight-only", action="store_true")
+    parser.add_argument("--status", action="store_true")
+    parser.add_argument("--start", action="store_true")
+    parser.add_argument("--stop", action="store_true")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--go-phrase", default="")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--skip-docker", action="store_true")
+    args = parser.parse_args(argv)
+
+    root = _repo_root()
+    manifest = load_data_capture_manifest(args.manifest)
+
+    try:
+        if args.preflight_only:
+            report = build_preflight_report(
+                manifest, repo_root=root, skip_docker=args.skip_docker
+            )
+        elif args.status:
+            report = build_status_report(manifest, repo_root=root)
+        elif args.start:
+            report = start_campaign(
+                manifest,
+                repo_root=root,
+                go_phrase=args.go_phrase or None,
+                skip_docker=args.skip_docker,
+            )
+        elif args.stop:
+            report = stop_campaign(
+                manifest, repo_root=root, skip_docker=args.skip_docker
+            )
+        elif args.resume:
+            report = resume_campaign(
+                manifest,
+                repo_root=root,
+                go_phrase=args.go_phrase or None,
+                skip_docker=args.skip_docker,
+            )
+        else:
+            parser.error("Specify --preflight-only, --status, --start, --stop, or --resume")
+            return 2
+    except (DataCaptureContractError, DataCaptureError) as exc:
+        print(str(exc), file=os.sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(json.dumps(report, indent=2))
+    if report.get("verdict") == "PREFLIGHT_FAIL" or report.get("passed") is False:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tools/arvp_vacation/data_capture_contract.py
+++ b/tools/arvp_vacation/data_capture_contract.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from .contract import VacationContractError, git_head_sha
+
+DATA_CAPTURE_SCHEMA_VERSION = "1.0"
+EVIDENCE_CLASS_CONTROLLED = "controlled_lab_evidence"
+RUNTIME_RESOLVE = "RUNTIME_RESOLVE"
+
+DEFAULT_ALLOWED_SERVICES: frozenset[str] = frozenset(
+    {
+        "cdb_postgres",
+        "cdb_redis",
+        "cdb_ws",
+        "cdb_candles",
+        "cdb_db_writer",
+    }
+)
+
+DEFAULT_FORBIDDEN_SERVICES: frozenset[str] = frozenset(
+    {
+        "cdb_signal",
+        "cdb_risk",
+        "cdb_allocation",
+        "cdb_execution",
+        "cdb_paper_runner",
+    }
+)
+
+DATA_CAPTURE_GO_PHRASE = (
+    "DATA-CAPTURE-GO #3990 vacation 14d preflight and acceptance drill"
+)
+
+
+class DataCaptureContractError(ValueError):
+    """Data-capture manifest or safety contract violation."""
+
+
+@dataclass(frozen=True, slots=True)
+class DataCaptureManifest:
+    schema_version: str
+    campaign_id: str
+    source_sha: str
+    symbol: str
+    venue: str
+    timeframe: str
+    start_utc: str
+    planned_end_utc: str
+    max_duration_days: int
+    allowed_services: tuple[str, ...]
+    forbidden_services: tuple[str, ...]
+    database_target: str
+    heartbeat_interval_seconds: int
+    stale_threshold_seconds: int
+    min_free_disk_gb: float
+    max_restart_budget: int
+    evidence_dir: str
+    allow_signal: bool
+    allow_execution: bool
+    allow_paper: bool
+    allow_live_trading: bool
+    compose_blue: str
+    compose_red: str
+    evidence_class: str = EVIDENCE_CLASS_CONTROLLED
+    drill_duration_minutes: int = 15
+
+    def validate_preflight(self) -> None:
+        if self.schema_version != DATA_CAPTURE_SCHEMA_VERSION:
+            raise DataCaptureContractError(
+                f"unsupported schema_version {self.schema_version!r}"
+            )
+        if not self.campaign_id.strip():
+            raise DataCaptureContractError("campaign_id is required")
+        if self.evidence_class != EVIDENCE_CLASS_CONTROLLED:
+            raise DataCaptureContractError(
+                f"evidence_class must be {EVIDENCE_CLASS_CONTROLLED!r}"
+            )
+        if self.symbol != "BTCUSDT":
+            raise DataCaptureContractError("symbol must be BTCUSDT for this campaign")
+        if self.venue.upper() != "MEXC":
+            raise DataCaptureContractError("venue must be MEXC")
+        if self.timeframe != "1m":
+            raise DataCaptureContractError("timeframe must be 1m")
+        if self.database_target != "public.candles_1m":
+            raise DataCaptureContractError("database_target must be public.candles_1m")
+        if self.max_duration_days != 14:
+            raise DataCaptureContractError("max_duration_days must be 14")
+        if self.allow_signal or self.allow_execution or self.allow_paper:
+            raise DataCaptureContractError(
+                "allow_signal, allow_execution, allow_paper must be false"
+            )
+        if self.allow_live_trading:
+            raise DataCaptureContractError("allow_live_trading must be false")
+        if not self.allowed_services:
+            raise DataCaptureContractError("allowed_services must be non-empty")
+        if self.min_free_disk_gb <= 0:
+            raise DataCaptureContractError("min_free_disk_gb must be > 0")
+        if self.heartbeat_interval_seconds < 30:
+            raise DataCaptureContractError("heartbeat_interval_seconds must be >= 30")
+        if self.stale_threshold_seconds < 60:
+            raise DataCaptureContractError("stale_threshold_seconds must be >= 60")
+        if self.max_restart_budget < 0:
+            raise DataCaptureContractError("max_restart_budget must be >= 0")
+        overlap = set(self.allowed_services) & set(self.forbidden_services)
+        if overlap:
+            raise DataCaptureContractError(
+                f"services cannot be both allowed and forbidden: {sorted(overlap)}"
+            )
+        for svc in self.forbidden_services:
+            if svc not in DEFAULT_FORBIDDEN_SERVICES:
+                raise DataCaptureContractError(
+                    f"unexpected forbidden service {svc!r}; "
+                    f"expected subset of {sorted(DEFAULT_FORBIDDEN_SERVICES)}"
+                )
+        for svc in self.allowed_services:
+            if svc not in DEFAULT_ALLOWED_SERVICES:
+                raise DataCaptureContractError(
+                    f"unexpected allowed service {svc!r}; "
+                    f"expected subset of {sorted(DEFAULT_ALLOWED_SERVICES)}"
+                )
+
+    def campaign_artifact_dir(self, repo_root: Path) -> Path:
+        return repo_root / self.evidence_dir / self.campaign_id
+
+
+def _parse_iso_utc(raw: str) -> datetime:
+    text = raw.strip()
+    if text.upper() in {RUNTIME_RESOLVE, "AUTO", ""}:
+        raise DataCaptureContractError(
+            "start_utc must be resolved before runtime start"
+        )
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def resolve_planned_end_utc(start_utc: str, max_duration_days: int) -> str:
+    start = _parse_iso_utc(start_utc)
+    end = start + timedelta(days=max_duration_days)
+    return end.isoformat().replace("+00:00", "Z")
+
+
+def validate_end_matches_start(
+    start_utc: str, planned_end_utc: str, max_duration_days: int
+) -> None:
+    start = _parse_iso_utc(start_utc)
+    end = _parse_iso_utc(planned_end_utc)
+    expected = start + timedelta(days=max_duration_days)
+    if end != expected:
+        raise DataCaptureContractError(
+            f"planned_end_utc must be exactly {max_duration_days} days after start_utc "
+            f"(expected {expected.isoformat().replace('+00:00', 'Z')}, "
+            f"got {planned_end_utc!r})"
+        )
+
+
+def load_data_capture_manifest(path: Path) -> DataCaptureManifest:
+    raw: Mapping[str, Any] = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    allowed = tuple(str(s) for s in raw.get("allowed_services") or ())
+    forbidden = tuple(str(s) for s in raw.get("forbidden_services") or ())
+    manifest = DataCaptureManifest(
+        schema_version=str(raw.get("schema_version", "")),
+        campaign_id=str(raw.get("campaign_id", "")),
+        source_sha=str(raw.get("source_sha", RUNTIME_RESOLVE)),
+        symbol=str(raw.get("symbol", "BTCUSDT")),
+        venue=str(raw.get("venue", "MEXC")),
+        timeframe=str(raw.get("timeframe", "1m")),
+        start_utc=str(raw.get("start_utc", RUNTIME_RESOLVE)),
+        planned_end_utc=str(raw.get("planned_end_utc", RUNTIME_RESOLVE)),
+        max_duration_days=int(raw.get("max_duration_days", 14)),
+        allowed_services=allowed or tuple(sorted(DEFAULT_ALLOWED_SERVICES)),
+        forbidden_services=forbidden or tuple(sorted(DEFAULT_FORBIDDEN_SERVICES)),
+        database_target=str(raw.get("database_target", "public.candles_1m")),
+        heartbeat_interval_seconds=int(raw.get("heartbeat_interval_seconds", 300)),
+        stale_threshold_seconds=int(raw.get("stale_threshold_seconds", 180)),
+        min_free_disk_gb=float(raw.get("min_free_disk_gb", 5)),
+        max_restart_budget=int(raw.get("max_restart_budget", 3)),
+        evidence_dir=str(
+            raw.get("evidence_dir", "artifacts/arvp_vacation/data_capture")
+        ),
+        allow_signal=bool(raw.get("allow_signal", False)),
+        allow_execution=bool(raw.get("allow_execution", False)),
+        allow_paper=bool(raw.get("allow_paper", False)),
+        allow_live_trading=bool(raw.get("allow_live_trading", False)),
+        compose_blue=str(
+            raw.get("compose_blue", "infrastructure/compose/compose.blue.yml")
+        ),
+        compose_red=str(
+            raw.get("compose_red", "infrastructure/compose/compose.red.yml")
+        ),
+        evidence_class=str(raw.get("evidence_class", EVIDENCE_CLASS_CONTROLLED)),
+        drill_duration_minutes=int(raw.get("drill_duration_minutes", 15)),
+    )
+    manifest.validate_preflight()
+    return manifest
+
+
+def resolve_source_sha(manifest: DataCaptureManifest, repo_root: Path | None = None) -> str:
+    raw = (manifest.source_sha or "").strip()
+    if not raw or raw.upper() in {RUNTIME_RESOLVE, "AUTO"}:
+        return git_head_sha(repo_root)
+    return raw
+
+
+def resolve_runtime_window(
+    manifest: DataCaptureManifest, *, now: datetime | None = None
+) -> tuple[str, str]:
+    moment = now or datetime.now(tz=UTC)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    start = moment.astimezone(UTC).replace(microsecond=0)
+    start_iso = start.isoformat().replace("+00:00", "Z")
+    end_iso = resolve_planned_end_utc(start_iso, manifest.max_duration_days)
+    return start_iso, end_iso
+
+
+def classify_running_services(
+    running: Sequence[str],
+    *,
+    allowed: Sequence[str],
+    forbidden: Sequence[str],
+) -> dict[str, list[str]]:
+    allowed_set = set(allowed)
+    forbidden_set = set(forbidden)
+    cdb = [name for name in running if name.startswith("cdb_")]
+    return {
+        "running_allowed": sorted(n for n in cdb if n in allowed_set),
+        "running_forbidden": sorted(n for n in cdb if n in forbidden_set),
+        "running_unexpected": sorted(
+            n for n in cdb if n not in allowed_set and n not in forbidden_set
+        ),
+    }

--- a/tools/arvp_vacation/data_capture_contract.py
+++ b/tools/arvp_vacation/data_capture_contract.py
@@ -7,6 +7,8 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+from core.utils.clock import utcnow as cdb_utcnow
+
 from .contract import VacationContractError, git_head_sha
 
 DATA_CAPTURE_SCHEMA_VERSION = "1.0"
@@ -214,7 +216,7 @@ def resolve_source_sha(manifest: DataCaptureManifest, repo_root: Path | None = N
 def resolve_runtime_window(
     manifest: DataCaptureManifest, *, now: datetime | None = None
 ) -> tuple[str, str]:
-    moment = now or datetime.now(tz=UTC)
+    moment = now or cdb_utcnow()
     if moment.tzinfo is None:
         moment = moment.replace(tzinfo=UTC)
     start = moment.astimezone(UTC).replace(microsecond=0)


### PR DESCRIPTION
## Summary
- Add no-trading 14-day MEXC BTCUSDT 1m data capture campaign manifest, runbook, PowerShell runner, and Python coordinator (preflight/start/status/stop/resume).
- Minimal verified service set: postgres, redis, ws, candles, db_writer only; forbidden signal/risk/allocation/execution/paper_runner.
- Start/Resume gated on exact DATA-CAPTURE-GO phrase; no runtime start in this slice.

## Test plan
- [x] pytest tests/unit/arvp/test_arvp_vacation_data_capture.py (9 tests)
- [x] ruff check on new Python files
- [ ] CI required checks
- [ ] Acceptance drill (operator, post-merge): preflight + short capture drill before 14d GO

## Delivered
Campaign manifest, runbook, PS1 wrapper, contract + coordinator modules, unit tests.

## Validation
Unit tests + ruff locally; CI pending.

## Non-goals
No Docker runtime start, no acceptance drill execution, no export script, no issue close.

## Remaining uncertainty
Host reboot auto-resume not proven; manual resume only. Drill and 14d run require explicit DATA-CAPTURE-GO.

Refs #3990