### PR TITLE
feat(arvp): add deterministic strategy metric extraction

### DIFF
--- a/docs/contracts/arvp_strategy_metrics.v1.schema.json
+++ b/docs/contracts/arvp_strategy_metrics.v1.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ARVP Strategy Metrics Contract",
+  "description": "Normalized per-job per-scenario strategy metrics for ARVP vacation replay campaigns. Issue #4015.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "campaign_id",
+    "canonical_job_selection",
+    "record_count",
+    "content_hash",
+    "records"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "arvp_strategy_metrics.v1"
+    },
+    "campaign_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "canonical_job_selection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "selector",
+        "queue_record_count",
+        "canonical_job_count",
+        "excluded_superseded_job_count"
+      ],
+      "properties": {
+        "selector": {
+          "const": "superseded_by_stress_v2_rerun != true"
+        },
+        "queue_record_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "canonical_job_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "excluded_superseded_job_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "record_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "content_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/strategy_metric_record"
+      }
+    }
+  },
+  "definitions": {
+    "strategy_metric_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "campaign_id",
+        "job_id",
+        "strategy_id",
+        "window_id",
+        "window_class",
+        "purpose",
+        "scenario",
+        "source_artifact",
+        "source_artifact_sha256",
+        "evidence_class",
+        "venue",
+        "canonical_job",
+        "gross_pnl_quote",
+        "net_pnl_quote",
+        "fees_total_quote",
+        "max_drawdown_r",
+        "fee_adjusted_max_drawdown_r",
+        "profit_factor",
+        "fee_adjusted_profit_factor",
+        "expectancy_r",
+        "fee_adjusted_expectancy_r",
+        "closed_trades_total",
+        "win_rate",
+        "avg_win_r",
+        "avg_loss_r",
+        "candles_total",
+        "slippage_availability",
+        "regime_availability",
+        "exposure_availability",
+        "rankable",
+        "not_rankable_reasons",
+        "data_quality_flags"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "arvp_strategy_metrics.v1"
+        },
+        "campaign_id": { "type": "string" },
+        "job_id": { "type": "string" },
+        "strategy_id": { "type": "string" },
+        "window_id": { "type": "string" },
+        "window_class": { "type": "string" },
+        "purpose": { "type": ["string", "null"] },
+        "scenario": {
+          "type": "string",
+          "enum": ["baseline", "pessimistic_execution", "feed_gap"]
+        },
+        "source_artifact": { "type": "string" },
+        "source_artifact_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "evidence_class": {
+          "const": "historical_cross_venue_research"
+        },
+        "venue": { "const": "binance" },
+        "canonical_job": { "const": true },
+        "gross_pnl_quote": { "type": ["number", "null"] },
+        "net_pnl_quote": { "type": ["number", "null"] },
+        "fees_total_quote": { "type": ["number", "null"] },
+        "max_drawdown_r": { "type": ["number", "null"] },
+        "fee_adjusted_max_drawdown_r": { "type": ["number", "null"] },
+        "profit_factor": {
+          "oneOf": [
+            { "type": "number" },
+            { "type": "null" },
+            { "const": "infinity" },
+            { "const": "-infinity" }
+          ]
+        },
+        "fee_adjusted_profit_factor": {
+          "oneOf": [
+            { "type": "number" },
+            { "type": "null" },
+            { "const": "infinity" },
+            { "const": "-infinity" }
+          ]
+        },
+        "expectancy_r": { "type": ["number", "null"] },
+        "fee_adjusted_expectancy_r": { "type": ["number", "null"] },
+        "closed_trades_total": { "type": ["integer", "null"] },
+        "win_rate": { "type": ["number", "null"] },
+        "avg_win_r": { "type": ["number", "null"] },
+        "avg_loss_r": { "type": ["number", "null"] },
+        "candles_total": { "type": ["integer", "null"] },
+        "slippage_availability": {
+          "type": "string",
+          "enum": ["available", "not_available", "partial"]
+        },
+        "regime_availability": {
+          "type": "string",
+          "enum": ["available", "not_available", "partial"]
+        },
+        "exposure_availability": {
+          "type": "string",
+          "enum": ["available", "not_available", "partial"]
+        },
+        "rankable": { "type": "boolean" },
+        "not_rankable_reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "data_quality_flags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/evidence/arvp_3990_strategy_metric_extraction.md
+++ b/docs/evidence/arvp_3990_strategy_metric_extraction.md
@@ -1,0 +1,99 @@
+# ARVP #3990 Strategy Metric Extraction Evidence
+
+**Date:** 2026-07-13  
+**Issue:** [#4015](https://github.com/jannekbuengener/Claire_de_Binare/issues/4015)  
+**Parent:** [#4013](https://github.com/jannekbuengener/Claire_de_Binare/issues/4013)  
+**Blocks:** [#4016](https://github.com/jannekbuengener/Claire_de_Binare/issues/4016)  
+**LR:** NO-GO  
+**Evidence class:** `historical_cross_venue_research`  
+**Outcome:** `READY_FOR_CANDIDATE_EVIDENCE`  
+**ranking_ready:** `false` (unchanged)
+
+---
+
+## Brain Evidence
+
+| Field | Value |
+|-------|-------|
+| brain_source | repo-only |
+| brain_status | not-used |
+| context_brain_attempted | true |
+| context_brain_used | false |
+| repo_fallback_reason | insufficient_evidence |
+| records_found | none |
+
+Repo crosscheck: live `queue_state.json`, `tools/arvp_vacation/strategy_metric_extraction.py`, `docs/contracts/arvp_strategy_metrics.v1.schema.json`, GitHub issues #4013/#4015/#4016.
+
+---
+
+## Canonical Selection
+
+| Field | Value |
+|-------|-------|
+| Campaign ID | `arvp_binance_historical_3990_2bb32b68_20260712T111944Z` |
+| Selector | `superseded_by_stress_v2_rerun != true` |
+| Queue records | 324 |
+| Canonical jobs | **318** |
+| Superseded excluded | **6** |
+| Scenario records emitted | **954** (318 × 3 scenarios) |
+
+Original legacy stress FAIL jobs and stress-v2 replacements are never aggregated together.
+
+---
+
+## Deterministic Content Hash
+
+| Field | Value |
+|-------|-------|
+| Algorithm | SHA-256 over canonical JSON (`core.replay.canonical_json`) |
+| Input set | Sorted list of per-record hashable payloads (318 canonical jobs × 3 scenarios) |
+| Excluded from hash | `source_artifact_sha256` only |
+| Content hash | `ad3d4ccc449e81e4aa5ec81185d6b3229d12a9e05b2e4970dd352b7471e5b7ad` |
+
+Re-run command (read-only):
+
+```bash
+python -m tools.arvp_vacation.strategy_metric_extraction \
+  --queue-state artifacts/arvp_vacation/arvp_binance_historical_3990_2bb32b68_20260712T111944Z/queue_state.json \
+  --hash-only
+```
+
+Second identical run reproduced the same hash on 2026-07-13.
+
+---
+
+## Contract and Mapping
+
+- Output contract: [`docs/contracts/arvp_strategy_metrics.v1.schema.json`](../contracts/arvp_strategy_metrics.v1.schema.json)
+- Input contract: [`docs/contracts/arvp_vacation_job_metrics.v1.schema.json`](../contracts/arvp_vacation_job_metrics.v1.schema.json)
+- Availability matrix: [`docs/evidence/arvp_3990_metric_availability_matrix.md`](arvp_3990_metric_availability_matrix.md)
+- Summary mapping fix: `tools/arvp_vacation/summary.py` reads nested `metrics.*` first, legacy aliases second
+- Missing semantics: absent/null stays null; zero trades stay `0`; `rankable=false` when `closed_trades_total == 0`
+- Slippage: `slippage_availability=not_available` (no invented per-trade slippage)
+- Candles: deterministic fallback prefers `candles_live`, else `candles_total`; mismatch flagged in `data_quality_flags`
+
+---
+
+## PR #4019 Review Findings Resolved
+
+| Finding | Resolution |
+|---------|------------|
+| schema-version-writer | Every record and bundle emit `schema_version=arvp_strategy_metrics.v1` |
+| slippage-path | `slippage_availability=not_available`; no fabricated slippage metric |
+| candle-count-path | `resolve_candles_total()` with live→total fallback and mismatch flag |
+
+---
+
+## Safety
+
+- LR remains **NO-GO**
+- `ranking_ready=false`
+- Binance historical research only; not MEXC same-venue confirmation
+- No replay reruns, no campaign artifact mutation, no promotion language
+
+---
+
+## Exit Gate for #4016
+
+Child 2 delivers versioned normalized metrics and a stable campaign content hash.  
+**Exit gate:** `READY_FOR_CANDIDATE_EVIDENCE`

--- a/tests/fixtures/arvp/strategy_metrics/extraction_queue_slice.v1.json
+++ b/tests/fixtures/arvp/strategy_metrics/extraction_queue_slice.v1.json
@@ -1,0 +1,179 @@
+{
+  "schema_version": "1.0",
+  "campaign_id": "arvp_binance_historical_3990_2bb32b68_20260712T111944Z",
+  "jobs": [
+    {
+      "job_id": "vac-donchian-breakout-v1-binance_1m_month_2017_10-scenarios",
+      "strategy_id": "donchian_breakout_v1",
+      "dataset_id": "binance_1m_month_2017_10",
+      "spec_path": "artifacts/market_data/window_bank/binance/spot/BTCUSDT/1m/binance_1m_month_2017_10/dataset_spec.json",
+      "status": "PASS",
+      "artifacts_complete": true,
+      "scenarios": ["baseline", "pessimistic_execution", "feed_gap"],
+      "scenario_metrics": {
+        "baseline": {
+          "scenario_id": "baseline",
+          "strategy_id": "donchian_breakout_v1",
+          "dataset_summary": {
+            "candles_live": 44620,
+            "candles_total": 44640
+          },
+          "metrics": {
+            "closed_trades_total": 563,
+            "gross_pnl_quote": -8601.13,
+            "net_pnl_quote": -12152.38,
+            "fees_total_quote": 3551.25,
+            "max_drawdown_r": 2.35,
+            "profit_factor": 0.42,
+            "fee_adjusted_profit_factor": 0.2,
+            "expectancy_r": -0.003,
+            "fee_adjusted_expectancy_r": -0.004,
+            "win_rate": 0.19,
+            "avg_win_r": 0.0063,
+            "avg_loss_r": -0.0053,
+            "signals_total": 563,
+            "metrics_availability": {
+              "slippage_per_trade_available": false
+            }
+          }
+        },
+        "pessimistic_execution": {
+          "scenario_id": "pessimistic_execution",
+          "strategy_id": "donchian_breakout_v1",
+          "dataset_summary": {
+            "candles_live": 44620,
+            "candles_total": 44640
+          },
+          "metrics": {
+            "closed_trades_total": 563,
+            "gross_pnl_quote": -9000.0,
+            "net_pnl_quote": -12500.0,
+            "fees_total_quote": 3500.0,
+            "max_drawdown_r": 2.4,
+            "profit_factor": 0.4,
+            "fee_adjusted_profit_factor": 0.19,
+            "expectancy_r": -0.004,
+            "fee_adjusted_expectancy_r": -0.005,
+            "win_rate": 0.18,
+            "signals_total": 563,
+            "metrics_availability": {
+              "slippage_per_trade_available": false
+            }
+          }
+        },
+        "feed_gap": {
+          "scenario_id": "feed_gap",
+          "strategy_id": "donchian_breakout_v1",
+          "dataset_summary": {
+            "candles_live": 44620,
+            "candles_total": 44640
+          },
+          "metrics": {
+            "closed_trades_total": 560,
+            "gross_pnl_quote": -8500.0,
+            "net_pnl_quote": -12000.0,
+            "fees_total_quote": 3500.0,
+            "max_drawdown_r": 2.3,
+            "profit_factor": 0.41,
+            "fee_adjusted_profit_factor": 0.2,
+            "expectancy_r": -0.003,
+            "fee_adjusted_expectancy_r": -0.004,
+            "win_rate": 0.19,
+            "signals_total": 560,
+            "metrics_availability": {
+              "slippage_per_trade_available": false
+            }
+          }
+        }
+      }
+    },
+    {
+      "job_id": "vac-primary-breakout-v1-binance_1m_month_2017_11-scenarios",
+      "strategy_id": "primary_breakout_v1",
+      "dataset_id": "binance_1m_month_2017_11",
+      "spec_path": "artifacts/market_data/window_bank/binance/spot/BTCUSDT/1m/binance_1m_month_2017_11/dataset_spec.json",
+      "status": "PASS",
+      "artifacts_complete": true,
+      "scenarios": ["baseline", "pessimistic_execution", "feed_gap"],
+      "scenario_metrics": {
+        "baseline": {
+          "scenario_id": "baseline",
+          "strategy_id": "primary_breakout_v1",
+          "dataset_summary": {
+            "candles_total": 43200
+          },
+          "metrics": {
+            "closed_trades_total": 0,
+            "gross_pnl_quote": 0,
+            "net_pnl_quote": 0,
+            "fees_total_quote": 0,
+            "max_drawdown_r": 0.0,
+            "profit_factor": 0.0,
+            "expectancy_r": 0.0,
+            "win_rate": 0.0,
+            "fee_adjusted_max_drawdown_r": null,
+            "fee_adjusted_profit_factor": null,
+            "fee_adjusted_expectancy_r": null,
+            "avg_win_r": null,
+            "avg_loss_r": null,
+            "signals_total": 0,
+            "metrics_availability": {
+              "slippage_per_trade_available": false
+            }
+          }
+        },
+        "pessimistic_execution": {
+          "scenario_id": "pessimistic_execution",
+          "strategy_id": "primary_breakout_v1",
+          "dataset_summary": {
+            "candles_total": 43200
+          },
+          "metrics": {
+            "closed_trades_total": 0,
+            "gross_pnl_quote": 0,
+            "net_pnl_quote": 0,
+            "fees_total_quote": 0,
+            "max_drawdown_r": 0.0,
+            "profit_factor": 0.0,
+            "expectancy_r": 0.0,
+            "win_rate": 0.0,
+            "signals_total": 0,
+            "metrics_availability": {
+              "slippage_per_trade_available": false
+            }
+          }
+        },
+        "feed_gap": {
+          "scenario_id": "feed_gap",
+          "strategy_id": "primary_breakout_v1",
+          "dataset_summary": {
+            "candles_total": 43200
+          },
+          "metrics": {
+            "closed_trades_total": 0,
+            "gross_pnl_quote": 0,
+            "net_pnl_quote": 0,
+            "fees_total_quote": 0,
+            "max_drawdown_r": 0.0,
+            "profit_factor": 0.0,
+            "expectancy_r": 0.0,
+            "win_rate": 0.0,
+            "signals_total": 0,
+            "metrics_availability": {
+              "slippage_per_trade_available": false
+            }
+          }
+        }
+      }
+    },
+    {
+      "job_id": "vac-donchian-breakout-v1-binance_1m_stress_max_drawdown-scenarios",
+      "strategy_id": "donchian_breakout_v1",
+      "dataset_id": "binance_1m_stress_max_drawdown",
+      "status": "FAIL",
+      "superseded_by_stress_v2_rerun": true,
+      "artifacts_complete": false
+    }
+  ],
+  "_fixture_note": "Redacted extraction slice: 2 canonical jobs + 1 superseded stress job."
+}

--- a/tests/unit/arvp/_arvp_vacation_metric_contract_helpers.py
+++ b/tests/unit/arvp/_arvp_vacation_metric_contract_helpers.py
@@ -13,15 +13,18 @@ SCHEMA_PATH = (
 )
 MATRIX_PATH = REPO_ROOT / "docs" / "evidence" / "arvp_3990_metric_availability_matrix.md"
 CAMPAIGN_ID = "arvp_binance_historical_3990_2bb32b68_20260712T111944Z"
-CANONICAL_JOB_COUNT = 318
-SUPERSEDED_JOB_COUNT = 6
-QUEUE_RECORD_COUNT = 324
-CANONICAL_SELECTOR = "superseded_by_stress_v2_rerun != true"
-OUTCOME_READY = "READY_FOR_METRIC_EXTRACTION"
-
-
-class VacationMetricContractError(ValueError):
-    """Fail-closed contract violation for vacation metric availability."""
+from tools.arvp_vacation.metric_contract import (
+    CANONICAL_JOB_COUNT,
+    CANONICAL_SELECTOR,
+    OUTCOME_READY,
+    QUEUE_RECORD_COUNT,
+    SUPERSEDED_JOB_COUNT,
+    VacationMetricContractError,
+    is_canonical_queue_job,
+    is_rankable_job_metrics,
+    metric_is_missing,
+    select_canonical_jobs,
+)
 
 
 METRIC_MATRIX: tuple[dict[str, str], ...] = (
@@ -229,45 +232,6 @@ METRIC_MATRIX: tuple[dict[str, str], ...] = (
 def load_json(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
-
-
-def is_canonical_queue_job(job: Mapping[str, Any]) -> bool:
-    """Return True for canonical jobs per superseded_by_stress_v2_rerun != true."""
-    superseded = job.get("superseded_by_stress_v2_rerun")
-    if superseded is True:
-        return False
-    if superseded is False or superseded is None:
-        return True
-    raise VacationMetricContractError(
-        f"unknown superseded_by_stress_v2_rerun value: {superseded!r}"
-    )
-
-
-def select_canonical_jobs(jobs: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    canonical: list[dict[str, Any]] = []
-    for job in jobs:
-        if not isinstance(job, dict):
-            raise VacationMetricContractError("queue job must be object")
-        if is_canonical_queue_job(job):
-            canonical.append(job)
-    return canonical
-
-
-def is_rankable_job_metrics(metrics: Mapping[str, Any]) -> bool:
-    if "closed_trades_total" not in metrics:
-        return False
-    try:
-        return int(metrics["closed_trades_total"]) > 0
-    except (TypeError, ValueError) as exc:
-        raise VacationMetricContractError(
-            "closed_trades_total must be integer-like"
-        ) from exc
-
-
-def metric_is_missing(metrics: Mapping[str, Any], field: str) -> bool:
-    if field not in metrics:
-        return True
-    return metrics[field] is None
 
 
 def scenario_metric_field_path(scenario_id: str, metric_field: str) -> str:

--- a/tests/unit/arvp/test_strategy_metric_extraction.py
+++ b/tests/unit/arvp/test_strategy_metric_extraction.py
@@ -1,0 +1,265 @@
+"""Deterministic ARVP strategy metric extraction tests (#4015)."""
+
+from __future__ import annotations
+
+import copy
+import json
+import math
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from core.replay.canonical_json import canonical_json_dumps
+from tools.arvp_vacation.metric_contract import (
+    CANONICAL_JOB_COUNT,
+    QUEUE_RECORD_COUNT,
+    SUPERSEDED_JOB_COUNT,
+)
+from tools.arvp_vacation.strategy_metric_extraction import (
+    PROFIT_FACTOR_INFINITY_TOKEN,
+    SCHEMA_VERSION,
+    StrategyMetricExtractionError,
+    build_extraction_bundle,
+    extract_campaign_metrics,
+    resolve_candles_total,
+)
+from tools.arvp_vacation.summary import _metrics_summary
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "arvp" / "strategy_metrics"
+SCHEMA_PATH = REPO_ROOT / "docs" / "contracts" / "arvp_strategy_metrics.v1.schema.json"
+CAMPAIGN_QUEUE = (
+    REPO_ROOT
+    / "artifacts"
+    / "arvp_vacation"
+    / "arvp_binance_historical_3990_2bb32b68_20260712T111944Z"
+    / "queue_state.json"
+)
+GOLDEN_CONTENT_HASH = (
+    "ad3d4ccc449e81e4aa5ec81185d6b3229d12a9e05b2e4970dd352b7471e5b7ad"
+)
+
+
+def _load(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return _load(SCHEMA_PATH)
+
+
+@pytest.fixture(scope="module")
+def schema_validator(schema: dict) -> Draft7Validator:
+    return Draft7Validator(schema)
+
+
+def test_schema_declares_version_and_selector(schema: dict) -> None:
+    assert schema["properties"]["schema_version"]["const"] == SCHEMA_VERSION
+    selection = schema["properties"]["canonical_job_selection"]["properties"]
+    assert selection["selector"]["const"] == "superseded_by_stress_v2_rerun != true"
+
+
+def test_slice_fixture_extracts_two_canonical_jobs_and_excludes_superseded() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    bundle = build_extraction_bundle(queue, repo_root=REPO_ROOT)
+    assert bundle["canonical_job_selection"]["canonical_job_count"] == 2
+    assert bundle["canonical_job_selection"]["excluded_superseded_job_count"] == 1
+    assert bundle["record_count"] == 6
+    job_ids = {record["job_id"] for record in bundle["records"]}
+    assert "vac-donchian-breakout-v1-binance_1m_stress_max_drawdown-scenarios" not in job_ids
+
+
+def test_zero_trade_job_is_not_rankable() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    records, _ = extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+    zero_trade = [
+        record
+        for record in records
+        if record["job_id"] == "vac-primary-breakout-v1-binance_1m_month_2017_11-scenarios"
+    ]
+    assert len(zero_trade) == 3
+    assert all(record["rankable"] is False for record in zero_trade)
+    assert all("zero_closed_trades_total" in record["not_rankable_reasons"] for record in zero_trade)
+
+
+def test_missing_trade_field_is_missing_not_zero() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    job = queue["jobs"][1]
+    del job["scenario_metrics"]["baseline"]["metrics"]["closed_trades_total"]
+    records, _ = extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+    baseline = next(
+        record
+        for record in records
+        if record["job_id"] == job["job_id"] and record["scenario"] == "baseline"
+    )
+    assert baseline["closed_trades_total"] is None
+    assert baseline["rankable"] is False
+    assert "missing_closed_trades_total" in baseline["not_rankable_reasons"]
+
+
+def test_nested_metrics_map_to_summary_fields() -> None:
+    job = {
+        "scenario_metrics": {
+            "baseline": {
+                "metrics": {
+                    "closed_trades_total": 12,
+                    "net_pnl_quote": -3.5,
+                    "profit_factor": 0.8,
+                    "expectancy_r": -0.01,
+                    "max_drawdown_r": 1.2,
+                    "win_rate": 0.4,
+                }
+            }
+        }
+    }
+    summary = _metrics_summary(job)
+    assert summary["baseline"]["trade_count"] == 12
+    assert summary["baseline"]["net_pnl"] == -3.5
+    assert summary["baseline"]["profit_factor"] == 0.8
+    assert summary["baseline"]["expectancy"] == -0.01
+    assert summary["baseline"]["max_drawdown"] == 1.2
+    assert summary["baseline"]["win_rate"] == 0.4
+
+
+def test_legacy_top_level_summary_fields_remain_supported() -> None:
+    job = {
+        "scenario_metrics": {
+            "baseline": {
+                "trade_count": 4,
+                "net_pnl": 1.5,
+                "win_rate": 0.5,
+            }
+        }
+    }
+    summary = _metrics_summary(job)
+    assert summary["baseline"]["trade_count"] == 4
+    assert summary["baseline"]["net_pnl"] == 1.5
+
+
+def test_slippage_availability_is_not_available() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    records, _ = extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+    assert all(record["slippage_availability"] == "not_available" for record in records)
+
+
+def test_candles_total_prefers_live_on_conflict() -> None:
+    candles, flags = resolve_candles_total(
+        {"candles_live": 100, "candles_total": 120}
+    )
+    assert candles == 100
+    assert "candles_live_candles_total_mismatch" in flags
+
+
+def test_candles_total_falls_back_to_total() -> None:
+    candles, flags = resolve_candles_total({"candles_total": 43200})
+    assert candles == 43200
+    assert flags == []
+
+
+def test_conflicting_candle_values_surface_data_quality_flag() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    records, _ = extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+    donchian = next(
+        record
+        for record in records
+        if record["job_id"].startswith("vac-donchian-breakout-v1-binance_1m_month")
+        and record["scenario"] == "baseline"
+    )
+    assert donchian["candles_total"] == 44620
+    assert "candles_live_candles_total_mismatch" in donchian["data_quality_flags"]
+
+
+def test_profit_factor_infinity_is_canonical() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    queue = copy.deepcopy(queue)
+    queue["jobs"][0]["scenario_metrics"]["baseline"]["metrics"]["profit_factor"] = (
+        math.inf
+    )
+    records, _ = extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+    baseline = next(
+        record
+        for record in records
+        if record["scenario"] == "baseline"
+        and record["job_id"].startswith("vac-donchian-breakout-v1-binance_1m_month")
+    )
+    assert baseline["profit_factor"] == PROFIT_FACTOR_INFINITY_TOKEN
+
+
+def test_nan_profit_factor_fails_closed() -> None:
+    queue = copy.deepcopy(_load(FIXTURES / "extraction_queue_slice.v1.json"))
+    queue["jobs"][0]["scenario_metrics"]["baseline"]["metrics"]["profit_factor"] = (
+        math.nan
+    )
+    with pytest.raises(StrategyMetricExtractionError, match="non-finite"):
+        extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+
+
+def test_extraction_is_byte_identical_on_repeat() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    first = canonical_json_dumps(build_extraction_bundle(queue, repo_root=REPO_ROOT))
+    second = canonical_json_dumps(build_extraction_bundle(queue, repo_root=REPO_ROOT))
+    assert first == second
+
+
+def test_input_job_order_does_not_change_hash() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    reversed_queue = copy.deepcopy(queue)
+    reversed_queue["jobs"] = list(reversed(reversed_queue["jobs"]))
+    first = build_extraction_bundle(queue, repo_root=REPO_ROOT)["content_hash"]
+    second = build_extraction_bundle(reversed_queue, repo_root=REPO_ROOT)["content_hash"]
+    assert first == second
+
+
+def test_slice_bundle_validates_against_schema(
+    schema_validator: Draft7Validator,
+) -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    bundle = build_extraction_bundle(queue, repo_root=REPO_ROOT)
+    errors = sorted(schema_validator.iter_errors(bundle), key=lambda err: err.message)
+    assert not errors, [error.message for error in errors]
+
+
+def test_campaign_queue_canonical_counts_when_present() -> None:
+    if not CAMPAIGN_QUEUE.is_file():
+        pytest.skip("local campaign queue_state.json not available")
+    queue = _load(CAMPAIGN_QUEUE)
+    bundle = build_extraction_bundle(queue, repo_root=REPO_ROOT)
+    assert bundle["canonical_job_selection"]["queue_record_count"] == QUEUE_RECORD_COUNT
+    assert bundle["canonical_job_selection"]["canonical_job_count"] == CANONICAL_JOB_COUNT
+    assert (
+        bundle["canonical_job_selection"]["excluded_superseded_job_count"]
+        == SUPERSEDED_JOB_COUNT
+    )
+    assert bundle["record_count"] == CANONICAL_JOB_COUNT * 3
+
+
+def test_campaign_content_hash_is_stable_when_present() -> None:
+    if not CAMPAIGN_QUEUE.is_file():
+        pytest.skip("local campaign queue_state.json not available")
+    queue = _load(CAMPAIGN_QUEUE)
+    first = build_extraction_bundle(queue, repo_root=REPO_ROOT)["content_hash"]
+    second = build_extraction_bundle(queue, repo_root=REPO_ROOT)["content_hash"]
+    assert first == second == GOLDEN_CONTENT_HASH
+
+
+def test_record_schema_version_is_emitted() -> None:
+    queue = _load(FIXTURES / "extraction_queue_slice.v1.json")
+    records, _ = extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+    assert all(record["schema_version"] == SCHEMA_VERSION for record in records)
+
+
+def test_purpose_and_window_class_are_separated() -> None:
+    if not CAMPAIGN_QUEUE.is_file():
+        pytest.skip("local campaign queue_state.json not available")
+    queue = _load(CAMPAIGN_QUEUE)
+    records, _ = extract_campaign_metrics(queue, repo_root=REPO_ROOT)
+    purposes = {record["purpose"] for record in records if record["purpose"]}
+    assert {"development", "validation", "out_of_sample", "stress"}.issuperset(purposes)
+    window_classes = {record["window_class"] for record in records}
+    assert "monthly" in window_classes
+    assert "stress" in window_classes

--- a/tools/arvp_vacation/__init__.py
+++ b/tools/arvp_vacation/__init__.py
@@ -6,6 +6,8 @@ __all__ = [
     "contract",
     "coordinator",
     "job_runner",
+    "metric_contract",
     "queue_store",
+    "strategy_metric_extraction",
     "summary",
 ]

--- a/tools/arvp_vacation/metric_contract.py
+++ b/tools/arvp_vacation/metric_contract.py
@@ -1,0 +1,54 @@
+"""Shared ARVP vacation metric contract helpers (#4014, #4015)."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+CANONICAL_JOB_COUNT = 318
+SUPERSEDED_JOB_COUNT = 6
+QUEUE_RECORD_COUNT = 324
+CANONICAL_SELECTOR = "superseded_by_stress_v2_rerun != true"
+OUTCOME_READY = "READY_FOR_METRIC_EXTRACTION"
+
+
+class VacationMetricContractError(ValueError):
+    """Fail-closed contract violation for vacation metric availability."""
+
+
+def is_canonical_queue_job(job: Mapping[str, Any]) -> bool:
+    """Return True for canonical jobs per superseded_by_stress_v2_rerun != true."""
+    superseded = job.get("superseded_by_stress_v2_rerun")
+    if superseded is True:
+        return False
+    if superseded is False or superseded is None:
+        return True
+    raise VacationMetricContractError(
+        f"unknown superseded_by_stress_v2_rerun value: {superseded!r}"
+    )
+
+
+def select_canonical_jobs(jobs: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    canonical: list[dict[str, Any]] = []
+    for job in jobs:
+        if not isinstance(job, dict):
+            raise VacationMetricContractError("queue job must be object")
+        if is_canonical_queue_job(job):
+            canonical.append(job)
+    return canonical
+
+
+def is_rankable_job_metrics(metrics: Mapping[str, Any]) -> bool:
+    if "closed_trades_total" not in metrics:
+        return False
+    try:
+        return int(metrics["closed_trades_total"]) > 0
+    except (TypeError, ValueError) as exc:
+        raise VacationMetricContractError(
+            "closed_trades_total must be integer-like"
+        ) from exc
+
+
+def metric_is_missing(metrics: Mapping[str, Any], field: str) -> bool:
+    if field not in metrics:
+        return True
+    return metrics[field] is None

--- a/tools/arvp_vacation/strategy_metric_extraction.py
+++ b/tools/arvp_vacation/strategy_metric_extraction.py
@@ -1,0 +1,479 @@
+"""Deterministic ARVP strategy metric extraction (#4015).
+
+Reads canonical vacation queue jobs and emits normalized ``arvp_strategy_metrics.v1``
+records with stable ordering and content hashing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+
+from .metric_contract import (
+    CANONICAL_JOB_COUNT,
+    CANONICAL_SELECTOR,
+    QUEUE_RECORD_COUNT,
+    SUPERSEDED_JOB_COUNT,
+    is_rankable_job_metrics,
+    metric_is_missing,
+    select_canonical_jobs,
+)
+
+SCHEMA_VERSION = "arvp_strategy_metrics.v1"
+EVIDENCE_CLASS = "historical_cross_venue_research"
+VENUE = "binance"
+ALLOWED_SCENARIOS = frozenset(
+    {"baseline", "pessimistic_execution", "feed_gap"}
+)
+
+REQUIRED_METRIC_FIELDS = (
+    "gross_pnl_quote",
+    "net_pnl_quote",
+    "fees_total_quote",
+    "max_drawdown_r",
+    "profit_factor",
+    "expectancy_r",
+    "closed_trades_total",
+    "win_rate",
+)
+
+OPTIONAL_METRIC_FIELDS = (
+    "fee_adjusted_max_drawdown_r",
+    "fee_adjusted_profit_factor",
+    "fee_adjusted_expectancy_r",
+    "avg_win_r",
+    "avg_loss_r",
+    "candles_total",
+)
+
+PROFIT_FACTOR_INFINITY_TOKEN = "infinity"
+PROFIT_FACTOR_NEGATIVE_INFINITY_TOKEN = "-infinity"
+
+
+class StrategyMetricExtractionError(ValueError):
+    """Fail-closed extraction violation."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionSummary:
+    queue_record_count: int
+    canonical_job_count: int
+    excluded_superseded_job_count: int
+    record_count: int
+    content_hash: str
+
+
+def _repo_relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise StrategyMetricExtractionError(f"JSON root must be object: {path}")
+    return payload
+
+
+def _load_dataset_spec(spec_path: str | None, repo_root: Path) -> dict[str, Any]:
+    if not spec_path:
+        return {}
+    candidate = Path(spec_path)
+    if not candidate.is_absolute():
+        candidate = repo_root / candidate
+    if not candidate.is_file():
+        return {}
+    payload = _load_json(candidate)
+    return payload
+
+
+def _window_class_from_spec(spec: Mapping[str, Any], dataset_id: str) -> str:
+    overlap = spec.get("overlap_class")
+    if isinstance(overlap, str) and overlap.strip():
+        return overlap.strip()
+    if "_stress" in dataset_id or dataset_id.endswith("_v2"):
+        return "stress"
+    return "unknown"
+
+
+def _purpose_from_spec(spec: Mapping[str, Any]) -> str | None:
+    purpose = spec.get("purpose")
+    if isinstance(purpose, str) and purpose.strip():
+        return purpose.strip()
+    return None
+
+
+def _window_id_from_spec(spec: Mapping[str, Any], dataset_id: str) -> str:
+    for key in ("window_id", "dataset_id"):
+        value = spec.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return dataset_id
+
+
+def _normalize_numeric(value: Any, *, field: str) -> Any:
+    if value is None:
+        return None
+    if field in {"profit_factor", "fee_adjusted_profit_factor"}:
+        if isinstance(value, str):
+            token = value.strip().lower()
+            if token == PROFIT_FACTOR_INFINITY_TOKEN:
+                return PROFIT_FACTOR_INFINITY_TOKEN
+            if token == PROFIT_FACTOR_NEGATIVE_INFINITY_TOKEN:
+                return PROFIT_FACTOR_NEGATIVE_INFINITY_TOKEN
+        if isinstance(value, (int, float)):
+            if math.isinf(value):
+                return (
+                    PROFIT_FACTOR_INFINITY_TOKEN
+                    if value > 0
+                    else PROFIT_FACTOR_NEGATIVE_INFINITY_TOKEN
+                )
+            if math.isnan(value):
+                raise StrategyMetricExtractionError(
+                    f"non-finite value for {field}: NaN"
+                )
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            raise StrategyMetricExtractionError(
+                f"non-finite value for {field}: {value!r}"
+            )
+    if field == "closed_trades_total":
+        return int(value)
+    if field == "candles_total":
+        return int(value)
+    if isinstance(value, bool):
+        raise StrategyMetricExtractionError(f"unexpected bool for {field}")
+    if isinstance(value, (int, float)):
+        return value
+    raise StrategyMetricExtractionError(
+        f"unsupported numeric type for {field}: {type(value).__name__}"
+    )
+
+
+def _resolve_metric_value(
+    metrics: Mapping[str, Any],
+    field: str,
+) -> Any:
+    if metric_is_missing(metrics, field):
+        return None
+    return _normalize_numeric(metrics[field], field=field)
+
+
+def resolve_candles_total(
+    dataset_summary: Mapping[str, Any],
+) -> tuple[int | None, list[str]]:
+    flags: list[str] = []
+    live = dataset_summary.get("candles_live")
+    total = dataset_summary.get("candles_total")
+    if live is not None and total is not None and live != total:
+        flags.append("candles_live_candles_total_mismatch")
+        return int(live), flags
+    if live is not None:
+        return int(live), flags
+    if total is not None:
+        return int(total), flags
+    flags.append("candles_total_missing")
+    return None, flags
+
+
+def _scenario_payload_sha256(payload: Mapping[str, Any]) -> str:
+    material = canonical_json_dumps(dict(payload)).encode("utf-8")
+    return hashlib.sha256(material).hexdigest()
+
+
+def _slippage_availability(metrics: Mapping[str, Any]) -> str:
+    availability = metrics.get("metrics_availability")
+    if isinstance(availability, dict):
+        if availability.get("slippage_per_trade_available") is True:
+            return "available"
+        if availability.get("slippage_per_trade_available") is False:
+            return "not_available"
+    return "not_available"
+
+
+def _regime_availability(dataset_spec: Mapping[str, Any]) -> str:
+    regime = dataset_spec.get("regime_distribution")
+    if isinstance(regime, dict) and regime:
+        return "available"
+    return "not_available"
+
+
+def _exposure_availability(
+    metrics: Mapping[str, Any],
+    candles_total: int | None,
+) -> str:
+    if candles_total is None:
+        return "not_available"
+    if "signals_total" not in metrics:
+        return "not_available"
+    return "partial"
+
+
+def _rankability_assessment(
+    metrics: Mapping[str, Any],
+    *,
+    data_quality_flags: Sequence[str],
+) -> tuple[bool, list[str]]:
+    reasons: list[str] = []
+    if "closed_trades_total" not in metrics:
+        reasons.append("missing_closed_trades_total")
+        return False, reasons
+    if not is_rankable_job_metrics(metrics):
+        reasons.append("zero_closed_trades_total")
+        return False, reasons
+    for field in REQUIRED_METRIC_FIELDS:
+        if field == "closed_trades_total":
+            continue
+        if metric_is_missing(metrics, field):
+            reasons.append(f"missing_{field}")
+    for flag in data_quality_flags:
+        if flag.startswith("missing_") or flag.endswith("_mismatch"):
+            reasons.append(flag)
+    if reasons:
+        return False, sorted(set(reasons))
+    return True, []
+
+
+def extract_scenario_record(
+    *,
+    campaign_id: str,
+    job: Mapping[str, Any],
+    scenario_id: str,
+    repo_root: Path,
+) -> dict[str, Any]:
+    if scenario_id not in ALLOWED_SCENARIOS:
+        raise StrategyMetricExtractionError(f"unsupported scenario_id: {scenario_id}")
+
+    scenario_metrics = job.get("scenario_metrics")
+    if not isinstance(scenario_metrics, dict):
+        raise StrategyMetricExtractionError(
+            f"{job.get('job_id')}: missing scenario_metrics"
+        )
+    payload = scenario_metrics.get(scenario_id)
+    if not isinstance(payload, dict):
+        raise StrategyMetricExtractionError(
+            f"{job.get('job_id')}: missing scenario payload for {scenario_id}"
+        )
+
+    metrics = payload.get("metrics")
+    if not isinstance(metrics, dict):
+        raise StrategyMetricExtractionError(
+            f"{job.get('job_id')}: missing metrics for {scenario_id}"
+        )
+
+    dataset_id = str(job.get("dataset_id") or "")
+    dataset_spec = _load_dataset_spec(job.get("spec_path"), repo_root)
+    dataset_summary = payload.get("dataset_summary")
+    if not isinstance(dataset_summary, dict):
+        dataset_summary = {}
+
+    candles_total, candle_flags = resolve_candles_total(dataset_summary)
+    data_quality_flags = list(candle_flags)
+
+    rankable, not_rankable_reasons = _rankability_assessment(
+        metrics,
+        data_quality_flags=data_quality_flags,
+    )
+
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_id": campaign_id,
+        "job_id": str(job.get("job_id") or ""),
+        "strategy_id": str(job.get("strategy_id") or ""),
+        "window_id": _window_id_from_spec(dataset_spec, dataset_id),
+        "window_class": _window_class_from_spec(dataset_spec, dataset_id),
+        "purpose": _purpose_from_spec(dataset_spec),
+        "scenario": scenario_id,
+        "source_artifact": f"queue_state.scenario_metrics.{scenario_id}",
+        "source_artifact_sha256": _scenario_payload_sha256(payload),
+        "evidence_class": EVIDENCE_CLASS,
+        "venue": VENUE,
+        "canonical_job": True,
+        "slippage_availability": _slippage_availability(metrics),
+        "regime_availability": _regime_availability(dataset_spec),
+        "exposure_availability": _exposure_availability(metrics, candles_total),
+        "rankable": rankable,
+        "not_rankable_reasons": not_rankable_reasons,
+        "data_quality_flags": sorted(set(data_quality_flags)),
+    }
+
+    for field in REQUIRED_METRIC_FIELDS + OPTIONAL_METRIC_FIELDS:
+        if field == "candles_total":
+            record[field] = candles_total
+            continue
+        record[field] = _resolve_metric_value(metrics, field)
+
+    return record
+
+
+def _record_sort_key(record: Mapping[str, Any]) -> tuple[str, str]:
+    return (str(record.get("job_id") or ""), str(record.get("scenario") or ""))
+
+
+def extract_campaign_metrics(
+    queue_state: Mapping[str, Any],
+    *,
+    repo_root: Path | None = None,
+) -> tuple[list[dict[str, Any]], ExtractionSummary]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    campaign_id = str(queue_state.get("campaign_id") or "")
+    if not campaign_id:
+        raise StrategyMetricExtractionError("queue_state.campaign_id is required")
+
+    jobs_raw = queue_state.get("jobs") or []
+    if not isinstance(jobs_raw, list):
+        raise StrategyMetricExtractionError("queue_state.jobs must be a list")
+
+    queue_record_count = len(jobs_raw)
+    canonical_jobs = select_canonical_jobs(jobs_raw)
+    canonical_job_count = len(canonical_jobs)
+    excluded_superseded = queue_record_count - canonical_job_count
+
+    if canonical_job_count != CANONICAL_JOB_COUNT and queue_record_count == QUEUE_RECORD_COUNT:
+        raise StrategyMetricExtractionError(
+            f"expected {CANONICAL_JOB_COUNT} canonical jobs, got {canonical_job_count}"
+        )
+    if excluded_superseded != SUPERSEDED_JOB_COUNT and queue_record_count == QUEUE_RECORD_COUNT:
+        raise StrategyMetricExtractionError(
+            f"expected {SUPERSEDED_JOB_COUNT} superseded exclusions, got {excluded_superseded}"
+        )
+
+    records: list[dict[str, Any]] = []
+    for job in sorted(canonical_jobs, key=lambda item: str(item.get("job_id") or "")):
+        scenarios = job.get("scenarios") or sorted(ALLOWED_SCENARIOS)
+        for scenario_id in sorted(str(s) for s in scenarios):
+            if scenario_id not in ALLOWED_SCENARIOS:
+                continue
+            records.append(
+                extract_scenario_record(
+                    campaign_id=campaign_id,
+                    job=job,
+                    scenario_id=scenario_id,
+                    repo_root=root,
+                )
+            )
+
+    records.sort(key=_record_sort_key)
+    content_hash = canonical_hash([_hashable_record(record) for record in records])
+
+    summary = ExtractionSummary(
+        queue_record_count=queue_record_count,
+        canonical_job_count=canonical_job_count,
+        excluded_superseded_job_count=excluded_superseded,
+        record_count=len(records),
+        content_hash=content_hash,
+    )
+    return records, summary
+
+
+def _hashable_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    excluded = {
+        "source_artifact_sha256",
+    }
+    return {k: v for k, v in record.items() if k not in excluded}
+
+
+def build_extraction_bundle(
+    queue_state: Mapping[str, Any],
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    records, summary = extract_campaign_metrics(queue_state, repo_root=repo_root)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "campaign_id": str(queue_state.get("campaign_id") or ""),
+        "canonical_job_selection": {
+            "selector": CANONICAL_SELECTOR,
+            "queue_record_count": summary.queue_record_count,
+            "canonical_job_count": summary.canonical_job_count,
+            "excluded_superseded_job_count": summary.excluded_superseded_job_count,
+        },
+        "record_count": summary.record_count,
+        "content_hash": summary.content_hash,
+        "records": records,
+    }
+
+
+def extract_from_queue_state_path(
+    queue_state_path: Path,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    root = repo_root or Path(__file__).resolve().parents[2]
+    queue_state = _load_json(queue_state_path)
+    return build_extraction_bundle(queue_state, repo_root=root)
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extract deterministic ARVP strategy metrics (arvp_strategy_metrics.v1)."
+    )
+    parser.add_argument(
+        "--queue-state",
+        required=True,
+        help="Path to vacation queue_state.json",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root for dataset_spec resolution",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional output JSON path for extraction bundle",
+    )
+    parser.add_argument(
+        "--hash-only",
+        action="store_true",
+        help="Print only the deterministic content hash",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = Path(args.repo_root).resolve()
+    bundle = extract_from_queue_state_path(
+        Path(args.queue_state).resolve(),
+        repo_root=repo_root,
+    )
+    if args.hash_only:
+        print(bundle["content_hash"])
+    else:
+        print(
+            json.dumps(
+                {
+                    "content_hash": bundle["content_hash"],
+                    "record_count": bundle["record_count"],
+                    "canonical_job_count": bundle["canonical_job_selection"][
+                        "canonical_job_count"
+                    ],
+                    "excluded_superseded_job_count": bundle["canonical_job_selection"][
+                        "excluded_superseded_job_count"
+                    ],
+                },
+                indent=2,
+            )
+        )
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            canonical_json_dumps(bundle) + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/arvp_vacation/summary.py
+++ b/tools/arvp_vacation/summary.py
@@ -21,6 +21,35 @@ VERDICT_REJECT_ECON = "REJECT_ECONOMICS"
 VERDICT_INSUFFICIENT = "INSUFFICIENT_DATA"
 VERDICT_TECH_INVALID = "TECHNICALLY_INVALID"
 
+_SUMMARY_METRIC_ALIASES: dict[str, tuple[str, ...]] = {
+    "trade_count": ("closed_trades_total", "trade_count"),
+    "net_pnl": ("net_pnl_quote", "net_pnl", "total_return"),
+    "profit_factor": ("profit_factor",),
+    "expectancy": ("expectancy_r", "expectancy"),
+    "max_drawdown": ("max_drawdown_r", "max_drawdown"),
+    "win_rate": ("win_rate",),
+    "total_return": ("total_return", "net_pnl_quote", "net_pnl"),
+}
+
+
+def _resolve_scenario_metric(payload: Mapping[str, Any], *field_names: str) -> Any:
+    metrics = payload.get("metrics")
+    if isinstance(metrics, dict):
+        for field in field_names:
+            if field in metrics and metrics[field] is not None:
+                return metrics[field]
+    for field in field_names:
+        if field in payload and payload[field] is not None:
+            return payload[field]
+    return None
+
+
+def _resolve_trade_count(payload: Mapping[str, Any]) -> int | None:
+    value = _resolve_scenario_metric(payload, "closed_trades_total", "trade_count")
+    if value is None:
+        return None
+    return int(value)
+
 
 def _job_verdict(job: Mapping[str, Any]) -> str:
     status = job.get("status")
@@ -40,14 +69,21 @@ def _job_verdict(job: Mapping[str, Any]) -> str:
             return VERDICT_TECH_INVALID
     baseline = metrics.get("baseline") if isinstance(metrics, dict) else None
     if isinstance(baseline, dict):
-        trade_count = int(baseline.get("trade_count") or 0)
+        trade_count = _resolve_trade_count(baseline)
         if trade_count == 0:
             return VERDICT_HOLD
-        net = baseline.get("net_pnl") or baseline.get("total_return")
+        if trade_count is None:
+            return VERDICT_HOLD
+        net = _resolve_scenario_metric(baseline, "net_pnl_quote", "net_pnl", "total_return")
         if net is not None and float(net) < 0:
             pessimistic = metrics.get("pessimistic_execution")
             if isinstance(pessimistic, dict):
-                p_net = pessimistic.get("net_pnl") or pessimistic.get("total_return")
+                p_net = _resolve_scenario_metric(
+                    pessimistic,
+                    "net_pnl_quote",
+                    "net_pnl",
+                    "total_return",
+                )
                 if p_net is not None and float(p_net) < 0:
                     return VERDICT_REJECT_ECON
             return VERDICT_HOLD
@@ -110,9 +146,9 @@ def _metrics_summary(job: Mapping[str, Any]) -> dict[str, Any]:
         if scenario_id.startswith("_") or not isinstance(payload, dict):
             continue
         summary[scenario_id] = {
-            k: payload[k]
-            for k in ("trade_count", "net_pnl", "total_return", "win_rate")
-            if k in payload
+            summary_key: _resolve_scenario_metric(payload, *aliases)
+            for summary_key, aliases in _SUMMARY_METRIC_ALIASES.items()
+            if _resolve_scenario_metric(payload, *aliases) is not None
         }
     return summary
 


### PR DESCRIPTION
## Summary
Closes #4015
Refs #4013
Blocks #4016

Implement deterministic extraction of normalized `arvp_strategy_metrics.v1` records from the canonical 318-job Binance historical vacation campaign, repair vacation summary nested metric mapping, and document a stable campaign content hash.

## Delivered
- `tools/arvp_vacation/strategy_metric_extraction.py` CLI/module with canonical job selection and stable record ordering
- `tools/arvp_vacation/metric_contract.py` shared canonical-selection helpers reused by #4014 tests
- `docs/contracts/arvp_strategy_metrics.v1.schema.json`
- `docs/evidence/arvp_3990_strategy_metric_extraction.md`
- Summary mapping fix in `tools/arvp_vacation/summary.py` (`metrics.closed_trades_total` -> `trade_count`, etc.)
- Unit + golden/contract tests and redacted fixtures under `tests/fixtures/arvp/strategy_metrics/`

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- repo_fallback_reason: insufficient_evidence
- records_found: none
- repo_crosscheck: live `queue_state.json`, contracts, GitHub issues #4013/#4015/#4016

## Canonical selection: 318 of 324
- Selector: `superseded_by_stress_v2_rerun != true`
- Queue records: 324
- Canonical jobs: 318
- Superseded excluded: 6
- Scenario records emitted: 954

## Deterministic hash
- Algorithm: SHA-256 over canonical JSON record list via `core.replay.canonical_json`
- Content hash: `ad3d4ccc449e81e4aa5ec81185d6b3229d12a9e05b2e4970dd352b7471e5b7ad`
- Identical re-run reproduced the same hash locally

## Resolved #4019 review findings
- schema-version-writer: bundle + records emit `schema_version=arvp_strategy_metrics.v1`
- slippage-path: `slippage_availability=not_available`; no fabricated per-trade slippage
- candle-count-path: deterministic `candles_live` -> `candles_total` fallback with mismatch flag

## Validation
- `python -m pytest -q tests/unit/arvp/test_strategy_metric_extraction.py tests/unit/arvp/test_vacation_metric_availability_contract.py` (35 passed)
- `python -m pytest -q tests/unit/arvp/test_arvp_vacation_mvp.py::test_summary_generation` (1 passed)
- `ruff check` on changed Python files (green)
- `python -m json.tool docs/contracts/arvp_strategy_metrics.v1.schema.json` (valid)
- `git diff --check` (green)
- Read-only full campaign extraction: 318 canonical jobs, 6 superseded excluded, stable hash on repeat

## Non-goals
- No PEP generation (#4016)
- No league scoring
- No replay reruns or campaign artifact mutation
- No runtime/Docker/workflow changes
- No `ranking_ready=true`

## Safety boundaries
- LR NO-GO unchanged
- `ranking_ready=false` unchanged
- `historical_cross_venue_research` only; no MEXC confirmation or promotion language

## Restunsicherheiten
- Full 318-job hash evidence depends on local campaign artifacts; CI validates via fixtures and skips full-campaign assertions when artifacts are absent
- `fee_adjusted_max_drawdown_r` remains adapter-dependent absent values on donchian/breakout_trend_filter jobs
- Exit gate for downstream work: `READY_FOR_CANDIDATE_EVIDENCE`