### PR TITLE
feat(arvp): add governance-safe strategy league report

### DIFF
--- a/docs/contracts/profitability_league_table_report.v1.schema.json
+++ b/docs/contracts/profitability_league_table_report.v1.schema.json
@@ -29,13 +29,149 @@
       "type": "string",
       "format": "date-time"
     },
+    "campaign_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generated_from_bundle_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "evidence_class": {
+      "type": "string",
+      "minLength": 1
+    },
     "table_status": {
       "type": "string",
       "enum": ["COMPLETE", "PARTIAL", "BLOCKED"]
     },
-    "candidate_rankings": {
+    "ranking_ready": {
+      "type": "boolean"
+    },
+    "official_ranking": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "candidate_id",
+          "official_rank",
+          "total_score",
+          "ranking_ready"
+        ],
+        "properties": {
+          "candidate_id": {
+            "type": "string",
+            "pattern": "^cand-[a-z0-9_-]{4,64}$"
+          },
+          "strategy_id": {
+            "type": "string"
+          },
+          "official_rank": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "total_score": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 100.0
+          },
+          "ranking_ready": {
+            "type": "boolean"
+          },
+          "net_return": {
+            "oneOf": [{ "type": "null" }, { "type": "number" }]
+          }
+        }
+      }
+    },
+    "winner": {
+      "oneOf": [{ "type": "null" }, { "type": "string" }]
+    },
+    "candidate_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "officially_ranked_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "not_rankable_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "partial_evidence_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "candidate_rows": {
       "type": "array",
       "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/candidate_row"
+      }
+    },
+    "dimension_definitions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "weights": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "number"
+      }
+    },
+    "normalization": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "exclusion_reasons": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    },
+    "paper_reference_status": {
+      "type": "string"
+    },
+    "same_venue_status": {
+      "type": "string"
+    },
+    "promotion_status": {
+      "type": "string",
+      "enum": ["NOT_AUTHORIZED", "AUTHORIZED"]
+    },
+    "source_content_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "candidate_bundle_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "source_packet_hashes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-f0-9]{64}$"
+      }
+    },
+    "scoring_formula_version": {
+      "type": "string"
+    },
+    "scorer_version": {
+      "type": "string"
+    },
+    "report_content_hash": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "candidate_rankings": {
+      "type": "array",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -135,6 +271,110 @@
       "items": {
         "type": "string",
         "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "candidate_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "rankability_status",
+        "official_rank",
+        "ranking_ready",
+        "sentinel_mode",
+        "total_score",
+        "net_return",
+        "comparison_dimensions",
+        "dimension_scores",
+        "recommendation",
+        "exclusion_reasons",
+        "limitations_summary"
+      ],
+      "properties": {
+        "candidate_id": {
+          "type": "string",
+          "pattern": "^cand-[a-z0-9_-]{4,64}$"
+        },
+        "strategy_id": {
+          "type": "string"
+        },
+        "rankability_status": {
+          "type": "string",
+          "enum": [
+            "RANKABLE_FOR_CROSS_VENUE_COMPARISON",
+            "NOT_RANKABLE",
+            "PARTIAL_EVIDENCE"
+          ]
+        },
+        "official_rank": {
+          "oneOf": [{ "type": "null" }, { "type": "integer", "minimum": 1 }]
+        },
+        "ranking_ready": {
+          "type": "boolean"
+        },
+        "sentinel_mode": {
+          "type": "boolean"
+        },
+        "total_score": {
+          "oneOf": [{ "type": "null" }, { "type": "number", "minimum": 0.0, "maximum": 100.0 }]
+        },
+        "net_return": {
+          "oneOf": [{ "type": "null" }, { "type": "number" }]
+        },
+        "comparison_dimensions": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "dimension_scores": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["dimension", "score"],
+            "properties": {
+              "dimension": {
+                "type": "string",
+                "enum": [
+                  "NET_ECONOMICS",
+                  "NET_RETURN",
+                  "ROBUSTNESS",
+                  "EVIDENCE_COMPLETENESS",
+                  "SAFETY_STATUS",
+                  "PAPER_REFERENCE_CONFIDENCE",
+                  "EXECUTION_REALISM",
+                  "DRAWDOWN_DISCIPLINE",
+                  "STRESS_RESILIENCE"
+                ]
+              },
+              "score": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 100.0
+              }
+            }
+          }
+        },
+        "recommendation": {
+          "type": "string",
+          "enum": [
+            "REJECT",
+            "PARK",
+            "PROMOTE_TO_NEXT_RESEARCH_GATE",
+            "UNSAFE",
+            "NO_RECOMMENDATION"
+          ]
+        },
+        "exclusion_reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "limitations_summary": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
       }
     }
   }

--- a/docs/evidence/arvp_3990_strategy_league_table.md
+++ b/docs/evidence/arvp_3990_strategy_league_table.md
@@ -1,0 +1,106 @@
+# ARVP Binance Historical Strategy League Table (#4017)
+
+**Issue:** [#4017](https://github.com/jannekbuengener/Claire_de_Binare/issues/4017)  
+**Parent:** [#4013](https://github.com/jannekbuengener/Claire_de_Binare/issues/4013)  
+**Epic:** [#1900](https://github.com/jannekbuengener/Claire_de_Binare/issues/1900)  
+**Evidence class:** `historical_cross_venue_research`  
+**Exit status:** `HISTORICAL_LEAGUE_PARTIAL_NO_RANKABLE_WINNER`  
+**LR:** NO-GO · **promotion_status:** NOT_AUTHORIZED
+
+## Source and bundle hashes
+
+| Field | Value |
+|---|---|
+| Campaign ID | `arvp_binance_historical_3990_2bb32b68_20260712T111944Z` |
+| Source contract | `arvp_strategy_metrics.v1` |
+| Source content hash | `ad3d4ccc449e81e4aa5ec81185d6b3229d12a9e05b2e4970dd352b7471e5b7ad` |
+| Scenario records | 954 (318 jobs × 3 scenarios) |
+| Candidate bundle hash | `4e7b4b88427d3fed84493721f97f82d0502c5a93ee96b81b8af8dab0671e26a4` |
+| Report content hash (full campaign) | `0252caea15ea5eb614bceda1bc0aeb3131fca896136079b67349c5724c296533` |
+
+Determinism: two identical CLI runs with the same `--report-id` reproduced the same
+`report_content_hash` locally.
+
+## Scoring formula and dimensions
+
+Normative Formula v1: [`docs/strategy/CDB_PROFITABILITY_LEAGUE_SCORING_FORMULA_V1.md`](../strategy/CDB_PROFITABILITY_LEAGUE_SCORING_FORMULA_V1.md)
+
+| Formula dimension | Weight % |
+|---|---:|
+| NET_ECONOMICS | 25.0 |
+| ROBUSTNESS | 20.0 |
+| EVIDENCE_COMPLETENESS | 15.0 |
+| SAFETY_STATUS | 15.0 |
+| PAPER_REFERENCE_CONFIDENCE | 15.0 |
+| EXECUTION_REALISM | 10.0 |
+
+Implementation: `services/validation/profitability_league_scorer.py`  
+Governance assembler: `services/validation/profitability_league_table_report_assembler.py`  
+CLI: `python -m tools.arvp_vacation.league_table_report`
+
+Comparison table dimensions (raw + descriptive, not ranking weights):
+
+`net_economic_result`, `drawdown`, `expectancy`, `profit_factor`,
+`stability_across_windows`, `cost_sensitivity`, `feed_gap_sensitivity`,
+`sample_size`, `split_coverage`, `stress_behavior`, `evidence_quality`
+
+## Rankability gates and league result
+
+Report-level gates (enforced, not overridden by scores):
+
+| Field | Value |
+|---|---|
+| `table_status` | `PARTIAL` |
+| `ranking_ready` | `false` |
+| `official_ranking` | `[]` |
+| `winner` | `null` |
+| `officially_ranked_count` | `0` |
+
+| Strategy | rankability_status | official_rank | total_score |
+|---|---|---:|---:|
+| `breakout_trend_filter_v1` | NOT_RANKABLE | null | null (withheld) |
+| `donchian_breakout_v1` | NOT_RANKABLE | null | null (withheld) |
+| `primary_breakout_v1` | PARTIAL_EVIDENCE | null | null (sentinel / withheld) |
+
+Hard-gate sentinel applies to all three PEPs because `replay_vs_paper_status=not_run`,
+`simulator_drift=not_assessed`, and `regime_scorecard.status=unavailable`. Scores are
+emitted as `0.0` sentinel components where applicable; `total_score` is withheld for
+`NOT_RANKABLE` candidates and not used as an official ranking input.
+
+## Why no official winner
+
+1. Zero candidates satisfy `rankability_status=RANKABLE_FOR_CROSS_VENUE_COMPARISON`.
+2. Two candidates are `NOT_RANKABLE` (no rankable baseline windows).
+3. One candidate is `PARTIAL_EVIDENCE` only — visible for comparison, not promotable.
+4. Paper reference and MEXC same-venue confirmation remain `not_run`.
+5. `promotion_status=NOT_AUTHORIZED`; LR remains NO-GO.
+
+## Missing evidence for honest full ranking
+
+- MEXC same-venue replay/paper reference (`same_venue_status=not_run`)
+- Paper-reference alignment (`paper_reference_status=not_run`)
+- Strategy regime scorecard artifacts (`regime_scorecard.status=unavailable`)
+- Rankable baseline windows with complete required metrics for all candidates
+- Independent (non-overlapping) sample design — current windows are descriptive only
+
+## Safety boundaries
+
+- Binance historical research ≠ MEXC production confirmation
+- No strategy promotion, paper-go, live-go, or capital authorization
+- Overlapping window quote PnL is never summed into total return
+- Month/quarter/year and dev/validation/OOS/stress splits remain separate in PEP slices
+- Descriptive `candidate_rows` must not be read as an official ranking
+
+## Validation
+
+```text
+pytest -q tests/unit/arvp/test_league_table_report_assembly.py
+pytest -q tests/unit/arvp/test_candidate_evidence_assembly.py
+pytest -q tests/unit/validation/test_profitability_league_scorer.py
+python -m tools.arvp_vacation.league_table_report \
+  --assemble-from-queue-state artifacts/arvp_vacation/.../queue_state.json \
+  --report-id pltr-arvp-binance-historical-4017 --hash-only
+```
+
+Full-campaign hash evidence depends on local `artifacts/arvp_vacation/`; CI uses slice
+fixtures under `tests/fixtures/arvp/`.

--- a/services/validation/profitability_league_table_report_assembler.py
+++ b/services/validation/profitability_league_table_report_assembler.py
@@ -1,0 +1,530 @@
+"""Governance-safe Strategy League table report assembler (#4017).
+
+Builds an extended ``profitability_league_table_report.v1`` from one or more
+``profitability_evidence_packet.v1`` payloads (typically an ARVP candidate bundle).
+
+Uses Formula v1 scoring from ``profitability_league_scorer.py`` but enforces
+ARVP rankability gates for *official* ranking. Descriptive comparison is allowed;
+forced winners are not.
+
+Safety: LR NO-GO, ranking_ready=false for cross-venue research, no promotion.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from jsonschema.validators import validator_for
+
+from core.replay.canonical_json import canonical_hash
+
+from services.validation.arvp_candidate_evidence_assembler import (
+    RANKABILITY_NOT,
+    RANKABILITY_PARTIAL,
+    RANKABILITY_RANKABLE,
+)
+from services.validation.profitability_league_scorer import (
+    DEFAULT_MODEL_ID,
+    FORMULA_REF,
+    SCORER_VERSION,
+    ProfitabilityLeagueScorerError,
+    _DIMENSION_ORDER,
+    _PACKET_SCHEMA_PATH,
+    _REPORT_SCHEMA_PATH,
+    _WEIGHTS,
+    _ranking_sort_key,
+    score_candidate,
+)
+
+SCORING_FORMULA_VERSION = "profitability_league_scoring_formula.v1"
+EXIT_STATUS_PARTIAL_NO_WINNER = "HISTORICAL_LEAGUE_PARTIAL_NO_RANKABLE_WINNER"
+
+_COMPARISON_DIMENSIONS: tuple[str, ...] = (
+    "net_economic_result",
+    "drawdown",
+    "expectancy",
+    "profit_factor",
+    "stability_across_windows",
+    "cost_sensitivity",
+    "feed_gap_sensitivity",
+    "sample_size",
+    "split_coverage",
+    "stress_behavior",
+    "evidence_quality",
+)
+
+_NORMALIZATION_DOC = {
+    "formula_dimensions": {
+        "range": "[0.0, 100.0]",
+        "method": "clamp per Formula v1 dimension rules",
+        "rounding": "one decimal place at emission",
+    },
+    "comparison_dimensions": {
+        "method": "raw PEP / arvp_evidence values; null means missing, not zero",
+        "overlap_policy": "quote PnL never summed across overlapping windows",
+    },
+}
+
+
+class ProfitabilityLeagueTableReportAssemblerError(ValueError):
+    """Raised when league report assembly cannot complete safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class LeagueReportAssemblyResult:
+    report: dict[str, Any]
+    report_content_hash: str
+
+
+def _load_schema(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_report(report: Mapping[str, Any]) -> None:
+    schema = _load_schema(_REPORT_SCHEMA_PATH)
+    validator_cls = validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+    errors = sorted(validator.iter_errors(dict(report)), key=lambda err: str(err.message))
+    if errors:
+        first = errors[0]
+        location = ".".join(str(part) for part in first.path) or "<root>"
+        raise ProfitabilityLeagueTableReportAssemblerError(
+            f"Report schema mismatch at {location}: {first.message}"
+        )
+
+
+def _validate_pep(pep: Mapping[str, Any], *, artifact_role: str) -> None:
+    schema = _load_schema(_PACKET_SCHEMA_PATH)
+    validator_cls = validator_for(schema)
+    validator_cls.check_schema(schema)
+    validator = validator_cls(schema)
+    errors = sorted(validator.iter_errors(dict(pep)), key=lambda err: str(err.message))
+    if errors:
+        first = errors[0]
+        location = ".".join(str(part) for part in first.path) or "<root>"
+        raise ProfitabilityLeagueTableReportAssemblerError(
+            f"Schema mismatch for {artifact_role} at {location}: {first.message}"
+        )
+
+
+def _rankability_status(pep: Mapping[str, Any]) -> str:
+    status = pep.get("rankability_status")
+    if status in (RANKABILITY_RANKABLE, RANKABILITY_NOT, RANKABILITY_PARTIAL):
+        return str(status)
+    return RANKABILITY_NOT
+
+
+def _is_officially_rankable(pep: Mapping[str, Any], score_ranking_ready: bool) -> bool:
+    return _rankability_status(pep) == RANKABILITY_RANKABLE and score_ranking_ready
+
+
+def _missing_marker(value: object) -> bool:
+    return value is None
+
+
+def _comparison_dimensions(pep: Mapping[str, Any]) -> dict[str, Any]:
+    arvp = pep.get("arvp_evidence") if isinstance(pep.get("arvp_evidence"), Mapping) else {}
+    coverage = pep.get("arvp_coverage") if isinstance(pep.get("arvp_coverage"), Mapping) else {}
+    readiness = (
+        pep.get("coverage_readiness")
+        if isinstance(pep.get("coverage_readiness"), Mapping)
+        else {}
+    )
+
+    split_stability = arvp.get("split_stability") if isinstance(arvp, Mapping) else None
+    scenario_sensitivity = (
+        arvp.get("scenario_sensitivity") if isinstance(arvp, Mapping) else None
+    )
+    stress_evidence = arvp.get("stress_evidence") if isinstance(arvp, Mapping) else None
+
+    return {
+        "net_economic_result": {
+            "gross_return": pep.get("gross_return"),
+            "net_return": pep.get("net_return"),
+            "fees": pep.get("fees"),
+        },
+        "drawdown": {
+            "max_drawdown": pep.get("max_drawdown"),
+            "fee_adjusted_max_drawdown_r": None,
+        },
+        "expectancy": pep.get("expectancy"),
+        "profit_factor": pep.get("profit_factor"),
+        "stability_across_windows": split_stability,
+        "cost_sensitivity": scenario_sensitivity,
+        "feed_gap_sensitivity": scenario_sensitivity,
+        "sample_size": {
+            "trade_count": pep.get("trade_count"),
+            "scenario_records": (
+                coverage.get("sample_counts", {}).get("scenario_records")
+                if isinstance(coverage.get("sample_counts"), Mapping)
+                else None
+            ),
+        },
+        "split_coverage": {
+            "purpose_splits": coverage.get("purpose_splits"),
+            "window_classes": coverage.get("window_classes"),
+        },
+        "stress_behavior": stress_evidence,
+        "evidence_quality": {
+            "rankability_status": pep.get("rankability_status"),
+            "rankability_reasons": pep.get("rankability_reasons") or [],
+            "missing_evidence": pep.get("missing_evidence") or [],
+            "coverage_readiness": readiness,
+            "paper_reference_status": pep.get("paper_reference_status"),
+            "same_venue_status": pep.get("same_venue_status"),
+        },
+    }
+
+
+def _dimension_definitions() -> list[dict[str, Any]]:
+    formula_dims = [
+        {
+            "dimension_id": name,
+            "kind": "formula_v1",
+            "weight_pct": _WEIGHTS[name],
+            "formula_ref": FORMULA_REF,
+        }
+        for name in _DIMENSION_ORDER
+    ]
+    comparison_dims = [
+        {
+            "dimension_id": name,
+            "kind": "comparison_raw",
+            "description": f"Descriptive {name} from PEP / arvp_evidence",
+        }
+        for name in _COMPARISON_DIMENSIONS
+    ]
+    return formula_dims + comparison_dims
+
+
+def _exclusion_reasons(
+    pep: Mapping[str, Any],
+    *,
+    score_sentinel: bool,
+    score_failures: Sequence[str],
+    officially_rankable: bool,
+) -> list[str]:
+    reasons: list[str] = []
+    status = _rankability_status(pep)
+    if status == RANKABILITY_NOT:
+        reasons.extend(pep.get("rankability_reasons") or [])
+        reasons.append("rankability_status=NOT_RANKABLE")
+    elif status == RANKABILITY_PARTIAL:
+        reasons.extend(pep.get("rankability_reasons") or [])
+        reasons.append("rankability_status=PARTIAL_EVIDENCE (no official rank)")
+    if score_sentinel:
+        reasons.extend(score_failures)
+    if not officially_rankable:
+        reasons.append("official_ranking_withheld_by_rankability_gate")
+    if pep.get("paper_reference_status") == "not_run":
+        reasons.append("paper_reference_status=not_run")
+    if pep.get("same_venue_status") == "not_run":
+        reasons.append("same_venue_status=not_run")
+    return _dedupe(reasons)
+
+
+def _dedupe(items: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            ordered.append(item)
+    return ordered
+
+
+def _hashable_report(report: Mapping[str, Any]) -> dict[str, Any]:
+    excluded = {"generated_at", "report_content_hash"}
+    return {key: value for key, value in report.items() if key not in excluded}
+
+
+def _report_content_hash(report: Mapping[str, Any]) -> str:
+    return canonical_hash(_hashable_report(report))
+
+
+def _coverage_counts(peps: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    not_rankable = partial = 0
+    for pep in peps:
+        status = _rankability_status(pep)
+        if status == RANKABILITY_NOT:
+            not_rankable += 1
+        elif status == RANKABILITY_PARTIAL:
+            partial += 1
+    return {
+        "candidate_count": len(peps),
+        "not_rankable_count": not_rankable,
+        "partial_evidence_count": partial,
+    }
+
+
+def _governance_status(peps: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    paper = {pep.get("paper_reference_status") for pep in peps}
+    same_venue = {pep.get("same_venue_status") for pep in peps}
+    return {
+        "paper_reference_status": "not_run" if paper <= {"not_run", None} else "mixed",
+        "same_venue_status": "not_run" if same_venue <= {"not_run", None} else "mixed",
+        "promotion_status": "NOT_AUTHORIZED",
+    }
+
+
+def build_governance_league_table_report(
+    peps: Sequence[Mapping[str, Any]],
+    *,
+    campaign_id: str,
+    evidence_class: str,
+    source_content_hash: str,
+    candidate_bundle_hash: str,
+    report_id: str | None = None,
+    model_id: str = DEFAULT_MODEL_ID,
+    generated_at: str = "2026-07-12T11:19:44Z",
+    validate: bool = True,
+) -> LeagueReportAssemblyResult:
+    """Build governance-extended league table report from PEPs."""
+
+    if not peps:
+        raise ProfitabilityLeagueTableReportAssemblerError(
+            "at least one PEP is required"
+        )
+
+    ordered_peps = sorted(peps, key=lambda pep: str(pep.get("strategy_id") or pep.get("candidate_id")))
+
+    scored: list[tuple[Mapping[str, Any], Any]] = []
+    for pep in ordered_peps:
+        if validate:
+            _validate_pep(pep, artifact_role=str(pep.get("candidate_id")))
+        scored.append((pep, score_candidate(pep)))
+
+    officially_rankable_entries: list[tuple[Mapping[str, Any], Any]] = [
+        (pep, result)
+        for pep, result in scored
+        if _is_officially_rankable(pep, result.ranking_ready)
+    ]
+    officially_rankable_entries.sort(key=lambda item: _ranking_sort_key(item[1]))
+
+    official_ranking: list[dict[str, Any]] = []
+    for rank, (pep, result) in enumerate(officially_rankable_entries, start=1):
+        official_ranking.append(
+            {
+                "candidate_id": result.candidate_id,
+                "strategy_id": pep.get("strategy_id"),
+                "official_rank": rank,
+                "total_score": result.total_score,
+                "ranking_ready": True,
+                "net_return": result.net_return,
+            }
+        )
+
+    candidate_rows: list[dict[str, Any]] = []
+    candidate_rankings: list[dict[str, Any]] = []
+
+    for pep, result in scored:
+        status = _rankability_status(pep)
+        officially_rankable = _is_officially_rankable(pep, result.ranking_ready)
+        exclusions = _exclusion_reasons(
+            pep,
+            score_sentinel=result.sentinel_mode,
+            score_failures=result.hard_gate_failures,
+            officially_rankable=officially_rankable,
+        )
+
+        emit_total_score = (
+            result.total_score
+            if status != RANKABILITY_NOT and not result.sentinel_mode
+            else None
+        )
+        if result.sentinel_mode:
+            emit_total_score = 0.0 if status != RANKABILITY_NOT else None
+
+        row: dict[str, Any] = {
+            "candidate_id": result.candidate_id,
+            "strategy_id": pep.get("strategy_id"),
+            "rankability_status": status,
+            "official_rank": next(
+                (
+                    item["official_rank"]
+                    for item in official_ranking
+                    if item["candidate_id"] == result.candidate_id
+                ),
+                None,
+            ),
+            "ranking_ready": result.ranking_ready,
+            "sentinel_mode": result.sentinel_mode,
+            "total_score": emit_total_score,
+            "net_return": result.net_return,
+            "comparison_dimensions": _comparison_dimensions(pep),
+            "dimension_scores": [
+                {"dimension": item.dimension, "score": item.score}
+                for item in result.dimension_scores
+            ],
+            "recommendation": result.recommendation,
+            "exclusion_reasons": exclusions,
+            "limitations_summary": list(result.limitations_summary),
+        }
+        candidate_rows.append(row)
+
+        if officially_rankable:
+            candidate_rankings.append(
+                {
+                    "candidate_id": result.candidate_id,
+                    "rank": row["official_rank"],
+                    "total_score": result.total_score,
+                    "ranking_ready": True,
+                    "net_return": result.net_return,
+                    "dimension_scores": row["dimension_scores"],
+                    "recommendation": result.recommendation,
+                    "limitations_summary": row["limitations_summary"],
+                }
+            )
+
+    counts = _coverage_counts(ordered_peps)
+    governance = _governance_status(ordered_peps)
+
+    source_packet_hashes = [
+        str(pep.get("content_hash"))
+        for pep in ordered_peps
+        if pep.get("content_hash")
+    ]
+
+    report: dict[str, Any] = {
+        "schema_version": "profitability_league_table_report.v1",
+        "report_id": report_id or "pltr-arvp-binance-historical-4017",
+        "model_id": model_id,
+        "generated_at": generated_at,
+        "campaign_id": campaign_id,
+        "generated_from_bundle_hash": candidate_bundle_hash,
+        "evidence_class": evidence_class,
+        "table_status": "PARTIAL",
+        "ranking_ready": False,
+        "official_ranking": official_ranking,
+        "winner": None,
+        "candidate_count": counts["candidate_count"],
+        "officially_ranked_count": len(official_ranking),
+        "not_rankable_count": counts["not_rankable_count"],
+        "partial_evidence_count": counts["partial_evidence_count"],
+        "candidate_rows": candidate_rows,
+        "dimension_definitions": _dimension_definitions(),
+        "weights": dict(_WEIGHTS),
+        "normalization": _NORMALIZATION_DOC,
+        "exclusion_reasons": {
+            row["candidate_id"]: row["exclusion_reasons"] for row in candidate_rows
+        },
+        "candidate_rankings": candidate_rankings,
+        "limitations": [
+            "Governance-safe Strategy League report for historical cross-venue research.",
+            "official_ranking is empty when no candidate satisfies rankability gates.",
+            "Descriptive candidate_rows are not an official ranking.",
+            f"Formula ref: {FORMULA_REF} ({SCORING_FORMULA_VERSION}).",
+            "LR remains NO-GO. promotion_status=NOT_AUTHORIZED.",
+            f"Exit status: {EXIT_STATUS_PARTIAL_NO_WINNER}.",
+        ],
+        "paper_reference_status": governance["paper_reference_status"],
+        "same_venue_status": governance["same_venue_status"],
+        "promotion_status": governance["promotion_status"],
+        "source_content_hash": source_content_hash,
+        "candidate_bundle_hash": candidate_bundle_hash,
+        "source_packet_hashes": source_packet_hashes,
+        "scoring_formula_version": SCORING_FORMULA_VERSION,
+        "scorer_version": SCORER_VERSION,
+    }
+
+    content_hash = _report_content_hash(report)
+    report["report_content_hash"] = content_hash
+
+    if validate:
+        _validate_report(report)
+
+    return LeagueReportAssemblyResult(report=report, report_content_hash=content_hash)
+
+
+def assemble_from_pep_paths(
+    pep_paths: Sequence[Path],
+    *,
+    campaign_id: str,
+    evidence_class: str,
+    source_content_hash: str,
+    candidate_bundle_hash: str,
+    validate: bool = True,
+) -> LeagueReportAssemblyResult:
+    peps: list[dict[str, Any]] = []
+    for path in sorted(pep_paths):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ProfitabilityLeagueTableReportAssemblerError(
+                f"PEP {path} must be a JSON object"
+            )
+        peps.append(payload)
+    return build_governance_league_table_report(
+        peps,
+        campaign_id=campaign_id,
+        evidence_class=evidence_class,
+        source_content_hash=source_content_hash,
+        candidate_bundle_hash=candidate_bundle_hash,
+        validate=validate,
+    )
+
+
+def assemble_from_candidate_bundle_dir(
+    bundle_dir: Path,
+    *,
+    validate: bool = True,
+) -> LeagueReportAssemblyResult:
+    manifest_path = bundle_dir / "bundle_manifest.json"
+    if not manifest_path.is_file():
+        raise ProfitabilityLeagueTableReportAssemblerError(
+            f"bundle manifest not found: {manifest_path}"
+        )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise ProfitabilityLeagueTableReportAssemblerError("bundle manifest must be object")
+
+    bundle_hash = str(manifest.get("bundle_hash") or "")
+    packets_meta = manifest.get("packets") or []
+    if not bundle_hash or not isinstance(packets_meta, list):
+        raise ProfitabilityLeagueTableReportAssemblerError(
+            "bundle manifest missing bundle_hash or packets"
+        )
+
+    pep_paths = [bundle_dir / str(item.get("path", "")) for item in packets_meta]
+    peps: list[dict[str, Any]] = []
+    for path in pep_paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ProfitabilityLeagueTableReportAssemblerError(
+                f"PEP {path} must be a JSON object"
+            )
+        peps.append(payload)
+
+    if not peps:
+        raise ProfitabilityLeagueTableReportAssemblerError("bundle contains no PEP files")
+
+    first = peps[0]
+    campaign_id = str(first.get("campaign_id") or "")
+    evidence_class = str(first.get("evidence_class") or "")
+    source_content_hash = str(first.get("source_content_hash") or "")
+    if not campaign_id or not source_content_hash:
+        raise ProfitabilityLeagueTableReportAssemblerError(
+            "PEPs must include campaign_id and source_content_hash"
+        )
+
+    return build_governance_league_table_report(
+        peps,
+        campaign_id=campaign_id,
+        evidence_class=evidence_class,
+        source_content_hash=source_content_hash,
+        candidate_bundle_hash=bundle_hash,
+        validate=validate,
+    )
+
+
+def write_report_output(
+    result: LeagueReportAssemblyResult,
+    *,
+    output_path: Path,
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(result.report, ensure_ascii=True, indent=2, sort_keys=True)
+    output_path.write_text(serialized + "\n", encoding="utf-8")

--- a/tests/fixtures/arvp/league_table/slice_report_expectations.v1.json
+++ b/tests/fixtures/arvp/league_table/slice_report_expectations.v1.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "arvp_league_table_report_fixture.v1",
+  "description": "Golden league report expectations for slice candidate bundle (#4017)",
+  "campaign_id": "arvp_binance_historical_3990_2bb32b68_20260712T111944Z",
+  "source_content_hash": "ad3d4ccc449e81e4aa5ec81185d6b3229d12a9e05b2e4970dd352b7471e5b7ad",
+  "candidate_bundle_hash": "60ab9973f898c5819d5f3cb56767ef22f124078416fc9fe1aaff530e5e9f0d80",
+  "table_status": "PARTIAL",
+  "ranking_ready": false,
+  "winner": null,
+  "official_ranking": [],
+  "candidate_count": 2,
+  "officially_ranked_count": 0,
+  "not_rankable_count": 2,
+  "partial_evidence_count": 0,
+  "promotion_status": "NOT_AUTHORIZED"
+}

--- a/tests/unit/arvp/test_league_table_report_assembly.py
+++ b/tests/unit/arvp/test_league_table_report_assembly.py
@@ -1,0 +1,192 @@
+"""Governance-safe Strategy League table report assembly tests (#4017)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from services.validation.arvp_candidate_evidence_assembler import (
+    RANKABILITY_NOT,
+    RANKABILITY_PARTIAL,
+    assemble_arvp_candidate_evidence,
+)
+from services.validation.profitability_league_table_report_assembler import (
+    EXIT_STATUS_PARTIAL_NO_WINNER,
+    build_governance_league_table_report,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "arvp" / "candidate_evidence"
+REPORT_SCHEMA_PATH = (
+    REPO_ROOT / "docs" / "contracts" / "profitability_league_table_report.v1.schema.json"
+)
+CAMPAIGN_QUEUE = (
+    REPO_ROOT
+    / "artifacts"
+    / "arvp_vacation"
+    / "arvp_binance_historical_3990_2bb32b68_20260712T111944Z"
+    / "queue_state.json"
+)
+GOLDEN_SOURCE_HASH = (
+    "ad3d4ccc449e81e4aa5ec81185d6b3229d12a9e05b2e4970dd352b7471e5b7ad"
+)
+GOLDEN_BUNDLE_HASH = (
+    "4e7b4b88427d3fed84493721f97f82d0502c5a93ee96b81b8af8dab0671e26a4"
+)
+CAMPAIGN_ID = "arvp_binance_historical_3990_2bb32b68_20260712T111944Z"
+
+
+def _load(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.fixture(scope="module")
+def report_validator() -> Draft7Validator:
+    return Draft7Validator(_load(REPORT_SCHEMA_PATH))
+
+
+def _assembly_from_slice() -> tuple[list[dict], str]:
+    bundle = _load(FIXTURES / "slice_metrics_bundle.v1.json")
+    result = assemble_arvp_candidate_evidence(bundle)
+    return result.packets, result.bundle_hash
+
+
+def _report_from_peps(peps: list[dict], *, bundle_hash: str) -> dict:
+    result = build_governance_league_table_report(
+        peps,
+        campaign_id=CAMPAIGN_ID,
+        evidence_class="historical_cross_venue_research",
+        source_content_hash=GOLDEN_SOURCE_HASH,
+        candidate_bundle_hash=bundle_hash,
+        report_id="pltr-arvp-league-test-4017",
+    )
+    return result.report
+
+
+def test_slice_bundle_report_is_partial_with_empty_official_ranking(
+    report_validator: Draft7Validator,
+) -> None:
+    peps, bundle_hash = _assembly_from_slice()
+    report = _report_from_peps(peps, bundle_hash=bundle_hash)
+
+    assert report["table_status"] == "PARTIAL"
+    assert report["ranking_ready"] is False
+    assert report["winner"] is None
+    assert report["official_ranking"] == []
+    assert report["candidate_rankings"] == []
+    assert report["officially_ranked_count"] == 0
+    assert report["not_rankable_count"] == 2
+    assert report["promotion_status"] == "NOT_AUTHORIZED"
+    assert report["paper_reference_status"] == "not_run"
+    assert report["same_venue_status"] == "not_run"
+    assert report["source_content_hash"] == GOLDEN_SOURCE_HASH
+    assert report["candidate_bundle_hash"] == bundle_hash
+
+    errors = sorted(report_validator.iter_errors(report), key=lambda err: str(err.message))
+    assert not errors, errors[0].message if errors else ""
+
+
+def test_not_rankable_candidates_have_no_total_score() -> None:
+    peps, bundle_hash = _assembly_from_slice()
+    report = _report_from_peps(peps, bundle_hash=bundle_hash)
+
+    for row in report["candidate_rows"]:
+        assert row["rankability_status"] == RANKABILITY_NOT
+        assert row["official_rank"] is None
+        assert row["total_score"] is None
+        assert row["sentinel_mode"] is True
+        assert "rankability_status=NOT_RANKABLE" in row["exclusion_reasons"]
+
+
+def test_partial_evidence_is_not_winner() -> None:
+    peps, _ = _assembly_from_slice()
+    partial_pep = copy.deepcopy(peps[0])
+    partial_pep["rankability_status"] = RANKABILITY_PARTIAL
+    partial_pep["rankability_reasons"] = ["partial_missing_required_metrics"]
+    partial_pep["candidate_id"] = "cand-partial-test-v1"
+
+    report = _report_from_peps([partial_pep], bundle_hash="a" * 64)
+    assert report["winner"] is None
+    assert report["official_ranking"] == []
+    row = report["candidate_rows"][0]
+    assert row["rankability_status"] == RANKABILITY_PARTIAL
+    assert row["official_rank"] is None
+
+
+def test_reverse_pep_order_yields_identical_report_hash() -> None:
+    peps, bundle_hash = _assembly_from_slice()
+    first = build_governance_league_table_report(
+        peps,
+        campaign_id=CAMPAIGN_ID,
+        evidence_class="historical_cross_venue_research",
+        source_content_hash=GOLDEN_SOURCE_HASH,
+        candidate_bundle_hash=bundle_hash,
+    )
+    second = build_governance_league_table_report(
+        list(reversed(peps)),
+        campaign_id=CAMPAIGN_ID,
+        evidence_class="historical_cross_venue_research",
+        source_content_hash=GOLDEN_SOURCE_HASH,
+        candidate_bundle_hash=bundle_hash,
+    )
+    assert first.report_content_hash == second.report_content_hash
+
+
+def test_comparison_dimensions_and_formula_weights_visible() -> None:
+    peps, bundle_hash = _assembly_from_slice()
+    report = _report_from_peps(peps, bundle_hash=bundle_hash)
+
+    assert report["weights"]["NET_ECONOMICS"] == 25.0
+    assert sum(report["weights"].values()) == pytest.approx(100.0)
+    assert len(report["dimension_definitions"]) == 17
+    row = report["candidate_rows"][0]
+    dims = row["comparison_dimensions"]
+    assert "net_economic_result" in dims
+    assert "sample_size" in dims
+    assert "evidence_quality" in dims
+
+
+def test_exit_status_documented_in_limitations() -> None:
+    peps, bundle_hash = _assembly_from_slice()
+    report = _report_from_peps(peps, bundle_hash=bundle_hash)
+    joined = " ".join(report["limitations"])
+    assert EXIT_STATUS_PARTIAL_NO_WINNER in joined
+
+
+@pytest.mark.skipif(not CAMPAIGN_QUEUE.is_file(), reason="full campaign artifacts absent")
+def test_full_campaign_league_report_when_artifacts_present(
+    report_validator: Draft7Validator,
+) -> None:
+    from tools.arvp_vacation.strategy_metric_extraction import build_extraction_bundle
+
+    bundle = build_extraction_bundle(_load(CAMPAIGN_QUEUE), repo_root=REPO_ROOT)
+    assembly = assemble_arvp_candidate_evidence(bundle)
+    assert assembly.bundle_hash == GOLDEN_BUNDLE_HASH
+
+    report = _report_from_peps(assembly.packets, bundle_hash=assembly.bundle_hash)
+    assert report["candidate_count"] == 3
+    assert report["official_ranking"] == []
+    assert report["winner"] is None
+
+    statuses = {row["rankability_status"] for row in report["candidate_rows"]}
+    assert RANKABILITY_NOT in statuses
+
+    second = build_governance_league_table_report(
+        list(reversed(assembly.packets)),
+        campaign_id=CAMPAIGN_ID,
+        evidence_class="historical_cross_venue_research",
+        source_content_hash=GOLDEN_SOURCE_HASH,
+        candidate_bundle_hash=assembly.bundle_hash,
+        report_id="pltr-arvp-league-test-4017",
+    )
+    assert second.report_content_hash == report["report_content_hash"]
+
+    errors = sorted(report_validator.iter_errors(report), key=lambda err: str(err.message))
+    assert not errors, errors[0].message if errors else ""

--- a/tools/arvp_vacation/league_table_report.py
+++ b/tools/arvp_vacation/league_table_report.py
@@ -1,0 +1,178 @@
+"""CLI for governance-safe Strategy League table reports (#4017)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from services.validation.profitability_league_table_report_assembler import (
+    ProfitabilityLeagueTableReportAssemblerError,
+    assemble_from_candidate_bundle_dir,
+    assemble_from_pep_paths,
+    build_governance_league_table_report,
+    write_report_output,
+)
+from services.validation.arvp_candidate_evidence_assembler import (
+    assemble_arvp_candidate_evidence,
+    assemble_from_metrics_bundle_path,
+)
+from tools.arvp_vacation.strategy_metric_extraction import extract_from_queue_state_path
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build governance-safe profitability_league_table_report.v1 from "
+            "profitability_evidence_packet.v1 candidate bundles."
+        )
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--bundle-dir",
+        type=Path,
+        help="Directory with bundle_manifest.json and *.pep.json files",
+    )
+    source.add_argument(
+        "--pep",
+        action="append",
+        type=Path,
+        dest="peps",
+        help="Path to a PEP JSON file (repeatable; requires provenance flags)",
+    )
+    source.add_argument(
+        "--assemble-from-metrics",
+        type=Path,
+        help="Assemble PEPs from arvp_strategy_metrics.v1 bundle then score",
+    )
+    source.add_argument(
+        "--assemble-from-queue-state",
+        type=Path,
+        help="Extract metrics from queue_state.json, assemble PEPs, then score",
+    )
+    parser.add_argument("--repo-root", default=".", help="Repo root for queue-state path")
+    parser.add_argument("--campaign-id", help="Required with --pep")
+    parser.add_argument("--evidence-class", default="historical_cross_venue_research")
+    parser.add_argument("--source-content-hash", help="Required with --pep")
+    parser.add_argument("--candidate-bundle-hash", help="Required with --pep")
+    parser.add_argument("--report-id", default=None)
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        help="Output path for league table report JSON",
+    )
+    parser.add_argument(
+        "--hash-only",
+        action="store_true",
+        help="Print report_content_hash only",
+    )
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Skip schema validation",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    validate = not args.no_validate
+
+    try:
+        if args.bundle_dir is not None:
+            result = assemble_from_candidate_bundle_dir(
+                args.bundle_dir.resolve(),
+                validate=validate,
+            )
+        elif args.assemble_from_metrics is not None:
+            assembly = assemble_from_metrics_bundle_path(
+                args.assemble_from_metrics.resolve()
+            )
+            first = assembly.packets[0]
+            result = build_governance_league_table_report(
+                assembly.packets,
+                campaign_id=str(first.get("campaign_id") or ""),
+                evidence_class=str(first.get("evidence_class") or ""),
+                source_content_hash=str(first.get("source_content_hash") or ""),
+                candidate_bundle_hash=assembly.bundle_hash,
+                validate=validate,
+            )
+        elif args.assemble_from_queue_state is not None:
+            repo_root = Path(args.repo_root).resolve()
+            bundle = extract_from_queue_state_path(
+                args.assemble_from_queue_state.resolve(),
+                repo_root=repo_root,
+            )
+            assembly = assemble_arvp_candidate_evidence(bundle)
+            first = assembly.packets[0]
+            result = build_governance_league_table_report(
+                assembly.packets,
+                campaign_id=str(first.get("campaign_id") or ""),
+                evidence_class=str(first.get("evidence_class") or ""),
+                source_content_hash=str(first.get("source_content_hash") or ""),
+                candidate_bundle_hash=assembly.bundle_hash,
+                validate=validate,
+            )
+        else:
+            if not args.peps:
+                raise ProfitabilityLeagueTableReportAssemblerError("--pep is required")
+            for field_name, value in (
+                ("campaign_id", args.campaign_id),
+                ("source_content_hash", args.source_content_hash),
+                ("candidate_bundle_hash", args.candidate_bundle_hash),
+            ):
+                if not value:
+                    raise ProfitabilityLeagueTableReportAssemblerError(
+                        f"{field_name} is required with --pep"
+                    )
+            result = assemble_from_pep_paths(
+                [path.resolve() for path in args.peps],
+                campaign_id=str(args.campaign_id),
+                evidence_class=str(args.evidence_class),
+                source_content_hash=str(args.source_content_hash),
+                candidate_bundle_hash=str(args.candidate_bundle_hash),
+                validate=validate,
+            )
+
+        if args.report_id:
+            result.report["report_id"] = args.report_id
+            from services.validation.profitability_league_table_report_assembler import (
+                _report_content_hash,
+            )
+
+            result.report["report_content_hash"] = _report_content_hash(result.report)
+
+        if args.hash_only:
+            print(result.report_content_hash)
+        elif args.out_json is not None:
+            write_report_output(result, output_path=args.out_json.resolve())
+            print(
+                json.dumps(
+                    {
+                        "report_id": result.report["report_id"],
+                        "table_status": result.report["table_status"],
+                        "officially_ranked_count": result.report.get(
+                            "officially_ranked_count"
+                        ),
+                        "report_content_hash": result.report_content_hash,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(json.dumps(result.report, indent=2, sort_keys=True))
+    except (
+        ProfitabilityLeagueTableReportAssemblerError,
+        ValueError,
+        OSError,
+    ) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Closes #4017
Refs #4013
Refs #1900

Deterministic governance-safe \profitability_league_table_report.v1\ from ARVP Binance historical candidate PEPs. Compares all three candidates multidimensionally without forcing an official winner when rankability gates fail.

## Delivered
- \services/validation/profitability_league_table_report_assembler.py\ — rankability-aware report assembly + content hash
- \	ools/arvp_vacation/league_table_report.py\ — offline CLI (bundle / PEP / queue-state paths)
- Backward-compatible schema extensions in \docs/contracts/profitability_league_table_report.v1.schema.json\
- Unit/contract tests + slice fixture expectations
- Evidence doc: \docs/evidence/arvp_3990_strategy_league_table.md\

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- repo_fallback_reason: insufficient_evidence
- records_found: none
- repo_crosscheck: origin/main @ f9e0cb0, #4013/#4016/#4017, PR #4022 merge

## Candidate bundle hash
- \4e7b4b88427d3fed84493721f97f82d0502c5a93ee96b81b8af8dab0671e26a4\
- Source content hash: \d3d4ccc449e81e4aa5ec81185d6b3229d12a9e05b2e4970dd352b7471e5b7ad\

## Scoring dimensions and formula
Formula v1 six weighted dimensions (25/20/15/15/15/10) via existing \profitability_league_scorer.py\.
Eleven descriptive comparison dimensions in \candidate_rows\ (raw PEP / arvp_evidence).

## Rankability and no-winner result
- \	able_status=PARTIAL\, \anking_ready=false\, \winner=null\, \official_ranking=[]\
- 2x NOT_RANKABLE, 1x PARTIAL_EVIDENCE; \promotion_status=NOT_AUTHORIZED\
- Exit: \HISTORICAL_LEAGUE_PARTIAL_NO_RANKABLE_WINNER\

## Report hash
Full campaign (local artifacts): \