### PR TITLE
feat(arvp): Batch-A slice 2b — breakout/volatility runners (#4031)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@
 !services/validation/momentum_backtest_runner.py
 !services/validation/donchian_breakout_backtest_runner.py
 !services/validation/breakout_trend_filter_backtest_runner.py
+!services/validation/breakout_volatility_filter_backtest_runner.py
+!services/validation/volatility_breakout_backtest_runner.py
+!services/validation/bollinger_squeeze_breakout_backtest_runner.py
+!services/validation/atr_expansion_backtest_runner.py
+!services/validation/pack_a_backtest_report.py
 !cdb_agent_sdk/tests/**/*.py
 !cdb_agent_sdk/tests/**/*.js
 debug_*.py

--- a/core/replay/batch_a_strategy_registry.py
+++ b/core/replay/batch_a_strategy_registry.py
@@ -73,7 +73,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "breakout_volatility_filter_v1": BatchAStrategyRecord(
         strategy_id="breakout_volatility_filter_v1",
         implementation_mode=ImplementationMode.EXTEND,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2b",
         adapter_id=None,
         runner_module=(
@@ -97,7 +97,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "volatility_breakout_v1": BatchAStrategyRecord(
         strategy_id="volatility_breakout_v1",
         implementation_mode=ImplementationMode.NEW,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2b",
         adapter_id=None,
         runner_module="services.validation.volatility_breakout_backtest_runner",
@@ -183,7 +183,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "bollinger_squeeze_breakout_v1": BatchAStrategyRecord(
         strategy_id="bollinger_squeeze_breakout_v1",
         implementation_mode=ImplementationMode.NEW,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2b",
         adapter_id=None,
         runner_module=(
@@ -246,7 +246,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "atr_expansion_v1": BatchAStrategyRecord(
         strategy_id="atr_expansion_v1",
         implementation_mode=ImplementationMode.NEW,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2b",
         adapter_id=None,
         runner_module="services.validation.atr_expansion_backtest_runner",

--- a/core/replay/pack_a_breakout_common.py
+++ b/core/replay/pack_a_breakout_common.py
@@ -1,10 +1,12 @@
 """Shared Pack-A breakout helpers for Donchian and trend-filter variants.
 
-Frozen parameters per docs/evidence/arvp_pack_a_breakout_baseline_spec_3748.md §7.2–7.3.
+Frozen parameters per docs/evidence/arvp_pack_a_breakout_baseline_spec_3748.md §7.2–7.5
+and Batch-A registry (#4031).
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any, Sequence
 
@@ -12,6 +14,10 @@ from core.replay.historical_bridge import ONE_MINUTE_MS, PRIMARY_BREAKOUT_SYMBOL
 
 DONCHIAN_BREAKOUT_STRATEGY_ID = "donchian_breakout_v1"
 BREAKOUT_TREND_FILTER_STRATEGY_ID = "breakout_trend_filter_v1"
+BREAKOUT_VOLATILITY_FILTER_STRATEGY_ID = "breakout_volatility_filter_v1"
+VOLATILITY_BREAKOUT_STRATEGY_ID = "volatility_breakout_v1"
+BOLLINGER_SQUEEZE_BREAKOUT_STRATEGY_ID = "bollinger_squeeze_breakout_v1"
+ATR_EXPANSION_STRATEGY_ID = "atr_expansion_v1"
 PACK_A_SYMBOL = PRIMARY_BREAKOUT_SYMBOL
 
 ENTRY_CHANNEL_BARS = 20
@@ -19,6 +25,25 @@ EXIT_CHANNEL_BARS = 10
 MIN_MINUTES_BETWEEN_ENTRIES = 30
 TREND_EMA_PERIOD_5M = 20
 FIVE_MINUTE_MS = 5 * ONE_MINUTE_MS
+
+ATR_PERIOD = 14
+VOL_FLOOR = 0.0003
+VOL_CEILING = 0.0030
+BREAKOUT_LOOKBACK = 20
+EXIT_LOOKBACK = 10
+EXPANSION_LAG = 5
+EXPANSION_MULTIPLIER = 1.15
+BB_PERIOD = 20
+BB_STD_DEV = 2.0
+SQUEEZE_THRESHOLD = 0.015
+SQUEEZE_BARS_MIN = 5
+EXPANSION_CEILING = 0.04
+ATR_RATIO_THRESHOLD = 0.0025
+ATR_RATIO_EXIT = 0.0018
+SMA_PERIOD = 20
+VOL_BREAKOUT_MIN_MINUTES_BETWEEN_ENTRIES = 30
+BOLLINGER_MIN_MINUTES_BETWEEN_ENTRIES = 60
+ATR_EXPANSION_MIN_MINUTES_BETWEEN_ENTRIES = 60
 
 ORDER_SIZE = 1.0
 ORDER_BOOK_DEPTH_MULT = 10_000.0
@@ -56,6 +81,100 @@ class BreakoutTrendFilterConfig(DonchianBreakoutConfig):
             raise PackABreakoutError("trend_ema_period_5m must be > 0")
 
 
+@dataclass(frozen=True, slots=True)
+class BreakoutVolatilityFilterConfig(DonchianBreakoutConfig):
+    atr_period: int = ATR_PERIOD
+    vol_floor: float = VOL_FLOOR
+    vol_ceiling: float = VOL_CEILING
+
+    def validate(self) -> None:
+        super().validate()
+        if self.atr_period <= 0:
+            raise PackABreakoutError("atr_period must be > 0")
+        if self.vol_floor < 0:
+            raise PackABreakoutError("vol_floor must be >= 0")
+        if self.vol_ceiling <= self.vol_floor:
+            raise PackABreakoutError("vol_ceiling must be > vol_floor")
+
+
+@dataclass(frozen=True, slots=True)
+class VolatilityBreakoutConfig:
+    breakout_lookback: int = BREAKOUT_LOOKBACK
+    exit_lookback: int = EXIT_LOOKBACK
+    atr_period: int = ATR_PERIOD
+    expansion_lag: int = EXPANSION_LAG
+    expansion_multiplier: float = EXPANSION_MULTIPLIER
+    min_minutes_between_entries: int = VOL_BREAKOUT_MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.breakout_lookback <= 0:
+            raise PackABreakoutError("breakout_lookback must be > 0")
+        if self.exit_lookback <= 0:
+            raise PackABreakoutError("exit_lookback must be > 0")
+        if self.atr_period <= 0:
+            raise PackABreakoutError("atr_period must be > 0")
+        if self.expansion_lag <= 0:
+            raise PackABreakoutError("expansion_lag must be > 0")
+        if self.expansion_multiplier <= 0:
+            raise PackABreakoutError("expansion_multiplier must be > 0")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
+@dataclass(frozen=True, slots=True)
+class BollingerSqueezeConfig:
+    bb_period: int = BB_PERIOD
+    bb_std_dev: float = BB_STD_DEV
+    squeeze_threshold: float = SQUEEZE_THRESHOLD
+    squeeze_bars_min: int = SQUEEZE_BARS_MIN
+    expansion_ceiling: float = EXPANSION_CEILING
+    min_minutes_between_entries: int = BOLLINGER_MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.bb_period <= 0:
+            raise PackABreakoutError("bb_period must be > 0")
+        if self.bb_std_dev <= 0:
+            raise PackABreakoutError("bb_std_dev must be > 0")
+        if self.squeeze_threshold <= 0:
+            raise PackABreakoutError("squeeze_threshold must be > 0")
+        if self.squeeze_bars_min <= 0:
+            raise PackABreakoutError("squeeze_bars_min must be > 0")
+        if self.expansion_ceiling <= 0:
+            raise PackABreakoutError("expansion_ceiling must be > 0")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
+@dataclass(frozen=True, slots=True)
+class AtrExpansionConfig:
+    atr_period: int = ATR_PERIOD
+    atr_ratio_threshold: float = ATR_RATIO_THRESHOLD
+    atr_ratio_exit: float = ATR_RATIO_EXIT
+    sma_period: int = SMA_PERIOD
+    min_minutes_between_entries: int = ATR_EXPANSION_MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.atr_period <= 0:
+            raise PackABreakoutError("atr_period must be > 0")
+        if self.atr_ratio_threshold <= 0:
+            raise PackABreakoutError("atr_ratio_threshold must be > 0")
+        if self.atr_ratio_exit <= 0:
+            raise PackABreakoutError("atr_ratio_exit must be > 0")
+        if self.sma_period <= 0:
+            raise PackABreakoutError("sma_period must be > 0")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
 def donchian_warmup_candles(config: DonchianBreakoutConfig | None = None) -> int:
     active = config or DonchianBreakoutConfig()
     active.validate()
@@ -71,6 +190,36 @@ def breakout_trend_warmup_candles(
     min_5m_bars = active.trend_ema_period_5m
     min_1m_for_5m = min_5m_bars * 5
     return max(donchian_warmup_candles(active), min_1m_for_5m)
+
+
+def breakout_volatility_filter_warmup_candles(
+    config: BreakoutVolatilityFilterConfig | None = None,
+) -> int:
+    active = config or BreakoutVolatilityFilterConfig()
+    active.validate()
+    return max(active.entry_channel_bars, active.exit_channel_bars) + active.atr_period
+
+
+def volatility_breakout_warmup_candles(
+    config: VolatilityBreakoutConfig | None = None,
+) -> int:
+    active = config or VolatilityBreakoutConfig()
+    active.validate()
+    return active.breakout_lookback + active.expansion_lag
+
+
+def bollinger_squeeze_warmup_candles(
+    config: BollingerSqueezeConfig | None = None,
+) -> int:
+    active = config or BollingerSqueezeConfig()
+    active.validate()
+    return active.bb_period
+
+
+def atr_expansion_warmup_candles(config: AtrExpansionConfig | None = None) -> int:
+    active = config or AtrExpansionConfig()
+    active.validate()
+    return max(active.sma_period + active.atr_period, 50)
 
 
 def _required_float(row: dict[str, Any], key: str) -> float:
@@ -138,6 +287,164 @@ def compute_donchian_channels(
             window = lows[index - exit_channel_bars : index]
             lower[index] = min(window)
     return upper, lower
+
+
+def compute_highest_high(
+    highs: Sequence[float],
+    lookback: int,
+) -> list[float | None]:
+    """Highest high over prior ``lookback`` closed bars (exclusive of index)."""
+    if lookback <= 0:
+        raise PackABreakoutError("lookback must be > 0")
+    result: list[float | None] = [None] * len(highs)
+    for index in range(len(highs)):
+        if index >= lookback:
+            result[index] = max(highs[index - lookback : index])
+    return result
+
+
+def compute_lowest_low(
+    lows: Sequence[float],
+    lookback: int,
+) -> list[float | None]:
+    """Lowest low over prior ``lookback`` closed bars (exclusive of index)."""
+    if lookback <= 0:
+        raise PackABreakoutError("lookback must be > 0")
+    result: list[float | None] = [None] * len(lows)
+    for index in range(len(lows)):
+        if index >= lookback:
+            result[index] = min(lows[index - lookback : index])
+    return result
+
+
+def compute_atr_series(
+    highs: Sequence[float],
+    lows: Sequence[float],
+    closes: Sequence[float],
+    period: int,
+) -> list[float | None]:
+    """Wilder ATR on closed 1m bars; ``None`` until the first smoothed value."""
+    if period <= 0:
+        raise PackABreakoutError("period must be > 0")
+    if not (len(highs) == len(lows) == len(closes)):
+        raise PackABreakoutError("highs, lows, closes length mismatch")
+    if len(closes) < 2:
+        return [None] * len(closes)
+
+    true_ranges: list[float] = []
+    for index in range(1, len(closes)):
+        prev_close = closes[index - 1]
+        tr = max(
+            highs[index] - lows[index],
+            abs(highs[index] - prev_close),
+            abs(lows[index] - prev_close),
+        )
+        true_ranges.append(tr)
+
+    atr: list[float | None] = [None] * len(closes)
+    if len(true_ranges) < period:
+        return atr
+
+    seed = sum(true_ranges[:period]) / period
+    atr_index = period
+    atr[atr_index] = seed
+    smoothed = seed
+    for tr in true_ranges[period:]:
+        atr_index += 1
+        smoothed = (smoothed * (period - 1) + tr) / period
+        atr[atr_index] = smoothed
+    return atr
+
+
+def compute_sma_series(
+    closes: Sequence[float],
+    period: int,
+) -> list[float | None]:
+    """Simple moving average using closed bars inclusive of index."""
+    if period <= 0:
+        raise PackABreakoutError("period must be > 0")
+    result: list[float | None] = [None] * len(closes)
+    for index in range(period - 1, len(closes)):
+        window = closes[index - period + 1 : index + 1]
+        result[index] = sum(window) / period
+    return result
+
+
+def compute_bollinger_series(
+    closes: Sequence[float],
+    *,
+    period: int,
+    std_dev: float,
+) -> tuple[list[float | None], list[float | None], list[float | None], list[float | None]]:
+    """Upper/middle/lower BB and bandwidth using closed bars inclusive of index."""
+    if period <= 0:
+        raise PackABreakoutError("period must be > 0")
+    if std_dev <= 0:
+        raise PackABreakoutError("std_dev must be > 0")
+
+    upper: list[float | None] = [None] * len(closes)
+    middle: list[float | None] = [None] * len(closes)
+    lower: list[float | None] = [None] * len(closes)
+    bandwidth: list[float | None] = [None] * len(closes)
+
+    for index in range(period - 1, len(closes)):
+        window = closes[index - period + 1 : index + 1]
+        sma = sum(window) / period
+        variance = sum((value - sma) ** 2 for value in window) / period
+        std = math.sqrt(variance)
+        upper_band = sma + std_dev * std
+        lower_band = sma - std_dev * std
+        upper[index] = upper_band
+        middle[index] = sma
+        lower[index] = lower_band
+        bandwidth[index] = (upper_band - lower_band) / sma if sma > 0 else 0.0
+    return upper, middle, lower, bandwidth
+
+
+def vol_ratio_in_band(
+    atr_value: float | None,
+    close: float,
+    *,
+    vol_floor: float,
+    vol_ceiling: float,
+) -> bool:
+    if atr_value is None or close <= 0:
+        return False
+    ratio = atr_value / close
+    return vol_floor <= ratio <= vol_ceiling
+
+
+def atr_expansion_holds(
+    atr_series: Sequence[float | None],
+    index: int,
+    *,
+    expansion_lag: int,
+    expansion_multiplier: float,
+) -> bool:
+    current = atr_series[index]
+    lag_index = index - expansion_lag
+    if current is None or lag_index < 0:
+        return False
+    lagged = atr_series[lag_index]
+    if lagged is None or lagged <= 0:
+        return False
+    return current > lagged * expansion_multiplier
+
+
+def squeeze_precedes_breakout(
+    bandwidth_series: Sequence[float | None],
+    index: int,
+    *,
+    squeeze_threshold: float,
+    squeeze_bars_min: int,
+) -> bool:
+    if index < squeeze_bars_min:
+        return False
+    for offset in range(1, squeeze_bars_min + 1):
+        prior = bandwidth_series[index - offset]
+        if prior is None or prior >= squeeze_threshold:
+            return False
+    return True
 
 
 def _ema(values: Sequence[float], period: int) -> list[float | None]:

--- a/core/replay/pack_a_breakout_common.py
+++ b/core/replay/pack_a_breakout_common.py
@@ -76,7 +76,7 @@ class BreakoutTrendFilterConfig(DonchianBreakoutConfig):
     trend_ema_period_5m: int = TREND_EMA_PERIOD_5M
 
     def validate(self) -> None:
-        super().validate()
+        DonchianBreakoutConfig.validate(self)
         if self.trend_ema_period_5m <= 0:
             raise PackABreakoutError("trend_ema_period_5m must be > 0")
 
@@ -88,7 +88,7 @@ class BreakoutVolatilityFilterConfig(DonchianBreakoutConfig):
     vol_ceiling: float = VOL_CEILING
 
     def validate(self) -> None:
-        super().validate()
+        DonchianBreakoutConfig.validate(self)
         if self.atr_period <= 0:
             raise PackABreakoutError("atr_period must be > 0")
         if self.vol_floor < 0:

--- a/services/validation/atr_expansion_backtest_runner.py
+++ b/services/validation/atr_expansion_backtest_runner.py
@@ -1,0 +1,181 @@
+"""Single-pass backtest runner for atr_expansion_v1 (Pack-A slice 2b)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    ATR_EXPANSION_STRATEGY_ID,
+    AtrExpansionConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    atr_expansion_warmup_candles,
+    compute_atr_series,
+    compute_sma_series,
+    cooldown_allows_entry,
+    validate_pack_a_candle_series,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_atr_expansion_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: AtrExpansionConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass ATR Expansion backtest returning a report dict."""
+    config = bridge_config or AtrExpansionConfig()
+    config.validate()
+    warmup = atr_expansion_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    atr_series = compute_atr_series(highs, lows, closes, config.atr_period)
+    sma_series = compute_sma_series(closes, config.sma_period)
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+        atr_value = atr_series[index]
+        sma_value = sma_series[index]
+        atr_ratio = (atr_value / close) if atr_value is not None and close > 0 else None
+
+        if open_position is None:
+            trend_ok = sma_value is not None and close > sma_value
+            ratio_ok = atr_ratio is not None and atr_ratio > config.atr_ratio_threshold
+            if (
+                trend_ok
+                and ratio_ok
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("atr_ratio_expansion_entry")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif open_position is not None:
+            ratio_exit = atr_ratio is not None and atr_ratio < config.atr_ratio_exit
+            trend_fail = sma_value is not None and close < sma_value
+            if ratio_exit or trend_fail:
+                exit_price = close
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="sell",
+                    size=ORDER_SIZE,
+                    current_price=exit_price,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                trade_r = (
+                    fill.avg_fill_price - open_position["entry_price"]
+                ) / open_position["entry_price"]
+                reason = "atr_ratio_contract" if ratio_exit and not trend_fail else "sma_trend_fail"
+                exit_reasons.append(reason)
+                trades.append(
+                    {
+                        "entry_ts_ms": open_position["entry_ts_ms"],
+                        "exit_ts_ms": ts_ms,
+                        "entry_price": open_position["entry_price"],
+                        "exit_price": fill.avg_fill_price,
+                        "entry_fee": open_position["entry_fee"],
+                        "exit_fee": fill.fees,
+                        "r_return": trade_r,
+                        "reason": reason,
+                    }
+                )
+                open_position = None
+
+    return build_pack_a_full_report(
+        strategy_id=ATR_EXPANSION_STRATEGY_ID,
+        source="atr_expansion_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "atr_period": config.atr_period,
+            "atr_ratio_threshold": config.atr_ratio_threshold,
+            "atr_ratio_exit": config.atr_ratio_exit,
+            "sma_period": config.sma_period,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "atr_ratio_expansion_entry": entry_reasons.count("atr_ratio_expansion_entry"),
+            "atr_ratio_contract": exit_reasons.count("atr_ratio_contract"),
+            "sma_trend_fail": exit_reasons.count("sma_trend_fail"),
+        },
+    )
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=ATR_EXPANSION_STRATEGY_ID,
+        source="atr_expansion_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/services/validation/bollinger_squeeze_breakout_backtest_runner.py
+++ b/services/validation/bollinger_squeeze_breakout_backtest_runner.py
@@ -1,0 +1,193 @@
+"""Single-pass backtest runner for bollinger_squeeze_breakout_v1 (Pack-A slice 2b)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    BOLLINGER_SQUEEZE_BREAKOUT_STRATEGY_ID,
+    BollingerSqueezeConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    bollinger_squeeze_warmup_candles,
+    compute_bollinger_series,
+    cooldown_allows_entry,
+    squeeze_precedes_breakout,
+    validate_pack_a_candle_series,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_bollinger_squeeze_breakout_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: BollingerSqueezeConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass Bollinger Squeeze Breakout backtest returning a report dict."""
+    config = bridge_config or BollingerSqueezeConfig()
+    config.validate()
+    warmup = bollinger_squeeze_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    upper, middle, lower, bandwidth = compute_bollinger_series(
+        closes,
+        period=config.bb_period,
+        std_dev=config.bb_std_dev,
+    )
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+        upper_band = upper[index]
+        middle_band = middle[index]
+        lower_band = lower[index]
+        bw = bandwidth[index]
+
+        if open_position is None:
+            squeeze_ok = squeeze_precedes_breakout(
+                bandwidth,
+                index,
+                squeeze_threshold=config.squeeze_threshold,
+                squeeze_bars_min=config.squeeze_bars_min,
+            )
+            expansion_ok = bw is not None and bw < config.expansion_ceiling
+            if (
+                upper_band is not None
+                and close > upper_band
+                and squeeze_ok
+                and expansion_ok
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("bb_squeeze_upper_break")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif open_position is not None:
+            middle_exit = middle_band is not None and close < middle_band
+            lower_exit = lower_band is not None and close < lower_band
+            if middle_exit or lower_exit:
+                exit_price = close
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="sell",
+                    size=ORDER_SIZE,
+                    current_price=exit_price,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                trade_r = (
+                    fill.avg_fill_price - open_position["entry_price"]
+                ) / open_position["entry_price"]
+                reason = "bb_middle_break" if middle_exit and not lower_exit else "bb_lower_break"
+                exit_reasons.append(reason)
+                trades.append(
+                    {
+                        "entry_ts_ms": open_position["entry_ts_ms"],
+                        "exit_ts_ms": ts_ms,
+                        "entry_price": open_position["entry_price"],
+                        "exit_price": fill.avg_fill_price,
+                        "entry_fee": open_position["entry_fee"],
+                        "exit_fee": fill.fees,
+                        "r_return": trade_r,
+                        "reason": reason,
+                    }
+                )
+                open_position = None
+
+    return build_pack_a_full_report(
+        strategy_id=BOLLINGER_SQUEEZE_BREAKOUT_STRATEGY_ID,
+        source="bollinger_squeeze_breakout_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "bb_period": config.bb_period,
+            "bb_std_dev": config.bb_std_dev,
+            "squeeze_threshold": config.squeeze_threshold,
+            "squeeze_bars_min": config.squeeze_bars_min,
+            "expansion_ceiling": config.expansion_ceiling,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "bb_squeeze_upper_break": entry_reasons.count("bb_squeeze_upper_break"),
+            "bb_middle_break": exit_reasons.count("bb_middle_break"),
+            "bb_lower_break": exit_reasons.count("bb_lower_break"),
+        },
+    )
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=BOLLINGER_SQUEEZE_BREAKOUT_STRATEGY_ID,
+        source="bollinger_squeeze_breakout_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/services/validation/breakout_volatility_filter_backtest_runner.py
+++ b/services/validation/breakout_volatility_filter_backtest_runner.py
@@ -1,0 +1,191 @@
+"""Single-pass backtest runner for breakout_volatility_filter_v1 (Pack-A slice 2b)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    BREAKOUT_VOLATILITY_FILTER_STRATEGY_ID,
+    BreakoutVolatilityFilterConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    compute_atr_series,
+    compute_donchian_channels,
+    cooldown_allows_entry,
+    breakout_volatility_filter_warmup_candles,
+    validate_pack_a_candle_series,
+    vol_ratio_in_band,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_breakout_volatility_filter_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: BreakoutVolatilityFilterConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass Breakout + Volatility Filter backtest returning a report dict."""
+    config = bridge_config or BreakoutVolatilityFilterConfig()
+    config.validate()
+    warmup = breakout_volatility_filter_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    upper, lower = compute_donchian_channels(
+        highs,
+        lows,
+        entry_channel_bars=config.entry_channel_bars,
+        exit_channel_bars=config.exit_channel_bars,
+    )
+    atr_series = compute_atr_series(highs, lows, closes, config.atr_period)
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+        upper_level = upper[index]
+        lower_level = lower[index]
+        atr_value = atr_series[index]
+
+        if open_position is None:
+            vol_ok = vol_ratio_in_band(
+                atr_value,
+                close,
+                vol_floor=config.vol_floor,
+                vol_ceiling=config.vol_ceiling,
+            )
+            if (
+                upper_level is not None
+                and close > upper_level
+                and vol_ok
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("donchian_upper_break_vol_ok")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif lower_level is not None and close < lower_level:
+            exit_price = close
+            volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+            order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+            fill = sim.simulate_market_order(
+                side="sell",
+                size=ORDER_SIZE,
+                current_price=exit_price,
+                order_book_depth=order_book_depth,
+                volatility=max(volatility, 0.0),
+            )
+            trade_r = (fill.avg_fill_price - open_position["entry_price"]) / open_position[
+                "entry_price"
+            ]
+            exit_reasons.append("donchian_lower_break")
+            trades.append(
+                {
+                    "entry_ts_ms": open_position["entry_ts_ms"],
+                    "exit_ts_ms": ts_ms,
+                    "entry_price": open_position["entry_price"],
+                    "exit_price": fill.avg_fill_price,
+                    "entry_fee": open_position["entry_fee"],
+                    "exit_fee": fill.fees,
+                    "r_return": trade_r,
+                    "reason": "donchian_lower_break",
+                }
+            )
+            open_position = None
+
+    report = build_pack_a_full_report(
+        strategy_id=BREAKOUT_VOLATILITY_FILTER_STRATEGY_ID,
+        source="breakout_volatility_filter_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "entry_channel_bars": config.entry_channel_bars,
+            "exit_channel_bars": config.exit_channel_bars,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "atr_period": config.atr_period,
+            "vol_floor": config.vol_floor,
+            "vol_ceiling": config.vol_ceiling,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "donchian_upper_break_vol_ok": entry_reasons.count(
+                "donchian_upper_break_vol_ok"
+            ),
+            "donchian_lower_break": exit_reasons.count("donchian_lower_break"),
+        },
+    )
+    return report
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=BREAKOUT_VOLATILITY_FILTER_STRATEGY_ID,
+        source="breakout_volatility_filter_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/services/validation/pack_a_backtest_report.py
+++ b/services/validation/pack_a_backtest_report.py
@@ -1,0 +1,168 @@
+"""Shared strategy_validation_report.v1 builders for Pack-A backtest runners."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.replay.pack_a_breakout_common import ORDER_SIZE
+from core.utils.clock import utcnow
+from core.utils.uuid_gen import generate_uuid
+
+
+def build_pack_a_full_report(
+    *,
+    strategy_id: str,
+    source: str,
+    candles: list[dict[str, Any]],
+    trades: list[dict[str, Any]],
+    signals_total: int,
+    entry_reasons: list[str],
+    exit_reasons: list[str],
+    config_snapshot: dict[str, Any],
+    warmup: int,
+    code_commit: str | None,
+    run_id: str | None,
+    thresholds_applied: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    closed_count = len(trades)
+    trade_returns = [t["r_return"] for t in trades]
+    wins = [r for r in trade_returns if r > 0]
+    losses = [r for r in trade_returns if r < 0]
+    win_count = len(wins)
+    loss_count = len(losses)
+
+    gross_profit = sum(wins)
+    gross_loss = abs(sum(losses))
+    epsilon = 1e-12
+    if gross_loss <= 0 and gross_profit > 0:
+        gross_loss = epsilon
+    profit_factor = gross_profit / gross_loss if gross_loss > 0 else 0.0
+    expectancy_r = sum(trade_returns) / closed_count if closed_count > 0 else 0.0
+
+    fee_adj_returns = []
+    for trade in trades:
+        adj = trade["r_return"] - (trade["entry_fee"] + trade["exit_fee"]) / (
+            trade["entry_price"] * ORDER_SIZE
+        )
+        fee_adj_returns.append(adj)
+    fee_adj_expectancy = (
+        sum(fee_adj_returns) / closed_count if closed_count > 0 else 0.0
+    )
+    fee_adj_wins = [r for r in fee_adj_returns if r > 0]
+    fee_adj_losses = [r for r in fee_adj_returns if r < 0]
+    fee_adj_pf = (
+        sum(fee_adj_wins) / abs(sum(fee_adj_losses))
+        if fee_adj_losses and abs(sum(fee_adj_losses)) > 0
+        else 0.0
+    )
+
+    equity = 0.0
+    peak = 0.0
+    max_drawdown_r = 0.0
+    for r_val in trade_returns:
+        equity += r_val
+        if equity > peak:
+            peak = equity
+        drawdown = peak - equity
+        if drawdown > max_drawdown_r:
+            max_drawdown_r = drawdown
+
+    gross_return_r = equity
+    avg_win_r = sum(wins) / win_count if win_count > 0 else None
+    avg_loss_r = sum(losses) / loss_count if loss_count > 0 else None
+    gross_pnl = sum((t["exit_price"] - t["entry_price"]) * ORDER_SIZE for t in trades)
+    fees_total = sum(t["entry_fee"] + t["exit_fee"] for t in trades)
+    net_pnl = gross_pnl - fees_total
+    fee_adj_return_r = sum(fee_adj_returns)
+
+    first_ts = candles[0]["ts_ms"]
+    last_ts = candles[-1]["ts_ms"]
+    resolved_run_id = run_id or generate_uuid()
+    snapshot = dict(config_snapshot)
+    snapshot.setdefault("ranking_ready", False)
+    snapshot.setdefault("warmup_candles", warmup)
+    snapshot.setdefault("order_size", ORDER_SIZE)
+
+    return {
+        "schema_version": "strategy_validation_report.v1",
+        "strategy_id": strategy_id,
+        "run_metadata": {
+            "run_id": resolved_run_id,
+            "generated_at": _utc_now_iso(),
+            "source": source,
+            "code_commit": code_commit or "unknown",
+        },
+        "config_snapshot": snapshot,
+        "dataset_summary": {
+            "symbol": "BTCUSDT",
+            "timeframe": "1m",
+            "candles_total": len(candles),
+            "candles_live": max(0, len(candles) - warmup),
+            "period_start_ts_ms": first_ts,
+            "period_end_ts_ms": last_ts,
+            "warmup_candles": warmup,
+        },
+        "metrics": {
+            "signals_total": signals_total,
+            "buy_signals_total": signals_total,
+            "sell_signals_total": closed_count,
+            "closed_trades_total": closed_count,
+            "gross_return_r": gross_return_r,
+            "fee_adjusted_return_r": fee_adj_return_r,
+            "profit_factor": profit_factor,
+            "fee_adjusted_profit_factor": fee_adj_pf,
+            "expectancy_r": expectancy_r,
+            "fee_adjusted_expectancy_r": fee_adj_expectancy,
+            "max_drawdown_r": max_drawdown_r,
+            "win_rate": win_count / closed_count if closed_count > 0 else 0.0,
+            "avg_win_r": avg_win_r,
+            "avg_loss_r": avg_loss_r,
+            "trades_win_count": win_count,
+            "trades_loss_count": loss_count,
+            "gross_pnl_quote": gross_pnl,
+            "net_pnl_quote": net_pnl,
+            "fees_total_quote": fees_total,
+            "deterministic_replay_ok": False,
+            "ranking_ready": False,
+        },
+        "trades": trades,
+        "thresholds_applied": thresholds_applied or {},
+        "entry_reasons": entry_reasons,
+        "exit_reasons": exit_reasons,
+        "gate_result": {
+            "status": "NOT_RANKING_READY",
+            "ranking_ready": False,
+        },
+    }
+
+
+def build_pack_a_minimal_report(
+    *,
+    strategy_id: str,
+    source: str,
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "strategy_validation_report.v1",
+        "strategy_id": strategy_id,
+        "run_metadata": {
+            "run_id": run_id or generate_uuid(),
+            "generated_at": _utc_now_iso(),
+            "source": source,
+            "code_commit": code_commit or "unknown",
+            "early_exit_reason": reason,
+        },
+        "config_snapshot": {"ranking_ready": False},
+        "dataset_summary": {},
+        "metrics": {"ranking_ready": False, "deterministic_replay_ok": False},
+        "trades": [],
+        "entry_reasons": [],
+        "exit_reasons": [],
+        "gate_result": {"status": "NOT_RANKING_READY", "ranking_ready": False},
+    }
+
+
+def _utc_now_iso() -> str:
+    return utcnow().replace(tzinfo=None).isoformat() + "Z"

--- a/services/validation/volatility_breakout_backtest_runner.py
+++ b/services/validation/volatility_breakout_backtest_runner.py
@@ -1,0 +1,193 @@
+"""Single-pass backtest runner for volatility_breakout_v1 (Pack-A slice 2b)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    VOLATILITY_BREAKOUT_STRATEGY_ID,
+    VolatilityBreakoutConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    atr_expansion_holds,
+    compute_atr_series,
+    compute_highest_high,
+    compute_lowest_low,
+    cooldown_allows_entry,
+    volatility_breakout_warmup_candles,
+    validate_pack_a_candle_series,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_volatility_breakout_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: VolatilityBreakoutConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass Volatility Breakout backtest returning a report dict."""
+    config = bridge_config or VolatilityBreakoutConfig()
+    config.validate()
+    warmup = volatility_breakout_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    highest_high = compute_highest_high(highs, config.breakout_lookback)
+    lowest_low = compute_lowest_low(lows, config.exit_lookback)
+    atr_series = compute_atr_series(highs, lows, closes, config.atr_period)
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+        breakout_level = highest_high[index]
+        exit_level = lowest_low[index]
+        expansion_ok = atr_expansion_holds(
+            atr_series,
+            index,
+            expansion_lag=config.expansion_lag,
+            expansion_multiplier=config.expansion_multiplier,
+        )
+
+        if open_position is None:
+            if (
+                breakout_level is not None
+                and close > breakout_level
+                and expansion_ok
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("volatility_breakout_entry")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif open_position is not None:
+            channel_exit = exit_level is not None and close < exit_level
+            expansion_fail = not expansion_ok
+            if channel_exit or expansion_fail:
+                exit_price = close
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="sell",
+                    size=ORDER_SIZE,
+                    current_price=exit_price,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                trade_r = (
+                    fill.avg_fill_price - open_position["entry_price"]
+                ) / open_position["entry_price"]
+                reason = (
+                    "atr_expansion_fail"
+                    if expansion_fail and not channel_exit
+                    else "lowest_low_break"
+                )
+                exit_reasons.append(reason)
+                trades.append(
+                    {
+                        "entry_ts_ms": open_position["entry_ts_ms"],
+                        "exit_ts_ms": ts_ms,
+                        "entry_price": open_position["entry_price"],
+                        "exit_price": fill.avg_fill_price,
+                        "entry_fee": open_position["entry_fee"],
+                        "exit_fee": fill.fees,
+                        "r_return": trade_r,
+                        "reason": reason,
+                    }
+                )
+                open_position = None
+
+    return build_pack_a_full_report(
+        strategy_id=VOLATILITY_BREAKOUT_STRATEGY_ID,
+        source="volatility_breakout_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "breakout_lookback": config.breakout_lookback,
+            "exit_lookback": config.exit_lookback,
+            "atr_period": config.atr_period,
+            "expansion_lag": config.expansion_lag,
+            "expansion_multiplier": config.expansion_multiplier,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "volatility_breakout_entry": entry_reasons.count("volatility_breakout_entry"),
+            "lowest_low_break": exit_reasons.count("lowest_low_break"),
+            "atr_expansion_fail": exit_reasons.count("atr_expansion_fail"),
+        },
+    )
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=VOLATILITY_BREAKOUT_STRATEGY_ID,
+        source="volatility_breakout_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/tests/fixtures/arvp/batch_a_scenario_matrix_v1.json
+++ b/tests/fixtures/arvp/batch_a_scenario_matrix_v1.json
@@ -22,18 +22,18 @@
     "momentum_capture_v1"
   ],
   "implemented_strategy_ids": [
+    "breakout_volatility_filter_v1",
+    "volatility_breakout_v1",
+    "bollinger_squeeze_breakout_v1",
+    "atr_expansion_v1",
     "range_mean_reversion_v1",
     "momentum_capture_v1"
   ],
   "implementation_pending_strategy_ids": [
-    "breakout_volatility_filter_v1",
-    "volatility_breakout_v1",
     "ema_trend_follow_v1",
     "ma_crossover_v1",
-    "bollinger_squeeze_breakout_v1",
     "roc_breakout_confirm_v1",
-    "opening_range_breakout_v1",
-    "atr_expansion_v1"
+    "opening_range_breakout_v1"
   ],
   "canonical_adapter_by_strategy": {
     "breakout_volatility_filter_v1": null,

--- a/tests/unit/contracts/test_batch_a_funnel_manifest_contract.py
+++ b/tests/unit/contracts/test_batch_a_funnel_manifest_contract.py
@@ -82,11 +82,18 @@ def test_registry_matches_manifest_strategy_ids(manifest: dict) -> None:
     assert set(batch_a_strategy_ids()) == manifest_ids
 
 
-def test_only_two_runners_executable() -> None:
+def test_slice_2b_runners_executable() -> None:
     assert executable_batch_a_strategy_ids() == frozenset(
-        {"range_mean_reversion_v1", "momentum_capture_v1"}
+        {
+            "range_mean_reversion_v1",
+            "momentum_capture_v1",
+            "breakout_volatility_filter_v1",
+            "volatility_breakout_v1",
+            "bollinger_squeeze_breakout_v1",
+            "atr_expansion_v1",
+        }
     )
-    assert len(pending_batch_a_strategy_ids()) == 8
+    assert len(pending_batch_a_strategy_ids()) == 4
 
 
 def test_pending_candidates_not_executable() -> None:

--- a/tests/unit/replay/test_batch_a_strategy_registry.py
+++ b/tests/unit/replay/test_batch_a_strategy_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from core.replay.batch_a_strategy_registry import (
+    ImplementationMode,
     assert_batch_a_executable,
     batch_a_strategy_ids,
     executable_batch_a_strategy_ids,
@@ -22,8 +23,8 @@ def test_registry_lists_all_ten_locked_candidates() -> None:
 def test_only_implemented_runners_are_executable() -> None:
     executable = executable_batch_a_strategy_ids()
     pending = pending_batch_a_strategy_ids()
-    assert len(executable) == 2
-    assert len(pending) == 8
+    assert len(executable) == 6
+    assert len(pending) == 4
     assert executable.isdisjoint(pending)
 
 
@@ -34,7 +35,11 @@ def test_only_implemented_runners_are_executable() -> None:
 def test_implemented_candidates_are_executable(strategy_id: str) -> None:
     record = get_batch_a_strategy(strategy_id)
     assert record.executable
-    assert record.adapter_id is not None
+    assert record.runner_module is not None
+    if record.implementation_mode in {
+        ImplementationMode.REUSE_RESCREEN_CROSS_VENUE_WITH_PRIOR_NEGATIVE_EVIDENCE,
+    }:
+        assert record.adapter_id is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/validation/test_atr_expansion_backtest_runner.py
+++ b/tests/unit/validation/test_atr_expansion_backtest_runner.py
@@ -1,0 +1,78 @@
+"""Tests for atr_expansion_v1 backtest runner (#4031 slice 2b)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    ATR_EXPANSION_MIN_MINUTES_BETWEEN_ENTRIES,
+    ATR_PERIOD,
+    ATR_RATIO_EXIT,
+    ATR_RATIO_THRESHOLD,
+    SMA_PERIOD,
+)
+from services.validation.atr_expansion_backtest_runner import run_atr_expansion_backtest
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.1) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _atr_expansion_candles() -> list[dict]:
+    rows: list[dict] = []
+    start_ts = 1_700_000_000_000
+    for index in range(100):
+        close = 100.0 + index * 0.01
+        spread = 0.08
+        if 55 <= index <= 65:
+            spread = 0.35
+        elif index == 70:
+            close = 100.0
+            spread = 0.05
+        elif 71 <= index <= 80:
+            close = 100.0 - (index - 71) * 0.05
+            spread = 0.05
+        rows.append(_candle(start_ts + index * 60_000, close, spread=spread))
+    return rows
+
+
+def test_atr_expansion_runs_and_closes_trade() -> None:
+    report = run_atr_expansion_backtest(
+        _atr_expansion_candles(),
+        code_commit="slice-2b-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "atr_expansion_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_atr_expansion_frozen_params_in_snapshot() -> None:
+    report = run_atr_expansion_backtest(
+        _atr_expansion_candles(),
+        code_commit="slice-2b-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["atr_period"] == ATR_PERIOD
+    assert snapshot["atr_ratio_threshold"] == ATR_RATIO_THRESHOLD
+    assert snapshot["atr_ratio_exit"] == ATR_RATIO_EXIT
+    assert snapshot["sma_period"] == SMA_PERIOD
+    assert (
+        snapshot["min_minutes_between_entries"]
+        == ATR_EXPANSION_MIN_MINUTES_BETWEEN_ENTRIES
+    )
+    assert snapshot["trade_side_mode"] == "long_only"

--- a/tests/unit/validation/test_bollinger_squeeze_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_bollinger_squeeze_breakout_backtest_runner.py
@@ -1,0 +1,82 @@
+"""Tests for bollinger_squeeze_breakout_v1 backtest runner (#4031 slice 2b)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    BB_PERIOD,
+    BB_STD_DEV,
+    BOLLINGER_MIN_MINUTES_BETWEEN_ENTRIES,
+    EXPANSION_CEILING,
+    SQUEEZE_BARS_MIN,
+    SQUEEZE_THRESHOLD,
+)
+from services.validation.bollinger_squeeze_breakout_backtest_runner import (
+    run_bollinger_squeeze_breakout_backtest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.01) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _bollinger_squeeze_candles() -> list[dict]:
+    rows: list[dict] = []
+    start_ts = 1_700_000_000_000
+    for index in range(80):
+        close = 100.0
+        spread = 0.01
+        if index == 40:
+            close = 100.8
+            spread = 0.05
+        elif 41 <= index <= 55:
+            close = 100.8 + (index - 41) * 0.03
+            spread = 0.05
+        elif index == 56:
+            close = 99.5
+            spread = 0.05
+        rows.append(_candle(start_ts + index * 60_000, close, spread=spread))
+    return rows
+
+
+def test_bollinger_squeeze_breakout_runs_and_closes_trade() -> None:
+    report = run_bollinger_squeeze_breakout_backtest(
+        _bollinger_squeeze_candles(),
+        code_commit="slice-2b-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "bollinger_squeeze_breakout_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_bollinger_squeeze_breakout_frozen_params_in_snapshot() -> None:
+    report = run_bollinger_squeeze_breakout_backtest(
+        _bollinger_squeeze_candles(),
+        code_commit="slice-2b-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["bb_period"] == BB_PERIOD
+    assert snapshot["bb_std_dev"] == BB_STD_DEV
+    assert snapshot["squeeze_threshold"] == SQUEEZE_THRESHOLD
+    assert snapshot["squeeze_bars_min"] == SQUEEZE_BARS_MIN
+    assert snapshot["expansion_ceiling"] == EXPANSION_CEILING
+    assert (
+        snapshot["min_minutes_between_entries"] == BOLLINGER_MIN_MINUTES_BETWEEN_ENTRIES
+    )
+    assert snapshot["trade_side_mode"] == "long_only"

--- a/tests/unit/validation/test_breakout_volatility_filter_backtest_runner.py
+++ b/tests/unit/validation/test_breakout_volatility_filter_backtest_runner.py
@@ -1,0 +1,80 @@
+"""Tests for breakout_volatility_filter_v1 backtest runner (#4031 slice 2b)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    ATR_PERIOD,
+    ENTRY_CHANNEL_BARS,
+    EXIT_CHANNEL_BARS,
+    MIN_MINUTES_BETWEEN_ENTRIES,
+    VOL_CEILING,
+    VOL_FLOOR,
+)
+from services.validation.breakout_volatility_filter_backtest_runner import (
+    run_breakout_volatility_filter_backtest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.1) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _breakout_vol_filter_candles() -> list[dict]:
+    rows: list[dict] = []
+    start_ts = 1_700_000_000_000
+    for index in range(90):
+        close = 100.0
+        spread = 0.1
+        if index == 60:
+            close = 101.2
+            spread = 0.15
+        elif 61 <= index <= 75:
+            close = 101.5 + (index - 61) * 0.05
+            spread = 0.15
+        elif index == 76:
+            close = 99.4
+            spread = 0.15
+        rows.append(_candle(start_ts + index * 60_000, close, spread=spread))
+    return rows
+
+
+def test_breakout_volatility_filter_runs_and_closes_trade() -> None:
+    report = run_breakout_volatility_filter_backtest(
+        _breakout_vol_filter_candles(),
+        code_commit="slice-2b-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "breakout_volatility_filter_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_breakout_volatility_filter_frozen_params_in_snapshot() -> None:
+    report = run_breakout_volatility_filter_backtest(
+        _breakout_vol_filter_candles(),
+        code_commit="slice-2b-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["entry_channel_bars"] == ENTRY_CHANNEL_BARS
+    assert snapshot["exit_channel_bars"] == EXIT_CHANNEL_BARS
+    assert snapshot["atr_period"] == ATR_PERIOD
+    assert snapshot["vol_floor"] == VOL_FLOOR
+    assert snapshot["vol_ceiling"] == VOL_CEILING
+    assert snapshot["min_minutes_between_entries"] == MIN_MINUTES_BETWEEN_ENTRIES
+    assert snapshot["trade_side_mode"] == "long_only"

--- a/tests/unit/validation/test_volatility_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_volatility_breakout_backtest_runner.py
@@ -1,0 +1,85 @@
+"""Tests for volatility_breakout_v1 backtest runner (#4031 slice 2b)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    ATR_PERIOD,
+    BREAKOUT_LOOKBACK,
+    EXIT_LOOKBACK,
+    EXPANSION_LAG,
+    EXPANSION_MULTIPLIER,
+    VOL_BREAKOUT_MIN_MINUTES_BETWEEN_ENTRIES,
+)
+from services.validation.volatility_breakout_backtest_runner import (
+    run_volatility_breakout_backtest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.1) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _volatility_breakout_candles() -> list[dict]:
+    rows: list[dict] = []
+    start_ts = 1_700_000_000_000
+    for index in range(90):
+        close = 100.0
+        spread = 0.05
+        if 40 <= index <= 54:
+            spread = 0.05 + (index - 40) * 0.08
+        elif index == 55:
+            close = 101.5
+            spread = 0.6
+        elif 56 <= index <= 70:
+            close = 101.5 + (index - 56) * 0.05
+            spread = 0.5
+        elif index == 71:
+            close = 99.2
+            spread = 0.4
+        rows.append(_candle(start_ts + index * 60_000, close, spread=spread))
+    return rows
+
+
+def test_volatility_breakout_runs_and_closes_trade() -> None:
+    report = run_volatility_breakout_backtest(
+        _volatility_breakout_candles(),
+        code_commit="slice-2b-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "volatility_breakout_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_volatility_breakout_frozen_params_in_snapshot() -> None:
+    report = run_volatility_breakout_backtest(
+        _volatility_breakout_candles(),
+        code_commit="slice-2b-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["breakout_lookback"] == BREAKOUT_LOOKBACK
+    assert snapshot["exit_lookback"] == EXIT_LOOKBACK
+    assert snapshot["atr_period"] == ATR_PERIOD
+    assert snapshot["expansion_lag"] == EXPANSION_LAG
+    assert snapshot["expansion_multiplier"] == EXPANSION_MULTIPLIER
+    assert (
+        snapshot["min_minutes_between_entries"]
+        == VOL_BREAKOUT_MIN_MINUTES_BETWEEN_ENTRIES
+    )
+    assert snapshot["trade_side_mode"] == "long_only"


### PR DESCRIPTION
## Summary

- Implement four Pack-A slice 2b backtest runners with frozen registry parameters: breakout_volatility_filter_v1, volatility_breakout_v1, bollinger_squeeze_breakout_v1, atr_expansion_v1.
- Extend pack_a_breakout_common with Wilder ATR, highest/lowest lookback helpers, config dataclasses, and warmup helpers.
- Extract shared pack_a_backtest_report builder; mark all four strategies implemented in batch_a_strategy_registry and scenario matrix fixture.

## Test plan

- [x] pytest -q on four new runner tests + test_batch_a_strategy_registry.py + test_batch_a_scenario_matrix_contract.py (26 passed)
- [x] ruff check on changed files (clean)
- [ ] CI policy-gate + unit/integration checks

## Refs #4031

Made with [Cursor](https://cursor.com)