### PR TITLE
docs(governance): reconcile GitHub community health files (#4005)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,23 +1,30 @@
 # Security Policy
 
+Claire de Binare (CDB) operates in shadow/paper mode. This policy documents
+security reporting and repository measures. It does **not** authorize live
+capital, production trading, or Echtgeld operations. Live-Readiness remains
+**NO-GO** — SSOT: [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).
+
+---
+
 ## Supported Versions
 
-Currently supported versions for security updates:
+Only the `main` branch receives security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| main    | :white_check_mark: |
-| dev     | :white_check_mark: |
-| < 1.0   | :x:                |
+| `main`  | :white_check_mark: |
+| other   | :x:                |
 
 ---
 
 ## Reporting a Vulnerability
 
-**DO NOT** create public issues for security vulnerabilities.
+**DO NOT** create public GitHub issues for security vulnerabilities.
 
-### Preferred Method
-1. **Email:** [Security contact - add your email]
+Report suspected vulnerabilities privately:
+
+1. **Email:** modusmono.dev@gmail.com
 2. **Subject:** `[SECURITY] CDB Vulnerability Report`
 3. **Include:**
    - Description of the vulnerability
@@ -25,118 +32,63 @@ Currently supported versions for security updates:
    - Potential impact
    - Suggested fix (if any)
 
-### Response Timeline
-- **Acknowledgment:** Within 24 hours
-- **Initial Assessment:** Within 72 hours
-- **Status Update:** Weekly until resolved
-- **Fix Timeline:** Critical (7 days), High (14 days), Medium (30 days)
+Reports are reviewed. Further handling and coordinated disclosure are managed
+case by case. **No fixed response, triage, patch, or disclosure timelines are
+promised.**
+
+Maintainers may also use [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories) for private coordination when appropriate. Private Vulnerability Reporting is not claimed as enabled in this repository unless separately verified on GitHub.
 
 ---
 
-## Security Measures
+## Security Scope
 
-### Implemented
-- ✅ Secrets scanning (Gitleaks)
-- ✅ Dependency audit (pip-audit)
-- ✅ Security linting (Bandit)
-- ✅ `.env` templates (no secrets in repo)
-- ✅ Docker secret management
-- ✅ API key restrictions (IP-binding, asset limits)
+In scope for this policy:
 
-### Planned (M8 - Production Hardening)
-- 🔄 Penetration testing
-- 🔄 Container image scanning (Trivy)
-- 🔄 TLS/SSL for all external connections
-- 🔄 Redis authentication
-- 🔄 PostgreSQL hardening
-- 🔄 Network isolation review
+- Secrets or credentials exposure in the repository or documented operator paths
+- Dependency and supply-chain vulnerabilities affecting supported code on `main`
+- CI/workflow misconfigurations with demonstrable security impact
+- Container image vulnerabilities surfaced by repository scanning workflows
+- Unsafe defaults on order, risk, or execution paths in code reviewed on `main`
 
----
+Out of scope:
 
-## Security Checklist (Pre-Deployment)
-
-### Code
-- [ ] No hardcoded secrets
-- [ ] All ENV vars in `.env.example`
-- [ ] Bandit scan passes
-- [ ] Dependencies audited (pip-audit)
-- [ ] Type checking passes (mypy)
-
-### Infrastructure
-- [ ] Docker secrets configured
-- [ ] PostgreSQL password rotation
-- [ ] Redis AUTH enabled
-- [ ] Firewall rules configured
-- [ ] Logs secured (no PII)
-
-### API Security
-- [ ] MEXC API key IP-bound
-- [ ] Asset whitelist active (BTC/USDC/USDE)
-- [ ] Rate limiting configured
-- [ ] TLS certificate valid
-
-### Monitoring
-- [ ] Security alerts configured
-- [ ] Audit logs enabled
-- [ ] Anomaly detection active
-- [ ] Incident response plan documented
+- Live trading authorization or capital deployment decisions
+- LR re-evaluation or board-stage changes
+- Production runtime changes without an explicit scoped issue
+- General feature requests or non-security bugs (use public issues)
+- Historical archive trees under `docs/archive/` and `knowledge/archive/`
 
 ---
 
-## Known Security Boundaries
+## Implemented Measures (live-verified)
 
-### By Design
-- **Paper Trading Mode:** No real capital at risk (M7 phase)
-- **Kill Switch:** Manual intervention required (not automated)
-- **Tresor Zone:** Physically separated (not in Docker stack)
+Repository and platform controls currently in use:
 
-### Dependencies
-- Root `requirements.txt` / `requirements-dev.txt` cover CI, test, and local convenience dependencies.
-- Active runtime Python dependencies are defined per service via service-local `requirements.txt` files or, where applicable, service Dockerfiles.
-- Regular updates via Dependabot
-- Critical CVEs patched within 7 days
+| Measure | Location / evidence |
+| ------- | ------------------- |
+| Gitleaks secret scanning | [`.github/workflows/gitleaks.yml`](workflows/gitleaks.yml) |
+| CodeQL Python analysis | [`.github/workflows/codeql-python.yml`](workflows/codeql-python.yml) |
+| Trivy container scanning | [`.github/workflows/trivy.yml`](workflows/trivy.yml), [`.github/workflows/security-scan.yml`](workflows/security-scan.yml) |
+| Dependabot version updates | [`.github/dependabot.yml`](dependabot.yml) |
+| GitHub Secret Scanning | enabled (repository security settings) |
+| GitHub Push Protection | enabled (repository security settings) |
+| Dependabot security updates | enabled (repository security settings) |
+| Local security scan helper | `make security-scan` (Gitleaks when installed, Bandit, Ruff) |
 
----
+Security triage and readouts: [`docs/security/README.md`](../docs/security/README.md).
 
-## Compliance
-
-### Standards
-- OWASP Top 10 awareness
-- Secure coding practices (Bandit rules)
-- Dependency hygiene (SemVer, audit)
-
-### Audit Trail
-- Git history (all changes tracked)
-- Event sourcing (all trading events logged)
-- PostgreSQL audit logs
+Secrets governance: [`knowledge/governance/SECRETS_POLICY.md`](../knowledge/governance/SECRETS_POLICY.md).
 
 ---
 
-## Security Roadmap
+## Operator Boundaries
 
-### M8 - Production Hardening & Security Review
-- [ ] Full penetration test
-- [ ] Container security scan
-- [ ] Network isolation review
-- [ ] Secrets rotation policy
-- [ ] Incident response playbook
-
-### M9 - Release 1.0
-- [ ] Security audit sign-off
-- [ ] Production deployment checklist
-- [ ] Monitoring dashboards live
-- [ ] Kill-switch tested
+- No secrets in the repository; use the documented secrets path and Docker secrets.
+- Productive database writes, MCP mutations, and BLUE/RED runtime changes require
+  explicit human scope — not implied by this policy.
+- Board stage `trade-capable` is orthogonal to live-readiness and does not grant
+  live-capital authorization.
 
 ---
 
-## Contact
-
-For security concerns:
-- **Repository:** Private (no public disclosure)
-- **Maintainer:** @jannekbuengener
-- **Security Lead:** TBD
-
----
-
-**Last Updated:** 2025-12-16  
-**Policy Version:** 1.0
+**Last Updated:** 2026-07-13

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,58 +1,94 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct — Claire de Binare
+
+Dieses Repository folgt dem Contributor Covenant 3.0. Der folgende englische Text
+ist die verbindliche Code-of-Conduct-Fassung für die Claire-de-Binare-Community
+(Entwickler, Mitwirkende und Agenten im Projektumfeld).
+
+**Sicherheitsrelevante Meldungen** gehören nicht in öffentliche Issues. Bitte
+nutze die kanonische Security Policy unter [`.github/SECURITY.md`](.github/SECURITY.md).
+
+---
+
+# Contributor Covenant 3.0 Code of Conduct
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+We pledge to make our community welcoming, safe, and equitable for all.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
 
-## Our Standards
+## Encouraged Behaviors
 
-Examples of behavior that contributes to a positive environment:
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes
-* Focusing on what is best not just for us as individuals, but for the overall community
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
 
-Examples of unacceptable behavior:
+1. Respecting the purpose of our community, our activities, and our ways of gathering.
+2. Engaging kindly and honestly with others.
+3. Respecting different viewpoints and experiences.
+4. Taking responsibility for our actions and contributions.
+5. Gracefully giving and accepting constructive feedback.
+6. Committing to repairing harm when it occurs.
+7. Behaving in other ways that promote and sustain the well-being of our community.
 
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+## Restricted Behaviors
 
-## Enforcement Responsibilities
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
 
-Project maintainers are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+1. Harassment. Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. Character attacks. Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. Stereotyping or discrimination. Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. Sexualization. Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. Violating confidentiality. Sharing or acting on someone's personal or private information without their permission.
+6. Endangerment. Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that threaten the well-being of our community.
+
+### Other Restrictions
+
+1. Misleading identity. Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. Failing to credit sources. Not properly crediting the sources of content you contribute.
+3. Promotional materials. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. Irresponsible communication. Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact the project maintainers at modusmono.dev@gmail.com.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1. Warning
+   1. Event: A violation involving a single incident or series of incidents.
+   2. Consequence: A private, written warning from the Community Moderators.
+   3. Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2. Temporarily Limited Activities
+   1. Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2. Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3. Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3. Temporary Suspension
+   1. Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2. Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3. Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4. Permanent Ban
+   1. Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2. Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3. Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainers at [buengener@gmail.com].
-
-All complaints will be reviewed and investigated promptly and fairly.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at https://www.contributor-covenant.org/version/3/0/.
 
-[homepage]: https://www.contributor-covenant.org
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
+
+For answers to common questions about Contributor Covenant, see the FAQ at https://www.contributor-covenant.org/faq. Translations are provided at https://www.contributor-covenant.org/translations. Additional enforcement and community guideline resources can be found at https://www.contributor-covenant.org/resources. The enforcement ladder was inspired by the work of Mozilla's code of conduct team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,18 @@ make context-doctor
 
 ## Development Workflow
 
+### Dedupe Before You Start
+
+Before opening an issue, branch, or PR:
+
+1. Search open issues and PRs for duplicates or overlapping scope.
+2. Extend existing work instead of creating parallel governance or doc hubs.
+3. Link related issues in the PR body (`Refs #...`).
+
+Worktree and branch cleanup of obsolete leftovers is tracked in
+[Issue #4006](https://github.com/jannekbuengener/Claire_de_Binare/issues/4006) —
+do not delete foreign worktrees or branches inside other scopes.
+
 ### Branch Naming
 
 Follow this pattern: `<type>/<issue-number>-<short-description>`
@@ -103,6 +115,15 @@ Follow this pattern: `<type>/<issue-number>-<short-description>`
 | `chore/` | Maintenance tasks |
 
 Example: `docs/3229-developer-onboarding-reconcile`
+
+### Branch and Worktree Hygiene
+
+- Branch from current `origin/main`.
+- Prefer a **dedicated git worktree** for issue-scoped delivery so parallel
+  sessions do not overwrite each other.
+- Keep the working tree clean before push; do not mix unrelated changes.
+- Cleanup of obsolete worktrees, branches, stashes, and remotes belongs to
+  [#4006](https://github.com/jannekbuengener/Claire_de_Binare/issues/4006).
 
 ### Commit Messages
 
@@ -166,10 +187,21 @@ pytest tests/e2e/ -v -m e2e
 
 ### Required Checks
 
-- CI gate (`.github/workflows/ci.yml`) must pass
-- `ruff check .` must pass
-- Tests must pass (unit + integration)
-- Coverage >= 80%
+Merge contract on `main` (SSOT:
+[`docs/runbooks/merge_policy_ci_gate.md`](docs/runbooks/merge_policy_ci_gate.md)):
+
+| Check | Source |
+|-------|--------|
+| `ci (Unit/Integration + Lint gesammelt)` | `.github/workflows/ci.yml` |
+| `policy-gate` | `.github/workflows/policy-gate.yml` |
+
+Inside the CI gate: `ruff check .`, unit/integration tests, and Black on changed
+Python under `services/` and `tests/`. Coverage >= 80% applies when running
+`make test-coverage` locally; the default CI slice does not enforce coverage on
+every PR.
+
+Classify your PR scope with the policy-gate rules in the merge-policy runbook.
+Do not assume labels without checking the live diff classification.
 
 ### Scope Boundaries
 
@@ -237,6 +269,29 @@ Claire_de_Binare/
 
 ---
 
+## Agents, Brain Evidence, and MCP Boundaries
+
+- Agent bootloader pointer: [`agents/AGENTS.md`](agents/AGENTS.md) (full Read Order
+  and operating rules live there — not duplicated here).
+- For strategy/runtime/module/service/contract/context scope, output the Brain
+  Evidence block from `agents/AGENTS.md` **before any plan**. Repo/GitHub live
+  evidence overrides brain or ledger claims.
+- Skills live under `.cursor/skills/`, `.codex/cdb_skills/`, `.opencode/skills/`
+  — load only what the task needs; skills do not grant write permission.
+- Context/MCP tools are read-only by default on `main`
+  (`PERSIST_ALLOWED=False`, `MUTATION_ALLOWED=False`). Productive DB writes, MCP
+  mutations, and runtime changes require explicit human scope.
+
+---
+
+## Security Reporting
+
+- **Do not** report security vulnerabilities as public GitHub issues.
+- Use the canonical policy: [`.github/SECURITY.md`](.github/SECURITY.md)
+- Contact: `modusmono.dev@gmail.com`
+
+---
+
 ## Safety / LR Boundaries
 
 - **LR bleibt NO-GO** — SSOT: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
@@ -250,7 +305,8 @@ Claire_de_Binare/
 
 ## Getting Help
 
-- **Issues:** Search existing issues or create a new one
+- **Issues:** Search existing issues or create a new one (not for security bugs)
 - **Documentation:** Start with [`docs/index.md`](docs/index.md)
 - **Repo Brain / Context:** `make context-doctor` or [`docs/surrealdb/README.md`](docs/surrealdb/README.md)
-- **Code of Conduct:** See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- **Code of Conduct:** [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- **Security:** [`.github/SECURITY.md`](.github/SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Diese Root-README ist die GitHub-Haupt-Landingpage. Der aktive Pfad bleibt Shado
 - Repo-/Engineering-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md)
 - Support: GitHub Sponsors is configured via [`.github/FUNDING.yml`](.github/FUNDING.yml) for people who want to support ongoing development.
 
+## Community & Governance
+
+- [Contributing](CONTRIBUTING.md) — development workflow, tests, and contribution rules
+- [Code of Conduct](CODE_OF_CONDUCT.md) — community standards (Contributor Covenant 3.0)
+- [License](LICENSE) — MIT License
+- [Security Policy](.github/SECURITY.md) — private vulnerability reporting (no public security issues)
+
 ## Safety / LR Status
 
 - **Control-Board Stage:** `trade-capable` (Board-Kontext, nicht LR-Freigabe)
@@ -59,13 +66,13 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 ## Current-main Snapshot
 
-Auf `origin/main` (`49eb7546`, Stand 2026-07-12) sind die juengsten relevanten Merge-Cluster u. a.:
+Auf `origin/main` (`f9e0cb0a`, Stand 2026-07-13) sind die juengsten relevanten Merge-Cluster u. a.:
 
 - **README / canon link guard ([#3994](https://github.com/jannekbuengener/Claire_de_Binare/issues/3994) / PR [#4011](https://github.com/jannekbuengener/Claire_de_Binare/pull/4011)):** Shared `markdown_link_utils`, offline README- und explizite Entry-Point-Linkpruefung in CI; CONTRIBUTING § README Link Convention.
-- **#3990 Binance historical campaign closeout ([#4010](https://github.com/jannekbuengener/Claire_de_Binare/issues/4010) / PR [#4009](https://github.com/jannekbuengener/Claire_de_Binare/pull/4009)):** Stress-v2 rerun; cross-venue research only; `ranking_ready=false`.
-- **Binance market_data relocation ([#4004](https://github.com/jannekbuengener/Claire_de_Binare/issues/4004) / PR [#4007](https://github.com/jannekbuengener/Claire_de_Binare/pull/4007)):** Ops tooling + evidence; keine LR-Implikation.
+- **Nav-/Snapshot-Reconcile ([#3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) / PR [#4018](https://github.com/jannekbuengener/Claire_de_Binare/pull/4018)):** Entry-Point-Reconcile, Snapshot-Reconcile, Cross-Hub-Navigation.
+- **ARVP candidate evidence ([#4022](https://github.com/jannekbuengener/Claire_de_Binare/pull/4022)):** Deterministic candidate evidence packet assembly (shadow/research scope).
 
-Operatives Cockpit: [Issue #1445](https://github.com/jannekbuengener/Claire_de_Binare/issues/1445). Nav-/Snapshot-Reconcile: [Issue #3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) (in delivery). Vollstaendiges Session-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md).
+Operatives Cockpit: [Issue #1445](https://github.com/jannekbuengener/Claire_de_Binare/issues/1445). Community-Health-Reconcile: [Issue #4005](https://github.com/jannekbuengener/Claire_de_Binare/issues/4005) (in delivery). Vollstaendiges Session-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md).
 
 LR bleibt **NO-GO** — SSOT: [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).
 

--- a/docs/evidence/community_health_audit_4005.md
+++ b/docs/evidence/community_health_audit_4005.md
@@ -1,0 +1,147 @@
+# Community Health Audit — Issue #4005
+
+**Task:** `cdb-execute-4005-community-health`  
+**Date:** 2026-07-13  
+**Base SHA:** `f9e0cb0a6025d6cb8b5843c68e3e74619f4b48f8` (`origin/main`)
+
+---
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+tools_or_queries:
+  - cdb_context_briefing (task_id: cdb-execute-4005-community-health)
+  - gh api community/profile (before)
+  - gh issue/pr live queries
+  - git worktree safety checks
+records_or_results:
+  - briefing operator_trust_level=LOW; records_found=none
+  - community profile before: health=100%, CoC key=other, license=MIT
+repo_crosscheck:
+  - README.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, .github/SECURITY.md, LICENSE
+impact_on_plan:
+  - Repo/GitHub live as SSOT; no DB-backed claims
+limitations:
+  - Post-merge community profile re-check required after PR merge
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+context_tool_status: available
+context_trust_level: none
+records_found: none
+```
+
+---
+
+## GitHub Community Profile (before)
+
+| Field | Value |
+|-------|-------|
+| health_percentage | 100 |
+| code_of_conduct | present (`key: other`) |
+| contributing | present |
+| license | MIT |
+| security policy | `.github/SECURITY.md` (not in community profile API fields) |
+
+---
+
+## Ist-/Soll-Matrix
+
+| Surface | Before | After |
+|---------|--------|-------|
+| README Community links | missing | `## Community & Governance` with 4 links |
+| CODE_OF_CONDUCT | CC 2.0, `buengener@gmail.com` | CC 3.0, `modusmono.dev@gmail.com` |
+| CONTRIBUTING | #3994/#3995 base only | + dedupe, worktree, merge policy, agents/MCP, security |
+| SECURITY | placeholders, SLAs, `dev` supported | `main` only, no SLAs, live measures |
+| LICENSE | MIT 2024–2026 | unchanged |
+| Contract test | none | `tests/unit/docs/test_community_health_contract.py` |
+
+---
+
+## Dedupe vs #3994 and #3995
+
+**Preserved:**
+- CONTRIBUTING § README Link Convention
+- `make readme-links-guard` / `make onboarding-docs-guard`
+- Setup, test, lint, safety/LR sections
+- Shared `tools/markdown_link_utils.py` (reused in contract test)
+
+**Not duplicated:**
+- No second link engine
+- No full agent governance copy (pointer to `agents/AGENTS.md` only)
+- No root `SECURITY.md`
+
+---
+
+## Contributor Covenant
+
+| Item | Value |
+|------|-------|
+| Version | 3.0 |
+| Official source | https://www.contributor-covenant.org/version/3/0/code_of_conduct/ |
+| Official markdown | https://www.contributor-covenant.org/version/3/0/code_of_conduct/code_of_conduct.md |
+| Project-specific header | German Claire de Binare context **outside** covenant text |
+| Security note | Outside covenant text → `.github/SECURITY.md` |
+| Filled template field | Reporting contact: `modusmono.dev@gmail.com` |
+| Attribution | CC BY-SA 4.0 block retained verbatim |
+
+---
+
+## Contact Reconcile
+
+| Item | Value |
+|------|-------|
+| Old active contact | `buengener@gmail.com` (CODE_OF_CONDUCT) |
+| Placeholder removed | `[Security contact - add your email]` (SECURITY) |
+| New canonical contact | `modusmono.dev@gmail.com` |
+| Active files updated | README (indirect), CODE_OF_CONDUCT, CONTRIBUTING, .github/SECURITY.md |
+
+**Historical (unchanged):**
+- `docs/archive/docs_hub_snapshot/meta/legacy/CODE_OF_CONDUCT.md`
+- `docs/archive/docs_hub_snapshot/meta/github/SECURITY.md`
+
+---
+
+## Security Policy Changes
+
+**Removed:**
+- `dev` as supported version
+- Response SLAs (24h/72h/weekly/7-14-30 days)
+- `Security Lead: TBD`
+- M7/M8/M9 roadmap placeholders
+- "Trivy planned" (Trivy workflows exist)
+
+**Added/updated:**
+- Supported: `main` only
+- Coordinated disclosure without fixed timelines
+- Live-verified measures table (Gitleaks, CodeQL, Trivy, Dependabot, GitHub secret scanning/push protection)
+- Out-of-scope section (no live/echtgeld implication)
+
+**PVR:** Not enabled or claimed.
+
+---
+
+## Non-goals and Safety Boundaries
+
+- No runtime, trading, ARVP, DB, MCP, Docker, or infra changes
+- No LR/board/live/echtgeld decision changes
+- No worktree/branch cleanup (#4006)
+- No issue-template redesign
+- LR remains NO-GO
+
+---
+
+## Handoff to #4006
+
+Worktree `Claire_de_Binare__docs-4005-community-health` and branch
+`docs/4005-community-health-reconcile` remain for operator cleanup under #4006.
+
+---
+
+## Validation (local)
+
+Recorded at implementation time in PR body and CI.

--- a/tests/unit/docs/test_community_health_contract.py
+++ b/tests/unit/docs/test_community_health_contract.py
@@ -1,0 +1,77 @@
+"""Stable community-health contracts for Issue #4005."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.markdown_link_utils import extract_relative_links
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+README = REPO_ROOT / "README.md"
+SECURITY = REPO_ROOT / ".github" / "SECURITY.md"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+CANONICAL_CONTACT = "modusmono.dev@gmail.com"
+REMOVED_CONTACT = "buengener@gmail.com"
+CONTACT_PLACEHOLDER = "[Security contact - add your email]"
+REMOVED_SLA_PATTERNS = (
+    "Within 24 hours",
+    "Within 72 hours",
+    "Weekly until resolved",
+    "Critical (7 days)",
+    "High (14 days)",
+    "Medium (30 days)",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _readme_links() -> set[str]:
+    return set(extract_relative_links(_read(README)))
+
+
+def test_readme_links_to_community_governance_files() -> None:
+    links = _readme_links()
+    assert "CONTRIBUTING.md" in links
+    assert "CODE_OF_CONDUCT.md" in links
+    assert "LICENSE" in links
+    assert ".github/SECURITY.md" in links
+
+
+def test_security_policy_has_canonical_contact() -> None:
+    content = _read(SECURITY)
+    assert CANONICAL_CONTACT in content
+
+
+def test_security_policy_has_no_contact_placeholder() -> None:
+    content = _read(SECURITY)
+    assert CONTACT_PLACEHOLDER not in content
+
+
+def test_security_policy_has_no_removed_active_contact() -> None:
+    content = _read(SECURITY)
+    assert REMOVED_CONTACT not in content
+
+
+def test_security_policy_does_not_claim_dev_branch_support() -> None:
+    content = _read(SECURITY)
+    lowered = content.lower()
+    assert "| dev" not in lowered
+    assert "dev branch" not in lowered
+
+
+def test_security_policy_has_no_removed_sla_patterns() -> None:
+    content = _read(SECURITY)
+    for pattern in REMOVED_SLA_PATTERNS:
+        assert pattern not in content
+
+
+def test_contributing_references_merge_policy_governance() -> None:
+    content = _read(CONTRIBUTING)
+    assert "docs/runbooks/merge_policy_ci_gate.md" in content


### PR DESCRIPTION
Closes #4005
Refs #3994
Refs #3995
Refs #4006

## Brain Evidence

- `brain_source: repo-only`, `brain_status: not-used`
- Context briefing attempted; `records_found=none`, `repo_fallback_reason=insufficient_evidence`
- GitHub live + repo files used as SSOT

## Delivered

- **README:** `## Community & Governance` with links to CONTRIBUTING, CODE_OF_CONDUCT, LICENSE, `.github/SECURITY.md`; snapshot updated to current `origin/main`
- **CODE_OF_CONDUCT:** Contributor Covenant **3.0** (official English text); German project header outside covenant; reporting contact `modusmono.dev@gmail.com`; security note outside covenant text
- **CONTRIBUTING:** preserved #3994/#3995 content; added dedupe, worktree hygiene (#4006 handoff), merge-policy required checks, agent/MCP pointers, security reporting
- **SECURITY:** `main` only supported; no SLAs; canonical contact; live-verified measures; out-of-scope boundaries
- **Evidence:** `docs/evidence/community_health_audit_4005.md`
- **Contract test:** `tests/unit/docs/test_community_health_contract.py`

## Contributor Covenant

- Version: **3.0**
- Source: https://www.contributor-covenant.org/version/3/0/code_of_conduct/
- Project header separated from official covenant text; only reporting field customized

## Security contact decision

- Canonical: `modusmono.dev@gmail.com`
- Removed: `buengener@gmail.com`, `[Security contact - add your email]`, SLA promises, `dev` branch support

## Supported Versions

- `main` only

## Validation

- `make readme-links-guard` — PASS
- `make onboarding-docs-guard` — PASS
- `pytest tests/unit/docs/test_community_health_contract.py` — 7 passed
- `pytest tests/unit/tools/test_validate_readme_links.py tests/unit/tools/test_validate_onboarding_docs.py` — 41 passed
- `ruff check tests/unit/docs/test_community_health_contract.py` — PASS
- `git diff --check` — PASS

## Non-goals

- No runtime/trading/ARVP/DB/MCP/Docker/infra changes
- No PVR activation
- No issue-template redesign
- No worktree/branch cleanup (#4006)

## Safety Boundaries

- LR remains NO-GO; board stage unchanged
- No live/echtgeld authorization
- Historical archives untouched

## Remaining uncertainty

- GitHub Community Profile CoC detection may remain `other` until GitHub re-indexes
- Post-merge manual rendering check on GitHub UI
