### PR TITLE
[OPS][HYGIENE] Local D:\Dev inventory tooling (#3999)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,9 @@ infrastructure/config/surrealdb/context_query.local.yaml
 # Local-only ops helper artifact (do not version)
 scripts/cdb_ops.ps1
 
+# Local D:\Dev hygiene raw scan outputs (#3999) — redacted summary only in docs/evidence/
+artifacts/local-dev-hygiene/
+
 # Decision Contract audit records (generated at runtime + by tests)
 reports/decision_contract/
 

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ help:
 	@echo "  make context-negative-controls - Write-intent/mutation negative-control regression (#2854)"
 	@echo "  make onboarding-docs-guard   - Validate active onboarding docs links/entrypoints (#3233)"
 	@echo "  make context-root-inventory  - Cross-repo root + GitHub target inventory (#2853)"
+	@echo "  make local-dev-hygiene-inventory - Local D:\\Dev read-only inventory (#3999)"
 	@echo ""
 	@echo "SurrealQL Syntax Validation:"
 	@echo "  make surreal-validate       - Validate .surql syntax via SurrealDB CLI (#3430)"
@@ -435,6 +436,11 @@ context-negative-controls:
 context-root-inventory:
 	@echo "=== Cross-repo root and GitHub target inventory (#2853) ==="
 	@$(PYTHON) -m tools.mcp.cross_repo_root_inventory --format markdown
+
+local-dev-hygiene-inventory:
+	@echo "=== Local D:\\Dev workspace inventory (#3999, read-only) ==="
+	@powershell -NoProfile -ExecutionPolicy Bypass -File tools/cleanup/local_dev_workspace_inventory.ps1 -ConfigPath infrastructure/config/ops/local_dev_hygiene.json
+	@$(PYTHON) -m tools.cleanup.local_dev_hygiene_classify --inventory artifacts/local-dev-hygiene/workspace_inventory.json
 
 # ============================================================================
 # SurrealQL Syntax Validation (#3430)

--- a/docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.json
+++ b/docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.json
@@ -1,0 +1,473 @@
+{
+  "schema_version": "local_dev_hygiene_evidence_redacted.v1",
+  "issue": "#3999",
+  "scan_as_of_utc": "2026-07-12T18:10:49.1235222Z",
+  "generated_at_utc": "2026-07-12T18:16:36.311757+00:00",
+  "aggregate": {
+    "total_size_gb": 120.06,
+    "total_files": 207113,
+    "total_directories": 45542,
+    "scan_completeness": "partial",
+    "baseline_delta": {
+      "screenshot_total_gb": 134.27,
+      "within_file_tolerance": false,
+      "screenshot_directories": 71093,
+      "delta_files_pct": -49.99,
+      "delta_gb": -14.21,
+      "measured_total_gb": 120.06,
+      "measured_files": 207113,
+      "screenshot_files": 414174,
+      "tolerance_notes": "Logical size vs Explorer may differ; compare using byte totals with documented tolerance.",
+      "measured_directories": 45542,
+      "delta_directories_pct": -35.94,
+      "within_directory_tolerance": false,
+      "within_size_tolerance": false
+    }
+  },
+  "roots": [
+    {
+      "root": "D:\\Dev\\AI",
+      "scan_status": "partial",
+      "completeness": "partial",
+      "size_gb": 40.22,
+      "file_count": 5264,
+      "directory_count": 367,
+      "scan_duration_seconds": 5.38,
+      "skipped_reparse_points_count": 0,
+      "access_error_count": 4,
+      "limitations": [
+        "Access or path-length errors encountered."
+      ],
+      "baseline_delta": {
+        "measured_gb": 40.22,
+        "within_tolerance": true,
+        "screenshot_gb": 40.2,
+        "delta_pct": 0.05,
+        "delta_gb": 0.02
+      },
+      "top_directories": [
+        {
+          "path": "D:\\Dev\\AI\\Ollama\\models",
+          "size_gb": 25.241
+        },
+        {
+          "path": "D:\\Dev\\AI\\Ollama",
+          "size_gb": 14.582
+        },
+        {
+          "path": "D:\\Dev\\AI\\Claude",
+          "size_gb": 0.388
+        },
+        {
+          "path": "D:\\Dev\\AI\\OpenAI",
+          "size_gb": 0.006
+        },
+        {
+          "path": "D:\\Dev\\AI\\AgentMemory",
+          "size_gb": 0.0
+        }
+      ],
+      "pattern_groups": [
+        {
+          "pattern_id": "ollama_models",
+          "size_gb": 25.241,
+          "hit_count": 1
+        }
+      ]
+    },
+    {
+      "root": "D:\\Dev\\Backups",
+      "scan_status": "partial",
+      "completeness": "partial",
+      "size_gb": 8.02,
+      "file_count": 83095,
+      "directory_count": 12553,
+      "scan_duration_seconds": 91.36,
+      "skipped_reparse_points_count": 0,
+      "access_error_count": 50,
+      "limitations": [
+        "Access or path-length errors encountered."
+      ],
+      "baseline_delta": {
+        "measured_gb": 8.02,
+        "within_tolerance": false,
+        "screenshot_gb": 9.27,
+        "delta_pct": -13.48,
+        "delta_gb": -1.25
+      },
+      "top_directories": [
+        {
+          "path": "D:\\Dev\\Backups\\extensions",
+          "size_gb": 7.913
+        },
+        {
+          "path": "D:\\Dev\\Backups\\docker_reinstall_20251231_075507",
+          "size_gb": 0.109
+        },
+        {
+          "path": "D:\\Dev\\Backups\\Claude",
+          "size_gb": 0.0
+        }
+      ],
+      "pattern_groups": []
+    },
+    {
+      "root": "D:\\Dev\\Workspaces\\Repos",
+      "scan_status": "partial",
+      "completeness": "partial",
+      "size_gb": 7.4,
+      "file_count": 38739,
+      "directory_count": 8614,
+      "scan_duration_seconds": 84.19,
+      "skipped_reparse_points_count": 20,
+      "access_error_count": 50,
+      "limitations": [
+        "Access or path-length errors encountered.",
+        "Reparse points recorded but not traversed."
+      ],
+      "baseline_delta": {
+        "measured_gb": 7.4,
+        "within_tolerance": false,
+        "screenshot_gb": 18.4,
+        "delta_pct": -59.78,
+        "delta_gb": -11
+      },
+      "top_directories": [
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare",
+          "size_gb": 6.554
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\sample-brain",
+          "size_gb": 0.129
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare-wt-diag-telemetry-preflight",
+          "size_gb": 0.103
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare-p1-telemetry",
+          "size_gb": 0.103
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare__arvp-3912-closeout",
+          "size_gb": 0.103
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare__feat-arvp-p15-campaign-id-compose-contract",
+          "size_gb": 0.103
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare__arvp-3912-telemetry",
+          "size_gb": 0.103
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Everlast-AI",
+          "size_gb": 0.066
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare_codex_slice6",
+          "size_gb": 0.039
+        },
+        {
+          "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare_codex_slice5",
+          "size_gb": 0.039
+        }
+      ],
+      "pattern_groups": []
+    },
+    {
+      "root": "D:\\Dev\\Tools",
+      "scan_status": "partial",
+      "completeness": "partial",
+      "size_gb": 64.42,
+      "file_count": 80015,
+      "directory_count": 24008,
+      "scan_duration_seconds": 116.69,
+      "skipped_reparse_points_count": 0,
+      "access_error_count": 27,
+      "limitations": [
+        "Access or path-length errors encountered."
+      ],
+      "baseline_delta": {
+        "measured_gb": 64.42,
+        "within_tolerance": true,
+        "screenshot_gb": 66.4,
+        "delta_pct": -2.98,
+        "delta_gb": -1.98
+      },
+      "top_directories": [
+        {
+          "path": "D:\\Dev\\Tools\\npm-cache",
+          "size_gb": 58.714
+        },
+        {
+          "path": "D:\\Dev\\Tools\\PowerShell",
+          "size_gb": 2.966
+        },
+        {
+          "path": "D:\\Dev\\Tools\\GitHub",
+          "size_gb": 2.4
+        },
+        {
+          "path": "D:\\Dev\\Tools\\trivy",
+          "size_gb": 0.16
+        },
+        {
+          "path": "D:\\Dev\\Tools\\Node",
+          "size_gb": 0.086
+        },
+        {
+          "path": "D:\\Dev\\Tools\\Terminal.Pre",
+          "size_gb": 0.031
+        },
+        {
+          "path": "D:\\Dev\\Tools\\npm",
+          "size_gb": 0.021
+        },
+        {
+          "path": "D:\\Dev\\Tools\\curl",
+          "size_gb": 0.019
+        },
+        {
+          "path": "D:\\Dev\\Tools\\Rye",
+          "size_gb": 0.013
+        },
+        {
+          "path": "D:\\Dev\\Tools\\bat",
+          "size_gb": 0.007
+        }
+      ],
+      "pattern_groups": [
+        {
+          "pattern_id": "npm_cache",
+          "size_gb": 58.714,
+          "hit_count": 1
+        }
+      ]
+    }
+  ],
+  "git_repository_count": 21,
+  "git_repositories": [
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare",
+      "head_commit": "d84ddbe3229f",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare-p1-telemetry",
+      "head_commit": "aa2c229bdcce",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare-wt-diag-telemetry-preflight",
+      "head_commit": "496c448638e1",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare_codex_slice5",
+      "head_commit": "f7d0f9a88e6b",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare_codex_slice6",
+      "head_commit": "cf73ed82e319",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare__arvp-3912-closeout",
+      "head_commit": "0b6b5b55ab3c",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare__arvp-3912-telemetry",
+      "head_commit": "d0cb727f3b0f",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare__feat-arvp-p15-campaign-id-compose-contract",
+      "head_commit": "08a8b7500853",
+      "remote_url": "https://github.com/jannekbuengener/Claire_de_Binare.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Clipboard-Brudi",
+      "head_commit": "7be7c989a516",
+      "remote_url": "https://github.com/jannekbuengener/Clipboard-Brudi.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\Everlast-AI",
+      "head_commit": "76f01cb4eea3",
+      "remote_url": "https://github.com/jannekbuengener/Everlast-AI.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\lazy-boy",
+      "head_commit": "ad70b277ac0f",
+      "remote_url": "git@github.com:jannekbuengener/lazy-boy.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\modusmono-blog",
+      "head_commit": "af8cad63292c",
+      "remote_url": "git@github.com:jannekbuengener/modusmono-blog.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\sample-brain",
+      "head_commit": "5aa7e255c38c",
+      "remote_url": "https://github.com/jannekbuengener/sample-brain.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer",
+      "head_commit": "8aa43b2d0622",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": false
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer-issue69",
+      "head_commit": "937e5de1f346",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer_issue58",
+      "head_commit": "c2ad9ec143e0",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer_issue60_next",
+      "head_commit": "08efaa818da6",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer_recut_workdir_contract",
+      "head_commit": "3107f28ce82f",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer_reslice_docs",
+      "head_commit": "0e9006efb161",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer_reslice_foundation",
+      "head_commit": "86f273d53aa7",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": true
+    },
+    {
+      "path": "D:\\Dev\\Workspaces\\Repos\\TraumTaenzer_reslice_runtime",
+      "head_commit": "7b98958386bd",
+      "remote_url": "https://github.com/jannekbuengener/TraumTaenzer.git",
+      "is_clean": true
+    }
+  ],
+  "worktree_count": 21,
+  "reclaim_summary": {
+    "candidate_count": 11,
+    "by_classification": {
+      "PROTECTED": 9,
+      "ARCHIVE_MOVE": 1,
+      "REGENERABLE": 1
+    },
+    "estimated_reclaim_bytes_by_confidence": {
+      "high": 63043417994,
+      "medium": 27101936073,
+      "low": 0
+    },
+    "estimated_reclaim_gb_by_confidence": {
+      "high": 58.714,
+      "medium": 25.241,
+      "low": 0.0
+    }
+  },
+  "candidates": [
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "PROTECTED",
+      "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+      "confidence": "high",
+      "estimated_reclaim_gb": 0
+    },
+    {
+      "classification": "ARCHIVE_MOVE",
+      "path": "pattern:ollama_models",
+      "pattern_id": "ollama_models",
+      "confidence": "medium",
+      "estimated_reclaim_gb": 25.241,
+      "required_approval": "human_go_archive",
+      "dedupe_evidence": null
+    },
+    {
+      "classification": "REGENERABLE",
+      "path": "pattern:npm_cache",
+      "pattern_id": "npm_cache",
+      "confidence": "high",
+      "estimated_reclaim_gb": 58.714,
+      "required_approval": "human_go_regenerable",
+      "dedupe_evidence": null
+    }
+  ],
+  "redaction_note": "Raw inventory under artifacts/local-dev-hygiene/ is gitignored. This file is aggregated and redacted; no secret paths or full file lists."
+}

--- a/docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.md
+++ b/docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.md
@@ -1,0 +1,32 @@
+# Local Dev Hygiene Evidence (redacted)
+
+Issue: #3999
+Scan as of (UTC): `2026-07-12T18:10:49.1235222Z`
+
+## Aggregate
+
+- Total: 120.06 GB / 207113 files / 45542 directories
+- Completeness: partial
+- Baseline delta GB: -14.21 (within tolerance: False)
+
+## Reclaim estimate
+
+- high confidence: 58.714 GB
+- medium confidence: 25.241 GB
+- low confidence: 0.0 GB
+
+## Discovery
+
+- Git repositories: 21
+- Worktrees (all PROTECTED): 21
+
+## Root completeness
+
+| Root | Status | Completeness | GB | Reparse skipped | Access errors |
+|------|--------|--------------|---:|----------------:|--------------:|
+| `D:\Dev\AI` | partial | partial | 40.22 | 0 | 4 |
+| `D:\Dev\Backups` | partial | partial | 8.02 | 0 | 50 |
+| `D:\Dev\Workspaces\Repos` | partial | partial | 7.4 | 20 | 50 |
+| `D:\Dev\Tools` | partial | partial | 64.42 | 0 | 27 |
+
+Raw inventory under artifacts/local-dev-hygiene/ is gitignored. This file is aggregated and redacted; no secret paths or full file lists.

--- a/docs/runbooks/LOCAL_DEV_HYGIENE_INVENTORY.md
+++ b/docs/runbooks/LOCAL_DEV_HYGIENE_INVENTORY.md
@@ -1,0 +1,125 @@
+# Runbook: Local Dev Hygiene Inventory (#3999)
+
+Status: canonical  
+Issue: [#3999](https://github.com/jannekbuengener/Claire_de_Binare/issues/3999)  
+Scope: read-only metadata inventory for `D:\Dev\{AI,Backups,Workspaces\Repos,Tools}`
+
+## Goal
+
+Produce a reproducible, read-only inventory and cleanup manifest for the local
+Windows development workspace without deleting, moving, or mutating files.
+
+## Boundaries
+
+- **In scope:** metadata scan, classification, redacted evidence publication.
+- **Out of scope:** deletion, archive moves, `git clean`, `docker prune`, child
+  issues, Docker/DB/runtime mutation.
+- **Not a duplicate of:** #282 (Docker), #291 (monthly cadence), #1332
+  (governance provenance inside CDB repo).
+
+## Outputs
+
+| Output | Location | Git tracked |
+|--------|----------|-------------|
+| Raw inventory JSON | `artifacts/local-dev-hygiene/workspace_inventory.json` | No (gitignored) |
+| Raw candidates/plan | `artifacts/local-dev-hygiene/cleanup_*.json/md` | No |
+| Redacted evidence | `docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.*` | Yes |
+
+Raw outputs may contain paths that must not be published. Only the redacted
+evidence summary is commit-worthy.
+
+## Prerequisites
+
+- Windows workstation with access to all four `D:\Dev` roots.
+- PowerShell 5.1+.
+- Python 3.12 + repo dependencies.
+- Git available on PATH.
+
+## Execution
+
+From repo root:
+
+```powershell
+make local-dev-hygiene-inventory
+```
+
+Or manually:
+
+```powershell
+.\tools\cleanup\local_dev_workspace_inventory.ps1 `
+  -ConfigPath infrastructure\config\ops\local_dev_hygiene.json
+python -m tools.cleanup.local_dev_hygiene_classify `
+  --inventory artifacts/local-dev-hygiene/workspace_inventory.json
+```
+
+## Scanner guarantees
+
+1. **Fixed timestamp:** `scan_as_of_utc` written once at scan start; classifier
+   and tests use this value for age buckets.
+2. **Reparse points:** junctions/symlinks recorded, never traversed.
+3. **Memory-safe:** streaming aggregation only; no full 400k+ file list in output.
+4. **Fail-closed:** `AccessDenied`, long paths, and partial scans set
+   `scan_status=partial` and populate `access_errors` / `limitations`.
+5. **Dynamic git discovery:** all top-level repos under `Repos`; all worktrees
+   from `git worktree list --porcelain` → `PROTECTED`.
+
+## Classification rules (8 classes)
+
+| Class | Meaning |
+|-------|---------|
+| KEEP_ACTIVE | Actively required |
+| KEEP_PROVENANCE | Historical evidence / provenance |
+| REGENERABLE | Rebuild from lockfile/installer |
+| ARCHIVE_MOVE | Keep, move out of active dev area |
+| DEDUPLICATE | Duplicate with evidence only |
+| QUARANTINE_REVIEW | Unclear; manual review |
+| DELETE_CANDIDATE | Removable after evidence review |
+| PROTECTED | Never automated |
+
+`DEDUPLICATE` requires one of:
+
+- identical git remote **and** commit, with clean worktree, or
+- bounded hash match on pre-narrowed candidates.
+
+Otherwise assign `QUARANTINE_REVIEW`.
+
+## Per-root completeness fields
+
+Each root entry includes:
+
+- `scan_status`, `access_errors`, `skipped_reparse_points`,
+  `scan_duration_seconds`, `baseline_delta`, `completeness`, `limitations`
+
+## Baseline plausibility
+
+Screenshot baseline (Explorer-oriented):
+
+- Total ~134.27 GB
+- 414,174 files
+- 71,093 directories
+
+Compare logical byte totals with documented tolerance (default ±10% size,
+±5% counts). Explorer vs logical size differences are expected.
+
+## Review gate
+
+Do **not** create child issues until a human reviews:
+
+1. `docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.md`
+2. Local raw `cleanup_plan.md` (if needed for detail)
+
+Proposed child slices remain deferred per issue body.
+
+## Validation
+
+```powershell
+pytest -q tests/unit/cleanup/test_local_dev_hygiene_classify.py -m unit
+ruff check tools/cleanup/local_dev_hygiene_classify.py tests/unit/cleanup/
+python -m tools.cleanup.local_dev_hygiene_classify --validate-only
+```
+
+## Related runbooks
+
+- [`local_ops_artifacts.md`](local_ops_artifacts.md) — repo-local artifact policy
+- [`mcp_worktree_hygiene.md`](mcp_worktree_hygiene.md) — worktree drift
+- [`MONTHLY_MAINTENANCE.md`](../../knowledge/operations/MONTHLY_MAINTENANCE.md) — cadence (#291)

--- a/infrastructure/config/ops/local_dev_hygiene.json
+++ b/infrastructure/config/ops/local_dev_hygiene.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": "local_dev_hygiene_config.v1",
+  "issue": "#3999",
+  "roots": [
+    "D:\\Dev\\AI",
+    "D:\\Dev\\Backups",
+    "D:\\Dev\\Workspaces\\Repos",
+    "D:\\Dev\\Tools"
+  ],
+  "repos_scan_root": "D:\\Dev\\Workspaces\\Repos",
+  "screenshot_baseline": {
+    "total_size_gb": 134.27,
+    "total_files": 414174,
+    "total_directories": 71093,
+    "per_root_gb": {
+      "D:\\Dev\\AI": 40.2,
+      "D:\\Dev\\Backups": 9.27,
+      "D:\\Dev\\Workspaces\\Repos": 18.4,
+      "D:\\Dev\\Tools": 66.4
+    },
+    "tolerance": {
+      "size_gb_pct": 10.0,
+      "file_count_pct": 5.0,
+      "directory_count_pct": 5.0,
+      "notes": "Logical size vs Explorer may differ; compare using byte totals with documented tolerance."
+    }
+  },
+  "scan_limits": {
+    "top_directories_per_root": 25,
+    "large_file_threshold_bytes": 524288000,
+    "large_files_max_entries": 40,
+    "skipped_reparse_points_max_samples": 30,
+    "access_errors_max_samples": 50,
+    "max_path_length": 260
+  },
+  "pattern_catalog": [
+    {
+      "id": "venv",
+      "match_type": "directory_name",
+      "pattern": ".venv",
+      "aggregate": true
+    },
+    {
+      "id": "node_modules",
+      "match_type": "directory_name",
+      "pattern": "node_modules",
+      "aggregate": true
+    },
+    {
+      "id": "pycache",
+      "match_type": "directory_name",
+      "pattern": "__pycache__",
+      "aggregate": true
+    },
+    {
+      "id": "logs",
+      "match_type": "file_extension",
+      "pattern": ".log",
+      "aggregate": true
+    },
+    {
+      "id": "npm_cache",
+      "match_type": "path_suffix",
+      "pattern": "Tools\\npm-cache",
+      "aggregate": true
+    },
+    {
+      "id": "ollama_models",
+      "match_type": "path_suffix",
+      "pattern": "AI\\Ollama\\models",
+      "aggregate": true
+    },
+    {
+      "id": "governance_work",
+      "match_type": "directory_glob",
+      "pattern": "governance_*_work",
+      "aggregate": true
+    },
+    {
+      "id": "temp_dirs",
+      "match_type": "directory_name",
+      "pattern": "temp",
+      "aggregate": true
+    },
+    {
+      "id": "tmp_dirs",
+      "match_type": "directory_name",
+      "pattern": "tmp",
+      "aggregate": true
+    }
+  ],
+  "secret_path_patterns": [
+    ".env",
+    ".secrets",
+    "api_key",
+    "api_secret",
+    "password",
+    "token",
+    "credential",
+    "mcp.json"
+  ],
+  "classification_rules": [
+    {
+      "rule_id": "protected_worktree",
+      "classification": "PROTECTED",
+      "confidence": "high",
+      "match": "is_worktree",
+      "reason": "Registered git worktree; never automated cleanup."
+    },
+    {
+      "rule_id": "protected_git_metadata",
+      "classification": "PROTECTED",
+      "confidence": "high",
+      "match": "path_contains",
+      "pattern": "\\.git",
+      "reason": "Git metadata must remain intact."
+    },
+    {
+      "rule_id": "keep_provenance_governance",
+      "classification": "KEEP_PROVENANCE",
+      "confidence": "high",
+      "match": "pattern_id",
+      "pattern_id": "governance_work",
+      "reason": "Historical governance provenance surface (#1332)."
+    },
+    {
+      "rule_id": "regenerable_npm_cache",
+      "classification": "REGENERABLE",
+      "confidence": "high",
+      "match": "pattern_id",
+      "pattern_id": "npm_cache",
+      "recovery_method": "npm cache clean / reinstall",
+      "risk": "low",
+      "required_approval": "human_go_regenerable"
+    },
+    {
+      "rule_id": "regenerable_venv",
+      "classification": "REGENERABLE",
+      "confidence": "high",
+      "match": "pattern_id",
+      "pattern_id": "venv",
+      "recovery_method": "python -m venv + pip install -r requirements",
+      "risk": "low",
+      "required_approval": "human_go_regenerable"
+    },
+    {
+      "rule_id": "regenerable_node_modules",
+      "classification": "REGENERABLE",
+      "confidence": "high",
+      "match": "pattern_id",
+      "pattern_id": "node_modules",
+      "recovery_method": "package manager reinstall from lockfile",
+      "risk": "low",
+      "required_approval": "human_go_regenerable"
+    },
+    {
+      "rule_id": "archive_ollama",
+      "classification": "ARCHIVE_MOVE",
+      "confidence": "medium",
+      "match": "pattern_id",
+      "pattern_id": "ollama_models",
+      "recovery_method": "ollama pull after archive restore",
+      "risk": "medium",
+      "required_approval": "human_go_archive"
+    },
+    {
+      "rule_id": "quarantine_logs",
+      "classification": "QUARANTINE_REVIEW",
+      "confidence": "medium",
+      "match": "pattern_id",
+      "pattern_id": "logs",
+      "reason": "Logs may contain evidence; review before delete.",
+      "required_approval": "human_go_quarantine"
+    },
+    {
+      "rule_id": "delete_candidate_temp",
+      "classification": "DELETE_CANDIDATE",
+      "confidence": "medium",
+      "match": "pattern_id",
+      "pattern_id": "temp_dirs",
+      "recovery_method": "regenerate from tooling",
+      "risk": "medium",
+      "required_approval": "human_go_delete"
+    }
+  ],
+  "deduplicate_evidence_requirements": [
+    "identical_git_remote_and_commit",
+    "clean_worktree_no_unique_changes",
+    "bounded_hash_match"
+  ],
+  "raw_output_dir": "artifacts/local-dev-hygiene",
+  "published_evidence_dir": "docs/evidence/local_dev_hygiene",
+  "age_bucket_days": {
+    "lt_30": 30,
+    "d30_90": 90,
+    "d90_180": 180
+  }
+}

--- a/knowledge/logs/sessions/2026-07-12-issue-3999-local-dev-hygiene-inventory.md
+++ b/knowledge/logs/sessions/2026-07-12-issue-3999-local-dev-hygiene-inventory.md
@@ -1,0 +1,53 @@
+# Session Log — Issue #3999: Local Dev Hygiene Inventory
+
+Date: 2026-07-12  
+Issue: #3999  
+Branch: feat/3999-local-dev-hygiene  
+Status: Phase 1–3 read-only complete
+
+## Delivered
+
+- SSOT config: `infrastructure/config/ops/local_dev_hygiene.json`
+- Scanner: `tools/cleanup/local_dev_workspace_inventory.ps1`
+- Classifier: `tools/cleanup/local_dev_hygiene_classify.py`
+- Runbook: `docs/runbooks/LOCAL_DEV_HYGIENE_INVENTORY.md`
+- Unit tests: `tests/unit/cleanup/test_local_dev_hygiene_classify.py`
+- Redacted evidence: `docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.{json,md}`
+- `.gitignore` entry for `artifacts/local-dev-hygiene/`
+- Makefile target: `local-dev-hygiene-inventory`
+
+## Live scan (2026-07-12T18:10:49Z)
+
+| Metric | Measured | Screenshot baseline | Delta |
+|--------|----------|---------------------|-------|
+| Total GB | 120.06 | 134.27 | -14.21 (-10.6%) |
+| Files | 207,113 | 414,174 | -49.99% |
+| Directories | 45,542 | 71,093 | -35.94% |
+
+Per-root GB (measured): AI 40.22, Backups 8.02, Repos 7.40, Tools 64.42.
+
+Discovery: 21 git repositories, 21 worktrees (all PROTECTED).
+
+Reclaim estimate (classified): high 58.7 GB, medium 25.2 GB.
+
+## Limitations
+
+- Scan completeness: **partial** (access errors on extensions/node_modules/npm paths).
+- Reparse points not traversed (20 skipped under Repos).
+- File/dir counts below baseline due to inaccessible subtrees and no reparse traversal.
+- Raw artifacts remain local-only (gitignored).
+
+## Validation
+
+- `pytest -q tests/unit/cleanup/test_local_dev_hygiene_classify.py -m unit` — 9 passed
+- `ruff check` on new Python files — pass
+- Live scan + classifier run on workstation
+
+## Boundaries
+
+- No deletion, move, docker prune, child issues, or runtime/DB mutation.
+- LR remains NO-GO.
+
+## Follow-ups
+
+- None created (child slices deferred per issue until human review of evidence).

--- a/tests/unit/cleanup/test_local_dev_hygiene_classify.py
+++ b/tests/unit/cleanup/test_local_dev_hygiene_classify.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from tools.cleanup.local_dev_hygiene_classify import (
+    Candidate,
+    build_candidates,
+    classify_duplicate_repos,
+    classify_pattern_group,
+    parse_scan_as_of,
+    summarize_reclaim,
+    validate_candidates,
+)
+
+FIXED_SCAN_AS_OF = datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC)
+
+
+def _base_inventory() -> dict:
+    return {
+        "schema_version": "local_dev_workspace_inventory.v1",
+        "scan_as_of_utc": FIXED_SCAN_AS_OF.isoformat().replace("+00:00", "Z"),
+        "roots": [
+            {
+                "path": "D:\\Dev\\Workspaces\\Repos",
+                "pattern_groups": [
+                    {
+                        "pattern_id": "venv",
+                        "size_bytes": 300_000_000,
+                        "hit_count": 1,
+                    },
+                    {
+                        "pattern_id": "governance_work",
+                        "size_bytes": 5_000_000,
+                        "hit_count": 2,
+                    },
+                    {
+                        "pattern_id": "temp_dirs",
+                        "size_bytes": 70_000_000,
+                        "hit_count": 1,
+                    },
+                ],
+                "top_directories": [],
+            }
+        ],
+        "worktrees": [
+            {
+                "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare",
+                "branch": "main",
+                "head": "abc123",
+            }
+        ],
+        "git_repositories": [],
+    }
+
+
+def _base_config() -> dict:
+    return {
+        "classification_rules": [
+            {
+                "rule_id": "protected_worktree",
+                "classification": "PROTECTED",
+                "confidence": "high",
+                "match": "is_worktree",
+            },
+            {
+                "rule_id": "keep_provenance_governance",
+                "classification": "KEEP_PROVENANCE",
+                "confidence": "high",
+                "match": "pattern_id",
+                "pattern_id": "governance_work",
+                "reason": "governance provenance",
+                "required_approval": "none",
+            },
+            {
+                "rule_id": "regenerable_venv",
+                "classification": "REGENERABLE",
+                "confidence": "high",
+                "match": "pattern_id",
+                "pattern_id": "venv",
+                "recovery_method": "venv rebuild",
+                "risk": "low",
+                "required_approval": "human_go_regenerable",
+            },
+            {
+                "rule_id": "delete_candidate_temp",
+                "classification": "DELETE_CANDIDATE",
+                "confidence": "medium",
+                "match": "pattern_id",
+                "pattern_id": "temp_dirs",
+                "recovery_method": "regenerate",
+                "risk": "medium",
+                "required_approval": "human_go_delete",
+            },
+        ],
+        "secret_path_patterns": [".env"],
+    }
+
+
+@pytest.mark.unit
+def test_parse_scan_as_of_uses_inventory_timestamp() -> None:
+    inventory = _base_inventory()
+    parsed = parse_scan_as_of(inventory)
+    assert parsed == FIXED_SCAN_AS_OF
+
+
+@pytest.mark.unit
+def test_worktree_classified_protected() -> None:
+    candidates = build_candidates(_base_inventory(), _base_config())
+    protected = [c for c in candidates if c.classification == "PROTECTED"]
+    assert protected
+    assert all(c.required_approval == "none" for c in protected)
+
+
+@pytest.mark.unit
+def test_pattern_group_regenerable_venv() -> None:
+    item = classify_pattern_group(
+        pattern_id="venv",
+        size_bytes=100,
+        rules=_base_config()["classification_rules"],
+    )
+    assert item is not None
+    assert item.classification == "REGENERABLE"
+    assert item.confidence == "high"
+
+
+@pytest.mark.unit
+def test_governance_pattern_keep_provenance() -> None:
+    candidates = build_candidates(_base_inventory(), _base_config())
+    gov = next(c for c in candidates if c.pattern_id == "governance_work")
+    assert gov.classification == "KEEP_PROVENANCE"
+
+
+@pytest.mark.unit
+def test_deduplicate_requires_clean_worktree_and_same_signature() -> None:
+    repos = [
+        {
+            "path": "D:\\Dev\\Workspaces\\Repos\\alpha",
+            "remote_url": "https://github.com/org/repo.git",
+            "head_commit": "deadbeef",
+            "is_clean": True,
+        },
+        {
+            "path": "D:\\Dev\\Workspaces\\Repos\\alpha-copy",
+            "remote_url": "https://github.com/org/repo.git",
+            "head_commit": "deadbeef",
+            "is_clean": True,
+        },
+    ]
+    candidates = classify_duplicate_repos(repos)
+    assert len(candidates) == 1
+    assert candidates[0].classification == "DEDUPLICATE"
+    assert candidates[0].dedupe_evidence is not None
+
+
+@pytest.mark.unit
+def test_duplicate_without_clean_tree_is_quarantine() -> None:
+    repos = [
+        {
+            "path": "D:\\Dev\\Workspaces\\Repos\\alpha",
+            "remote_url": "https://github.com/org/repo.git",
+            "head_commit": "deadbeef",
+            "is_clean": True,
+        },
+        {
+            "path": "D:\\Dev\\Workspaces\\Repos\\alpha-dirty",
+            "remote_url": "https://github.com/org/repo.git",
+            "head_commit": "deadbeef",
+            "is_clean": False,
+        },
+    ]
+    candidates = classify_duplicate_repos(repos)
+    assert len(candidates) == 1
+    assert candidates[0].classification == "QUARANTINE_REVIEW"
+
+
+@pytest.mark.unit
+def test_duplicate_without_remote_commit_is_quarantine() -> None:
+    repos = [
+        {"path": "D:\\Dev\\Workspaces\\Repos\\a", "remote_url": None, "head_commit": None},
+        {"path": "D:\\Dev\\Workspaces\\Repos\\b", "remote_url": None, "head_commit": None},
+    ]
+    candidates = classify_duplicate_repos(repos)
+    assert candidates
+    assert all(c.classification == "QUARANTINE_REVIEW" for c in candidates)
+
+
+@pytest.mark.unit
+def test_validate_candidates_required_fields() -> None:
+    candidate = Candidate(
+        path="pattern:venv",
+        size=1,
+        last_relevant_change=None,
+        classification="REGENERABLE",
+        reason="test",
+        estimated_reclaim=1,
+        recovery_method="rebuild",
+        risk="low",
+        confidence="high",
+        required_approval="human_go_regenerable",
+        pattern_id="venv",
+    )
+    validate_candidates([candidate])
+
+
+@pytest.mark.unit
+def test_reclaim_summary_buckets_confidence() -> None:
+    candidates = [
+        Candidate(
+            path="pattern:venv",
+            size=1_000,
+            last_relevant_change=None,
+            classification="REGENERABLE",
+            reason="r",
+            estimated_reclaim=1_000,
+            recovery_method="rebuild",
+            risk="low",
+            confidence="high",
+            required_approval="human_go_regenerable",
+        ),
+        Candidate(
+            path="pattern:temp_dirs",
+            size=500,
+            last_relevant_change=None,
+            classification="DELETE_CANDIDATE",
+            reason="r",
+            estimated_reclaim=500,
+            recovery_method="delete",
+            risk="medium",
+            confidence="medium",
+            required_approval="human_go_delete",
+        ),
+    ]
+    summary = summarize_reclaim(candidates)
+    assert summary["estimated_reclaim_bytes_by_confidence"]["high"] == 1_000
+    assert summary["estimated_reclaim_bytes_by_confidence"]["medium"] == 500

--- a/tools/cleanup/local_dev_hygiene_classify.py
+++ b/tools/cleanup/local_dev_hygiene_classify.py
@@ -11,6 +11,8 @@ import json
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
+
+from core.utils.clock import utcnow
 from pathlib import Path
 from typing import Any, Literal
 
@@ -595,7 +597,7 @@ def build_redacted_evidence(
         "schema_version": "local_dev_hygiene_evidence_redacted.v1",
         "issue": ISSUE_REF,
         "scan_as_of_utc": inventory.get("scan_as_of_utc"),
-        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "generated_at_utc": utcnow().isoformat(),
         "aggregate": {
             "total_size_gb": agg.get("total_size_gb"),
             "total_files": agg.get("total_files"),

--- a/tools/cleanup/local_dev_hygiene_classify.py
+++ b/tools/cleanup/local_dev_hygiene_classify.py
@@ -1,0 +1,770 @@
+"""Local D:\\Dev hygiene classification and redacted evidence (#3999).
+
+Read-only: consumes workspace_inventory.json, emits local candidates/plan and
+git-tracked redacted evidence summary. No deletion or mutation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+Classification = Literal[
+    "KEEP_ACTIVE",
+    "KEEP_PROVENANCE",
+    "REGENERABLE",
+    "ARCHIVE_MOVE",
+    "DEDUPLICATE",
+    "QUARANTINE_REVIEW",
+    "DELETE_CANDIDATE",
+    "PROTECTED",
+]
+
+REQUIRED_CANDIDATE_FIELDS = (
+    "path",
+    "size",
+    "last_relevant_change",
+    "classification",
+    "reason",
+    "estimated_reclaim",
+    "recovery_method",
+    "risk",
+    "confidence",
+    "required_approval",
+)
+
+CONFIG_REL = Path("infrastructure/config/ops/local_dev_hygiene.json")
+ISSUE_REF = "#3999"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def load_config(repo_root: Path | None = None) -> dict[str, Any]:
+    root = _repo_root() if repo_root is None else repo_root
+    path = root / CONFIG_REL
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("config must be a JSON object")
+    return payload
+
+
+def load_inventory(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8-sig") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("inventory must be a JSON object")
+    return payload
+
+
+def parse_scan_as_of(inventory: dict[str, Any]) -> datetime:
+    raw = inventory.get("scan_as_of_utc")
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError("inventory missing scan_as_of_utc")
+    normalized = raw.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def redact_path(path: str, secret_patterns: list[str]) -> str:
+    lowered = path.lower().replace("/", "\\")
+    for pattern in secret_patterns:
+        if pattern.lower() in lowered:
+            return "[REDACTED_SECRET_PATH]"
+    return path
+
+
+def redact_remote_url(url: str | None) -> str | None:
+    if url is None:
+        return None
+    if "@" in url:
+        return re.sub(r"//[^@]+@", "//[REDACTED]@", url)
+    return url
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    path: str
+    size: int
+    last_relevant_change: str | None
+    classification: Classification
+    reason: str
+    estimated_reclaim: int
+    recovery_method: str
+    risk: str
+    confidence: str
+    required_approval: str
+    pattern_id: str | None = None
+    dedupe_evidence: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "path": self.path,
+            "size": self.size,
+            "last_relevant_change": self.last_relevant_change,
+            "classification": self.classification,
+            "reason": self.reason,
+            "estimated_reclaim": self.estimated_reclaim,
+            "recovery_method": self.recovery_method,
+            "risk": self.risk,
+            "confidence": self.confidence,
+            "required_approval": self.required_approval,
+        }
+        if self.pattern_id:
+            payload["pattern_id"] = self.pattern_id
+        if self.dedupe_evidence:
+            payload["dedupe_evidence"] = self.dedupe_evidence
+        return payload
+
+
+def _rule_matches_pattern(pattern_id: str, rule: dict[str, Any]) -> bool:
+    return rule.get("match") == "pattern_id" and rule.get("pattern_id") == pattern_id
+
+
+def classify_pattern_group(
+    *,
+    pattern_id: str,
+    size_bytes: int,
+    rules: list[dict[str, Any]],
+) -> Candidate | None:
+    rule = next((r for r in rules if _rule_matches_pattern(pattern_id, r)), None)
+    if rule is None:
+        return None
+    return Candidate(
+        path=f"pattern:{pattern_id}",
+        size=size_bytes,
+        last_relevant_change=None,
+        classification=rule["classification"],
+        reason=rule.get("reason", f"Matched pattern group {pattern_id}"),
+        estimated_reclaim=size_bytes,
+        recovery_method=rule.get("recovery_method", "review_required"),
+        risk=rule.get("risk", "unknown"),
+        confidence=rule["confidence"],
+        required_approval=rule.get("required_approval", "human_go"),
+        pattern_id=pattern_id,
+    )
+
+
+def build_worktree_candidates(worktrees: list[dict[str, Any]]) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for entry in worktrees:
+        path = str(entry.get("path", ""))
+        if not path:
+            continue
+        candidates.append(
+            Candidate(
+                path=path,
+                size=0,
+                last_relevant_change=None,
+                classification="PROTECTED",
+                reason="Dynamically discovered git worktree.",
+                estimated_reclaim=0,
+                recovery_method="n/a",
+                risk="high",
+                confidence="high",
+                required_approval="none",
+            )
+        )
+    return candidates
+
+
+def _repo_signature(repo: dict[str, Any]) -> tuple[str | None, str | None]:
+    remote = repo.get("remote_url")
+    head = repo.get("head_commit")
+    remote_s = str(remote) if remote else None
+    head_s = str(head) if head else None
+    return remote_s, head_s
+
+
+def classify_duplicate_repos(
+    git_repositories: list[dict[str, Any]],
+) -> list[Candidate]:
+    """DEDUPLICATE only with identical remote+commit and clean tree evidence."""
+    by_signature: dict[tuple[str | None, str | None], list[dict[str, Any]]] = {}
+    for repo in git_repositories:
+        sig = _repo_signature(repo)
+        by_signature.setdefault(sig, []).append(repo)
+
+    candidates: list[Candidate] = []
+    for sig, group in by_signature.items():
+        if len(group) < 2:
+            continue
+        remote, commit = sig
+        if not remote or not commit:
+            for repo in group[1:]:
+                candidates.append(
+                    Candidate(
+                        path=str(repo.get("path", "")),
+                        size=0,
+                        last_relevant_change=None,
+                        classification="QUARANTINE_REVIEW",
+                        reason="Potential duplicate repo without remote+commit evidence.",
+                        estimated_reclaim=0,
+                        recovery_method="manual_review",
+                        risk="high",
+                        confidence="low",
+                        required_approval="human_go_quarantine",
+                    )
+                )
+            continue
+
+        canonical = sorted(group, key=lambda item: str(item.get("path", "")))[0]
+        for repo in group[1:]:
+            is_clean = repo.get("is_clean")
+            if is_clean is True:
+                candidates.append(
+                    Candidate(
+                        path=str(repo.get("path", "")),
+                        size=0,
+                        last_relevant_change=None,
+                        classification="DEDUPLICATE",
+                        reason=(
+                            f"Same remote and commit as canonical repo "
+                            f"{canonical.get('path')}; clean worktree."
+                        ),
+                        estimated_reclaim=0,
+                        recovery_method="archive_or_remove_after_canonical_confirmed",
+                        risk="medium",
+                        confidence="medium",
+                        required_approval="human_go_deduplicate",
+                        dedupe_evidence="identical_git_remote_and_commit+clean_worktree",
+                    )
+                )
+            else:
+                candidates.append(
+                    Candidate(
+                        path=str(repo.get("path", "")),
+                        size=0,
+                        last_relevant_change=None,
+                        classification="QUARANTINE_REVIEW",
+                        reason=(
+                            "Same remote/commit as another repo but worktree not clean; "
+                            "cannot assign DEDUPLICATE."
+                        ),
+                        estimated_reclaim=0,
+                        recovery_method="manual_review",
+                        risk="high",
+                        confidence="low",
+                        required_approval="human_go_quarantine",
+                    )
+                )
+    return candidates
+
+
+def classify_top_directories(
+    roots: list[dict[str, Any]],
+    *,
+    worktree_paths: set[str],
+    rules: list[dict[str, Any]],
+) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    normalized_worktrees = {p.lower().rstrip("\\/") for p in worktree_paths}
+    for root in roots:
+        for entry in root.get("top_directories") or []:
+            path = str(entry.get("path", ""))
+            size = int(entry.get("size_bytes", 0))
+            norm = path.lower().rstrip("\\/")
+            if any(norm == wt or norm.startswith(wt + "\\") for wt in normalized_worktrees):
+                continue
+            if "\\.git" in norm or norm.endswith(".git"):
+                candidates.append(
+                    Candidate(
+                        path=path,
+                        size=size,
+                        last_relevant_change=None,
+                        classification="PROTECTED",
+                        reason="Git metadata path.",
+                        estimated_reclaim=0,
+                        recovery_method="n/a",
+                        risk="high",
+                        confidence="high",
+                        required_approval="none",
+                    )
+                )
+                continue
+            matched_rule = next(
+                (
+                    r
+                    for r in rules
+                    if r.get("match") == "path_contains"
+                    and isinstance(r.get("pattern"), str)
+                    and r["pattern"].lower() in norm
+                ),
+                None,
+            )
+            if matched_rule:
+                candidates.append(
+                    Candidate(
+                        path=path,
+                        size=size,
+                        last_relevant_change=None,
+                        classification=matched_rule["classification"],
+                        reason=matched_rule.get("reason", "Rule match"),
+                        estimated_reclaim=size,
+                        recovery_method=matched_rule.get("recovery_method", "review"),
+                        risk=matched_rule.get("risk", "unknown"),
+                        confidence=matched_rule["confidence"],
+                        required_approval=matched_rule.get("required_approval", "human_go"),
+                    )
+                )
+    return candidates
+
+
+def build_candidates(
+    inventory: dict[str, Any],
+    config: dict[str, Any],
+) -> list[Candidate]:
+    rules = list(config.get("classification_rules") or [])
+    candidates: list[Candidate] = []
+
+    worktrees = list(inventory.get("worktrees") or [])
+    worktree_paths = {str(w.get("path", "")) for w in worktrees if w.get("path")}
+    candidates.extend(build_worktree_candidates(worktrees))
+
+    for root in inventory.get("roots") or []:
+        for group in root.get("pattern_groups") or []:
+            pattern_id = str(group.get("pattern_id", ""))
+            size_bytes = int(group.get("size_bytes", 0))
+            item = classify_pattern_group(
+                pattern_id=pattern_id,
+                size_bytes=size_bytes,
+                rules=rules,
+            )
+            if item is not None:
+                candidates.append(item)
+
+    candidates.extend(
+        classify_top_directories(
+            list(inventory.get("roots") or []),
+            worktree_paths=worktree_paths,
+            rules=rules,
+        )
+    )
+    candidates.extend(classify_duplicate_repos(list(inventory.get("git_repositories") or [])))
+
+    deduped: dict[str, Candidate] = {}
+    for item in candidates:
+        key = f"{item.classification}:{item.path}:{item.pattern_id or ''}"
+        deduped[key] = item
+    return list(deduped.values())
+
+
+def validate_candidates(candidates: list[Candidate]) -> None:
+    for item in candidates:
+        payload = item.to_dict()
+        missing = [field for field in REQUIRED_CANDIDATE_FIELDS if field not in payload]
+        if missing:
+            raise ValueError(f"candidate missing fields {missing}: {payload}")
+
+
+def summarize_reclaim(candidates: list[Candidate]) -> dict[str, Any]:
+    by_confidence: dict[str, int] = {"high": 0, "medium": 0, "low": 0}
+    by_class: dict[str, int] = {}
+    for item in candidates:
+        by_class[item.classification] = by_class.get(item.classification, 0) + 1
+        if item.classification in {
+            "REGENERABLE",
+            "DELETE_CANDIDATE",
+            "ARCHIVE_MOVE",
+            "DEDUPLICATE",
+        }:
+            by_confidence[item.confidence] = (
+                by_confidence.get(item.confidence, 0) + item.estimated_reclaim
+            )
+    return {
+        "candidate_count": len(candidates),
+        "by_classification": by_class,
+        "estimated_reclaim_bytes_by_confidence": by_confidence,
+        "estimated_reclaim_gb_by_confidence": {
+            key: round(value / (1024**3), 3) for key, value in by_confidence.items()
+        },
+    }
+
+
+def render_cleanup_plan_md(
+    *,
+    inventory: dict[str, Any],
+    candidates: list[Candidate],
+    reclaim_summary: dict[str, Any],
+) -> str:
+    scan_as_of = inventory.get("scan_as_of_utc", "unknown")
+    lines = [
+        "# Local Dev Cleanup Plan (read-only manifest)",
+        "",
+        f"Issue: {ISSUE_REF}",
+        f"Scan as of (UTC): `{scan_as_of}`",
+        "",
+        "This document is a reversible cleanup manifest. **No actions are executed.**",
+        "",
+        "## Human-GO thresholds",
+        "",
+        "| Action type | Approval gate |",
+        "|-------------|---------------|",
+        "| REGENERABLE caches/venvs | `human_go_regenerable` |",
+        "| ARCHIVE_MOVE | `human_go_archive` |",
+        "| DELETE_CANDIDATE | `human_go_delete` |",
+        "| DEDUPLICATE | `human_go_deduplicate` + evidence |",
+        "| QUARANTINE_REVIEW | `human_go_quarantine` |",
+        "| PROTECTED / KEEP_* | no automated action |",
+        "",
+        "## Estimated reclaim (by confidence)",
+        "",
+        f"- high: {reclaim_summary['estimated_reclaim_gb_by_confidence'].get('high', 0)} GB",
+        f"- medium: {reclaim_summary['estimated_reclaim_gb_by_confidence'].get('medium', 0)} GB",
+        f"- low: {reclaim_summary['estimated_reclaim_gb_by_confidence'].get('low', 0)} GB",
+        "",
+        "## Candidates by confidence",
+        "",
+    ]
+    for confidence in ("high", "medium", "low"):
+        lines.append(f"### {confidence}")
+        lines.append("")
+        group = [c for c in candidates if c.confidence == confidence]
+        if not group:
+            lines.append("_none_")
+            lines.append("")
+            continue
+        for item in sorted(group, key=lambda c: (-c.estimated_reclaim, c.path)):
+            lines.append(
+                f"- **{item.classification}** `{item.path}` "
+                f"({item.estimated_reclaim} bytes) — {item.reason}"
+            )
+        lines.append("")
+    protected = [c for c in candidates if c.classification == "PROTECTED"]
+    lines.extend(
+        [
+            "## PROTECTED summary",
+            "",
+            f"Protected entries: {len(protected)} (includes all discovered worktrees).",
+            "",
+            "## Restore notes",
+            "",
+            "- REGENERABLE: rebuild from lockfiles/installers.",
+            "- ARCHIVE_MOVE: move to archive volume before deleting active copy.",
+            "- DEDUPLICATE: keep canonical repo; archive duplicate only after review.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_inventory_md(inventory: dict[str, Any]) -> str:
+    agg = inventory.get("aggregate") or {}
+    delta = agg.get("baseline_delta") or {}
+    lines = [
+        "# Local Dev Workspace Inventory (raw local summary)",
+        "",
+        f"Issue: {ISSUE_REF}",
+        f"Scan as of (UTC): `{inventory.get('scan_as_of_utc')}`",
+        "",
+        "## Aggregate",
+        "",
+        f"- Total size: {agg.get('total_size_gb')} GB",
+        f"- Files: {agg.get('total_files')}",
+        f"- Directories: {agg.get('total_directories')}",
+        f"- Completeness: {agg.get('scan_completeness')}",
+        "",
+        "## Baseline delta",
+        "",
+        f"- Screenshot total GB: {delta.get('screenshot_total_gb')}",
+        f"- Measured total GB: {delta.get('measured_total_gb')}",
+        f"- Delta GB: {delta.get('delta_gb')}",
+        f"- Within size tolerance: {delta.get('within_size_tolerance')}",
+        f"- Notes: {delta.get('tolerance_notes')}",
+        "",
+        "## Roots",
+        "",
+        "| Root | Status | GB | Files | Dirs | Duration s | Completeness |",
+        "|------|--------|---:|------:|-----:|-----------:|--------------|",
+    ]
+    for root in inventory.get("roots") or []:
+        lines.append(
+            f"| `{root.get('path')}` | {root.get('scan_status')} | "
+            f"{root.get('size_gb')} | {root.get('file_count')} | "
+            f"{root.get('directory_count')} | {root.get('scan_duration_seconds')} | "
+            f"{root.get('completeness')} |"
+        )
+    lines.extend(
+        [
+            "",
+            f"Git repositories discovered: {len(inventory.get('git_repositories') or [])}",
+            f"Worktrees discovered: {len(inventory.get('worktrees') or [])}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_redacted_evidence(
+    *,
+    inventory: dict[str, Any],
+    candidates: list[Candidate],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    secret_patterns = list(config.get("secret_path_patterns") or [])
+    reclaim = summarize_reclaim(candidates)
+    roots_summary = []
+    for root in inventory.get("roots") or []:
+        top_dirs = []
+        for entry in (root.get("top_directories") or [])[:10]:
+            top_dirs.append(
+                {
+                    "path": redact_path(str(entry.get("path", "")), secret_patterns),
+                    "size_gb": round(int(entry.get("size_bytes", 0)) / (1024**3), 3),
+                }
+            )
+        roots_summary.append(
+            {
+                "root": redact_path(str(root.get("path", "")), secret_patterns),
+                "scan_status": root.get("scan_status"),
+                "completeness": root.get("completeness"),
+                "size_gb": root.get("size_gb"),
+                "file_count": root.get("file_count"),
+                "directory_count": root.get("directory_count"),
+                "scan_duration_seconds": root.get("scan_duration_seconds"),
+                "skipped_reparse_points_count": root.get(
+                    "skipped_reparse_points_count", 0
+                ),
+                "access_error_count": len(root.get("access_errors") or []),
+                "limitations": list(root.get("limitations") or []),
+                "baseline_delta": root.get("baseline_delta") or {},
+                "top_directories": top_dirs,
+                "pattern_groups": [
+                    {
+                        "pattern_id": g.get("pattern_id"),
+                        "size_gb": g.get("size_gb"),
+                        "hit_count": g.get("hit_count"),
+                    }
+                    for g in (root.get("pattern_groups") or [])
+                ],
+            }
+        )
+
+    git_summary = []
+    for repo in inventory.get("git_repositories") or []:
+        git_summary.append(
+            {
+                "path": redact_path(str(repo.get("path", "")), secret_patterns),
+                "head_commit": (
+                    str(repo.get("head_commit", ""))[:12]
+                    if repo.get("head_commit")
+                    else None
+                ),
+                "remote_url": redact_remote_url(
+                    str(repo.get("remote_url")) if repo.get("remote_url") else None
+                ),
+                "is_clean": repo.get("is_clean"),
+            }
+        )
+
+    candidate_summary = []
+    for item in candidates:
+        if item.classification == "PROTECTED":
+            candidate_summary.append(
+                {
+                    "classification": item.classification,
+                    "path": "[PROTECTED_WORKTREE_OR_GIT_PATH]",
+                    "confidence": item.confidence,
+                    "estimated_reclaim_gb": 0,
+                }
+            )
+            continue
+        candidate_summary.append(
+            {
+                "classification": item.classification,
+                "path": redact_path(item.path, secret_patterns),
+                "pattern_id": item.pattern_id,
+                "confidence": item.confidence,
+                "estimated_reclaim_gb": round(item.estimated_reclaim / (1024**3), 3),
+                "required_approval": item.required_approval,
+                "dedupe_evidence": item.dedupe_evidence,
+            }
+        )
+
+    agg = inventory.get("aggregate") or {}
+    payload = {
+        "schema_version": "local_dev_hygiene_evidence_redacted.v1",
+        "issue": ISSUE_REF,
+        "scan_as_of_utc": inventory.get("scan_as_of_utc"),
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "aggregate": {
+            "total_size_gb": agg.get("total_size_gb"),
+            "total_files": agg.get("total_files"),
+            "total_directories": agg.get("total_directories"),
+            "scan_completeness": agg.get("scan_completeness"),
+            "baseline_delta": agg.get("baseline_delta"),
+        },
+        "roots": roots_summary,
+        "git_repository_count": len(git_summary),
+        "git_repositories": git_summary,
+        "worktree_count": len(inventory.get("worktrees") or []),
+        "reclaim_summary": reclaim,
+        "candidates": candidate_summary,
+        "redaction_note": (
+            "Raw inventory under artifacts/local-dev-hygiene/ is gitignored. "
+            "This file is aggregated and redacted; no secret paths or full file lists."
+        ),
+    }
+    return payload
+
+
+def render_redacted_evidence_md(evidence: dict[str, Any]) -> str:
+    agg = evidence.get("aggregate") or {}
+    delta = agg.get("baseline_delta") or {}
+    reclaim = evidence.get("reclaim_summary") or {}
+    lines = [
+        "# Local Dev Hygiene Evidence (redacted)",
+        "",
+        f"Issue: {ISSUE_REF}",
+        f"Scan as of (UTC): `{evidence.get('scan_as_of_utc')}`",
+        "",
+        "## Aggregate",
+        "",
+        f"- Total: {agg.get('total_size_gb')} GB / {agg.get('total_files')} files / "
+        f"{agg.get('total_directories')} directories",
+        f"- Completeness: {agg.get('scan_completeness')}",
+        f"- Baseline delta GB: {delta.get('delta_gb')} "
+        f"(within tolerance: {delta.get('within_size_tolerance')})",
+        "",
+        "## Reclaim estimate",
+        "",
+        f"- high confidence: "
+        f"{reclaim.get('estimated_reclaim_gb_by_confidence', {}).get('high', 0)} GB",
+        f"- medium confidence: "
+        f"{reclaim.get('estimated_reclaim_gb_by_confidence', {}).get('medium', 0)} GB",
+        f"- low confidence: "
+        f"{reclaim.get('estimated_reclaim_gb_by_confidence', {}).get('low', 0)} GB",
+        "",
+        "## Discovery",
+        "",
+        f"- Git repositories: {evidence.get('git_repository_count')}",
+        f"- Worktrees (all PROTECTED): {evidence.get('worktree_count')}",
+        "",
+        "## Root completeness",
+        "",
+        "| Root | Status | Completeness | GB | Reparse skipped | Access errors |",
+        "|------|--------|--------------|---:|----------------:|--------------:|",
+    ]
+    for root in evidence.get("roots") or []:
+        lines.append(
+            f"| `{root.get('root')}` | {root.get('scan_status')} | "
+            f"{root.get('completeness')} | {root.get('size_gb')} | "
+            f"{root.get('skipped_reparse_points_count')} | "
+            f"{root.get('access_error_count')} |"
+        )
+    lines.extend(["", evidence.get("redaction_note", ""), ""])
+    return "\n".join(lines)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def run_classification(
+    *,
+    inventory_path: Path,
+    repo_root: Path | None = None,
+    write_local_outputs: bool = True,
+    write_published_evidence: bool = True,
+) -> dict[str, Any]:
+    root = _repo_root() if repo_root is None else repo_root
+    config = load_config(root)
+    inventory = load_inventory(inventory_path)
+    _ = parse_scan_as_of(inventory)
+
+    candidates = build_candidates(inventory, config)
+    validate_candidates(candidates)
+    reclaim = summarize_reclaim(candidates)
+
+    raw_dir = root / str(config.get("raw_output_dir", "artifacts/local-dev-hygiene"))
+    published_dir = root / str(
+        config.get("published_evidence_dir", "docs/evidence/local_dev_hygiene")
+    )
+
+    if write_local_outputs:
+        candidates_payload = {
+            "schema_version": "local_dev_cleanup_candidates.v1",
+            "issue": ISSUE_REF,
+            "scan_as_of_utc": inventory.get("scan_as_of_utc"),
+            "candidate_count": len(candidates),
+            "candidates": [item.to_dict() for item in candidates],
+            "reclaim_summary": reclaim,
+        }
+        write_json(raw_dir / "cleanup_candidates.json", candidates_payload)
+        (raw_dir / "cleanup_plan.md").write_text(
+            render_cleanup_plan_md(
+                inventory=inventory,
+                candidates=candidates,
+                reclaim_summary=reclaim,
+            ),
+            encoding="utf-8",
+        )
+        (raw_dir / "workspace_inventory.md").write_text(
+            render_inventory_md(inventory),
+            encoding="utf-8",
+        )
+
+    evidence = build_redacted_evidence(
+        inventory=inventory, candidates=candidates, config=config
+    )
+    if write_published_evidence:
+        write_json(published_dir / "LOCAL_DEV_HYGIENE_EVIDENCE.json", evidence)
+        (published_dir / "LOCAL_DEV_HYGIENE_EVIDENCE.md").write_text(
+            render_redacted_evidence_md(evidence),
+            encoding="utf-8",
+        )
+
+    return {
+        "candidate_count": len(candidates),
+        "reclaim_summary": reclaim,
+        "published_evidence_dir": str(published_dir),
+        "raw_output_dir": str(raw_dir),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Local dev hygiene classifier (#3999)")
+    parser.add_argument(
+        "--inventory",
+        default="artifacts/local-dev-hygiene/workspace_inventory.json",
+    )
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--no-local-outputs", action="store_true")
+    parser.add_argument("--no-published-evidence", action="store_true")
+    args = parser.parse_args(argv)
+
+    root = _repo_root()
+    inventory_path = Path(args.inventory)
+    if not inventory_path.is_absolute():
+        inventory_path = root / inventory_path
+
+    if args.validate_only:
+        config = load_config(root)
+        inventory = load_inventory(inventory_path)
+        candidates = build_candidates(inventory, config)
+        validate_candidates(candidates)
+        print(json.dumps({"valid": True, "candidate_count": len(candidates)}, indent=2))
+        return 0
+
+    result = run_classification(
+        inventory_path=inventory_path,
+        repo_root=root,
+        write_local_outputs=not args.no_local_outputs,
+        write_published_evidence=not args.no_published_evidence,
+    )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/cleanup/local_dev_workspace_inventory.ps1
+++ b/tools/cleanup/local_dev_workspace_inventory.ps1
@@ -1,0 +1,805 @@
+<#
+.SYNOPSIS
+    Read-only metadata inventory for D:\Dev local development workspace (#3999).
+
+.DESCRIPTION
+    Streaming/incremental aggregation only. Does not follow reparse points (junctions/symlinks).
+    Does not read file contents. Raw output is local-only (gitignored).
+    Discovers all git repositories and worktrees dynamically.
+
+.PARAMETER ConfigPath
+    Path to local_dev_hygiene.json SSOT config.
+
+.PARAMETER OutputPath
+    Raw JSON output path (default from config raw_output_dir).
+
+.EXAMPLE
+    .\tools\cleanup\local_dev_workspace_inventory.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ConfigPath = "infrastructure\config\ops\local_dev_hygiene.json",
+    [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-EnumerationOptions {
+    $type = [System.Type]::GetType("System.IO.EnumerationOptions")
+    if ($null -eq $type) { return $null }
+    try {
+        $options = [System.Activator]::CreateInstance($type)
+        $type.GetProperty("RecurseSubdirectories").SetValue($options, $false)
+        $type.GetProperty("IgnoreInaccessible").SetValue($options, $true)
+        $type.GetProperty("AttributesToSkip").SetValue(
+            $options,
+            [System.IO.FileAttributes]::ReparsePoint
+        )
+        return $options
+    } catch {
+        return $null
+    }
+}
+
+function Get-EnumerationEntries {
+    param([string]$DirectoryPath)
+    $options = Get-EnumerationOptions
+    if ($null -ne $options) {
+        return [System.IO.Directory]::EnumerateFileSystemEntries(
+            $DirectoryPath,
+            "*",
+            $options
+        )
+    }
+    return [System.IO.Directory]::EnumerateFileSystemEntries($DirectoryPath)
+}
+
+function Get-DirectoryEntriesResilient {
+    param(
+        [string]$DirectoryPath,
+        [System.Collections.Generic.List[object]]$AccessErrors,
+        [int]$MaxAccessErrors,
+        [string]$Phase
+    )
+    $entries = [System.Collections.Generic.List[string]]::new()
+    try {
+        foreach ($entry in Get-EnumerationEntries -DirectoryPath $DirectoryPath) {
+            $entries.Add([string]$entry) | Out-Null
+        }
+        return $entries
+    } catch {
+        if ($AccessErrors.Count -lt $MaxAccessErrors) {
+            $AccessErrors.Add([pscustomobject]@{
+                path = $DirectoryPath
+                error = $_.Exception.GetType().Name
+                phase = $Phase
+            }) | Out-Null
+        }
+        try {
+            foreach ($item in Get-ChildItem -LiteralPath $DirectoryPath -Force -ErrorAction SilentlyContinue) {
+                $entries.Add($item.FullName) | Out-Null
+            }
+        } catch {
+            if ($AccessErrors.Count -lt $MaxAccessErrors) {
+                $AccessErrors.Add([pscustomobject]@{
+                    path = $DirectoryPath
+                    error = "fallback_failed:$($_.Exception.GetType().Name)"
+                    phase = $Phase
+                }) | Out-Null
+            }
+        }
+        return $entries
+    }
+}
+
+function Read-JsonFile {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Config not found: $Path"
+    }
+    return (Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json)
+}
+
+function Normalize-FullPath {
+    param([string]$PathValue)
+    return [System.IO.Path]::GetFullPath($PathValue.TrimEnd('\', '/'))
+}
+
+function Get-AgeBucket {
+    param(
+        [datetime]$LastWriteUtc,
+        [datetime]$ScanAsOfUtc,
+        [hashtable]$BucketDays
+    )
+    $age = ($ScanAsOfUtc - $LastWriteUtc).TotalDays
+    if ($age -lt $BucketDays.lt_30) { return "lt_30d" }
+    if ($age -lt $BucketDays.d30_90) { return "d30_90d" }
+    if ($age -lt $BucketDays.d90_180) { return "d90_180d" }
+    return "gt_180d"
+}
+
+function Test-DirectoryGlob {
+    param([string]$Name, [string]$Pattern)
+    if ($Pattern -like '*`**') {
+        $prefix = $Pattern.Substring(0, $Pattern.Length - 1)
+        return $Name -like "${prefix}*"
+    }
+    return $Name -eq $Pattern
+}
+
+function Match-PatternCatalog {
+    param(
+        [string]$FullPath,
+        [string]$Name,
+        [bool]$IsDirectory,
+        $Catalog
+    )
+    $matches = @()
+    foreach ($entry in $Catalog) {
+        $matched = $false
+        switch ($entry.match_type) {
+            "directory_name" {
+                $matched = $IsDirectory -and ($Name -eq $entry.pattern)
+            }
+            "file_extension" {
+                $matched = (-not $IsDirectory) -and ($Name.ToLower().EndsWith($entry.pattern.ToLower()))
+            }
+            "path_suffix" {
+                $normalized = $FullPath.Replace('/', '\')
+                $matched = $normalized.ToLower().EndsWith($entry.pattern.ToLower())
+            }
+            "directory_glob" {
+                $matched = $IsDirectory -and (Test-DirectoryGlob -Name $Name -Pattern $entry.pattern)
+            }
+        }
+        if ($matched) { $matches += $entry.id }
+    }
+    return $matches
+}
+
+function Add-TopEntry {
+    param(
+        [System.Collections.Generic.List[object]]$List,
+        [string]$Path,
+        [long]$SizeBytes,
+        [int]$MaxEntries
+    )
+    $List.Add([pscustomobject]@{ path = $Path; size_bytes = $SizeBytes }) | Out-Null
+    if ($List.Count -gt ($MaxEntries * 3)) {
+        $sorted = $List | Sort-Object -Property size_bytes -Descending | Select-Object -First $MaxEntries
+        $List.Clear()
+        foreach ($item in $sorted) { [void]$List.Add($item) }
+    }
+}
+
+function Finalize-TopEntries {
+    param(
+        [System.Collections.Generic.List[object]]$List,
+        [int]$MaxEntries
+    )
+    return @(
+        $List |
+            Sort-Object -Property size_bytes -Descending |
+            Select-Object -First $MaxEntries
+    )
+}
+
+function Measure-DirectorySubtree {
+    param(
+        [string]$DirectoryPath,
+        [datetime]$ScanAsOfUtc,
+        [hashtable]$BucketDays,
+        [hashtable]$PatternTotals,
+        [System.Collections.Generic.List[object]]$AccessErrors,
+        [int]$MaxAccessErrors,
+        [int]$MaxPathLength
+    )
+    $fileCount = 0L
+    $dirCount = 0L
+    $sizeBytes = 0L
+    $ageBuckets = @{
+        lt_30d = 0L; d30_90d = 0L; d90_180d = 0L; gt_180d = 0L
+    }
+    $stack = [System.Collections.Stack]::new()
+    $stack.Push($DirectoryPath)
+    while ($stack.Count -gt 0) {
+        $current = [string]$stack.Pop()
+        if ($current.Length -gt $MaxPathLength) {
+            if ($AccessErrors.Count -lt $MaxAccessErrors) {
+                $AccessErrors.Add([pscustomobject]@{
+                    path = $current; error = "path_too_long"; phase = "pattern_subtree"
+                }) | Out-Null
+            }
+            continue
+        }
+        try {
+            $childEntries = Get-DirectoryEntriesResilient -DirectoryPath $current `
+                -AccessErrors $AccessErrors -MaxAccessErrors $MaxAccessErrors -Phase "pattern_subtree"
+            foreach ($entry in $childEntries) {
+                if ($entry.Length -gt $MaxPathLength) {
+                    if ($AccessErrors.Count -lt $MaxAccessErrors) {
+                        $AccessErrors.Add([pscustomobject]@{
+                            path = $entry; error = "path_too_long"; phase = "pattern_subtree"
+                        }) | Out-Null
+                    }
+                    continue
+                }
+                $isDir = $false
+                try {
+                    $attrs = [System.IO.File]::GetAttributes($entry)
+                    if ($attrs -band [System.IO.FileAttributes]::ReparsePoint) { continue }
+                    $isDir = $attrs -band [System.IO.FileAttributes]::Directory
+                } catch {
+                    if ($AccessErrors.Count -lt $MaxAccessErrors) {
+                        $AccessErrors.Add([pscustomobject]@{
+                            path = $entry; error = $_.Exception.GetType().Name; phase = "pattern_subtree"
+                        }) | Out-Null
+                    }
+                    continue
+                }
+                if ($isDir) {
+                    $dirCount++
+                    $stack.Push($entry)
+                    continue
+                }
+                try {
+                    $info = [System.IO.FileInfo]::new($entry)
+                    $fileCount++
+                    $sizeBytes += [long]$info.Length
+                    $bucket = Get-AgeBucket -LastWriteUtc $info.LastWriteTimeUtc `
+                        -ScanAsOfUtc $ScanAsOfUtc -BucketDays $BucketDays
+                    $ageBuckets[$bucket] += [long]$info.Length
+                } catch {
+                    if ($AccessErrors.Count -lt $MaxAccessErrors) {
+                        $AccessErrors.Add([pscustomobject]@{
+                            path = $entry; error = $_.Exception.GetType().Name; phase = "pattern_subtree"
+                        }) | Out-Null
+                    }
+                }
+            }
+        } catch {
+            if ($AccessErrors.Count -lt $MaxAccessErrors) {
+                $AccessErrors.Add([pscustomobject]@{
+                    path = $current; error = $_.Exception.GetType().Name; phase = "pattern_subtree"
+                }) | Out-Null
+            }
+        }
+    }
+    return [pscustomobject]@{
+        file_count = $fileCount
+        directory_count = $dirCount
+        size_bytes = $sizeBytes
+        age_buckets = $ageBuckets
+    }
+}
+
+function Measure-ConfiguredSuffixPaths {
+    param(
+        [string]$RootPath,
+        [datetime]$ScanAsOfUtc,
+        $Config,
+        [hashtable]$PatternTotals,
+        [hashtable]$AgeBuckets,
+        [ref]$FileCount,
+        [ref]$DirCount,
+        [ref]$SizeBytes,
+        [hashtable]$TopChildMap,
+        [System.Collections.Generic.List[object]]$AccessErrors,
+        [int]$MaxAccessErrors,
+        [int]$MaxPathLength
+    )
+    $bucketDays = @{
+        lt_30 = [int]$Config.age_bucket_days.lt_30
+        d30_90 = [int]$Config.age_bucket_days.d30_90
+        d90_180 = [int]$Config.age_bucket_days.d90_180
+    }
+    $rootNorm = $RootPath.TrimEnd('\')
+    $devRoot = Split-Path $rootNorm -Parent
+    foreach ($entry in $Config.pattern_catalog) {
+        if ($entry.match_type -ne "path_suffix") { continue }
+        $suffix = [string]$entry.pattern
+        $candidate = Join-Path $devRoot $suffix
+        if (-not $candidate.StartsWith($rootNorm, [StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        if (-not (Test-Path -LiteralPath $candidate)) { continue }
+        $existing = $PatternTotals[$entry.id]
+        if ($existing.size_bytes -gt 0) { continue }
+        try {
+            $subtree = Measure-DirectorySubtree -DirectoryPath $candidate `
+                -ScanAsOfUtc $ScanAsOfUtc -BucketDays $bucketDays `
+                -PatternTotals $PatternTotals -AccessErrors $AccessErrors `
+                -MaxAccessErrors $MaxAccessErrors -MaxPathLength $MaxPathLength
+            $PatternTotals[$entry.id].count++
+            $PatternTotals[$entry.id].directory_count += $subtree.directory_count
+            $PatternTotals[$entry.id].file_count += $subtree.file_count
+            $PatternTotals[$entry.id].size_bytes += $subtree.size_bytes
+            $FileCount.Value += $subtree.file_count
+            $DirCount.Value += $subtree.directory_count
+            $SizeBytes.Value += $subtree.size_bytes
+            foreach ($key in $subtree.age_buckets.Keys) {
+                $AgeBuckets[$key] += $subtree.age_buckets[$key]
+            }
+            if (-not $TopChildMap.ContainsKey($candidate)) {
+                $TopChildMap[$candidate] = 0L
+            }
+            $TopChildMap[$candidate] += $subtree.size_bytes
+        } catch {
+            if ($AccessErrors.Count -lt $MaxAccessErrors) {
+                $AccessErrors.Add([pscustomobject]@{
+                    path = $candidate
+                    error = $_.Exception.GetType().Name
+                    phase = "suffix_measure"
+                }) | Out-Null
+            }
+        }
+    }
+}
+
+function Scan-Root {
+    param(
+        [string]$RootPath,
+        [datetime]$ScanAsOfUtc,
+        $Config
+    )
+    $limits = $Config.scan_limits
+    $bucketDays = @{
+        lt_30 = [int]$Config.age_bucket_days.lt_30
+        d30_90 = [int]$Config.age_bucket_days.d30_90
+        d90_180 = [int]$Config.age_bucket_days.d90_180
+    }
+    $maxTop = [int]$limits.top_directories_per_root
+    $largeThreshold = [long]$limits.large_file_threshold_bytes
+    $maxLarge = [int]$limits.large_files_max_entries
+    $maxReparseSamples = [int]$limits.skipped_reparse_points_max_samples
+    $maxAccessErrors = [int]$limits.access_errors_max_samples
+    $maxPathLength = [int]$limits.max_path_length
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $fileCount = 0L
+    $dirCount = 0L
+    $sizeBytes = 0L
+    $ageBuckets = @{
+        lt_30d = 0L; d30_90d = 0L; d90_180d = 0L; gt_180d = 0L
+    }
+    $topDirs = [System.Collections.Generic.List[object]]::new()
+    $largeFiles = [System.Collections.Generic.List[object]]::new()
+    $accessErrors = [System.Collections.Generic.List[object]]::new()
+    $skippedReparse = [System.Collections.Generic.List[object]]::new()
+    $patternTotals = @{}
+    foreach ($entry in $Config.pattern_catalog) {
+        $patternTotals[$entry.id] = @{
+            count = 0; size_bytes = 0L; directory_count = 0; file_count = 0
+        }
+    }
+    $topChildMap = @{}
+    $scanStatus = "complete"
+    $limitations = [System.Collections.Generic.List[string]]::new()
+
+    if (-not (Test-Path -LiteralPath $RootPath)) {
+        return [pscustomobject]@{
+            path = $RootPath
+            scan_status = "failed"
+            access_errors = @(@{ path = $RootPath; error = "root_missing" })
+            skipped_reparse_points = @()
+            skipped_reparse_points_count = 0
+            scan_duration_seconds = 0
+            baseline_delta = @{}
+            completeness = "none"
+            limitations = @("Root path does not exist.")
+            size_bytes = 0
+            file_count = 0
+            directory_count = 0
+            age_buckets_bytes = $ageBuckets
+            top_directories = @()
+            large_files = @()
+            pattern_groups = @()
+        }
+    }
+
+    $stack = [System.Collections.Stack]::new()
+    $stack.Push([pscustomobject]@{ path = $RootPath; depth = 0; top_child = $null })
+    $aggregateSkip = @{}
+
+    while ($stack.Count -gt 0) {
+        $frame = $stack.Pop()
+        $current = [string]$frame.path
+        $depth = [int]$frame.depth
+        $topChild = $frame.top_child
+
+        if ($current.Length -gt $maxPathLength) {
+            $scanStatus = "partial"
+            if ($accessErrors.Count -lt $maxAccessErrors) {
+                $accessErrors.Add([pscustomobject]@{
+                    path = $current; error = "path_too_long"; phase = "walk"
+                }) | Out-Null
+            }
+            continue
+        }
+        if ($aggregateSkip.ContainsKey($current.ToLower())) { continue }
+
+        $childEntries = Get-DirectoryEntriesResilient -DirectoryPath $current `
+            -AccessErrors $accessErrors -MaxAccessErrors $maxAccessErrors -Phase "walk"
+        foreach ($entry in $childEntries) {
+            try {
+                if ($entry.Length -gt $maxPathLength) {
+                    $scanStatus = "partial"
+                    if ($accessErrors.Count -lt $maxAccessErrors) {
+                        $accessErrors.Add([pscustomobject]@{
+                            path = $entry; error = "path_too_long"; phase = "walk"
+                        }) | Out-Null
+                    }
+                    continue
+                }
+                $name = [System.IO.Path]::GetFileName($entry)
+                $isDir = $false
+                $isReparse = $false
+                try {
+                    $attrs = [System.IO.File]::GetAttributes($entry)
+                    $isReparse = [bool]($attrs -band [System.IO.FileAttributes]::ReparsePoint)
+                    $isDir = [bool]($attrs -band [System.IO.FileAttributes]::Directory)
+                } catch {
+                    $scanStatus = "partial"
+                    if ($accessErrors.Count -lt $maxAccessErrors) {
+                        $accessErrors.Add([pscustomobject]@{
+                            path = $entry; error = $_.Exception.GetType().Name; phase = "walk"
+                        }) | Out-Null
+                    }
+                    continue
+                }
+
+                if ($isReparse) {
+                    if ($skippedReparse.Count -lt $maxReparseSamples) {
+                        $skippedReparse.Add([pscustomobject]@{
+                            path = $entry; kind = $(if ($isDir) { "directory" } else { "file" })
+                        }) | Out-Null
+                    }
+                    continue
+                }
+
+                $resolvedTopChild = $topChild
+                if ($depth -eq 0) { $resolvedTopChild = $entry }
+
+                if ($isDir) {
+                    $dirCount++
+                    $patternIds = Match-PatternCatalog -FullPath $entry -Name $name `
+                        -IsDirectory $true -Catalog $Config.pattern_catalog
+                    if ($patternIds.Count -gt 0) {
+                        try {
+                            $subtree = Measure-DirectorySubtree -DirectoryPath $entry `
+                                -ScanAsOfUtc $ScanAsOfUtc -BucketDays $bucketDays `
+                                -PatternTotals $patternTotals -AccessErrors $accessErrors `
+                                -MaxAccessErrors $maxAccessErrors -MaxPathLength $maxPathLength
+                        } catch {
+                            $scanStatus = "partial"
+                            if ($accessErrors.Count -lt $maxAccessErrors) {
+                                $accessErrors.Add([pscustomobject]@{
+                                    path = $entry
+                                    error = $_.Exception.GetType().Name
+                                    phase = "pattern_subtree_walk"
+                                }) | Out-Null
+                            }
+                            $stack.Push([pscustomobject]@{
+                                path = $entry; depth = $depth + 1; top_child = $resolvedTopChild
+                            })
+                            continue
+                        }
+                        foreach ($pid in $patternIds) {
+                            $patternTotals[$pid].count++
+                            $patternTotals[$pid].directory_count += $subtree.directory_count
+                            $patternTotals[$pid].file_count += $subtree.file_count
+                            $patternTotals[$pid].size_bytes += $subtree.size_bytes
+                        }
+                        $fileCount += $subtree.file_count
+                        $dirCount += $subtree.directory_count
+                        $sizeBytes += $subtree.size_bytes
+                        foreach ($key in $subtree.age_buckets.Keys) {
+                            $ageBuckets[$key] += $subtree.age_buckets[$key]
+                        }
+                        if ($null -ne $resolvedTopChild) {
+                            if (-not $topChildMap.ContainsKey($resolvedTopChild)) {
+                                $topChildMap[$resolvedTopChild] = 0L
+                            }
+                            $topChildMap[$resolvedTopChild] += $subtree.size_bytes
+                        }
+                        $aggregateSkip[$entry.ToLower()] = $true
+                        continue
+                    }
+                    $stack.Push([pscustomobject]@{
+                        path = $entry; depth = $depth + 1; top_child = $resolvedTopChild
+                    })
+                    continue
+                }
+
+                try {
+                    $info = [System.IO.FileInfo]::new($entry)
+                    $len = [long]$info.Length
+                    $fileCount++
+                    $sizeBytes += $len
+                    $bucket = Get-AgeBucket -LastWriteUtc $info.LastWriteTimeUtc `
+                        -ScanAsOfUtc $ScanAsOfUtc -BucketDays $bucketDays
+                    $ageBuckets[$bucket] += $len
+                    if ($null -ne $resolvedTopChild) {
+                        if (-not $topChildMap.ContainsKey($resolvedTopChild)) {
+                            $topChildMap[$resolvedTopChild] = 0L
+                        }
+                        $topChildMap[$resolvedTopChild] += $len
+                    }
+                    $patternIds = Match-PatternCatalog -FullPath $entry -Name $name `
+                        -IsDirectory $false -Catalog $Config.pattern_catalog
+                    foreach ($pid in $patternIds) {
+                        $patternTotals[$pid].count++
+                        $patternTotals[$pid].file_count++
+                        $patternTotals[$pid].size_bytes += $len
+                    }
+                    if ($len -ge $largeThreshold) {
+                        Add-TopEntry -List $largeFiles -Path $entry -SizeBytes $len -MaxEntries $maxLarge
+                    }
+                } catch {
+                    $scanStatus = "partial"
+                    if ($accessErrors.Count -lt $maxAccessErrors) {
+                        $accessErrors.Add([pscustomobject]@{
+                            path = $entry; error = $_.Exception.GetType().Name; phase = "walk"
+                        }) | Out-Null
+                    }
+                }
+            } catch {
+                $scanStatus = "partial"
+                if ($accessErrors.Count -lt $maxAccessErrors) {
+                    $accessErrors.Add([pscustomobject]@{
+                        path = $entry; error = $_.Exception.GetType().Name; phase = "walk_entry"
+                    }) | Out-Null
+                }
+            }
+        }
+    }
+
+    Measure-ConfiguredSuffixPaths -RootPath $RootPath -ScanAsOfUtc $ScanAsOfUtc -Config $Config `
+        -PatternTotals $patternTotals -AgeBuckets $ageBuckets `
+        -FileCount ([ref]$fileCount) -DirCount ([ref]$dirCount) -SizeBytes ([ref]$sizeBytes) `
+        -TopChildMap $topChildMap -AccessErrors $accessErrors `
+        -MaxAccessErrors $maxAccessErrors -MaxPathLength $maxPathLength
+
+    foreach ($key in $topChildMap.Keys) {
+        Add-TopEntry -List $topDirs -Path $key -SizeBytes $topChildMap[$key] -MaxEntries $maxTop
+    }
+
+    $sw.Stop()
+    if ($accessErrors.Count -gt 0) { $limitations.Add("Access or path-length errors encountered.") | Out-Null }
+    if ($skippedReparse.Count -gt 0) {
+        $limitations.Add("Reparse points recorded but not traversed.") | Out-Null
+    }
+    $completeness = if ($scanStatus -eq "complete") { "full" } else { "partial" }
+
+    $rootBaselineGb = $null
+    $baselineKey = $RootPath
+    if ($Config.screenshot_baseline.per_root_gb.PSObject.Properties.Name -contains $baselineKey) {
+        $rootBaselineGb = [double]$Config.screenshot_baseline.per_root_gb.$baselineKey
+    }
+    $sizeGb = [math]::Round($sizeBytes / 1GB, 2)
+    $baselineDelta = @{}
+    if ($null -ne $rootBaselineGb) {
+        $deltaGb = [math]::Round($sizeGb - $rootBaselineGb, 2)
+        $pct = if ($rootBaselineGb -gt 0) {
+            [math]::Round(($deltaGb / $rootBaselineGb) * 100, 2)
+        } else { 0 }
+        $within = [math]::Abs($pct) -le [double]$Config.screenshot_baseline.tolerance.size_gb_pct
+        $baselineDelta = @{
+            screenshot_gb = $rootBaselineGb
+            measured_gb = $sizeGb
+            delta_gb = $deltaGb
+            delta_pct = $pct
+            within_tolerance = $within
+        }
+    }
+
+    $patternGroups = @()
+    foreach ($entry in $Config.pattern_catalog) {
+        $totals = $patternTotals[$entry.id]
+        if ($totals.size_bytes -gt 0 -or $totals.count -gt 0) {
+            $patternGroups += [ordered]@{
+                pattern_id = $entry.id
+                hit_count = $totals.count
+                file_count = $totals.file_count
+                directory_count = $totals.directory_count
+                size_bytes = $totals.size_bytes
+                size_gb = [math]::Round($totals.size_bytes / 1GB, 3)
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        path = $RootPath
+        scan_status = $scanStatus
+        access_errors = @($accessErrors)
+        skipped_reparse_points = @($skippedReparse)
+        skipped_reparse_points_count = $skippedReparse.Count
+        scan_duration_seconds = [math]::Round($sw.Elapsed.TotalSeconds, 2)
+        baseline_delta = $baselineDelta
+        completeness = $completeness
+        limitations = @($limitations)
+        size_bytes = $sizeBytes
+        size_gb = $sizeGb
+        file_count = $fileCount
+        directory_count = $dirCount
+        age_buckets_bytes = $ageBuckets
+        top_directories = @(Finalize-TopEntries -List $topDirs -MaxEntries $maxTop)
+        large_files = @(Finalize-TopEntries -List $largeFiles -MaxEntries $maxLarge)
+        pattern_groups = $patternGroups
+    }
+}
+
+function Parse-WorktreeList {
+    param([string]$RawText, [string]$RepoPath)
+    $entries = @()
+    $current = [ordered]@{}
+    foreach ($line in ($RawText -split "`r?`n")) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            if ($current.Count -gt 0) {
+                $entries += [pscustomobject]$current
+                $current = [ordered]@{}
+            }
+            continue
+        }
+        if ($line.StartsWith("worktree ")) {
+            $current["path"] = $line.Substring(9).Trim()
+            continue
+        }
+        if ($line.StartsWith("HEAD ")) {
+            $current["head"] = $line.Substring(5).Trim()
+            continue
+        }
+        if ($line.StartsWith("branch ")) {
+            $current["branch"] = $line.Substring(7).Trim().Replace("refs/heads/", "")
+            continue
+        }
+        if ($line.StartsWith("bare")) { $current["bare"] = $true }
+    }
+    if ($current.Count -gt 0) { $entries += [pscustomobject]$current }
+    foreach ($entry in $entries) {
+        $entry | Add-Member -NotePropertyName repo_path -NotePropertyValue $RepoPath -Force
+    }
+    return $entries
+}
+
+function Get-GitRepoMetadata {
+    param([string]$RepoPath)
+    $meta = [ordered]@{
+        path = $RepoPath
+        is_git = $false
+        remote_url = $null
+        head_commit = $null
+        is_clean = $null
+        status_error = $null
+    }
+    $gitMarker = Join-Path $RepoPath ".git"
+    if (-not (Test-Path -LiteralPath $gitMarker)) { return [pscustomobject]$meta }
+    $meta.is_git = $true
+    try {
+        $remote = & git -C $RepoPath remote get-url origin 2>&1
+        if ($LASTEXITCODE -eq 0) { $meta.remote_url = [string]$remote.Trim() }
+    } catch { $meta.status_error = "remote_lookup_failed" }
+    try {
+        $head = & git -C $RepoPath rev-parse HEAD 2>&1
+        if ($LASTEXITCODE -eq 0) { $meta.head_commit = [string]$head.Trim() }
+    } catch { $meta.status_error = "head_lookup_failed" }
+    try {
+        $status = & git -C $RepoPath status --porcelain 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            $meta.is_clean = [string]::IsNullOrWhiteSpace(($status -join "`n"))
+        }
+    } catch { $meta.status_error = "status_lookup_failed" }
+    return [pscustomobject]$meta
+}
+
+function Discover-GitRepositories {
+    param([string]$ReposRoot)
+    $repos = @()
+    if (-not (Test-Path -LiteralPath $ReposRoot)) { return $repos }
+    foreach ($child in [System.IO.Directory]::EnumerateDirectories($ReposRoot)) {
+        $meta = Get-GitRepoMetadata -RepoPath $child
+        if ($meta.is_git) { $repos += $meta }
+    }
+    return $repos
+}
+
+function Discover-Worktrees {
+    param([array]$GitRepositories)
+    $all = @()
+    foreach ($repo in $GitRepositories) {
+        try {
+            $raw = & git -C $repo.path worktree list --porcelain 2>&1
+            if ($LASTEXITCODE -ne 0) { continue }
+            $all += Parse-WorktreeList -RawText ([string]$raw) -RepoPath $repo.path
+        } catch { continue }
+    }
+    return $all
+}
+
+$repoRoot = Normalize-FullPath -PathValue (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+Set-Location $repoRoot
+$config = Read-JsonFile -Path (Join-Path $repoRoot $ConfigPath)
+$scanAsOfUtc = [datetime]::UtcNow
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $repoRoot ($config.raw_output_dir + "\workspace_inventory.json")
+}
+
+Write-Host "=== Local Dev Workspace Inventory (#3999) ===" -ForegroundColor Cyan
+Write-Host "scan_as_of_utc: $($scanAsOfUtc.ToString('o'))"
+Write-Host "boundary: read-only metadata; reparse points not traversed; raw output gitignored."
+
+$ErrorActionPreference = "Continue"
+$rootResults = @()
+foreach ($root in $config.roots) {
+    $normalizedRoot = Normalize-FullPath -PathValue $root
+    Write-Host "Scanning $normalizedRoot ..."
+    $rootResults += Scan-Root -RootPath $normalizedRoot -ScanAsOfUtc $scanAsOfUtc -Config $config
+}
+
+$gitRepos = Discover-GitRepositories -ReposRoot $config.repos_scan_root
+$worktrees = Discover-Worktrees -GitRepositories $gitRepos
+
+$totalSize = ($rootResults | Measure-Object -Property size_bytes -Sum).Sum
+$totalFiles = ($rootResults | Measure-Object -Property file_count -Sum).Sum
+$totalDirs = ($rootResults | Measure-Object -Property directory_count -Sum).Sum
+$baseline = $config.screenshot_baseline
+$measuredGb = [math]::Round($totalSize / 1GB, 2)
+$deltaGb = [math]::Round($measuredGb - [double]$baseline.total_size_gb, 2)
+$deltaFilesPct = if ([int]$baseline.total_files -gt 0) {
+    [math]::Round((($totalFiles - [int]$baseline.total_files) / [int]$baseline.total_files) * 100, 2)
+} else { 0 }
+$deltaDirsPct = if ([int]$baseline.total_directories -gt 0) {
+    [math]::Round((($totalDirs - [int]$baseline.total_directories) / [int]$baseline.total_directories) * 100, 2)
+} else { 0 }
+
+$aggregateBaselineDelta = @{
+    screenshot_total_gb = [double]$baseline.total_size_gb
+    measured_total_gb = $measuredGb
+    delta_gb = $deltaGb
+    screenshot_files = [int]$baseline.total_files
+    measured_files = [long]$totalFiles
+    delta_files_pct = $deltaFilesPct
+    screenshot_directories = [int]$baseline.total_directories
+    measured_directories = [long]$totalDirs
+    delta_directories_pct = $deltaDirsPct
+    within_size_tolerance = (
+        [math]::Abs($deltaGb) -le ([double]$baseline.total_size_gb * [double]$baseline.tolerance.size_gb_pct / 100)
+    )
+    within_file_tolerance = (
+        [math]::Abs($deltaFilesPct) -le [double]$baseline.tolerance.file_count_pct
+    )
+    within_directory_tolerance = (
+        [math]::Abs($deltaDirsPct) -le [double]$baseline.tolerance.directory_count_pct
+    )
+    tolerance_notes = [string]$baseline.tolerance.notes
+}
+
+$anyPartial = @($rootResults | Where-Object { $_.scan_status -ne "complete" }).Count -gt 0
+$inventory = [ordered]@{
+    schema_version = "local_dev_workspace_inventory.v1"
+    issue = "#3999"
+    scan_as_of_utc = $scanAsOfUtc.ToString("o")
+    boundary_note = "Read-only metadata scan. Reparse points not traversed. Raw output local-only."
+    aggregate = [ordered]@{
+        total_size_bytes = [long]$totalSize
+        total_size_gb = $measuredGb
+        total_files = [long]$totalFiles
+        total_directories = [long]$totalDirs
+        baseline_delta = $aggregateBaselineDelta
+        scan_completeness = if ($anyPartial) { "partial" } else { "full" }
+    }
+    roots = @($rootResults)
+    git_repositories = @($gitRepos)
+    worktrees = @($worktrees)
+}
+
+$outputDir = Split-Path -Parent $OutputPath
+if ($outputDir) { New-Item -ItemType Directory -Path $outputDir -Force | Out-Null }
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($OutputPath, ($inventory | ConvertTo-Json -Depth 12), $utf8NoBom)
+
+Write-Host ""
+Write-Host "Aggregate: $measuredGb GB, $totalFiles files, $totalDirs directories" -ForegroundColor Yellow
+Write-Host "Git repos: $($gitRepos.Count); worktrees: $($worktrees.Count)"
+Write-Host "Report written to: $OutputPath" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Add read-only D:\\Dev metadata scanner (streaming aggregation, reparse-point skip, dynamic git/worktree discovery).
- Add classifier producing redacted evidence in docs/evidence/local_dev_hygiene/; raw outputs gitignored.
- Add SSOT config, runbook, Makefile target, and unit tests for classification rules.

## Test plan
- [x] pytest tests/unit/cleanup/test_local_dev_hygiene_classify.py -m unit (9 passed)
- [x] ruff check on new Python files
- [x] Live workstation scan: 120.06 GB measured vs 134.27 GB baseline (partial completeness documented)
- [x] 21 git repos / 21 worktrees discovered; all worktrees PROTECTED

## Non-goals
- No deletion, move, docker prune, child issues, or runtime/DB mutation.

## Delivered evidence
- docs/evidence/local_dev_hygiene/LOCAL_DEV_HYGIENE_EVIDENCE.md

Closes #3999

Made with [Cursor](https://cursor.com)