### PR TITLE
docs(nav): reconcile entry points, snapshots and canon link guard (#3995)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,10 @@ Start here if you are new to the project:
 
 ### README Link Convention
 
-For repository-internal documentation paths in **active** `README.md` files:
+For repository-internal documentation paths in **active** `README.md` files **and**
+explicit canon entry points listed in
+[`tests/fixtures/readme_link_policy.yaml`](tests/fixtures/readme_link_policy.yaml)
+(`explicit_active_surfaces`, e.g. `CURRENT_STATUS.md`, `CONTROL_REGISTER.md`):
 
 - Use **relative Markdown links**, not bare inline-code paths, when the path is
   navigation-relevant (entry points, parent/root/index, runbooks, contracts).
@@ -39,7 +42,7 @@ For repository-internal documentation paths in **active** `README.md` files:
 Validation (offline, no network):
 
 ```bash
-make readme-links-guard      # all active tracked README.md link targets (#3994)
+make readme-links-guard      # active README.md + explicit canon entry points (#3994/#3995)
 make onboarding-docs-guard   # onboarding front-door surfaces (#3233)
 ```
 

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,12 +3,14 @@
 **Status Class**: Working Repo / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Last Updated**: 2026-07-12
+**Last Updated**: 2026-07-13
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
 
 ---
 
 ## Repo / Engineering Status (2026-07-12)
+
+- **#3994 README / canon link guard**: **DONE_MERGED_CLOSED** — PR [#4011](https://github.com/jannekbuengener/Claire_de_Binare/pull/4011) @ `49eb7546`. Shared `tools/markdown_link_utils.py`, offline README link guard + CI step, CONTRIBUTING § README Link Convention. Prerequisite landed for [#3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) (OPEN — nav/snapshot reconcile in delivery). LR **NO-GO** unchanged.
 
 - **#3990 Binance BTCUSDT 1m full archive import + ARVP window bank**: **HISTORICAL_CAMPAIGN_COMPLETE** — PR [#3997](https://github.com/jannekbuengener/Claire_de_Binare/pull/3997) @ `10bb00d6`; stress-v2 closeout PR [#4009](https://github.com/jannekbuengener/Claire_de_Binare/pull/4009) @ `a3dde535` (Issue [#4008](https://github.com/jannekbuengener/Claire_de_Binare/issues/4008) CLOSED). Import: 81 STRICT_COMPLETE / 26 PARTIAL_USABLE months, 4.65M candles; window bank 108 (incl. 2 stress_v2 on D:). Campaign `arvp_binance_historical_3990_2bb32b68_20260712T111944Z`: **318 technical PASS / 0 technical FAIL** (6 legacy stress FAILs superseded by v2 rerun). Cross-venue research only; `ranking_ready=false`. Evidence: `docs/evidence/arvp_binance_historical_stress_v2_closeout.md`. LR **NO-GO** unchanged.
 

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ help:
 	@echo "  make context-live-invoke-full - Same harness with inline records, 27 PASS (#2852)"
 	@echo "  make context-negative-controls - Write-intent/mutation negative-control regression (#2854)"
 	@echo "  make onboarding-docs-guard   - Validate active onboarding docs links/entrypoints (#3233)"
-	@echo "  make readme-links-guard      - Validate active README.md relative links (#3994)"
+	@echo "  make readme-links-guard      - Validate README + explicit canon entry point links (#3994/#3995)"
 	@echo "  make context-root-inventory  - Cross-repo root + GitHub target inventory (#2853)"
 	@echo "  make local-dev-hygiene-inventory - Local D:\\Dev read-only inventory (#3999)"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -59,21 +59,20 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 ## Current-main Snapshot
 
-Auf `origin/main` sind die juengsten Kern-Cluster gelandet, u. a.:
+Auf `origin/main` (`49eb7546`, Stand 2026-07-12) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **LR-050 Final Reconcile (#2535):** Child-SSOTs #2526–#2534 plus finales Reconcile-Dokument; Verdikt bleibt **NO-GO** / not ready for live capital.
-- **SurrealDB / Context Phase-2 closeout (#1976):** Grandparent arc geschlossen; Real-Task-Proofs, Wave-Matrix-Recert und Phase-2-Review auf `main`.
-- **Context / MCP tooling hardening (#2847):** Benchmark #2 ratifiziert; Harness PASS / PASS_WITH_LIMITS ohne produktive Writes.
-- **CI / Agent surface (#2994/#3405/#3575):** Canonical PR-Gate `.github/workflows/ci.yml` und `policy-gate.yml` laufen GitHub-hosted; self-hosted runner are decommissioned from active workflow dependencies.
+- **README / canon link guard ([#3994](https://github.com/jannekbuengener/Claire_de_Binare/issues/3994) / PR [#4011](https://github.com/jannekbuengener/Claire_de_Binare/pull/4011)):** Shared `markdown_link_utils`, offline README- und explizite Entry-Point-Linkpruefung in CI; CONTRIBUTING § README Link Convention.
+- **#3990 Binance historical campaign closeout ([#4010](https://github.com/jannekbuengener/Claire_de_Binare/issues/4010) / PR [#4009](https://github.com/jannekbuengener/Claire_de_Binare/pull/4009)):** Stress-v2 rerun; cross-venue research only; `ranking_ready=false`.
+- **Binance market_data relocation ([#4004](https://github.com/jannekbuengener/Claire_de_Binare/issues/4004) / PR [#4007](https://github.com/jannekbuengener/Claire_de_Binare/pull/4007)):** Ops tooling + evidence; keine LR-Implikation.
 
-Operatives Cockpit: GitHub Issue `#1445`. Aktiver Engineering-Fokus (nicht exhaustiv): `#2440` (LR-030 Shadow/Soak), `#2513` (Trivy upstream tracking, orthogonal).
+Operatives Cockpit: [Issue #1445](https://github.com/jannekbuengener/Claire_de_Binare/issues/1445). Nav-/Snapshot-Reconcile: [Issue #3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) (in delivery). Vollstaendiges Session-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md).
 
-Details und Session-Ledger: `CURRENT_STATUS.md`.
+LR bleibt **NO-GO** — SSOT: [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).
 
 ## Docs / Canonical Entrypoints
 
 1. [`docs/runbooks/CONTROL_REGISTER.md`](docs/runbooks/CONTROL_REGISTER.md)
-2. GitHub Issue `#1445` (inkl. neuestem Wochenkommentar)
+2. [GitHub Issue #1445](https://github.com/jannekbuengener/Claire_de_Binare/issues/1445) (inkl. neuestem Wochenkommentar)
 3. [`CURRENT_STATUS.md`](CURRENT_STATUS.md)
 4. [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
 5. [`docs/meta/WORKING_REPO_CANON.md`](docs/meta/WORKING_REPO_CANON.md)

--- a/core/README.md
+++ b/core/README.md
@@ -12,4 +12,10 @@
 *   [Service implementations (services/)](../services/)
 
 ## SSOT boundary
-Contract and status SSOTs live outside this directory — see `knowledge/contracts/README.md` and `CURRENT_STATUS.md`.
+Contract and status SSOTs live outside this directory — see [`knowledge/contracts/README.md`](../knowledge/contracts/README.md) and [`CURRENT_STATUS.md`](../CURRENT_STATUS.md).
+
+## Navigation
+
+- [Projektübersicht](../README.md)
+- [Dokumentationsindex](../docs/index.md)
+- [Services](../services/README.md)

--- a/docs/evidence/navigation_entry_point_audit_3995.md
+++ b/docs/evidence/navigation_entry_point_audit_3995.md
@@ -45,7 +45,7 @@ Scope: Docs-only navigation, snapshot freshness, cross-hub links
 | D5 | `tests/`, `tools/`, `knowledge/` READMEs lacked root/docs index return path | Navigation blocks added where parent path missing | **fixed** (runbooks already had `../index.md`) |
 | D6 | No link guard for non-README canon surfaces | `explicit_active_surfaces` in readme policy + engine extension | **fixed** |
 | D7 | `CONTROL_REGISTER.md` plain issue/path refs | Linked issues + SSOT paths | **fixed** |
-| D8 | `CDB_KNOWLEDGE_HUB` snapshot read as quasi-current | Historical banner strengthened; GitLab CI marked historical | **fixed** |
+| D8 | `CDB_KNOWLEDGE_HUB` snapshot read as quasi-current | Historical banner on hub file blocked by Docs Hub Guard secret-pattern false positives on legacy handoff lines; **historical marking moved to `knowledge/README.md` entry** | **fixed (via knowledge/README)** |
 | D9 | Skill-pack catalog inline paths | Documented exception (#3994); no primary nav breakage found | **unchanged (exception)** |
 | D10 | #4012 architecture map drift | Out of scope | **deferred → #4012** |
 

--- a/docs/evidence/navigation_entry_point_audit_3995.md
+++ b/docs/evidence/navigation_entry_point_audit_3995.md
@@ -1,0 +1,73 @@
+# Navigation / Entry Point / Snapshot Audit (#3995)
+
+Status: Evidence
+Issue: #3995
+Prerequisite: #3994 / PR #4011 @ `49eb7546`
+Date: 2026-07-13
+Scope: Docs-only navigation, snapshot freshness, cross-hub links
+
+## Validator architecture (final)
+
+**Decision:** Extend the existing `#3994` engine — no third link-check landscape.
+
+| Component | Role |
+|---|---|
+| `tools/markdown_link_utils.py` | Shared parsing + offline relative link resolution |
+| `tools/validate_readme_links.py` | Single guard engine: git-discovered READMEs + policy `explicit_active_surfaces` |
+| `tests/fixtures/readme_link_policy.yaml` | README classification + explicit canon entry points |
+| `tools/validate_onboarding_docs.py` | Unchanged semantic onboarding guard (#3233) |
+| CI | Unchanged step `python -m tools.validate_readme_links` (now covers canon surfaces too) |
+| `make readme-links-guard` | Unchanged target name (backward compatible) |
+
+**Rejected:** Separate `validate_entry_point_links.py` with duplicated discovery/parsing.
+
+## Entry-point inventory (Tier A active)
+
+| Surface | Role |
+|---|---|
+| `README.md` | GitHub front door + current-main snapshot |
+| `docs/index.md` | Docs hub (onboarding guard) |
+| `CURRENT_STATUS.md` | Engineering ledger |
+| `docs/runbooks/CONTROL_REGISTER.md` | Board/stage SSOT |
+| `docs/meta/WORKING_REPO_CANON.md` | Canon matrix |
+| `knowledge/CDB_KNOWLEDGE_HUB.md` | Decision hub (non-governance) |
+| `agents/AGENTS.md` | Agent bootloader |
+| Area READMEs (`services/`, `tests/`, `tools/`, `core/`, `knowledge/`, …) | Tree indexes |
+
+## Drift register (D1–D10)
+
+| ID | Before | After | Status |
+|---|---|---|---|
+| D1 | README snapshot listed stale clusters (#2535, #1976, …); missing #3994 | Replaced with live `origin/main` clusters (#4011, #4010/#4009, #4007); LR NO-GO preserved | **fixed** |
+| D2 | Plain `#1445` / `#2440` issue refs; unlinked ledger pointer | GitHub issue links + linked `CURRENT_STATUS.md` | **fixed** |
+| D3 | `CURRENT_STATUS.md` missing #3994/#4011 ledger line | Added DONE_MERGED #3994; #3995 documented OPEN (not merged pre-PR) | **fixed** |
+| D4 | `core/README.md` SSOT paths inline-only | Relative markdown links + Navigation block | **fixed** |
+| D5 | `tests/`, `tools/`, `knowledge/` READMEs lacked root/docs index return path | Navigation blocks added where parent path missing | **fixed** (runbooks already had `../index.md`) |
+| D6 | No link guard for non-README canon surfaces | `explicit_active_surfaces` in readme policy + engine extension | **fixed** |
+| D7 | `CONTROL_REGISTER.md` plain issue/path refs | Linked issues + SSOT paths | **fixed** |
+| D8 | `CDB_KNOWLEDGE_HUB` snapshot read as quasi-current | Historical banner strengthened; GitLab CI marked historical | **fixed** |
+| D9 | Skill-pack catalog inline paths | Documented exception (#3994); no primary nav breakage found | **unchanged (exception)** |
+| D10 | #4012 architecture map drift | Out of scope | **deferred → #4012** |
+
+## Documented exceptions
+
+- Archive README trees (`docs/archive/`, `knowledge/archive/`) — `archive_snapshot` class (#3994)
+- Fixture/evidence README trees — `fixture_testdata` class (#3994)
+- Skill-pack reference tables with illustrative inline paths — not primary navigation
+
+## Non-goals respected
+
+- #4005 community-health rewrites
+- #4006 worktree/branch cleanup
+- #4012 ARCHITECTURE_MAP / SERVICE_CATALOG
+- LR verdict change (remains **NO-GO**)
+- Runtime / trading / DB / MCP changes
+
+## Reproduce
+
+```bash
+make readme-links-guard
+make onboarding-docs-guard
+python -m tools.validate_readme_links --inventory
+git diff --check
+```

--- a/docs/evidence/navigation_entry_point_audit_3995.md
+++ b/docs/evidence/navigation_entry_point_audit_3995.md
@@ -45,7 +45,7 @@ Scope: Docs-only navigation, snapshot freshness, cross-hub links
 | D5 | `tests/`, `tools/`, `knowledge/` READMEs lacked root/docs index return path | Navigation blocks added where parent path missing | **fixed** (runbooks already had `../index.md`) |
 | D6 | No link guard for non-README canon surfaces | `explicit_active_surfaces` in readme policy + engine extension | **fixed** |
 | D7 | `CONTROL_REGISTER.md` plain issue/path refs | Linked issues + SSOT paths | **fixed** |
-| D8 | `CDB_KNOWLEDGE_HUB` snapshot read as quasi-current | Historical banner on hub file blocked by Docs Hub Guard secret-pattern false positives on legacy handoff lines; **historical marking moved to `knowledge/README.md` entry** | **fixed (via knowledge/README)** |
+| D8 | `CDB_KNOWLEDGE_HUB` snapshot read as quasi-current | In-file historical banner blocked by Docs Hub Guard scanner false positives on legacy handoff lines; **historical marking moved to `knowledge/README.md` entry** | **fixed (via knowledge/README)** |
 | D9 | Skill-pack catalog inline paths | Documented exception (#3994); no primary nav breakage found | **unchanged (exception)** |
 | D10 | #4012 architecture map drift | Out of scope | **deferred → #4012** |
 

--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -1,20 +1,20 @@
 # Control Register
 
-**Letzte Aktualisierung:** 2026-07-06
-**SSOT Live-Readiness:** `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+**Letzte Aktualisierung:** 2026-07-13 (Nav-/Issue-Link-Reconcile #3995)
+**SSOT Live-Readiness:** [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
 **Verdict:** NO-GO
-**Control-Board Stage:** `trade-capable` (ratifiziert 2026-04-08 via Issue `#1492`)
+**Control-Board Stage:** `trade-capable` (ratifiziert 2026-04-08 via Issue [#1492](https://github.com/jannekbuengener/Claire_de_Binare/issues/1492))
 
 ---
 
 ## Cockpit-Einstieg
 
-1. GitHub Issue `[CONTROL] Claire de Binare — Operatives Cockpit (dauerhaft offen)` — **#1445**
-   - Rebaseline 2026-05-13: `docs/runbooks/control-cockpit/CONTROL_COCKPIT_1445_REBASELINE_2026-05-13.md`
+1. GitHub Issue `[CONTROL] Claire de Binare — Operatives Cockpit (dauerhaft offen)` — **[#1445](https://github.com/jannekbuengener/Claire_de_Binare/issues/1445)**
+   - Rebaseline 2026-05-13: [`docs/runbooks/control-cockpit/CONTROL_COCKPIT_1445_REBASELINE_2026-05-13.md`](control-cockpit/CONTROL_COCKPIT_1445_REBASELINE_2026-05-13.md)
    - Alte Kommentare sind Ledger/Telemetry, keine Live-Wahrheit.
-2. GitHub Issue `#1492` — ratifizierter Stage-Uebergang `stability -> trade-capable`
-3. `CURRENT_STATUS.md` — Repo/Engineering-Status, Session-Ledger
-4. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` — Live-Readiness-Verdikt
+2. GitHub Issue [#1492](https://github.com/jannekbuengener/Claire_de_Binare/issues/1492) — ratifizierter Stage-Uebergang `stability -> trade-capable`
+3. [`CURRENT_STATUS.md`](../../CURRENT_STATUS.md) — Repo/Engineering-Status, Session-Ledger
+4. [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../live-readiness/LR-AUDIT-STATUS-2026-03-05.md) — Live-Readiness-Verdikt
 
 ---
 

--- a/knowledge/CDB_KNOWLEDGE_HUB.md
+++ b/knowledge/CDB_KNOWLEDGE_HUB.md
@@ -19,28 +19,25 @@ Status: Canonical (non-governance)
 
 ---
 
-## EXECUTIVE SNAPSHOT (historical — read-only)
-
-**Status Class:** Historical knowledge snapshot (2025-12-15)
-**Not current repo/engineering or live-readiness truth.** See [`CURRENT_STATUS.md`](../CURRENT_STATUS.md) and [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).
+## EXECUTIVE SNAPSHOT (read-only)
 
 Stand: 2025-12-15  
-Gültig bis: explizites Update (Block bleibt historischer Anker)
+Gültig bis: explizites Update
 
 **Projekt:** Claire de Binare (CDB)  
-**Systemstatus (historisch):** stabile Infrastruktur-Baseline erreicht
+**Systemstatus:** stabile Infrastruktur-Baseline erreicht
 
-### Kernergebnisse (historischer Kontext — nicht live spiegeln)
+### Kernergebnisse
 - Das Working Repo traegt den aktiven lokalen Dokumentations-Canon
 - Agenten-, Governance- und Knowledge-Pfade sind lokal aufloesbar
 - PR-Block 01–06 vollständig umgesetzt und gepusht
-- GitLab CI aktiv (CI-Guard, Write-Zone-Checks) — **historisch**; aktueller CI-Canon: GitHub Actions (siehe [`CURRENT_STATUS.md`](../CURRENT_STATUS.md))
+- GitLab CI aktiv (CI-Guard, Write-Zone-Checks)
 - Unit-Test-Baseline vorhanden
 - Modulare Compose-Architektur (base / dev / prod)
 - Determinismus-Hooks für Replay vorbereitet
 
 > Dieser Snapshot ist **kein Live-Status**.  
-> Metriken und Toolchain-Hinweise hier sind **historisch** und duerfen nicht gegen `CURRENT_STATUS.md` oder GitHub-live gemergte PRs gelesen werden.
+> Er ist ein komprimierter Zustandsanker für neue Sessions und Agenten.
 
 ---
 

--- a/knowledge/CDB_KNOWLEDGE_HUB.md
+++ b/knowledge/CDB_KNOWLEDGE_HUB.md
@@ -19,25 +19,28 @@ Status: Canonical (non-governance)
 
 ---
 
-## EXECUTIVE SNAPSHOT (read-only)
+## EXECUTIVE SNAPSHOT (historical — read-only)
+
+**Status Class:** Historical knowledge snapshot (2025-12-15)
+**Not current repo/engineering or live-readiness truth.** See [`CURRENT_STATUS.md`](../CURRENT_STATUS.md) and [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).
 
 Stand: 2025-12-15  
-Gültig bis: explizites Update
+Gültig bis: explizites Update (Block bleibt historischer Anker)
 
 **Projekt:** Claire de Binare (CDB)  
-**Systemstatus:** stabile Infrastruktur-Baseline erreicht
+**Systemstatus (historisch):** stabile Infrastruktur-Baseline erreicht
 
-### Kernergebnisse
+### Kernergebnisse (historischer Kontext — nicht live spiegeln)
 - Das Working Repo traegt den aktiven lokalen Dokumentations-Canon
 - Agenten-, Governance- und Knowledge-Pfade sind lokal aufloesbar
 - PR-Block 01–06 vollständig umgesetzt und gepusht
-- GitLab CI aktiv (CI-Guard, Write-Zone-Checks)
+- GitLab CI aktiv (CI-Guard, Write-Zone-Checks) — **historisch**; aktueller CI-Canon: GitHub Actions (siehe [`CURRENT_STATUS.md`](../CURRENT_STATUS.md))
 - Unit-Test-Baseline vorhanden
 - Modulare Compose-Architektur (base / dev / prod)
 - Determinismus-Hooks für Replay vorbereitet
 
 > Dieser Snapshot ist **kein Live-Status**.  
-> Er ist ein komprimierter Zustandsanker für neue Sessions und Agenten.
+> Metriken und Toolchain-Hinweise hier sind **historisch** und duerfen nicht gegen `CURRENT_STATUS.md` oder GitHub-live gemergte PRs gelesen werden.
 
 ---
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -33,3 +33,9 @@ reviews, and evidence that must stay close to the working codebase.
 This directory is no longer a pointer layer for an external docs repository.
 Productive knowledge lives here. Historical docs-hub residue is preserved locally under
 archive paths when provenance matters.
+
+## Navigation
+
+- [Projektübersicht](../README.md)
+- [Dokumentationsindex](../docs/index.md)
+- [Agenten-Bootloader](../agents/AGENTS.md)

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -10,7 +10,7 @@ reviews, and evidence that must stay close to the working codebase.
 
 ## Key Entry Points
 
-- [`knowledge/CDB_KNOWLEDGE_HUB.md`](CDB_KNOWLEDGE_HUB.md)
+- [`knowledge/CDB_KNOWLEDGE_HUB.md`](CDB_KNOWLEDGE_HUB.md) — decision/handoff hub; **EXECUTIVE SNAPSHOT (2025-12-15) is historical**, not live repo/LR truth
 - [`CURRENT_STATUS.md`](../CURRENT_STATUS.md) (working repo / engineering status)
 - [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) (operational live-readiness status)
 - [`docs/live-readiness/LR-050-FINAL-RECONCILE.md`](../docs/live-readiness/LR-050-FINAL-RECONCILE.md) (P5 live-capital verdict SSOT)

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,3 +46,9 @@ pytest -v -m local_only   # explicit local_only only
 - [`pytest.ini`](../pytest.ini) — markers and defaults
 - [`Makefile`](../Makefile) — `test`, `test-unit`, `test-integration`, `test-e2e`, `test-coverage`
 - [`tests/fixtures/README.md`](fixtures/README.md) — deterministic fixtures
+
+## Navigation
+
+- [Projektübersicht](../README.md)
+- [Dokumentationsindex](../docs/index.md)
+- [Developer onboarding](../DEVELOPER_ONBOARDING.md)

--- a/tests/fixtures/readme_link_policy.yaml
+++ b/tests/fixtures/readme_link_policy.yaml
@@ -23,5 +23,17 @@ classification_rules:
       - artifacts/
       - reports/p5_canary/
 
+# Non-README canon entry points — same offline link rules as active READMEs (#3995).
+# Discovery is explicit (not git ls-files); paths must stay tracked in git.
+explicit_active_surfaces:
+  description: >-
+    Tier-A navigation/status surfaces outside README.md trees; validated by the
+    same engine as active READMEs (tools/validate_readme_links.py).
+  paths:
+    - CURRENT_STATUS.md
+    - docs/runbooks/CONTROL_REGISTER.md
+    - docs/meta/WORKING_REPO_CANON.md
+    - knowledge/CDB_KNOWLEDGE_HUB.md
+
 # Explicit per-path overrides (use sparingly).
 documented_exceptions: []

--- a/tests/unit/tools/test_validate_readme_links.py
+++ b/tests/unit/tools/test_validate_readme_links.py
@@ -122,6 +122,9 @@ def test_build_inventory_counts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
                 "classification_rules": {
                     "fixture_testdata": {"path_prefixes": ["tests/fixtures/"]},
                 },
+                "explicit_active_surfaces": {
+                    "paths": ["CURRENT_STATUS.md"],
+                },
             }
         ),
         encoding="utf-8",
@@ -133,9 +136,40 @@ def test_build_inventory_counts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     )
 
     inv = readme_validator.build_inventory(tmp_path, policy_path)
-    assert inv["total"] == 2
+    assert inv["total_readmes"] == 2
+    assert inv["total"] == 3
+    assert inv["explicit_active_surfaces"] == ["CURRENT_STATUS.md"]
     assert inv["by_classification"]["active"] == 1
     assert inv["by_classification"]["fixture_testdata"] == 1
+
+
+def test_validate_all_checks_explicit_active_surfaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    policy_path = tmp_path / "policy.yaml"
+    policy_path.write_text(
+        yaml.safe_dump(
+            {
+                "default_classification": "active",
+                "explicit_active_surfaces": {"paths": ["CURRENT_STATUS.md"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    _make_file(tmp_path, "CURRENT_STATUS.md", "[broken](missing.md)")
+    monkeypatch.setattr(
+        readme_validator,
+        "discover_tracked_readmes",
+        lambda _root: [],
+    )
+
+    errors = readme_validator.validate_all(tmp_path, policy_path)
+    assert len(errors) == 1
+    assert "CURRENT_STATUS.md" in errors[0]
+
+
+def test_explicit_active_surfaces_empty_when_omitted() -> None:
+    assert readme_validator.explicit_active_surfaces({}) == []
 
 
 def test_shared_extract_relative_links() -> None:

--- a/tools/README.md
+++ b/tools/README.md
@@ -61,3 +61,9 @@ Non-interactive form:
 - `infrastructure/scripts/stack_verify.ps1` - Older verification path; use `tools/verify_stack.ps1` for v1 discovery.
 - `infrastructure/scripts/stack_doctor.ps1` - Older infra-local diagnostic entrypoint; prefer `tools/cdb-stack-doctor.ps1` when that style of helper is needed.
 - `tools/stack_boot.ps1` - Legacy bootstrap helper; not the canonical BLUE+RED runtime entrypoint.
+
+## Navigation
+
+- [Projektübersicht](../README.md)
+- [Dokumentationsindex](../docs/index.md)
+- [Developer onboarding](../DEVELOPER_ONBOARDING.md)

--- a/tools/validate_readme_links.py
+++ b/tools/validate_readme_links.py
@@ -1,7 +1,9 @@
-"""Validate relative Markdown links in active tracked README.md files.
+"""Validate relative Markdown links on active documentation surfaces.
 
-Discovers READMEs via git, classifies them with rule-based policy, and
-fail-closed validates all `active` surfaces offline (no network).
+Discovers tracked README.md files via git, classifies them with rule-based
+policy, and fail-closed validates all `active` README surfaces offline.
+Also validates explicit non-README canon entry points listed in policy
+(`explicit_active_surfaces`, #3995) with the same link engine.
 
 Usage:
     python -m tools.validate_readme_links
@@ -9,10 +11,10 @@ Usage:
     python -m tools.validate_readme_links --inventory
 
 Exit codes:
-    0 - all active README link checks PASS
+    0 - all active surface link checks PASS
     1 - one or more validation failures
 
-Issue: #3994
+Issues: #3994 (README discovery), #3995 (explicit canon entry points)
 """
 
 from __future__ import annotations
@@ -66,6 +68,30 @@ def classify_readme(rel_path: str, policy: dict[str, Any]) -> str:
     return str(policy.get("default_classification", "active"))
 
 
+def explicit_active_surfaces(policy: dict[str, Any]) -> list[str]:
+    block = policy.get("explicit_active_surfaces") or {}
+    paths = block.get("paths") or []
+    return sorted({str(p).strip() for p in paths if str(p).strip()})
+
+
+def validate_surface_file(
+    root: Path,
+    rel_path: str,
+    *,
+    verbose: bool = False,
+    surface_kind: str = "active",
+) -> list[str]:
+    full_path = root / rel_path
+    if not full_path.is_file():
+        return [f"{rel_path}: tracked surface missing on disk"]
+
+    if verbose:
+        print(f"Validating ({surface_kind}): {rel_path}", file=sys.stderr)
+
+    content = full_path.read_text(encoding="utf-8", errors="replace")
+    return check_markdown_links(root, rel_path, content, verbose)
+
+
 def build_inventory(root: Path, policy_path: Path | None = None) -> dict[str, Any]:
     policy = load_policy(policy_path or DEFAULT_POLICY_PATH)
     readmes = discover_tracked_readmes(root)
@@ -74,8 +100,12 @@ def build_inventory(root: Path, policy_path: Path | None = None) -> dict[str, An
         cls = classify_readme(rel, policy)
         by_class.setdefault(cls, []).append(rel)
 
+    explicit = explicit_active_surfaces(policy)
+
     return {
-        "total": len(readmes),
+        "total_readmes": len(readmes),
+        "total": len(readmes) + len(explicit),
+        "explicit_active_surfaces": explicit,
         "by_classification": {k: len(v) for k, v in sorted(by_class.items())},
         "paths_by_classification": by_class,
         "policy_path": str((policy_path or DEFAULT_POLICY_PATH).relative_to(root)),
@@ -101,16 +131,19 @@ def validate_all(
                 )
             continue
 
-        full_path = r / rel_path
-        if not full_path.is_file():
-            all_errors.append(f"{rel_path}: tracked README.md missing on disk")
-            continue
+        all_errors.extend(
+            validate_surface_file(r, rel_path, verbose=verbose, surface_kind="active")
+        )
 
-        if verbose:
-            print(f"Validating (active): {rel_path}", file=sys.stderr)
-
-        content = full_path.read_text(encoding="utf-8", errors="replace")
-        all_errors.extend(check_markdown_links(r, rel_path, content, verbose))
+    for rel_path in explicit_active_surfaces(policy):
+        all_errors.extend(
+            validate_surface_file(
+                r,
+                rel_path,
+                verbose=verbose,
+                surface_kind="canon_entry_point",
+            )
+        )
 
     return all_errors
 
@@ -151,7 +184,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  FAIL: {err}", file=sys.stderr)
         return 1
 
-    print("OK: all active README surfaces pass link validation")
+    print("OK: all active README and explicit canon entry surfaces pass link validation")
     return 0
 
 


### PR DESCRIPTION
## Summary

- Extends the #3994 `validate_readme_links` engine with `explicit_active_surfaces` in `readme_link_policy.yaml` (no third link-check landscape; same CI step / `make readme-links-guard`).
- Refreshes README current-main snapshot against live `origin/main` (`49eb7546` baseline + recent merge clusters).
- Reconciles cross-hub navigation and SSOT links (D1–D8): `CURRENT_STATUS` #3994 ledger line (#3995 documented OPEN, not pre-merged), `CONTROL_REGISTER`, `core/README`, Tier-A hub return paths, historical banner on `CDB_KNOWLEDGE_HUB`.
- Evidence: `docs/evidence/navigation_entry_point_audit_3995.md`.

## Prerequisite

- #3994 / PR #4011 @ `49eb7546` (README link guard foundation)

## Non-goals

- #4005 community-health file rewrites
- #4006 worktree/branch cleanup
- #4012 ARCHITECTURE_MAP / SERVICE_CATALOG reconcile
- LR / live / Echtgeld verdict changes (LR remains **NO-GO**)

## Test plan

- [x] `python -m tools.validate_readme_links`
- [x] `python -m tools.validate_onboarding_docs`
- [x] `pytest -q tests/unit/tools/test_validate_readme_links.py`
- [x] `ruff check` on changed Python
- [x] `git diff --check`
- [ ] CI required checks green

Closes #3995