### PR TITLE
feat(arvp): define vacation replay metric contract

### DIFF
--- a/docs/contracts/arvp_vacation_job_metrics.v1.schema.json
+++ b/docs/contracts/arvp_vacation_job_metrics.v1.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ARVP Vacation Job Metrics Contract",
+  "description": "Minimal machine-readable contract for per-scenario vacation replay metrics consumed from {scenario}_metrics.json and queue_state.scenario_metrics. Issue #4014.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "scenario_id",
+    "strategy_id",
+    "metrics",
+    "ranking_ready"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "arvp_vacation_job_metrics.v1",
+      "description": "Fixed schema version identifier"
+    },
+    "scenario_id": {
+      "type": "string",
+      "enum": ["baseline", "pessimistic_execution", "feed_gap"],
+      "description": "Scenario identifier within a vacation job scenario group"
+    },
+    "strategy_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Strategy identifier (e.g. donchian_breakout_v1)"
+    },
+    "run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Replay run identifier"
+    },
+    "ranking_ready": {
+      "const": false,
+      "description": "Campaign remains non-ranking; must stay false for #3990 historical research"
+    },
+    "dataset_summary": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "symbol": { "type": "string" },
+        "timeframe": { "type": "string" },
+        "candles_live": { "type": "number" },
+        "candles_total": { "type": "number" },
+        "period_start_ts_ms": { "type": "number" },
+        "period_end_ts_ms": { "type": "number" },
+        "warmup_candles": { "type": "number" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["closed_trades_total"],
+      "properties": {
+        "gross_pnl_quote": { "type": "number" },
+        "net_pnl_quote": { "type": "number" },
+        "fees_total_quote": { "type": "number" },
+        "max_drawdown_r": { "type": "number" },
+        "fee_adjusted_max_drawdown_r": {
+          "type": ["number", "null"],
+          "description": "Present for primary_breakout_v1 with trades; absent/null otherwise"
+        },
+        "profit_factor": { "type": "number" },
+        "fee_adjusted_profit_factor": {
+          "type": ["number", "null"]
+        },
+        "expectancy_r": { "type": "number" },
+        "fee_adjusted_expectancy_r": {
+          "type": ["number", "null"]
+        },
+        "closed_trades_total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Zero is valid; missing field is not zero"
+        },
+        "win_rate": { "type": "number" },
+        "avg_win_r": { "type": ["number", "null"] },
+        "avg_loss_r": { "type": ["number", "null"] },
+        "signals_total": { "type": "integer", "minimum": 0 },
+        "trades_win_count": { "type": "integer", "minimum": 0 },
+        "trades_loss_count": { "type": "integer", "minimum": 0 },
+        "sample_size_verdict": { "type": "string" },
+        "metrics_availability": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "slippage_per_trade_available": { "type": "boolean" },
+            "slippage_note": { "type": "string" },
+            "trade_level_pnl_available": { "type": "boolean" },
+            "equity_curve_available": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "canonical_job_selection": {
+      "type": "object",
+      "description": "Documented selector for queue_state jobs; not embedded in each metrics file at runtime",
+      "additionalProperties": false,
+      "required": ["selector", "canonical_job_count", "superseded_job_count"],
+      "properties": {
+        "selector": {
+          "const": "superseded_by_stress_v2_rerun != true"
+        },
+        "canonical_job_count": {
+          "const": 318
+        },
+        "superseded_job_count": {
+          "const": 6
+        },
+        "queue_record_count": {
+          "const": 324
+        },
+        "fail_closed_on_unknown_superseded": {
+          "const": true
+        },
+        "zero_trade_rankable": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/docs/evidence/arvp_3990_metric_availability_matrix.md
+++ b/docs/evidence/arvp_3990_metric_availability_matrix.md
@@ -1,0 +1,190 @@
+# ARVP #3990 Metric Availability Matrix
+
+**Date:** 2026-07-13  
+**Issue:** [#4014](https://github.com/jannekbuengener/Claire_de_Binare/issues/4014)  
+**Parent:** [#4013](https://github.com/jannekbuengener/Claire_de_Binare/issues/4013)  
+**Blocks:** [#4015](https://github.com/jannekbuengener/Claire_de_Binare/issues/4015)  
+**LR:** NO-GO  
+**Evidence class:** `historical_cross_venue_research`  
+**Outcome:** `READY_FOR_METRIC_EXTRACTION`  
+**ranking_ready:** `false` (unchanged)
+
+---
+
+## Brain Evidence
+
+| Field | Value |
+|-------|-------|
+| brain_source | repo-only |
+| brain_status | not-used |
+| context_brain_attempted | true |
+| context_brain_used | false |
+| repo_fallback_reason | insufficient_evidence |
+| records_found | none |
+
+Repo crosscheck: `artifacts/arvp_vacation/arvp_binance_historical_3990_2bb32b68_20260712T111944Z/queue_state.json`, `tools/arvp_vacation/summary.py`, `tools/arvp_vacation/job_runner.py`, live GitHub issues #4013/#4014/#4015.
+
+---
+
+## Campaign Boundary
+
+| Field | Value |
+|-------|-------|
+| Campaign ID | `arvp_binance_historical_3990_2bb32b68_20260712T111944Z` |
+| Queue records | 324 |
+| Canonical jobs | **318** |
+| Superseded excluded | **6** |
+| Strategies | `donchian_breakout_v1`, `breakout_trend_filter_v1`, `primary_breakout_v1` |
+| Scenarios | `baseline`, `pessimistic_execution`, `feed_gap` |
+| Venues | Binance historical only — **not** MEXC same-venue confirmation |
+
+Technical PASS on 318 jobs does **not** imply profitable or promotion-ready strategies.
+
+---
+
+## Canonical Job Selection Contract
+
+| Rule | Definition |
+|------|------------|
+| Selector | `superseded_by_stress_v2_rerun != true` |
+| Canonical count | 318 |
+| Superseded count | 6 |
+| Fail-closed | Unknown/non-boolean `superseded_by_stress_v2_rerun` rejects job |
+| Aggregation ban | Original + stress-v2 replacement must never be aggregated together |
+| Zero trades | `closed_trades_total == 0` is valid; missing field is not zero |
+| Rankable | `rankable=false` when `closed_trades_total == 0` or field missing |
+| Stress-only legacy | Six superseded FAIL jobs are excluded from all downstream extraction |
+
+Excluded superseded job IDs (informative):
+
+- `vac-donchian-breakout-v1-binance_1m_stress_max_drawdown-scenarios`
+- `vac-breakout-trend-filter-v1-binance_1m_stress_max_drawdown-scenarios`
+- `vac-primary-breakout-v1-binance_1m_stress_max_drawdown-scenarios`
+- `vac-donchian-breakout-v1-binance_1m_stress_max_volatility-scenarios`
+- `vac-breakout-trend-filter-v1-binance_1m_stress_max_volatility-scenarios`
+- `vac-primary-breakout-v1-binance_1m_stress_max_volatility-scenarios`
+
+Machine-readable schema: [`docs/contracts/arvp_vacation_job_metrics.v1.schema.json`](../contracts/arvp_vacation_job_metrics.v1.schema.json)
+
+---
+
+## Artifact Inventory
+
+| Artifact | Schema / version | Role |
+|----------|------------------|------|
+| `queue_state.json` | `1.0` | Job status, `scenario_metrics` mirror, superseded flags |
+| `{scenario}_metrics.json` | `arvp_vacation_job_metrics.v1` | Per-scenario economics payload |
+| `scenario_group_manifest.json` | replay group manifest | Scenario pass/fail counts |
+| `dataset_spec.json` | `dataset_spec.v2` | `purpose`, `overlap_class`, `regime_distribution` |
+| `window_bank_manifest.json` | `binance_window_bank.v1` | `temporal_split` Dev/Val/OOS mapping |
+| `vacation_summary.json` | `1.0` | MVP summary; **known field-alias gap** (`trade_count`/`net_pnl`) |
+
+Field path convention:
+
+- File artifact: `jobs/<job_id>/replay/<group_id>/{scenario}_metrics.json`
+- Queue mirror: `queue_state.jobs[].scenario_metrics.{scenario}.metrics.<field>`
+
+---
+
+## Metric Availability Matrix
+
+| metric | classification | artifact_type | field_path | unit | sign_convention | aggregation_rule | missing_semantics | limitations |
+|--------|----------------|---------------|------------|------|-----------------|------------------|-------------------|-------------|
+| gross_pnl_quote | directly_available | scenario_metrics_json | metrics.gross_pnl_quote | quote_currency | positive_profit_negative_loss | per_job_per_scenario | absent=missing; 0 with zero trades valid | Binance historical only |
+| net_pnl_quote | directly_available | scenario_metrics_json | metrics.net_pnl_quote | quote_currency | positive_profit_negative_loss | per_job_per_scenario | absent=missing; 0 with zero trades valid | Summary alias bug deferred to #4015 |
+| fees_total_quote | directly_available | scenario_metrics_json | metrics.fees_total_quote | quote_currency | non_negative_cost | per_job_per_scenario sum | absent=missing; 0 valid at zero trades | Slippage embedded, not itemized |
+| slippage | not_available | scenario_metrics_json | metrics_availability.slippage_per_trade_available | n/a | n/a | not_aggregable | always missing standalone | `slippage_note` only |
+| max_drawdown_r | directly_available | scenario_metrics_json | metrics.max_drawdown_r | r_multiple | non_negative_depth | per_job_per_scenario | absent=missing; 0 valid at zero trades | Point-estimate drawdown only |
+| fee_adjusted_max_drawdown_r | directly_available | scenario_metrics_json | metrics.fee_adjusted_max_drawdown_r | r_multiple | non_negative_depth | per_job when present | null/absent=missing | primary_breakout only; absent on donchian/btf |
+| profit_factor | directly_available | scenario_metrics_json | metrics.profit_factor | ratio | non_negative | per_job_per_scenario | absent=missing; 0 valid at zero trades | Not profitability proof |
+| fee_adjusted_profit_factor | directly_available | scenario_metrics_json | metrics.fee_adjusted_profit_factor | ratio | non_negative | per_job when present | null/absent=missing on zero-trade primary_breakout | Adapter-dependent emission |
+| expectancy_r | directly_available | scenario_metrics_json | metrics.expectancy_r | r_multiple | signed | per_job_per_scenario | absent=missing; 0 valid at zero trades | Point-estimate only |
+| fee_adjusted_expectancy_r | directly_available | scenario_metrics_json | metrics.fee_adjusted_expectancy_r | r_multiple | signed | per_job when present | null/absent=missing on zero-trade primary_breakout | Adapter-dependent emission |
+| closed_trades_total | directly_available | scenario_metrics_json | metrics.closed_trades_total | count | non_negative_integer | per_job_per_scenario | absent=missing; **0 is valid zero** | Zero-trade jobs rankable=false |
+| win_rate | directly_available | scenario_metrics_json | metrics.win_rate | ratio_0_1 | non_negative | per_job_per_scenario | absent=missing; 0 valid at zero trades | Not cross-scenario weighted |
+| avg_win_r | directly_available | scenario_metrics_json | metrics.avg_win_r | r_multiple | typically_positive | per_job when wins exist | null/absent when no wins | Missing ≠ 0 |
+| avg_loss_r | directly_available | scenario_metrics_json | metrics.avg_loss_r | r_multiple | typically_negative | per_job when losses exist | null/absent when no losses | Missing ≠ 0 |
+| exposure_or_time_in_market | derivable_with_assumption | scenario_metrics_json+dataset_spec | metrics.signals_total / dataset_summary.candles_live | ratio_proxy | non_negative | proxy only | needs both fields | No per-bar occupancy |
+| regime_behavior | directly_available | dataset_spec_json | regime_distribution | candle_count_by_regime | non_negative_counts | per_dataset window | dataset_spec missing=missing | Window-level only |
+| scenario_sensitivity | deterministically_derivable | queue_state.scenario_metrics | scenario_metrics.*.metrics.net_pnl_quote deltas | quote_currency_delta | delta_vs_baseline | intra-job scenario compare | partial if scenario missing | Windows not independent |
+| window_stability | derivable_with_assumption | campaign_aggregate | cross-job dispersion (#4015) | policy_defined | n/a | deferred | single-job scope N/A | League/extraction stage |
+
+---
+
+## Sample Validation (12 Jobs)
+
+Validated read-only against campaign artifacts. Overlapping calendar windows are **not** treated as independent statistical samples.
+
+| # | strategy_id | window_class | dataset_id | job_id | baseline closed_trades_total | rankable |
+|---|-------------|--------------|------------|--------|------------------------------|----------|
+| 1 | donchian_breakout_v1 | monthly | binance_1m_month_2017_10 | vac-donchian-breakout-v1-binance_1m_month_2017_10-scenarios | 563 | true |
+| 2 | donchian_breakout_v1 | quarterly | binance_1m_quarter_2020_Q3 | vac-donchian-breakout-v1-binance_1m_quarter_2020_Q3-scenarios | 2087 | true |
+| 3 | donchian_breakout_v1 | yearly | binance_1m_year_2022 | vac-donchian-breakout-v1-binance_1m_year_2022-scenarios | 7553 | true |
+| 4 | donchian_breakout_v1 | stress_v2 | binance_1m_stress_max_drawdown_v2 | vac-donchian-breakout-v1-binance_1m_stress_max_drawdown_v2-scenarios | 140 | true |
+| 5 | breakout_trend_filter_v1 | monthly | binance_1m_month_2017_10 | vac-breakout-trend-filter-v1-binance_1m_month_2017_10-scenarios | 464 | true |
+| 6 | breakout_trend_filter_v1 | quarterly | binance_1m_quarter_2020_Q3 | vac-breakout-trend-filter-v1-binance_1m_quarter_2020_Q3-scenarios | 1674 | true |
+| 7 | breakout_trend_filter_v1 | yearly | binance_1m_year_2022 | vac-breakout-trend-filter-v1-binance_1m_year_2022-scenarios | 5890 | true |
+| 8 | breakout_trend_filter_v1 | stress_v2 | binance_1m_stress_max_drawdown_v2 | vac-breakout-trend-filter-v1-binance_1m_stress_max_drawdown_v2-scenarios | 100 | true |
+| 9 | primary_breakout_v1 | monthly | binance_1m_month_2017_10 | vac-primary-breakout-v1-binance_1m_month_2017_10-scenarios | 3 | true |
+| 10 | primary_breakout_v1 | quarterly | binance_1m_quarter_2020_Q3 | vac-primary-breakout-v1-binance_1m_quarter_2020_Q3-scenarios | 2 | true |
+| 11 | primary_breakout_v1 | yearly | binance_1m_year_2022 | vac-primary-breakout-v1-binance_1m_year_2022-scenarios | 0 | false |
+| 12 | primary_breakout_v1 | stress_v2 | binance_1m_stress_max_drawdown_v2 | vac-primary-breakout-v1-binance_1m_stress_max_drawdown_v2-scenarios | 0 | false |
+
+Canonical campaign baseline snapshot (informative, not promotion evidence):
+
+- 89 zero-trade baseline jobs among canonical 318
+- 229 traded baseline jobs
+- 223 negative net_pnl_quote among traded baseline jobs
+
+---
+
+## Temporal Split Mapping
+
+Dev/Val/OOS assignment uses:
+
+- `dataset_spec.purpose` (`development`, `validation`, `out_of_sample`, `stress`)
+- `window_bank_manifest.temporal_split` month lists
+
+Stress-v2 windows (`*_v2`) carry `purpose=stress` and must not be mixed with superseded legacy stress FAIL jobs.
+
+---
+
+## Known Gaps (Out of #4014 Scope)
+
+| Gap | Owner |
+|-----|-------|
+| `summary.py` reads `trade_count`/`net_pnl` instead of `metrics.closed_trades_total`/`metrics.net_pnl_quote` | #4015 extractor + summary fix |
+| Deterministic 318-job hash manifest | #4015 |
+| PEP assembly | #4016 |
+| League table | #4017 |
+
+---
+
+## Safety Boundaries
+
+- LR remains **NO-GO**
+- `ranking_ready` remains **false**
+- Binance results are cross-venue research, not MEXC confirmation
+- No paper/live/promotion language authorized
+- Technical PASS ≠ economic success
+- 223 negative traded baseline jobs are baseline evidence only, not optimization input
+
+---
+
+## Validation
+
+```bash
+python -m pytest -q tests/unit/arvp/test_vacation_metric_availability_contract.py
+ruff check tests/unit/arvp/test_vacation_metric_availability_contract.py
+python -m json.tool docs/contracts/arvp_vacation_job_metrics.v1.schema.json
+```
+
+Contract test fixtures: `tests/fixtures/arvp/vacation_metrics/` (redacted deterministic subsets).
+
+---
+
+## Restunsicherheiten
+
+- `fee_adjusted_max_drawdown_r` absence on donchian/breakout_trend_filter is artifact reality, not proof those metrics are theoretically impossible.
+- `window_stability` policy is intentionally deferred; cross-window correlation/overlap not resolved in this issue.
+- Local `queue_state.json` contains absolute Windows paths in some fields; extractor must normalize paths in #4015.

--- a/tests/fixtures/arvp/vacation_metrics/canonical_selection_queue_slice.v1.json
+++ b/tests/fixtures/arvp/vacation_metrics/canonical_selection_queue_slice.v1.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "1.0",
+  "campaign_id": "arvp_binance_historical_3990_2bb32b68_20260712T111944Z",
+  "jobs": [
+    {
+      "job_id": "vac-donchian-breakout-v1-binance_1m_month_2017_10-scenarios",
+      "strategy_id": "donchian_breakout_v1",
+      "dataset_id": "binance_1m_month_2017_10",
+      "status": "PASS",
+      "artifacts_complete": true,
+      "scenario_metrics": {
+        "baseline": {
+          "metrics": {
+            "closed_trades_total": 563,
+            "net_pnl_quote": -12000.0,
+            "gross_pnl_quote": -9000.0,
+            "fees_total_quote": 3000.0
+          }
+        }
+      }
+    },
+    {
+      "job_id": "vac-donchian-breakout-v1-binance_1m_stress_max_drawdown-scenarios",
+      "strategy_id": "donchian_breakout_v1",
+      "dataset_id": "binance_1m_stress_max_drawdown",
+      "status": "FAIL",
+      "superseded_by_stress_v2_rerun": true,
+      "artifacts_complete": false
+    },
+    {
+      "job_id": "vac-breakout-trend-filter-v1-binance_1m_stress_max_drawdown-scenarios",
+      "strategy_id": "breakout_trend_filter_v1",
+      "dataset_id": "binance_1m_stress_max_drawdown",
+      "status": "FAIL",
+      "superseded_by_stress_v2_rerun": true,
+      "artifacts_complete": false
+    },
+    {
+      "job_id": "vac-primary-breakout-v1-binance_1m_stress_max_drawdown-scenarios",
+      "strategy_id": "primary_breakout_v1",
+      "dataset_id": "binance_1m_stress_max_drawdown",
+      "status": "FAIL",
+      "superseded_by_stress_v2_rerun": true,
+      "artifacts_complete": false
+    },
+    {
+      "job_id": "vac-donchian-breakout-v1-binance_1m_stress_max_volatility-scenarios",
+      "strategy_id": "donchian_breakout_v1",
+      "dataset_id": "binance_1m_stress_max_volatility",
+      "status": "FAIL",
+      "superseded_by_stress_v2_rerun": true,
+      "artifacts_complete": false
+    },
+    {
+      "job_id": "vac-breakout-trend-filter-v1-binance_1m_stress_max_volatility-scenarios",
+      "strategy_id": "breakout_trend_filter_v1",
+      "dataset_id": "binance_1m_stress_max_volatility",
+      "status": "FAIL",
+      "superseded_by_stress_v2_rerun": true,
+      "artifacts_complete": false
+    },
+    {
+      "job_id": "vac-primary-breakout-v1-binance_1m_stress_max_volatility-scenarios",
+      "strategy_id": "primary_breakout_v1",
+      "dataset_id": "binance_1m_stress_max_volatility",
+      "status": "FAIL",
+      "superseded_by_stress_v2_rerun": true,
+      "artifacts_complete": false
+    },
+    {
+      "job_id": "vac-donchian-breakout-v1-binance_1m_stress_max_drawdown_v2-scenarios",
+      "strategy_id": "donchian_breakout_v1",
+      "dataset_id": "binance_1m_stress_max_drawdown_v2",
+      "status": "PASS",
+      "artifacts_complete": true,
+      "scenario_metrics": {
+        "baseline": {
+          "metrics": {
+            "closed_trades_total": 140,
+            "net_pnl_quote": -24608.44
+          }
+        }
+      }
+    },
+    {
+      "job_id": "vac-primary-breakout-v1-binance_1m_month_2017_11-scenarios",
+      "strategy_id": "primary_breakout_v1",
+      "dataset_id": "binance_1m_month_2017_11",
+      "status": "PASS",
+      "artifacts_complete": true,
+      "scenario_metrics": {
+        "baseline": {
+          "metrics": {
+            "closed_trades_total": 0,
+            "net_pnl_quote": 0,
+            "fee_adjusted_max_drawdown_r": null,
+            "avg_win_r": null
+          }
+        }
+      }
+    }
+  ],
+  "_fixture_note": "Redacted queue slice from campaign arvp_binance_historical_3990_2bb32b68_20260712T111944Z. Six superseded stress jobs + canonical replacements and zero-trade sample."
+}

--- a/tests/fixtures/arvp/vacation_metrics/donchian_monthly_baseline_metrics.v1.json
+++ b/tests/fixtures/arvp/vacation_metrics/donchian_monthly_baseline_metrics.v1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "arvp_vacation_job_metrics.v1",
+  "scenario_id": "baseline",
+  "strategy_id": "donchian_breakout_v1",
+  "run_id": "redacted-run-id",
+  "ranking_ready": false,
+  "dataset_summary": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1m",
+    "candles_live": 44620,
+    "candles_total": 44640,
+    "period_start_ts_ms": 1506816000000,
+    "period_end_ts_ms": 1509494340000,
+    "warmup_candles": 20
+  },
+  "metrics": {
+    "closed_trades_total": 563,
+    "gross_pnl_quote": -8601.13,
+    "net_pnl_quote": -12152.38,
+    "fees_total_quote": 3551.25,
+    "max_drawdown_r": 2.35,
+    "profit_factor": 0.42,
+    "fee_adjusted_profit_factor": 0.20,
+    "expectancy_r": -0.003,
+    "fee_adjusted_expectancy_r": -0.004,
+    "win_rate": 0.19,
+    "avg_win_r": 0.0063,
+    "avg_loss_r": -0.0053,
+    "signals_total": 563
+  },
+  "_fixture_note": "Redacted from vac-donchian-breakout-v1-binance_1m_month_2017_10-scenarios baseline_metrics.json"
+}

--- a/tests/fixtures/arvp/vacation_metrics/donchian_stress_v2_baseline_metrics.v1.json
+++ b/tests/fixtures/arvp/vacation_metrics/donchian_stress_v2_baseline_metrics.v1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "arvp_vacation_job_metrics.v1",
+  "scenario_id": "baseline",
+  "strategy_id": "donchian_breakout_v1",
+  "run_id": "redacted-run-id",
+  "ranking_ready": false,
+  "dataset_summary": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1m",
+    "candles_live": 10060,
+    "candles_total": 10080,
+    "period_start_ts_ms": 1620885600000,
+    "period_end_ts_ms": 1621490340000,
+    "warmup_candles": 20
+  },
+  "metrics": {
+    "closed_trades_total": 140,
+    "gross_pnl_quote": -16912.74,
+    "net_pnl_quote": -24608.44,
+    "fees_total_quote": 7695.70,
+    "max_drawdown_r": 0.4166,
+    "profit_factor": 0.3805,
+    "fee_adjusted_profit_factor": 0.2553,
+    "expectancy_r": -0.0028,
+    "fee_adjusted_expectancy_r": -0.0040,
+    "win_rate": 0.3286,
+    "avg_win_r": 0.0052,
+    "avg_loss_r": -0.0066,
+    "signals_total": 141
+  },
+  "_fixture_note": "Redacted from stress_v2 closeout vac-donchian-breakout-v1-binance_1m_stress_max_drawdown_v2-scenarios baseline_metrics.json"
+}

--- a/tests/fixtures/arvp/vacation_metrics/primary_zero_trade_baseline_metrics.v1.json
+++ b/tests/fixtures/arvp/vacation_metrics/primary_zero_trade_baseline_metrics.v1.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "arvp_vacation_job_metrics.v1",
+  "scenario_id": "baseline",
+  "strategy_id": "primary_breakout_v1",
+  "run_id": "redacted-run-id",
+  "ranking_ready": false,
+  "dataset_summary": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1m",
+    "candles_total": 43200,
+    "period_start_ts_ms": 1509508800000,
+    "period_end_ts_ms": 1512086340000
+  },
+  "metrics": {
+    "closed_trades_total": 0,
+    "gross_pnl_quote": 0,
+    "net_pnl_quote": 0,
+    "fees_total_quote": 0,
+    "max_drawdown_r": 0.0,
+    "profit_factor": 0.0,
+    "expectancy_r": 0.0,
+    "win_rate": 0.0,
+    "fee_adjusted_max_drawdown_r": null,
+    "fee_adjusted_profit_factor": null,
+    "fee_adjusted_expectancy_r": null,
+    "avg_win_r": null,
+    "avg_loss_r": null,
+    "signals_total": 0,
+    "sample_size_verdict": "no_trades",
+    "metrics_availability": {
+      "slippage_per_trade_available": false,
+      "trade_level_pnl_available": false
+    }
+  },
+  "_fixture_note": "Redacted from vac-primary-breakout-v1-binance_1m_month_2017_11-scenarios zero-trade baseline_metrics.json"
+}

--- a/tests/unit/arvp/_arvp_vacation_metric_contract_helpers.py
+++ b/tests/unit/arvp/_arvp_vacation_metric_contract_helpers.py
@@ -1,0 +1,279 @@
+"""Helpers for ARVP vacation replay metric availability contract (#4014)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "arvp" / "vacation_metrics"
+SCHEMA_PATH = (
+    REPO_ROOT / "docs" / "contracts" / "arvp_vacation_job_metrics.v1.schema.json"
+)
+MATRIX_PATH = REPO_ROOT / "docs" / "evidence" / "arvp_3990_metric_availability_matrix.md"
+CAMPAIGN_ID = "arvp_binance_historical_3990_2bb32b68_20260712T111944Z"
+CANONICAL_JOB_COUNT = 318
+SUPERSEDED_JOB_COUNT = 6
+QUEUE_RECORD_COUNT = 324
+CANONICAL_SELECTOR = "superseded_by_stress_v2_rerun != true"
+OUTCOME_READY = "READY_FOR_METRIC_EXTRACTION"
+
+
+class VacationMetricContractError(ValueError):
+    """Fail-closed contract violation for vacation metric availability."""
+
+
+METRIC_MATRIX: tuple[dict[str, str], ...] = (
+    {
+        "metric": "gross_pnl_quote",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.gross_pnl_quote",
+        "unit": "quote_currency",
+        "sign_convention": "positive_profit_negative_loss",
+        "aggregation_rule": "per_job_per_scenario; cross-job sums require explicit weighting policy in #4015",
+        "missing_semantics": "field absent => missing; 0.0 with closed_trades_total=0 is valid zero",
+        "limitations": "Binance historical replay only; not MEXC same-venue evidence",
+    },
+    {
+        "metric": "net_pnl_quote",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.net_pnl_quote",
+        "unit": "quote_currency",
+        "sign_convention": "positive_profit_negative_loss",
+        "aggregation_rule": "per_job_per_scenario; gross_pnl_quote - fees_total_quote when both present",
+        "missing_semantics": "field absent => missing; 0.0 with closed_trades_total=0 is valid zero",
+        "limitations": "Summary layer currently reads net_pnl alias; extractor must use metrics.net_pnl_quote (#4015)",
+    },
+    {
+        "metric": "fees_total_quote",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.fees_total_quote",
+        "unit": "quote_currency",
+        "sign_convention": "non_negative_cost",
+        "aggregation_rule": "per_job_per_scenario sum",
+        "missing_semantics": "field absent => missing; 0 with zero trades is valid zero",
+        "limitations": "Fees include simulated execution costs; slippage not itemized separately",
+    },
+    {
+        "metric": "slippage",
+        "classification": "not_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics_availability.slippage_per_trade_available",
+        "unit": "n/a",
+        "sign_convention": "n/a",
+        "aggregation_rule": "not_aggregable",
+        "missing_semantics": "always missing as standalone metric; embedded in fill prices",
+        "limitations": "metrics_availability.slippage_note documents embedded slippage only",
+    },
+    {
+        "metric": "max_drawdown_r",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.max_drawdown_r",
+        "unit": "r_multiple",
+        "sign_convention": "non_negative_drawdown_depth",
+        "aggregation_rule": "per_job_per_scenario; cross-window max requires explicit policy",
+        "missing_semantics": "field absent => missing; 0.0 with zero trades is valid zero",
+        "limitations": "Point-estimate drawdown from end-of-trade equity only",
+    },
+    {
+        "metric": "fee_adjusted_max_drawdown_r",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.fee_adjusted_max_drawdown_r",
+        "unit": "r_multiple",
+        "sign_convention": "non_negative_drawdown_depth",
+        "aggregation_rule": "per_job_per_scenario when present",
+        "missing_semantics": "null or absent when closed_trades_total=0 or adapter omits field => missing",
+        "limitations": "Emitted only by primary_breakout_v1 adapter with trades; absent for donchian/breakout_trend_filter",
+    },
+    {
+        "metric": "profit_factor",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.profit_factor",
+        "unit": "ratio",
+        "sign_convention": "non_negative; 0.0 when no winning trades",
+        "aggregation_rule": "per_job_per_scenario only",
+        "missing_semantics": "field absent => missing; 0.0 with zero trades is valid zero not missing",
+        "limitations": "Not a campaign-level profitability proof",
+    },
+    {
+        "metric": "fee_adjusted_profit_factor",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.fee_adjusted_profit_factor",
+        "unit": "ratio",
+        "sign_convention": "non_negative",
+        "aggregation_rule": "per_job_per_scenario when present",
+        "missing_semantics": "null or absent when no trades on primary_breakout_v1 => missing; always present on donchian/btf",
+        "limitations": "Adapter-dependent emission for zero-trade primary_breakout jobs",
+    },
+    {
+        "metric": "expectancy_r",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.expectancy_r",
+        "unit": "r_multiple",
+        "sign_convention": "positive_expected_gain_negative_expected_loss",
+        "aggregation_rule": "per_job_per_scenario only",
+        "missing_semantics": "field absent => missing; 0.0 with zero trades is valid zero",
+        "limitations": "Per-trade point estimate expectancy",
+    },
+    {
+        "metric": "fee_adjusted_expectancy_r",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.fee_adjusted_expectancy_r",
+        "unit": "r_multiple",
+        "sign_convention": "positive_expected_gain_negative_expected_loss",
+        "aggregation_rule": "per_job_per_scenario when present",
+        "missing_semantics": "null or absent when no trades on primary_breakout_v1 => missing",
+        "limitations": "Adapter-dependent for zero-trade primary_breakout jobs",
+    },
+    {
+        "metric": "closed_trades_total",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.closed_trades_total",
+        "unit": "count",
+        "sign_convention": "non_negative_integer",
+        "aggregation_rule": "per_job_per_scenario sum; zero is valid",
+        "missing_semantics": "field absent => missing; 0 is valid zero-trade outcome not missing",
+        "limitations": "Zero-trade jobs are rankable=false",
+    },
+    {
+        "metric": "win_rate",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.win_rate",
+        "unit": "ratio_0_1",
+        "sign_convention": "non_negative",
+        "aggregation_rule": "per_job_per_scenario only",
+        "missing_semantics": "field absent => missing; 0.0 with zero trades is valid zero",
+        "limitations": "Not recomputed across scenarios without weighting policy",
+    },
+    {
+        "metric": "avg_win_r",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.avg_win_r",
+        "unit": "r_multiple",
+        "sign_convention": "typically_positive_when_present",
+        "aggregation_rule": "per_job_per_scenario when winning trades exist",
+        "missing_semantics": "null or absent when trades_win_count=0 => missing not zero",
+        "limitations": "Requires at least one winning trade",
+    },
+    {
+        "metric": "avg_loss_r",
+        "classification": "directly_available",
+        "artifact_type": "scenario_metrics_json",
+        "field_path": "metrics.avg_loss_r",
+        "unit": "r_multiple",
+        "sign_convention": "typically_negative_when_present",
+        "aggregation_rule": "per_job_per_scenario when losing trades exist",
+        "missing_semantics": "null or absent when trades_loss_count=0 => missing not zero",
+        "limitations": "Requires at least one losing trade",
+    },
+    {
+        "metric": "exposure_or_time_in_market",
+        "classification": "derivable_with_assumption",
+        "artifact_type": "scenario_metrics_json+dataset_spec",
+        "field_path": "metrics.signals_total / dataset_summary.candles_live",
+        "unit": "ratio_proxy",
+        "sign_convention": "non_negative",
+        "aggregation_rule": "proxy only; true time-in-market needs per-bar position state",
+        "missing_semantics": "requires both signals_total and candles_live; else missing",
+        "limitations": "Proxy only; no per-bar position occupancy in artifacts",
+    },
+    {
+        "metric": "regime_behavior",
+        "classification": "directly_available",
+        "artifact_type": "dataset_spec_json",
+        "field_path": "regime_distribution",
+        "unit": "candle_count_by_regime",
+        "sign_convention": "non_negative_counts",
+        "aggregation_rule": "per_dataset window; join by dataset_id",
+        "missing_semantics": "dataset_spec missing => missing",
+        "limitations": "Window-level regime mix; not per-trade regime attribution",
+    },
+    {
+        "metric": "scenario_sensitivity",
+        "classification": "deterministically_derivable",
+        "artifact_type": "queue_state.scenario_metrics",
+        "field_path": "scenario_metrics.{baseline,pessimistic_execution,feed_gap}.metrics.net_pnl_quote",
+        "unit": "quote_currency_delta",
+        "sign_convention": "delta_relative_to_baseline",
+        "aggregation_rule": "per_job compare scenarios within same job fingerprint",
+        "missing_semantics": "any scenario payload missing => partial missing for sensitivity pair",
+        "limitations": "Sensitivity is intra-job only; windows are not independent samples",
+    },
+    {
+        "metric": "window_stability",
+        "classification": "derivable_with_assumption",
+        "artifact_type": "campaign_aggregate",
+        "field_path": "cross_job metric dispersion (out of #4014 single-job scope)",
+        "unit": "policy_defined",
+        "sign_convention": "n/a",
+        "aggregation_rule": "requires cross-window aggregation policy in #4015/#4017",
+        "missing_semantics": "not defined at single-job artifact level",
+        "limitations": "Deferred to metric extraction and league table stages",
+    },
+)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def is_canonical_queue_job(job: Mapping[str, Any]) -> bool:
+    """Return True for canonical jobs per superseded_by_stress_v2_rerun != true."""
+    superseded = job.get("superseded_by_stress_v2_rerun")
+    if superseded is True:
+        return False
+    if superseded is False or superseded is None:
+        return True
+    raise VacationMetricContractError(
+        f"unknown superseded_by_stress_v2_rerun value: {superseded!r}"
+    )
+
+
+def select_canonical_jobs(jobs: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    canonical: list[dict[str, Any]] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise VacationMetricContractError("queue job must be object")
+        if is_canonical_queue_job(job):
+            canonical.append(job)
+    return canonical
+
+
+def is_rankable_job_metrics(metrics: Mapping[str, Any]) -> bool:
+    if "closed_trades_total" not in metrics:
+        return False
+    try:
+        return int(metrics["closed_trades_total"]) > 0
+    except (TypeError, ValueError) as exc:
+        raise VacationMetricContractError(
+            "closed_trades_total must be integer-like"
+        ) from exc
+
+
+def metric_is_missing(metrics: Mapping[str, Any], field: str) -> bool:
+    if field not in metrics:
+        return True
+    return metrics[field] is None
+
+
+def scenario_metric_field_path(scenario_id: str, metric_field: str) -> str:
+    return f"scenario_metrics.{scenario_id}.metrics.{metric_field}"
+
+
+def artifact_metrics_field_path(metric_field: str) -> str:
+    return f"metrics.{metric_field}"
+

--- a/tests/unit/arvp/test_vacation_metric_availability_contract.py
+++ b/tests/unit/arvp/test_vacation_metric_availability_contract.py
@@ -1,0 +1,172 @@
+"""ARVP vacation replay metric availability contract tests (#4014)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from tests.unit.arvp import _arvp_vacation_metric_contract_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+FIXTURES = helpers.FIXTURES_DIR
+SCENARIO_FIXTURES = (
+    FIXTURES / "donchian_monthly_baseline_metrics.v1.json",
+    FIXTURES / "donchian_stress_v2_baseline_metrics.v1.json",
+    FIXTURES / "primary_zero_trade_baseline_metrics.v1.json",
+)
+
+
+def _load(path: Path) -> dict:
+    return helpers.load_json(path)
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return _load(helpers.SCHEMA_PATH)
+
+
+@pytest.fixture(scope="module")
+def schema_validator(schema: dict) -> Draft7Validator:
+    return Draft7Validator(schema)
+
+
+@pytest.mark.parametrize("fixture_path", SCENARIO_FIXTURES, ids=lambda p: p.stem)
+def test_scenario_metrics_fixtures_validate_against_schema(
+    fixture_path: Path,
+    schema_validator: Draft7Validator,
+) -> None:
+    payload = _load(fixture_path)
+    errors = sorted(schema_validator.iter_errors(payload), key=lambda e: e.message)
+    assert not errors, [e.message for e in errors]
+
+
+def test_schema_declares_version_and_canonical_selection_documentation(
+    schema: dict,
+) -> None:
+    assert schema["properties"]["schema_version"]["const"] == (
+        "arvp_vacation_job_metrics.v1"
+    )
+    selection = schema["properties"]["canonical_job_selection"]["properties"]
+    assert selection["selector"]["const"] == helpers.CANONICAL_SELECTOR
+    assert selection["canonical_job_count"]["const"] == helpers.CANONICAL_JOB_COUNT
+    assert selection["superseded_job_count"]["const"] == helpers.SUPERSEDED_JOB_COUNT
+
+
+def test_matrix_documents_all_required_metrics() -> None:
+    documented = {row["metric"] for row in helpers.METRIC_MATRIX}
+    required = {
+        "gross_pnl_quote",
+        "net_pnl_quote",
+        "fees_total_quote",
+        "slippage",
+        "max_drawdown_r",
+        "fee_adjusted_max_drawdown_r",
+        "profit_factor",
+        "fee_adjusted_profit_factor",
+        "expectancy_r",
+        "fee_adjusted_expectancy_r",
+        "closed_trades_total",
+        "win_rate",
+        "avg_win_r",
+        "avg_loss_r",
+        "exposure_or_time_in_market",
+        "regime_behavior",
+        "scenario_sensitivity",
+        "window_stability",
+    }
+    assert documented == required
+
+
+def test_matrix_markdown_exists_and_declares_ready_outcome() -> None:
+    text = helpers.MATRIX_PATH.read_text(encoding="utf-8")
+    assert helpers.OUTCOME_READY in text
+    assert helpers.CANONICAL_SELECTOR in text
+    assert "ranking_ready" in text
+    assert "historical_cross_venue_research" in text
+    for row in helpers.METRIC_MATRIX:
+        assert row["metric"] in text
+
+
+def test_canonical_selection_excludes_superseded_jobs() -> None:
+    queue = _load(FIXTURES / "canonical_selection_queue_slice.v1.json")
+    jobs = queue["jobs"]
+    assert len(jobs) == 9
+    canonical = helpers.select_canonical_jobs(jobs)
+    assert len(canonical) == 3
+    superseded = [j for j in jobs if j.get("superseded_by_stress_v2_rerun") is True]
+    assert len(superseded) == helpers.SUPERSEDED_JOB_COUNT
+
+
+def test_unknown_superseded_status_fails_closed() -> None:
+    with pytest.raises(helpers.VacationMetricContractError, match="unknown"):
+        helpers.is_canonical_queue_job(
+            {"job_id": "bad", "superseded_by_stress_v2_rerun": "maybe"}
+        )
+
+
+def test_zero_trade_is_valid_not_missing() -> None:
+    payload = _load(FIXTURES / "primary_zero_trade_baseline_metrics.v1.json")
+    metrics = payload["metrics"]
+    assert metrics["closed_trades_total"] == 0
+    assert helpers.metric_is_missing(metrics, "closed_trades_total") is False
+    assert helpers.is_rankable_job_metrics(metrics) is False
+
+
+def test_missing_trade_dependent_fields_are_not_zero() -> None:
+    payload = _load(FIXTURES / "primary_zero_trade_baseline_metrics.v1.json")
+    metrics = payload["metrics"]
+    for field in (
+        "fee_adjusted_max_drawdown_r",
+        "fee_adjusted_profit_factor",
+        "fee_adjusted_expectancy_r",
+        "avg_win_r",
+        "avg_loss_r",
+    ):
+        assert helpers.metric_is_missing(metrics, field) is True
+
+
+def test_traded_job_is_rankable() -> None:
+    payload = _load(FIXTURES / "donchian_monthly_baseline_metrics.v1.json")
+    assert helpers.is_rankable_job_metrics(payload["metrics"]) is True
+
+
+def test_campaign_queue_state_canonical_counts_when_present() -> None:
+    campaign_queue = (
+        helpers.REPO_ROOT
+        / "artifacts"
+        / "arvp_vacation"
+        / helpers.CAMPAIGN_ID
+        / "queue_state.json"
+    )
+    if not campaign_queue.is_file():
+        pytest.skip("local campaign queue_state.json not available")
+    state = _load(campaign_queue)
+    jobs = state.get("jobs") or []
+    assert len(jobs) == helpers.QUEUE_RECORD_COUNT
+    canonical = helpers.select_canonical_jobs(jobs)
+    assert len(canonical) == helpers.CANONICAL_JOB_COUNT
+    superseded = [j for j in jobs if j.get("superseded_by_stress_v2_rerun") is True]
+    assert len(superseded) == helpers.SUPERSEDED_JOB_COUNT
+
+
+def test_slippage_classified_not_available() -> None:
+    row = next(r for r in helpers.METRIC_MATRIX if r["metric"] == "slippage")
+    assert row["classification"] == "not_available"
+
+
+@pytest.mark.parametrize(
+    ("fixture_path", "expect_rankable"),
+    [
+        (FIXTURES / "donchian_monthly_baseline_metrics.v1.json", True),
+        (FIXTURES / "donchian_stress_v2_baseline_metrics.v1.json", True),
+        (FIXTURES / "primary_zero_trade_baseline_metrics.v1.json", False),
+    ],
+    ids=["donchian_monthly", "donchian_stress_v2", "primary_zero_trade"],
+)
+def test_fixture_rankable_semantics(fixture_path: Path, expect_rankable: bool) -> None:
+    payload = _load(fixture_path)
+    assert helpers.is_rankable_job_metrics(payload["metrics"]) is expect_rankable


### PR DESCRIPTION
## Summary
Closes #4014
Refs #4013
Blocks #4015

Define the versioned ARVP vacation replay artifact contract and a belegte Metric Availability Matrix for the Binance historical campaign #3990.

## Delivered
- `docs/evidence/arvp_3990_metric_availability_matrix.md` with campaign boundary, 18-metric matrix, 12-job sample validation, and `READY_FOR_METRIC_EXTRACTION`
- `docs/contracts/arvp_vacation_job_metrics.v1.schema.json` minimal JSON Schema with canonical 318-job selection documentation
- `tests/unit/arvp/test_vacation_metric_availability_contract.py` + redacted fixtures under `tests/fixtures/arvp/vacation_metrics/`
- Canonical selector `superseded_by_stress_v2_rerun != true`, fail-closed unknown superseded, zero-trade rankable=false semantics

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- repo_fallback_reason: insufficient_evidence
- Live GitHub issues #4013/#4014/#4015 verified via `gh issue view`
- Campaign queue_state crosscheck: 324 records, 318 canonical, 6 superseded

## Canonical 318-job selection
- Selector: `superseded_by_stress_v2_rerun != true`
- 6 superseded legacy stress FAIL jobs excluded by ID
- Original + v2 stress replacements never aggregated together
- Zero `closed_trades_total` is valid; missing field is missing

## Validation
- `python -m pytest -q tests/unit/arvp/test_vacation_metric_availability_contract.py` (16 passed)
- `ruff check` on changed Python files (green)
- `python -m json.tool docs/contracts/arvp_vacation_job_metrics.v1.schema.json` (valid)
- `git diff --check` (green)

## Non-goals
- No metric extractor implementation (#4015)
- No summary.py field-mapping fix (#4015)
- No PEP generation (#4016) or league table (#4017)
- No replay reruns, runtime changes, or campaign mutation

## Safety boundaries
- LR NO-GO unchanged
- ranking_ready remains false
- historical_cross_venue_research only; no MEXC confirmation or promotion language

## Restunsicherheiten
- `fee_adjusted_max_drawdown_r` absent on donchian/breakout_trend_filter adapters is documented as artifact reality
- `window_stability` aggregation policy deferred to #4015/#4017
- Absolute paths in local queue_state artifacts require normalization in extractor stage