### PR TITLE
feat(ops): Binance market_data E→D relocation tooling and evidence (#4004)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,10 @@ scripts/cdb_ops.ps1
 # Local D:\Dev hygiene raw scan outputs (#3999) — redacted summary only in docs/evidence/
 artifacts/local-dev-hygiene/
 
+# Binance market_data relocation staging and raw evidence (#4004)
+/market_data.__incoming_*/
+/data-relocation/
+
 # Decision Contract audit records (generated at runtime + by tests)
 reports/decision_contract/
 

--- a/docs/evidence/market_data/BINANCE_HISTORICAL_DATA_RELOCATION_E_TO_D_2026-07-12.json
+++ b/docs/evidence/market_data/BINANCE_HISTORICAL_DATA_RELOCATION_E_TO_D_2026-07-12.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": "cdb.market_data_relocation.v1",
+  "issue": 4004,
+  "upstream_issue": 3990,
+  "status": "DONE_MERGED_DATA_RELOCATED_E_TO_D",
+  "completed_at_utc": "2026-07-12T20:55:30Z",
+  "lr_status": "NO-GO",
+  "source": {
+    "volume_label": "Backup II",
+    "drive": "E:",
+    "path": "E:\\CDB_artifacts\\market_data",
+    "bytes": 8553025212,
+    "file_count": 1403,
+    "directory_count": 429
+  },
+  "destination": {
+    "volume_label": "DevDrive",
+    "drive": "D:",
+    "path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare\\artifacts\\market_data",
+    "physical": true,
+    "reparse_point": false
+  },
+  "staging_path": "D:\\Dev\\Workspaces\\Repos\\Claire_de_Binare\\market_data.__incoming_20260712T204710Z",
+  "copy": {
+    "robocopy_exit_code": 1,
+    "files_copied": 1403,
+    "bytes_copied": 8553025212,
+    "errors": 0
+  },
+  "hash_pre_transform": {
+    "verdict": "PASS",
+    "source_manifest_fingerprint": "434dde78d11434cedd691fd55be08b1674e4279ed6c6b48d0ad3f3d64ab1fb86",
+    "missing": 0,
+    "extra": 0,
+    "mismatched": 0
+  },
+  "manifest_transformation": {
+    "performed": true,
+    "relative_path": "manifests/binance_btcusdt_1m_full_import.json",
+    "old_sha256": "d80feda1fbedee702a27d60b97691f4ba8c76e9901f0239f7eb4131f848c1be5",
+    "new_sha256": "f3ed12dc320bd7fd933aa70c7e088be8762799fc7c374ae32ea5d686b01983b3",
+    "post_transform_mismatched_files": 1
+  },
+  "dataset_contract": {
+    "total_months": 107,
+    "strict_complete": 81,
+    "partial_usable": 26,
+    "failed": 0,
+    "total_candles": 4656799,
+    "base_window_count": 106,
+    "stress_v2_window_count": 2,
+    "total_window_count": 108,
+    "verdict": "PASS"
+  },
+  "cutover": {
+    "artifacts_junction_removed": true,
+    "per_subtree_rejunction": true,
+    "tracked_artifacts_missing": 0,
+    "verdict": "PASS"
+  },
+  "functional_validation": {
+    "smoke_replay_2026_06": "PASS",
+    "window_bank_pilot_manifest": "PASS",
+    "arvp_preflight_only": "PASS",
+    "post_rename_retests": "PASS",
+    "hidden_e_dependency_hits": 0
+  },
+  "source_lifecycle": {
+    "renamed_to": "E:\\CDB_artifacts\\market_data.__relocated_verified_20260712T205513Z",
+    "deleted": true,
+    "original_path_exists_after_delete": false
+  },
+  "limitations": [
+    "Full SHA256 jsonl manifests not committed; stored locally under data-relocation/4004/",
+    "ARVP preflight uses pilot dataset manifest (2 months); full bank remains offline-reconciled"
+  ]
+}

--- a/docs/evidence/market_data/BINANCE_HISTORICAL_DATA_RELOCATION_E_TO_D_2026-07-12.md
+++ b/docs/evidence/market_data/BINANCE_HISTORICAL_DATA_RELOCATION_E_TO_D_2026-07-12.md
@@ -1,0 +1,81 @@
+# Binance Historical Data Relocation E: → D: — Issue #4004
+
+**Date:** 2026-07-12  
+**Issue:** [#4004](https://github.com/jannekbuengener/Claire_de_Binare/issues/4004)  
+**Upstream:** [#3990](https://github.com/jannekbuengener/Claire_de_Binare/issues/3990), PR #3997  
+**Final status:** `DONE_MERGED_DATA_RELOCATED_E_TO_D`  
+**LR:** NO-GO (unchanged)
+
+---
+
+## Summary
+
+The #3990 Binance BTCUSDT 1m corpus was relocated from external volume **Backup II** (`E:\CDB_artifacts\market_data`) to physical `REPO_ROOT/artifacts/market_data` on DevDrive `D:`. The top-level `artifacts` junction was broken; `market_data` is now a normal directory on `D:`; all other `E:\CDB_artifacts` subtrees remain reachable via per-subtree junctions.
+
+---
+
+## Source / Destination
+
+| Field | Source (pre-migration) | Post-cutover |
+|-------|------------------------|--------------|
+| Volume | `E:` Backup II (Fixed USB) | `D:` DevDrive |
+| Path | `E:\CDB_artifacts\market_data` | `D:\Dev\Workspaces\Repos\Claire_de_Binare\artifacts\market_data` |
+| Bytes | 8,553,025,212 (~7.97 GiB) | same corpus |
+| Files | 1,403 | 1,403 |
+| Reparse in `market_data` path | via parent junction | **none** (physical) |
+
+---
+
+## Verification Chain
+
+| Step | Result |
+|------|--------|
+| robocopy staging | exit 1 (success), 1,403 files, 0 errors |
+| SHA256 source vs staging (pre-transform) | **PASS** (0 missing/extra/mismatched) |
+| Offline reconcile (source + staging) | **PASS** |
+| Manifest transform (staging only) | 1 intentional delta: `manifests/binance_btcusdt_1m_full_import.json` |
+| SHA256 post-transform | exactly 1 mismatched file (manifest only) |
+| Junction cutover | **PASS**, 0 tracked artifact drift |
+| Smoke replay 2026-06 | **PASS** |
+| Window bank pilot manifest | **PASS** |
+| ARVP preflight-only | **PASS** |
+| Post-rename re-tests | **PASS**, 0 hidden `E:\CDB_artifacts\market_data` refs |
+| Source delete | only `market_data.__relocated_verified_20260712T205513Z` removed |
+
+---
+
+## Dataset Contract (unchanged)
+
+| Metric | Value |
+|--------|-------|
+| Months | 107 (2017-08 … 2026-06) |
+| STRICT_COMPLETE | 81 |
+| PARTIAL_USABLE | 26 |
+| Failed | 0 |
+| Total candles | 4,656,799 |
+| Window bank | 108 (106 base + 2 stress_v2) |
+
+---
+
+## Tooling Delivered
+
+- `tools/market_data/binance_archive_manifest_reconcile.py` — read-only offline reconcile
+- `tools/market_data/market_data_storage_guard.py` — fail-closed import guard
+- `tools/market_data/relocate_hash_manifest.py` — streaming SHA256 manifests
+- Runbook update: `docs/runbooks/ARVP_BINANCE_HISTORICAL_IMPORT.md`
+
+---
+
+## Boundaries
+
+- No Docker / DB / MCP / runtime mutation
+- No ARVP campaign start
+- No live / Echtgeld scope
+- Other `E:\CDB_artifacts` content preserved (junctions + copied top-level files)
+- Full hash manifests and copy logs remain local under `data-relocation/4004/` (gitignored)
+
+---
+
+## Machine-readable companion
+
+See `BINANCE_HISTORICAL_DATA_RELOCATION_E_TO_D_2026-07-12.json`.

--- a/docs/runbooks/ARVP_BINANCE_HISTORICAL_IMPORT.md
+++ b/docs/runbooks/ARVP_BINANCE_HISTORICAL_IMPORT.md
@@ -113,3 +113,57 @@ python -m tools.market_data.binance_window_bank --run-campaign --manifest-path a
 - Disk below `min_free_disk_gb` → fatal stop
 - Regime contract blocking → `FULL_IMPORT_PARTIAL_REGIME_BLOCKED`
 - Smoke/pilot FAIL → do not start full bank campaign
+
+---
+
+## Storage Location & Guard (#4004)
+
+**Canonical path:** `REPO_ROOT/artifacts/market_data` (physically on the repository volume, typically DevDrive `D:`).
+
+Historical full imports are **fail-closed** unless `tools.market_data.market_data_storage_guard` passes:
+
+- Repository and `artifacts/market_data` on the **same volume**
+- Volume label matches DevDrive (when resolvable)
+- No Reparse Point / Junction / Symlink in the path chain to the target
+- Resolved target **not** on blocked external drives (e.g. `E:` Backup II)
+- No Removable/Network storage
+- Free space ≥ expected write volume × 1.25
+
+**No automatic external-drive fallback.** Imports must not silently redirect to `E:` or other Backup volumes.
+
+`--list-months` and read-only offline reconcile are **not** blocked by the guard.
+
+---
+
+## Offline Reconcile vs Import (#4004)
+
+**Do not** use `binance_full_archive_import --skip-download` as a general read-only manifest rebuild. It may still touch network listing, download fallbacks, and dataset writes.
+
+Use the read-only reconciler instead:
+
+```powershell
+python -m tools.market_data.binance_archive_manifest_reconcile `
+  --market-data-root "<ROOT>" `
+  --output-dir "<OUTPUT_DIR>"
+```
+
+Outputs only under `--output-dir`: `reconciled_import_manifest.json`, `reconcile_report.json`, `reconcile_report.md`.
+
+---
+
+## E: → D: Relocation Flow (#4004)
+
+1. **Preflight** — read-only source/destination inventory
+2. **Copy** — `robocopy` to `market_data.__incoming_<UTC>` on D: (outside `artifacts` junction)
+3. **Verify** — streaming SHA256 source vs staging (`relocate_hash_manifest`)
+4. **Reconcile** — offline reconciler on staging copy
+5. **Cutover** — break `artifacts` junction; physical `market_data` on D:; per-subtree re-junction for other `E:\CDB_artifacts` content
+6. **Rename-test** — rename `E:\CDB_artifacts\market_data` → `market_data.__relocated_verified_<UTC>`; re-run smoke/preflight without E: dependency
+7. **Delete** — remove only the renamed verified source folder after all gates PASS
+
+Hash tooling:
+
+```powershell
+python -m tools.market_data.relocate_hash_manifest create --root "<ROOT>" --output "<FILE.jsonl>"
+python -m tools.market_data.relocate_hash_manifest compare --source "<SRC.jsonl>" --destination "<DST.jsonl>" --output "<COMPARE.json>"
+```

--- a/knowledge/logs/sessions/2026-07-12-binance-reloc-4004-complete.md
+++ b/knowledge/logs/sessions/2026-07-12-binance-reloc-4004-complete.md
@@ -1,0 +1,27 @@
+# Session Log — Binance E→D Relocation #4004 (Complete)
+
+**Date:** 2026-07-12  
+**Issue:** #4004  
+**Branch:** `ops/binance-reloc-4004-e-to-d`  
+**Status:** `DONE_MERGED_DATA_RELOCATED_E_TO_D`
+
+## Delivered
+
+- Offline reconciler, storage guard, hash manifest tooling + tests
+- Copy/verify chain PASS (SHA256, reconcile, manifest transform)
+- Junction cutover: `artifacts/market_data` physical on D:
+- Functional validation: smoke, window bank, ARVP preflight
+- Rename-before-delete on E: source; verified folder removed
+- Tracked evidence: `docs/evidence/market_data/BINANCE_HISTORICAL_DATA_RELOCATION_E_TO_D_2026-07-12.*`
+
+## Validation
+
+- pytest 37/37 scoped unit tests
+- ruff clean on touched files
+- Live smoke/window/preflight on D: path post-cutover and post-rename
+
+## Boundaries
+
+- LR NO-GO unchanged
+- No Docker/DB/MCP/runtime mutation
+- No ARVP campaign start

--- a/knowledge/logs/sessions/2026-07-12-binance-reloc-4004-phase1.md
+++ b/knowledge/logs/sessions/2026-07-12-binance-reloc-4004-phase1.md
@@ -1,0 +1,71 @@
+# Session 2026-07-12 — Binance E→D Relocation Phase 1 (#4004)
+
+**Issue:** [#4004](https://github.com/jannekbuengener/Claire_de_Binare/issues/4004) (OPEN)  
+**Branch:** `ops/binance-reloc-4004-e-to-d`  
+**Worktree:** `D:\Dev\Workspaces\Repos\Claire_de_Binare__binance-reloc-4004`  
+**Base SHA:** `b67d9ef960d55a1f492e666e630c382ddedc0b3a` (= `origin/main`)  
+**Operator-GO:** `GO — BINANCE E→D MIGRATION PHASE 1` (2026-07-12)  
+**Phase-1-Status:** `READY_FOR_SOURCE_DESTINATION_PREFLIGHT`
+
+## Bootloader / Read Order
+
+| Step | Pfad | Status |
+|------|------|--------|
+| Root pointer | `AGENTS.md` | gelesen |
+| Agent registry + Read Order | `agents/AGENTS.md` | gelesen |
+| Engineering status | `CURRENT_STATUS.md` | gelesen |
+| LR verdict | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | gelesen (NO-GO) |
+| Board stage | `docs/runbooks/CONTROL_REGISTER.md` | gelesen (`trade-capable`) |
+| Session skill | `.cursor/skills/cdb-session-start/SKILL.md` | angewendet |
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+context_tool_status: available
+context_trust_level: none
+records_found: none
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+tools_or_queries:
+ - cdb_context_briefing (task_id=cdb-briefing-binance-reloc-phase1)
+ - git fetch/status/rev-parse/worktree list
+ - gh issue list (dedupe)
+repo_crosscheck:
+ - CURRENT_STATUS.md (#3990/PR #3997 DONE_MERGED)
+ - agents/AGENTS.md Read Order
+limitations:
+ - Kein DB-backed Context; operative Wahrheit = GitHub + lokales FS (noch nicht in Phase 1 inventarisiert)
+```
+
+## GitHub Dedupe
+
+- Suche: `Binance Backup E: D:`, `Binance-Historiendaten Backup 2`, `in:title Binance E: D:`
+- Ergebnis: **0 offene Duplikate**
+- Neues Issue angelegt: **#4004**
+
+## Repo / Worktree Lage
+
+| Surface | Branch | SHA | Working tree |
+|---------|--------|-----|--------------|
+| Main (`Claire_de_Binare`) | `main` | `b67d9ef9` | `?? tests/unit/market_data/test_binance_stress_rebuild.py` (unberührt) |
+| Migration worktree | `ops/binance-reloc-4004-e-to-d` | `b67d9ef9` | clean |
+
+## Phase 1 Grenzen (eingehalten)
+
+- Keine Datenkopie, kein Hash, kein Manifest-Write, kein Junction-Cutover
+- Keine Umbenennung/Löschung auf E:
+- Keine Runtime/Docker/DB/MCP-Mutation
+
+## Nächster Schritt
+
+Phase 2: Source/Destination Preflight (read-only Inventar E:\CDB_artifacts\market_data, D: DevDrive/Space, Dry-run Evidence)
+
+## Boundaries
+
+- LR NO-GO; kein Live/Echtgeld
+- Scope nur #3990 Binance-Korpus auf Backup II (E:)

--- a/knowledge/logs/sessions/2026-07-12-binance-reloc-4004-phase2.md
+++ b/knowledge/logs/sessions/2026-07-12-binance-reloc-4004-phase2.md
@@ -1,0 +1,55 @@
+# Session 2026-07-12 — Binance E→D Relocation Phase 2 (#4004)
+
+**Issue:** [#4004](https://github.com/jannekbuengener/Claire_de_Binare/issues/4004)  
+**Branch:** `ops/binance-reloc-4004-e-to-d`  
+**Worktree:** `D:\Dev\Workspaces\Repos\Claire_de_Binare__binance-reloc-4004`  
+**Phase-2-Status:** `READY_FOR_IMPLEMENTATION_AND_COPY`
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+context_tool_status: available
+context_trust_level: none
+records_found: none
+context_brain_attempted: true
+context_brain_used: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+tools_or_queries:
+ - cdb_context_briefing (phase2)
+ - Get-Volume / Get-Partition / Get-Disk
+ - read-only filesystem scan E:\CDB_artifacts\market_data
+ - quality_report.json aggregation (107 months)
+ - gh issue view 4004
+repo_crosscheck:
+ - docs/evidence/binance_full_archive_import_3990.md
+ - CURRENT_STATUS.md
+limitations:
+ - Kein SHA256-Gesamtlauf, kein Offline-Reconciler in Phase 2
+```
+
+## Preflight Summary
+
+| Gate | Result |
+|------|--------|
+| Source unique (Backup II @ E:) | PASS |
+| Source structure complete | PASS |
+| Dataset prefind vs #3990 | PASS (filesystem) |
+| Stale import manifest | DOCUMENTED (2 months; not repaired) |
+| D: reserve ≥ 1.25× source | PASS (73.1 GB vs ~9.97 GB req.) |
+| Destination conflict | none |
+| Junction blocker | DOCUMENTED (artifacts → E:\CDB_artifacts) |
+
+## Evidence (local, gitignored)
+
+`data-relocation/4004/` — source_inventory.json, destination_inventory.json, artifacts_top_level_inventory.json, preflight_dry_run.md
+
+## Phase 2 Boundaries
+
+No copy, hash, manifest write, junction change, E: mutation, runtime/docker/DB/MCP.
+
+## Next Step
+
+Phase 3: Storage Guard + Offline-Reconciler implementation, then Phase 4 Copy.

--- a/tests/unit/market_data/test_binance_archive_manifest_reconcile.py
+++ b/tests/unit/market_data/test_binance_archive_manifest_reconcile.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.market_data import binance_archive_manifest_reconcile as reconcile
+from tools.market_data.historical_common import write_json
+
+
+def _write_month(
+    root: Path,
+    month: str,
+    *,
+    verdict: str = "STRICT_COMPLETE",
+    candles: int = 100,
+) -> None:
+    month_dir = (
+        root
+        / "normalized"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+        / month
+    )
+    month_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        month_dir / "quality_report.json",
+        {
+            "verdict": verdict,
+            "gaps": {"actual_candles": candles},
+            "duplicates": {},
+        },
+    )
+    write_json(month_dir / "gap_report.json", {"actual_candles": candles})
+
+
+@pytest.mark.unit
+def test_reconcile_writes_only_output_dir(tmp_path: Path) -> None:
+    root = tmp_path / "dataset"
+    out = tmp_path / "out"
+    _write_month(root, "2020-01", candles=50)
+    wb_path = (
+        root
+        / "window_bank"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+        / "window_bank_manifest.json"
+    )
+    wb_path.parent.mkdir(parents=True)
+    write_json(wb_path, {"windows": [], "stress_v2_rebuild": {"written_v2": []}})
+    before = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+    report = reconcile.reconcile_market_data_root(
+        market_data_root=root,
+        output_dir=out,
+        expected={
+            "earliest_month": "2020-01",
+            "latest_month": "2020-01",
+            "total_months": 1,
+            "strict_complete": 1,
+            "partial_usable": 0,
+            "failed": 0,
+            "total_candles": 50,
+            "base_window_count": 0,
+            "stress_v2_window_count": 0,
+            "total_window_count": 0,
+        },
+    )
+    after = {p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file()}
+    assert before == after
+    assert (out / "reconcile_report.json").is_file()
+    assert report["verdict"] == "PASS"
+
+
+@pytest.mark.unit
+def test_reconcile_detects_stale_manifest_without_mutation(tmp_path: Path) -> None:
+    root = tmp_path / "dataset"
+    out = tmp_path / "out"
+    _write_month(root, "2020-01", candles=10)
+    manifest_path = root / "manifests" / "binance_btcusdt_1m_full_import.json"
+    manifest_path.parent.mkdir(parents=True)
+    stale = {"import_status": "FULL_IMPORT_PARTIAL", "coverage": {"month_count": 2}}
+    write_json(manifest_path, stale)
+    before = manifest_path.read_text(encoding="utf-8")
+    reconcile.reconcile_market_data_root(
+        market_data_root=root,
+        output_dir=out,
+        expected={
+            "earliest_month": "2020-01",
+            "latest_month": "2020-01",
+            "total_months": 1,
+            "strict_complete": 1,
+            "partial_usable": 0,
+            "failed": 0,
+            "total_candles": 10,
+            "base_window_count": 0,
+            "stress_v2_window_count": 0,
+            "total_window_count": 0,
+        },
+    )
+    assert manifest_path.read_text(encoding="utf-8") == before
+    payload = json.loads((out / "reconcile_report.json").read_text(encoding="utf-8"))
+    assert payload["stale_manifest_summary"]["month_count"] == 2
+
+
+@pytest.mark.unit
+def test_reconcile_missing_quality_report_fails_contract(tmp_path: Path) -> None:
+    root = tmp_path / "dataset"
+    out = tmp_path / "out"
+    month_dir = root / "normalized" / "binance" / "spot" / "BTCUSDT" / "1m" / "2020-02"
+    month_dir.mkdir(parents=True)
+    report = reconcile.reconcile_market_data_root(
+        market_data_root=root,
+        output_dir=out,
+        expected={
+            "earliest_month": "2020-02",
+            "latest_month": "2020-02",
+            "total_months": 1,
+            "strict_complete": 0,
+            "partial_usable": 0,
+            "failed": 0,
+            "total_candles": 0,
+            "base_window_count": 0,
+            "stress_v2_window_count": 0,
+            "total_window_count": 0,
+        },
+    )
+    assert report["verdict"] == "HOLD_DATASET_CONTRACT_MISMATCH"
+    assert report["missing_files"]
+
+
+@pytest.mark.unit
+def test_reconcile_network_guard_blocks_urlopen() -> None:
+    reconcile._guard_network_import()
+    import urllib.request
+
+    with pytest.raises(reconcile.NetworkAttemptError):
+        urllib.request.urlopen("https://example.com")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_window_bank_stress_v2_split(tmp_path: Path) -> None:
+    root = tmp_path / "dataset"
+    out = tmp_path / "out"
+    _write_month(root, "2020-01", candles=10)
+    wb_path = (
+        root
+        / "window_bank"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+        / "window_bank_manifest.json"
+    )
+    wb_path.parent.mkdir(parents=True)
+    write_json(
+        wb_path,
+        {
+            "windows": [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+            "stress_v2_rebuild": {"written_v2": ["stress_a_v2", "stress_b_v2"]},
+        },
+    )
+    report = reconcile.reconcile_market_data_root(
+        market_data_root=root,
+        output_dir=out,
+        expected={
+            "earliest_month": "2020-01",
+            "latest_month": "2020-01",
+            "total_months": 1,
+            "strict_complete": 1,
+            "partial_usable": 0,
+            "failed": 0,
+            "total_candles": 10,
+            "base_window_count": 1,
+            "stress_v2_window_count": 2,
+            "total_window_count": 3,
+        },
+    )
+    assert report["base_window_count"] == 1
+    assert report["stress_v2_window_count"] == 2
+    assert report["total_window_count"] == 3

--- a/tests/unit/market_data/test_binance_full_archive_import.py
+++ b/tests/unit/market_data/test_binance_full_archive_import.py
@@ -101,6 +101,7 @@ def test_missing_month_not_in_range() -> None:
                 end_month="2020-03",
                 fetcher=fetcher,
                 max_retries=1,
+                skip_storage_guard=True,
             )
     assert manifest["summary"]["failed"] >= 1
 

--- a/tests/unit/market_data/test_market_data_storage_guard.py
+++ b/tests/unit/market_data/test_market_data_storage_guard.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from tools.market_data.historical_common import HistoricalProbeError
+from tools.market_data.market_data_storage_guard import (
+    DefaultVolumeProbe,
+    StorageGuardResult,
+    VolumeInfo,
+    enforce_market_data_storage,
+    validate_market_data_storage,
+)
+
+
+@dataclass
+class FakeVolumeProbe:
+    repo_volume: VolumeInfo
+    target_volume: VolumeInfo
+    reparse_paths: frozenset[str] = frozenset()
+
+    def resolve_path(self, path: Path) -> Path:
+        return path.resolve()
+
+    def volume_for_path(self, path: Path) -> VolumeInfo:
+        resolved = path.resolve()
+        if "artifacts" in resolved.parts and "market_data" in resolved.parts:
+            return self.target_volume
+        return self.repo_volume
+
+
+def _vol(
+    *,
+    letter: str = "D",
+    label: str = "DevDrive",
+    drive_type: str = "Fixed",
+    free_bytes: int = 100_000_000_000,
+    unique_id: str = "serial:DEADBEEF",
+) -> VolumeInfo:
+    return VolumeInfo(
+        drive_letter=letter,
+        unique_id=unique_id,
+        file_system_label=label,
+        drive_type=drive_type,
+        free_bytes=free_bytes,
+        total_bytes=free_bytes * 2,
+    )
+
+
+@pytest.mark.unit
+def test_storage_guard_same_devdrive_passes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(repo_volume=_vol(), target_volume=_vol())
+    result = validate_market_data_storage(
+        repo_root=repo,
+        required_write_bytes=1_000_000_000,
+        volume_probe=probe,
+    )
+    assert result.allowed is True
+    assert result.reason_code == "PASS"
+
+
+@pytest.mark.unit
+def test_storage_guard_external_fixed_drive_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(
+        repo_volume=_vol(letter="D", unique_id="serial:AAA"),
+        target_volume=_vol(letter="E", unique_id="serial:BBB", label="Backup II"),
+    )
+    result = validate_market_data_storage(
+        repo_root=repo,
+        required_write_bytes=1_000_000_000,
+        volume_probe=probe,
+    )
+    assert result.allowed is False
+    assert result.reason_code == "DIFFERENT_VOLUME"
+
+
+@pytest.mark.unit
+def test_storage_guard_blocked_drive_letter_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(repo_volume=_vol(), target_volume=_vol(letter="E"))
+    result = validate_market_data_storage(
+        repo_root=repo,
+        required_write_bytes=1_000,
+        volume_probe=probe,
+    )
+    assert result.allowed is False
+    assert result.reason_code in {"DIFFERENT_VOLUME", "BLOCKED_DRIVE"}
+
+
+@pytest.mark.unit
+def test_storage_guard_removable_drive_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(
+        repo_volume=_vol(),
+        target_volume=_vol(drive_type="Removable"),
+    )
+    result = validate_market_data_storage(
+        repo_root=repo,
+        required_write_bytes=1_000,
+        volume_probe=probe,
+    )
+    assert result.allowed is False
+    assert result.reason_code == "UNSUPPORTED_DRIVE_TYPE"
+
+
+@pytest.mark.unit
+def test_storage_guard_network_drive_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(
+        repo_volume=_vol(),
+        target_volume=_vol(drive_type="Remote"),
+    )
+    result = validate_market_data_storage(
+        repo_root=repo,
+        required_write_bytes=1_000,
+        volume_probe=probe,
+    )
+    assert result.allowed is False
+    assert result.reason_code == "UNSUPPORTED_DRIVE_TYPE"
+
+
+@pytest.mark.unit
+def test_storage_guard_unknown_volume_id_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(
+        repo_volume=_vol(unique_id=None),
+        target_volume=_vol(unique_id="serial:OTHER", letter="C"),
+    )
+    result = validate_market_data_storage(
+        repo_root=repo,
+        required_write_bytes=1_000,
+        volume_probe=probe,
+    )
+    assert result.allowed is False
+    assert result.reason_code == "UNKNOWN_VOLUME_ID"
+
+
+@pytest.mark.unit
+def test_storage_guard_insufficient_space_fails(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(
+        repo_volume=_vol(free_bytes=1_000),
+        target_volume=_vol(free_bytes=1_000),
+    )
+    result = validate_market_data_storage(
+        repo_root=repo,
+        required_write_bytes=10_000_000_000,
+        volume_probe=probe,
+    )
+    assert result.allowed is False
+    assert result.reason_code == "INSUFFICIENT_SPACE"
+
+
+@pytest.mark.unit
+def test_storage_guard_enforce_raises(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / "artifacts" / "market_data").mkdir(parents=True)
+    probe = FakeVolumeProbe(
+        repo_volume=_vol(),
+        target_volume=_vol(letter="E", unique_id="serial:EEE"),
+    )
+    with pytest.raises(HistoricalProbeError, match="STORAGE_GUARD_BLOCKED"):
+        enforce_market_data_storage(
+            repo_root=repo,
+            required_write_bytes=1_000,
+            volume_probe=probe,
+        )
+
+
+@pytest.mark.unit
+def test_default_volume_probe_is_constructible() -> None:
+    assert DefaultVolumeProbe() is not None

--- a/tests/unit/market_data/test_relocate_hash_manifest.py
+++ b/tests/unit/market_data/test_relocate_hash_manifest.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.market_data.relocate_hash_manifest import (
+    RelocateHashError,
+    compare_manifests,
+    create_manifest,
+    iter_hash_entries,
+    manifest_fingerprint,
+)
+
+
+@pytest.mark.unit
+def test_hash_manifest_create_and_compare_pass(tmp_path: Path) -> None:
+    root = tmp_path / "data"
+    (root / "nested").mkdir(parents=True)
+    file_a = root / "nested" / "a.txt"
+    file_b = root / "b.txt"
+    file_a.write_text("alpha", encoding="utf-8")
+    file_b.write_text("beta", encoding="utf-8")
+    source_manifest = tmp_path / "source.jsonl"
+    dest_manifest = tmp_path / "dest.jsonl"
+    create_manifest(root=root, output=source_manifest)
+    create_manifest(root=root, output=dest_manifest)
+    report_path = tmp_path / "compare.json"
+    report = compare_manifests(
+        source=source_manifest,
+        destination=dest_manifest,
+        output=report_path,
+    )
+    assert report["verdict"] == "PASS"
+    assert report["missing"] == []
+    assert report["extra"] == []
+    assert report["mismatched"] == []
+
+
+@pytest.mark.unit
+def test_hash_manifest_detects_missing_and_extra(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    dest_root = tmp_path / "dest"
+    source_root.mkdir()
+    dest_root.mkdir()
+    (source_root / "only_source.txt").write_text("x", encoding="utf-8")
+    (dest_root / "only_dest.txt").write_text("y", encoding="utf-8")
+    source_manifest = tmp_path / "source.jsonl"
+    dest_manifest = tmp_path / "dest.jsonl"
+    create_manifest(root=source_root, output=source_manifest)
+    create_manifest(root=dest_root, output=dest_manifest)
+    report = compare_manifests(
+        source=source_manifest,
+        destination=dest_manifest,
+        output=tmp_path / "compare.json",
+    )
+    assert report["verdict"] == "FAIL"
+    assert report["missing"]
+    assert report["extra"]
+
+
+@pytest.mark.unit
+def test_hash_manifest_detects_mismatch(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    dest_root = tmp_path / "dest"
+    source_root.mkdir()
+    dest_root.mkdir()
+    (source_root / "same.txt").write_text("one", encoding="utf-8")
+    (dest_root / "same.txt").write_text("two", encoding="utf-8")
+    source_manifest = tmp_path / "source.jsonl"
+    dest_manifest = tmp_path / "dest.jsonl"
+    create_manifest(root=source_root, output=source_manifest)
+    create_manifest(root=dest_root, output=dest_manifest)
+    report = compare_manifests(
+        source=source_manifest,
+        destination=dest_manifest,
+        output=tmp_path / "compare.json",
+    )
+    assert report["verdict"] == "FAIL"
+    assert report["mismatched"]
+
+
+@pytest.mark.unit
+def test_hash_manifest_reparse_point_blocks(tmp_path: Path) -> None:
+    if not hasattr(os, "symlink"):
+        pytest.skip("symlinks unavailable")
+    root = tmp_path / "data"
+    root.mkdir()
+    real = tmp_path / "real.txt"
+    real.write_text("x", encoding="utf-8")
+    link = root / "link.txt"
+    link.symlink_to(real)
+    with pytest.raises(RelocateHashError, match="reparse point"):
+        list(iter_hash_entries(root))
+
+
+@pytest.mark.unit
+def test_hash_manifest_deterministic_fingerprint(tmp_path: Path) -> None:
+    root = tmp_path / "data"
+    root.mkdir()
+    (root / "a.txt").write_text("a", encoding="utf-8")
+    entries_a = sorted(iter_hash_entries(root), key=lambda item: item.relative_path)
+    entries_b = sorted(iter_hash_entries(root), key=lambda item: item.relative_path)
+    assert manifest_fingerprint(entries_a) == manifest_fingerprint(entries_b)
+
+
+@pytest.mark.unit
+def test_hash_manifest_access_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "data"
+    root.mkdir()
+    blocked = root / "blocked.txt"
+    blocked.write_text("x", encoding="utf-8")
+
+    original_stat = Path.stat
+
+    def _fail_stat(self: Path, *args, **kwargs):  # noqa: ANN002, ANN003
+        if self == blocked:
+            raise OSError("access denied")
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _fail_stat)
+    with pytest.raises(RelocateHashError, match="access error"):
+        list(iter_hash_entries(root))

--- a/tests/unit/market_data/test_relocate_hash_manifest.py
+++ b/tests/unit/market_data/test_relocate_hash_manifest.py
@@ -115,13 +115,23 @@ def test_hash_manifest_access_error(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     blocked = root / "blocked.txt"
     blocked.write_text("x", encoding="utf-8")
 
-    original_stat = Path.stat
+    if sys.platform == "win32":
+        original_stat = Path.stat
 
-    def _fail_stat(self: Path, *args, **kwargs):  # noqa: ANN002, ANN003
-        if self == blocked:
-            raise OSError("access denied")
-        return original_stat(self, *args, **kwargs)
+        def _fail_stat(self: Path, *args, **kwargs):  # noqa: ANN002, ANN003
+            if self.name == blocked.name and self.parent == blocked.parent:
+                raise OSError("access denied")
+            return original_stat(self, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "stat", _fail_stat)
+        monkeypatch.setattr(Path, "stat", _fail_stat)
+    else:
+        blocked.chmod(0)
+        try:
+            with pytest.raises(RelocateHashError, match="access error"):
+                list(iter_hash_entries(root))
+            return
+        finally:
+            blocked.chmod(stat.S_IWUSR | stat.S_IRUSR)
+
     with pytest.raises(RelocateHashError, match="access error"):
         list(iter_hash_entries(root))

--- a/tools/market_data/binance_archive_manifest_reconcile.py
+++ b/tools/market_data/binance_archive_manifest_reconcile.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from tools.market_data.historical_common import HistoricalProbeError, write_json
+from tools.market_data.historical_common import HistoricalProbeError, utc_now_iso, write_json
 
 SCHEMA_VERSION = "binance_archive_reconcile.v1"
 SYMBOL = "BTCUSDT"
@@ -195,7 +195,7 @@ def reconcile_market_data_root(
 
     earliest_month = norm_months[0] if norm_months else None
     latest_month = norm_months[-1] if norm_months else None
-    scan_as_of_utc = datetime.now(tz=UTC).isoformat()
+    scan_as_of_utc = utc_now_iso()
 
     report_core = {
         "schema_version": SCHEMA_VERSION,

--- a/tools/market_data/binance_archive_manifest_reconcile.py
+++ b/tools/market_data/binance_archive_manifest_reconcile.py
@@ -1,0 +1,339 @@
+"""Read-only offline manifest reconcile for Binance market_data (#4004)."""
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.market_data.historical_common import HistoricalProbeError, write_json
+
+SCHEMA_VERSION = "binance_archive_reconcile.v1"
+SYMBOL = "BTCUSDT"
+VENUE = "binance"
+TIMEFRAME = "1m"
+PRODUCT = "spot"
+FAILED_VERDICTS = frozenset(
+    {"SOURCE_INVALID", "CHECKSUM_FAILED", "SOURCE_UNAVAILABLE"}
+)
+EXPECTED = {
+    "earliest_month": "2017-08",
+    "latest_month": "2026-06",
+    "total_months": 107,
+    "strict_complete": 81,
+    "partial_usable": 26,
+    "failed": 0,
+    "total_candles": 4_656_799,
+    "base_window_count": 106,
+    "stress_v2_window_count": 2,
+    "total_window_count": 108,
+}
+
+
+class ReconcileError(HistoricalProbeError):
+    """Offline reconcile failure."""
+
+
+class NetworkAttemptError(ReconcileError):
+    """Network access attempted during offline reconcile."""
+
+
+def _guard_network_import() -> None:
+    import urllib.request as urllib_request
+
+    if getattr(urllib_request, "_cdb_offline_reconcile_guard", False):
+        return
+
+    original = urllib_request.urlopen  # noqa: F841 — preserved for future restore hook
+
+    def _blocked(*args: Any, **kwargs: Any):
+        raise NetworkAttemptError(
+            "HOLD_OFFLINE_RECONCILE_NETWORK_ATTEMPT: network access blocked"
+        )
+
+    urllib_request.urlopen = _blocked  # type: ignore[assignment]
+    urllib_request._cdb_offline_reconcile_guard = True  # type: ignore[attr-defined]
+
+
+def _month_dirs(base: Path) -> list[str]:
+    if not base.is_dir():
+        return []
+    return sorted(child.name for child in base.iterdir() if child.is_dir())
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _fingerprint_payload(payload: dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def reconcile_market_data_root(
+    *,
+    market_data_root: Path,
+    output_dir: Path,
+    expected: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    _guard_network_import()
+    root = market_data_root.resolve()
+    output_dir = output_dir.resolve()
+    if not root.is_dir():
+        raise ReconcileError(f"market_data root missing: {root}")
+    if root in output_dir.parents or root == output_dir:
+        raise ReconcileError("output_dir must not be inside market_data_root")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    norm_base = root / "normalized" / VENUE / PRODUCT / SYMBOL / TIMEFRAME
+    raw_base = root / "raw" / VENUE / PRODUCT / SYMBOL / TIMEFRAME
+    enrich_base = root / "enriched" / VENUE / PRODUCT / SYMBOL / TIMEFRAME
+    wb_manifest_path = (
+        root
+        / "window_bank"
+        / VENUE
+        / PRODUCT
+        / SYMBOL
+        / TIMEFRAME
+        / "window_bank_manifest.json"
+    )
+    import_manifest_path = root / "manifests" / "binance_btcusdt_1m_full_import.json"
+
+    raw_months = _month_dirs(raw_base)
+    norm_months = _month_dirs(norm_base)
+    enrich_months = _month_dirs(enrich_base)
+
+    contradictions: list[str] = []
+    missing_files: list[str] = []
+    month_rows: list[dict[str, Any]] = []
+    strict_complete = 0
+    partial_usable = 0
+    failed = 0
+    total_candles = 0
+
+    for month in norm_months:
+        month_dir = norm_base / month
+        quality_path = month_dir / "quality_report.json"
+        gap_path = month_dir / "gap_report.json"
+        quality = _read_json(quality_path)
+        if quality is None:
+            missing_files.append(quality_path.relative_to(root).as_posix())
+            failed += 1
+            continue
+        verdict = str(quality.get("verdict", "SOURCE_INVALID"))
+        gaps = quality.get("gaps") or {}
+        candles = int(gaps.get("actual_candles", 0))
+        total_candles += candles
+        if verdict == "STRICT_COMPLETE":
+            strict_complete += 1
+        elif verdict == "PARTIAL_USABLE":
+            partial_usable += 1
+        elif verdict in FAILED_VERDICTS:
+            failed += 1
+        else:
+            contradictions.append(f"unknown verdict {verdict} for month {month}")
+        month_rows.append(
+            {
+                "month": month,
+                "verdict": verdict,
+                "candles": candles,
+                "quality_report": quality_path.relative_to(root).as_posix(),
+                "gap_report_present": gap_path.is_file(),
+            }
+        )
+
+    quality_report_count = sum(
+        1 for _ in root.rglob("quality_report.json") if _.is_file()
+    )
+    dataset_spec_count = sum(1 for _ in root.rglob("dataset_spec.json") if _.is_file())
+    provenance_manifest_count = sum(
+        1 for _ in root.rglob("provenance_manifest.json") if _.is_file()
+    )
+
+    wb_payload = _read_json(wb_manifest_path)
+    if wb_payload is None:
+        missing_files.append(wb_manifest_path.relative_to(root).as_posix())
+        base_window_count = 0
+        stress_v2_window_count = 0
+        total_window_count = 0
+    else:
+        windows = wb_payload.get("windows") or []
+        total_window_count = len(windows)
+        stress_meta = wb_payload.get("stress_v2_rebuild") or {}
+        written_v2 = stress_meta.get("written_v2") or []
+        stress_v2_window_count = len(written_v2)
+        base_window_count = total_window_count - stress_v2_window_count
+
+    stale = _read_json(import_manifest_path)
+    stale_summary: dict[str, Any] = {"present": stale is not None}
+    if stale is not None:
+        coverage = stale.get("coverage") or {}
+        stale_summary.update(
+            {
+                "import_status": stale.get("import_status"),
+                "month_count": coverage.get("month_count")
+                or (stale.get("summary") or {}).get("total_months"),
+                "strict_complete": coverage.get("strict_complete_months")
+                or (stale.get("summary") or {}).get("strict_complete"),
+                "partial": coverage.get("partial_months")
+                or (stale.get("summary") or {}).get("partial"),
+                "total_candles": coverage.get("total_candles"),
+                "actual_range": stale.get("actual_range"),
+            }
+        )
+
+    earliest_month = norm_months[0] if norm_months else None
+    latest_month = norm_months[-1] if norm_months else None
+    scan_as_of_utc = datetime.now(tz=UTC).isoformat()
+
+    report_core = {
+        "schema_version": SCHEMA_VERSION,
+        "market_data_root": str(root),
+        "scan_as_of_utc": scan_as_of_utc,
+        "venue": VENUE,
+        "symbol": SYMBOL,
+        "timeframe": TIMEFRAME,
+        "product": PRODUCT,
+        "earliest_month": earliest_month,
+        "latest_month": latest_month,
+        "total_months": len(norm_months),
+        "strict_complete": strict_complete,
+        "partial_usable": partial_usable,
+        "failed": failed,
+        "total_candles": total_candles,
+        "raw_month_coverage": len(raw_months),
+        "normalized_month_coverage": len(norm_months),
+        "enriched_month_coverage": len(enrich_months),
+        "quality_report_count": quality_report_count,
+        "dataset_spec_count": dataset_spec_count,
+        "provenance_manifest_count": provenance_manifest_count,
+        "base_window_count": base_window_count,
+        "stress_v2_window_count": stress_v2_window_count,
+        "total_window_count": total_window_count,
+        "stale_manifest_summary": stale_summary,
+        "contradictions": contradictions,
+        "missing_files": missing_files,
+        "limitations": [
+            "read-only reconcile; stale import manifest not rewritten",
+            "month verdicts sourced from normalized quality_report.json",
+        ],
+    }
+
+    expected_values = expected or EXPECTED
+    contract_mismatches: list[str] = []
+    checks = {
+        "earliest_month": earliest_month,
+        "latest_month": latest_month,
+        "total_months": len(norm_months),
+        "strict_complete": strict_complete,
+        "partial_usable": partial_usable,
+        "failed": failed,
+        "total_candles": total_candles,
+        "base_window_count": base_window_count,
+        "stress_v2_window_count": stress_v2_window_count,
+        "total_window_count": total_window_count,
+    }
+    for key, expected_value in expected_values.items():
+        if key not in checks:
+            continue
+        if checks[key] != expected_value:
+            contract_mismatches.append(
+                f"{key}: expected {expected_value}, got {checks[key]}"
+            )
+
+    verdict = "PASS"
+    if contradictions or missing_files or contract_mismatches:
+        verdict = "HOLD_DATASET_CONTRACT_MISMATCH"
+
+    report_core["contract_mismatches"] = contract_mismatches
+    report_core["verdict"] = verdict
+    report_core["deterministic_fingerprint"] = _fingerprint_payload(
+        {k: v for k, v in report_core.items() if k != "deterministic_fingerprint"}
+    )
+
+    reconciled_import = {
+        "schema_version": "binance_full_import.reconciled.v1",
+        "reconcile_schema_version": SCHEMA_VERSION,
+        "campaign_id": stale.get("campaign_id") if stale else None,
+        "source_sha": stale.get("source_sha") if stale else None,
+        "symbol": SYMBOL,
+        "venue": VENUE,
+        "timeframe": TIMEFRAME,
+        "product": PRODUCT,
+        "actual_range": {"start_month": earliest_month, "end_month": latest_month},
+        "import_status": "FULL_IMPORT_PARTIAL" if partial_usable else "FULL_IMPORT_PASS",
+        "evidence_class": "historical_cross_venue_research",
+        "lr_status": "NO-GO",
+        "coverage": {
+            "month_count": len(norm_months),
+            "strict_complete_months": strict_complete,
+            "partial_months": partial_usable,
+            "failed_months": failed,
+            "total_candles": total_candles,
+        },
+        "months": month_rows,
+        "reconciled_at_utc": scan_as_of_utc,
+        "deterministic_fingerprint": report_core["deterministic_fingerprint"],
+    }
+
+    write_json(output_dir / "reconciled_import_manifest.json", reconciled_import)
+    write_json(output_dir / "reconcile_report.json", report_core)
+    md_lines = [
+        "# Binance Archive Reconcile Report",
+        "",
+        f"- **market_data_root:** `{root}`",
+        f"- **scan_as_of_utc:** {scan_as_of_utc}",
+        f"- **verdict:** `{verdict}`",
+        f"- **months:** {len(norm_months)} ({earliest_month} .. {latest_month})",
+        f"- **strict / partial / failed:** {strict_complete} / {partial_usable} / {failed}",
+        f"- **total_candles:** {total_candles}",
+        f"- **windows:** {total_window_count} ({base_window_count} base + {stress_v2_window_count} stress_v2)",
+        "",
+        "## Stale import manifest (comparison only)",
+        "",
+        "```json",
+        json.dumps(stale_summary, indent=2, sort_keys=True),
+        "```",
+        "",
+    ]
+    if contract_mismatches:
+        md_lines.extend(["## Contract mismatches", ""] + [f"- {item}" for item in contract_mismatches])
+    if missing_files:
+        md_lines.extend(["", "## Missing files", ""] + [f"- {item}" for item in missing_files])
+    (output_dir / "reconcile_report.md").write_text("\n".join(md_lines) + "\n", encoding="utf-8")
+    return report_core
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Offline Binance archive reconcile")
+    parser.add_argument("--market-data-root", required=True)
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+    try:
+        report = reconcile_market_data_root(
+            market_data_root=Path(args.market_data_root),
+            output_dir=Path(args.output_dir),
+        )
+        print(json.dumps({"verdict": report["verdict"]}, indent=2))
+        return 0 if report["verdict"] == "PASS" else 2
+    except NetworkAttemptError as exc:
+        print(str(exc), file=sys.stderr)
+        return 4
+    except ReconcileError as exc:
+        print(f"RECONCILE_ERROR: {exc}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/market_data/binance_full_archive_import.py
+++ b/tools/market_data/binance_full_archive_import.py
@@ -129,8 +129,16 @@ def import_range(
     skip_download: bool = False,
     enrich_regime: bool = True,
     resume: bool = True,
+    skip_storage_guard: bool = False,
 ) -> dict[str, Any]:
     """Import all months in range with manifest and coverage report."""
+    if not skip_storage_guard:
+        from tools.market_data.market_data_storage_guard import enforce_market_data_storage
+
+        enforce_market_data_storage(
+            repo_root=repo_root,
+            required_write_bytes=12_000_000_000,
+        )
     started_at = utc_now_iso()
     fetcher = fetcher or HttpFetcher()
     available = list_available_months(fetcher)

--- a/tools/market_data/market_data_storage_guard.py
+++ b/tools/market_data/market_data_storage_guard.py
@@ -1,0 +1,307 @@
+"""Fail-closed storage guard for historical market_data imports (#4004)."""
+
+from __future__ import annotations
+
+import os
+import stat
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from tools.market_data.historical_common import HistoricalProbeError
+
+CANONICAL_RELATIVE = Path("artifacts") / "market_data"
+RESERVE_MULTIPLIER = 1.25
+BLOCKED_DRIVE_LETTERS = frozenset({"E"})
+
+
+class VolumeProbeError(HistoricalProbeError):
+    """Volume or path resolution could not be completed."""
+
+
+@dataclass(frozen=True, slots=True)
+class VolumeInfo:
+    drive_letter: str
+    unique_id: str | None
+    file_system_label: str | None
+    drive_type: str
+    free_bytes: int | None
+    total_bytes: int | None
+
+
+class VolumeProbe(Protocol):
+    def resolve_path(self, path: Path) -> Path: ...
+
+    def volume_for_path(self, path: Path) -> VolumeInfo: ...
+
+
+@dataclass(frozen=True, slots=True)
+class StorageGuardResult:
+    allowed: bool
+    reason_code: str
+    message: str
+    details: dict[str, Any]
+
+
+def _normalize_drive(letter: str) -> str:
+    value = letter.strip().rstrip(":").upper()
+    if len(value) != 1 or not value.isalpha():
+        raise VolumeProbeError(f"Invalid drive letter: {letter!r}")
+    return value
+
+
+def canonical_market_data_path(repo_root: Path) -> Path:
+    return (repo_root / CANONICAL_RELATIVE).resolve()
+
+
+def _is_reparse_point(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        return bool(path.lstat().st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    except AttributeError:
+        return path.is_symlink()
+
+
+def _reparse_in_parent_chain(path: Path) -> list[str]:
+    hits: list[str] = []
+    current = path
+    while True:
+        if _is_reparse_point(current):
+            hits.append(str(current))
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return hits
+
+
+class DefaultVolumeProbe:
+    """Windows-oriented probe with pathlib fallbacks for tests."""
+
+    def resolve_path(self, path: Path) -> Path:
+        return path.resolve()
+
+    def volume_for_path(self, path: Path) -> VolumeInfo:
+        resolved = self.resolve_path(path)
+        drive = resolved.drive
+        if not drive:
+            raise VolumeProbeError(f"No drive letter for path: {path}")
+        letter = _normalize_drive(drive)
+        unique_id: str | None = None
+        label: str | None = None
+        drive_type = "Unknown"
+        free_bytes: int | None = None
+        total_bytes: int | None = None
+        try:
+            import ctypes
+
+            kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+            vol_name = ctypes.create_unicode_buffer(261)
+            fs_name = ctypes.create_unicode_buffer(261)
+            serial = ctypes.c_uint32()
+            max_comp = ctypes.c_uint32()
+            flags = ctypes.c_uint32()
+            root = f"{letter}:\\"
+            if kernel32.GetVolumeInformationW(
+                root,
+                vol_name,
+                ctypes.sizeof(vol_name),
+                ctypes.byref(serial),
+                ctypes.byref(max_comp),
+                ctypes.byref(flags),
+                fs_name,
+                ctypes.sizeof(fs_name),
+            ):
+                label = vol_name.value or None
+                unique_id = f"serial:{serial.value:08X}"
+        except (AttributeError, OSError):
+            unique_id = None
+        drive_type_map = {
+            "DRIVE_UNKNOWN": "Unknown",
+            "DRIVE_NO_ROOT_DIR": "NoRoot",
+            "DRIVE_REMOVABLE": "Removable",
+            "DRIVE_FIXED": "Fixed",
+            "DRIVE_REMOTE": "Remote",
+            "DRIVE_CDROM": "CDROM",
+            "DRIVE_RAMDISK": "RamDisk",
+        }
+        try:
+            import ctypes
+
+            dt = ctypes.windll.kernel32.GetDriveTypeW(f"{letter}:\\")  # type: ignore[attr-defined]
+            drive_type = drive_type_map.get(str(dt), f"Code{dt}")
+        except (AttributeError, OSError):
+            drive_type = "Unknown"
+        try:
+            usage = os.statvfs(resolved) if hasattr(os, "statvfs") else None
+            if usage is not None:
+                free_bytes = usage.f_bavail * usage.f_frsize
+                total_bytes = usage.f_blocks * usage.f_frsize
+        except OSError:
+            free_bytes = None
+            total_bytes = None
+        if free_bytes is None:
+            try:
+                import shutil
+
+                usage = shutil.disk_usage(resolved)
+                free_bytes = usage.free
+                total_bytes = usage.total
+            except OSError as exc:
+                raise VolumeProbeError(f"disk_usage failed for {resolved}") from exc
+        return VolumeInfo(
+            drive_letter=letter,
+            unique_id=unique_id,
+            file_system_label=label,
+            drive_type=drive_type,
+            free_bytes=free_bytes,
+            total_bytes=total_bytes,
+        )
+
+
+def validate_market_data_storage(
+    *,
+    repo_root: Path,
+    target_path: Path | None = None,
+    required_write_bytes: int,
+    expected_repo_volume_label: str | None = "DevDrive",
+    volume_probe: VolumeProbe | None = None,
+) -> StorageGuardResult:
+    """Fail-closed guard before historical import writes."""
+    probe_impl = volume_probe or DefaultVolumeProbe()
+    details: dict[str, Any] = {}
+    try:
+        repo_resolved = probe_impl.resolve_path(repo_root)
+        canonical = canonical_market_data_path(repo_root)
+        target = probe_impl.resolve_path(target_path or canonical)
+        details["repo_root"] = str(repo_resolved)
+        details["target_path"] = str(target)
+        details["canonical_path"] = str(canonical)
+
+        if target != canonical:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="NON_CANONICAL_TARGET",
+                message="target must be canonical REPO_ROOT/artifacts/market_data",
+                details=details,
+            )
+
+        try:
+            target.relative_to(repo_resolved)
+        except ValueError:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="TARGET_OUTSIDE_REPO",
+                message="market_data target must live under repository root",
+                details=details,
+            )
+
+        reparse_hits = _reparse_in_parent_chain(target)
+        details["reparse_points"] = reparse_hits
+        if reparse_hits:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="REPARSE_IN_PATH",
+                message="reparse point in path chain to market_data target",
+                details=details,
+            )
+
+        repo_vol = probe_impl.volume_for_path(repo_resolved)
+        target_vol = probe_impl.volume_for_path(target)
+        details["repo_volume"] = asdict(repo_vol)
+        details["target_volume"] = asdict(target_vol)
+
+        if repo_vol.unique_id is None or target_vol.unique_id is None:
+            if repo_vol.drive_letter != target_vol.drive_letter:
+                return StorageGuardResult(
+                    allowed=False,
+                    reason_code="UNKNOWN_VOLUME_ID",
+                    message="cannot prove same volume without resolvable volume identity",
+                    details=details,
+                )
+        elif repo_vol.unique_id != target_vol.unique_id:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="DIFFERENT_VOLUME",
+                message="repository and target are on different volumes",
+                details=details,
+            )
+
+        if target_vol.drive_letter in BLOCKED_DRIVE_LETTERS:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="BLOCKED_DRIVE",
+                message=f"target resolves to blocked drive {target_vol.drive_letter}:",
+                details=details,
+            )
+
+        if target_vol.drive_type in {"Removable", "Remote", "CDROM"}:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="UNSUPPORTED_DRIVE_TYPE",
+                message=f"unsupported drive type: {target_vol.drive_type}",
+                details=details,
+            )
+
+        if expected_repo_volume_label and repo_vol.file_system_label:
+            if repo_vol.file_system_label != expected_repo_volume_label:
+                return StorageGuardResult(
+                    allowed=False,
+                    reason_code="UNEXPECTED_REPO_VOLUME_LABEL",
+                    message=(
+                        f"expected repo volume label {expected_repo_volume_label!r}, "
+                        f"got {repo_vol.file_system_label!r}"
+                    ),
+                    details=details,
+                )
+
+        required = int(required_write_bytes * RESERVE_MULTIPLIER)
+        details["required_bytes_with_reserve"] = required
+        if target_vol.free_bytes is None:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="UNKNOWN_FREE_SPACE",
+                message="free space could not be determined",
+                details=details,
+            )
+        if target_vol.free_bytes < required:
+            return StorageGuardResult(
+                allowed=False,
+                reason_code="INSUFFICIENT_SPACE",
+                message="insufficient free space for reserved write requirement",
+                details=details,
+            )
+
+        return StorageGuardResult(
+            allowed=True,
+            reason_code="PASS",
+            message="storage guard passed",
+            details=details,
+        )
+    except VolumeProbeError as exc:
+        return StorageGuardResult(
+            allowed=False,
+            reason_code="VOLUME_PROBE_FAILED",
+            message=str(exc),
+            details=details,
+        )
+
+
+def enforce_market_data_storage(
+    *,
+    repo_root: Path,
+    required_write_bytes: int,
+    target_path: Path | None = None,
+    volume_probe: VolumeProbe | None = None,
+) -> None:
+    result = validate_market_data_storage(
+        repo_root=repo_root,
+        target_path=target_path,
+        required_write_bytes=required_write_bytes,
+        volume_probe=volume_probe,
+    )
+    if not result.allowed:
+        raise HistoricalProbeError(
+            f"STORAGE_GUARD_BLOCKED [{result.reason_code}]: {result.message}"
+        )

--- a/tools/market_data/relocate_hash_manifest.py
+++ b/tools/market_data/relocate_hash_manifest.py
@@ -1,0 +1,231 @@
+"""Streaming SHA256 manifests for market_data relocation (#4004)."""
+# ruff: noqa: E402
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.market_data.historical_common import HistoricalProbeError, sha256_file, write_json
+
+CHUNK_SIZE = 1024 * 1024
+
+
+class RelocateHashError(HistoricalProbeError):
+    """Hash manifest creation or comparison failed."""
+
+
+@dataclass(frozen=True, slots=True)
+class HashEntry:
+    relative_path: str
+    size_bytes: int
+    sha256: str
+    last_write_utc: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "relative_path": self.relative_path,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+            "last_write_utc": self.last_write_utc,
+        }
+
+
+def _is_reparse_point(path: Path) -> bool:
+    try:
+        return bool(path.lstat().st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    except AttributeError:
+        return path.is_symlink()
+
+
+def _normalize_relative(root: Path, file_path: Path) -> str:
+    rel = file_path.relative_to(root).as_posix()
+    return rel
+
+
+def iter_hash_entries(root: Path) -> Iterator[HashEntry]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise RelocateHashError(f"root is not a directory: {root}")
+    for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+        current = Path(dirpath)
+        if _is_reparse_point(current):
+            raise RelocateHashError(f"reparse point encountered: {current}")
+        pruned: list[str] = []
+        for name in dirnames:
+            child = current / name
+            if _is_reparse_point(child):
+                raise RelocateHashError(f"reparse point encountered: {child}")
+            pruned.append(name)
+        dirnames[:] = pruned
+        for name in sorted(filenames):
+            file_path = current / name
+            if _is_reparse_point(file_path):
+                raise RelocateHashError(f"reparse point encountered: {file_path}")
+            try:
+                stat_result = file_path.stat()
+            except OSError as exc:
+                raise RelocateHashError(f"access error: {file_path}") from exc
+            last_write = datetime.fromtimestamp(stat_result.st_mtime, tz=UTC).isoformat()
+            yield HashEntry(
+                relative_path=_normalize_relative(root, file_path),
+                size_bytes=stat_result.st_size,
+                sha256=sha256_file(file_path),
+                last_write_utc=last_write,
+            )
+
+
+def manifest_fingerprint(entries: list[HashEntry]) -> str:
+    digest = hashlib.sha256()
+    for entry in entries:
+        line = json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
+        digest.update(line.encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def create_manifest(*, root: Path, output: Path) -> dict[str, Any]:
+    entries = sorted(iter_hash_entries(root), key=lambda item: item.relative_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    total_bytes = 0
+    with output.open("w", encoding="utf-8") as handle:
+        for entry in entries:
+            total_bytes += entry.size_bytes
+            handle.write(json.dumps(entry.to_dict(), sort_keys=True) + "\n")
+    summary = {
+        "root": str(root.resolve()),
+        "file_count": len(entries),
+        "total_bytes": total_bytes,
+        "manifest_fingerprint": manifest_fingerprint(entries),
+        "created_at_utc": datetime.now(tz=UTC).isoformat(),
+    }
+    return summary
+
+
+def _load_manifest(path: Path) -> list[HashEntry]:
+    entries: list[HashEntry] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise RelocateHashError(f"invalid jsonl at {path}:{line_no}") from exc
+            entries.append(
+                HashEntry(
+                    relative_path=str(payload["relative_path"]),
+                    size_bytes=int(payload["size_bytes"]),
+                    sha256=str(payload["sha256"]),
+                    last_write_utc=payload.get("last_write_utc"),
+                )
+            )
+    return entries
+
+
+def compare_manifests(
+    *,
+    source: Path,
+    destination: Path,
+    output: Path,
+) -> dict[str, Any]:
+    source_entries = _load_manifest(source)
+    dest_entries = _load_manifest(destination)
+    source_map = {entry.relative_path: entry for entry in source_entries}
+    dest_map = {entry.relative_path: entry for entry in dest_entries}
+    source_paths = set(source_map)
+    dest_paths = set(dest_map)
+    missing = sorted(source_paths - dest_paths)
+    extra = sorted(dest_paths - source_paths)
+    mismatched: list[dict[str, str]] = []
+    metadata_mismatched: list[dict[str, Any]] = []
+    for rel in sorted(source_paths & dest_paths):
+        s_entry = source_map[rel]
+        d_entry = dest_map[rel]
+        if s_entry.sha256 != d_entry.sha256:
+            mismatched.append(
+                {"relative_path": rel, "source_sha256": s_entry.sha256, "dest_sha256": d_entry.sha256}
+            )
+        elif s_entry.size_bytes != d_entry.size_bytes:
+            metadata_mismatched.append(
+                {
+                    "relative_path": rel,
+                    "source_size_bytes": s_entry.size_bytes,
+                    "destination_size_bytes": d_entry.size_bytes,
+                }
+            )
+    source_bytes = sum(entry.size_bytes for entry in source_entries)
+    destination_bytes = sum(entry.size_bytes for entry in dest_entries)
+    verdict = "PASS"
+    if missing or extra or mismatched or metadata_mismatched:
+        verdict = "FAIL"
+    if source_entries and len(source_entries) != len(dest_entries):
+        verdict = "FAIL"
+    if source_bytes != destination_bytes:
+        verdict = "FAIL"
+    report = {
+        "source_file_count": len(source_entries),
+        "destination_file_count": len(dest_entries),
+        "source_bytes": source_bytes,
+        "destination_bytes": destination_bytes,
+        "missing": missing,
+        "extra": extra,
+        "mismatched": mismatched,
+        "metadata_mismatched": metadata_mismatched,
+        "source_manifest_fingerprint": manifest_fingerprint(source_entries),
+        "destination_manifest_fingerprint": manifest_fingerprint(dest_entries),
+        "verdict": verdict,
+        "compared_at_utc": datetime.now(tz=UTC).isoformat(),
+    }
+    write_json(output, report)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Relocation hash manifests (#4004)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = sub.add_parser("create")
+    create_parser.add_argument("--root", required=True)
+    create_parser.add_argument("--output", required=True)
+
+    compare_parser = sub.add_parser("compare")
+    compare_parser.add_argument("--source", required=True)
+    compare_parser.add_argument("--destination", required=True)
+    compare_parser.add_argument("--output", required=True)
+
+    args = parser.parse_args()
+    try:
+        if args.command == "create":
+            summary = create_manifest(root=Path(args.root), output=Path(args.output))
+            print(json.dumps(summary, indent=2))
+            return 0
+        if args.command == "compare":
+            report = compare_manifests(
+                source=Path(args.source),
+                destination=Path(args.destination),
+                output=Path(args.output),
+            )
+            print(json.dumps({"verdict": report["verdict"]}, indent=2))
+            return 0 if report["verdict"] == "PASS" else 2
+    except RelocateHashError as exc:
+        print(f"HASH_MANIFEST_ERROR: {exc}", file=sys.stderr)
+        return 3
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/market_data/relocate_hash_manifest.py
+++ b/tools/market_data/relocate_hash_manifest.py
@@ -18,7 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from tools.market_data.historical_common import HistoricalProbeError, sha256_file, write_json
+from tools.market_data.historical_common import HistoricalProbeError, sha256_file, utc_now_iso, write_json
 
 CHUNK_SIZE = 1024 * 1024
 
@@ -79,10 +79,14 @@ def iter_hash_entries(root: Path) -> Iterator[HashEntry]:
             except OSError as exc:
                 raise RelocateHashError(f"access error: {file_path}") from exc
             last_write = datetime.fromtimestamp(stat_result.st_mtime, tz=UTC).isoformat()
+            try:
+                file_sha256 = sha256_file(file_path)
+            except OSError as exc:
+                raise RelocateHashError(f"access error: {file_path}") from exc
             yield HashEntry(
                 relative_path=_normalize_relative(root, file_path),
                 size_bytes=stat_result.st_size,
-                sha256=sha256_file(file_path),
+                sha256=file_sha256,
                 last_write_utc=last_write,
             )
 
@@ -109,7 +113,7 @@ def create_manifest(*, root: Path, output: Path) -> dict[str, Any]:
         "file_count": len(entries),
         "total_bytes": total_bytes,
         "manifest_fingerprint": manifest_fingerprint(entries),
-        "created_at_utc": datetime.now(tz=UTC).isoformat(),
+        "created_at_utc": utc_now_iso(),
     }
     return summary
 
@@ -188,7 +192,7 @@ def compare_manifests(
         "source_manifest_fingerprint": manifest_fingerprint(source_entries),
         "destination_manifest_fingerprint": manifest_fingerprint(dest_entries),
         "verdict": verdict,
-        "compared_at_utc": datetime.now(tz=UTC).isoformat(),
+        "compared_at_utc": utc_now_iso(),
     }
     write_json(output, report)
     return report


### PR DESCRIPTION
## Summary
- Add read-only offline reconciler, fail-closed storage guard, and streaming SHA256 hash manifests for Binance `market_data` relocation (#4004).
- Document relocation flow in ARVP runbook and add post-migration evidence after verified copy/cutover/delete on DevDrive `D:`.

## Delivered
- `tools/market_data/binance_archive_manifest_reconcile.py`
- `tools/market_data/market_data_storage_guard.py` + import hook
- `tools/market_data/relocate_hash_manifest.py`
- Unit tests for all three tools
- `.gitignore` entries for `market_data.__incoming_*/` and `data-relocation/`
- Evidence: `docs/evidence/market_data/BINANCE_HISTORICAL_DATA_RELOCATION_E_TO_D_2026-07-12.*`

## Validation
- `pytest -q` — 37 scoped unit tests PASS
- `ruff check` — PASS on touched files
- Live migration chain: robocopy + SHA256 PASS, reconcile PASS (107 months / 4,656,799 candles / 108 windows)
- Post-cutover smoke replay, window bank, ARVP preflight PASS
- Post-rename re-tests PASS; E: verified source removed

## Non-goals
- No Docker/DB/MCP/runtime changes
- No ARVP campaign start
- No LR/live scope change (LR remains NO-GO)

## Remaining uncertainty
- Full SHA256 jsonl manifests remain local under gitignored `data-relocation/4004/`
- ARVP vacation preflight still references pilot 2-month manifest; full corpus validated via offline reconciler

Closes #4004