### PR TITLE
feat(arvp): Batch-A slice 2c — trend/MA/ORB runners (#4031)

### DIFF
--- a/core/replay/batch_a_strategy_registry.py
+++ b/core/replay/batch_a_strategy_registry.py
@@ -118,7 +118,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "ema_trend_follow_v1": BatchAStrategyRecord(
         strategy_id="ema_trend_follow_v1",
         implementation_mode=ImplementationMode.NEW,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2c",
         adapter_id=None,
         runner_module="services.validation.ema_trend_follow_backtest_runner",
@@ -136,7 +136,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "ma_crossover_v1": BatchAStrategyRecord(
         strategy_id="ma_crossover_v1",
         implementation_mode=ImplementationMode.NEW,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2c",
         adapter_id=None,
         runner_module="services.validation.ma_crossover_backtest_runner",
@@ -227,7 +227,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "opening_range_breakout_v1": BatchAStrategyRecord(
         strategy_id="opening_range_breakout_v1",
         implementation_mode=ImplementationMode.NEW,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2c",
         adapter_id=None,
         runner_module="services.validation.opening_range_breakout_backtest_runner",

--- a/core/replay/pack_a_breakout_common.py
+++ b/core/replay/pack_a_breakout_common.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Sequence
 
 from core.replay.historical_bridge import ONE_MINUTE_MS, PRIMARY_BREAKOUT_SYMBOL
@@ -18,6 +19,9 @@ BREAKOUT_VOLATILITY_FILTER_STRATEGY_ID = "breakout_volatility_filter_v1"
 VOLATILITY_BREAKOUT_STRATEGY_ID = "volatility_breakout_v1"
 BOLLINGER_SQUEEZE_BREAKOUT_STRATEGY_ID = "bollinger_squeeze_breakout_v1"
 ATR_EXPANSION_STRATEGY_ID = "atr_expansion_v1"
+EMA_TREND_FOLLOW_STRATEGY_ID = "ema_trend_follow_v1"
+MA_CROSSOVER_STRATEGY_ID = "ma_crossover_v1"
+OPENING_RANGE_BREAKOUT_STRATEGY_ID = "opening_range_breakout_v1"
 PACK_A_SYMBOL = PRIMARY_BREAKOUT_SYMBOL
 
 ENTRY_CHANNEL_BARS = 20
@@ -44,6 +48,16 @@ SMA_PERIOD = 20
 VOL_BREAKOUT_MIN_MINUTES_BETWEEN_ENTRIES = 30
 BOLLINGER_MIN_MINUTES_BETWEEN_ENTRIES = 60
 ATR_EXPANSION_MIN_MINUTES_BETWEEN_ENTRIES = 60
+FAST_EMA_PERIOD = 20
+SLOW_EMA_PERIOD = 50
+FAST_SMA_PERIOD = 20
+SLOW_SMA_PERIOD = 50
+TREND_MIN_MINUTES_BETWEEN_ENTRIES = 60
+OR_START_UTC = "00:00"
+OR_END_UTC = "01:00"
+TRADE_END_UTC = "20:00"
+ORB_MIN_MINUTES_BETWEEN_ENTRIES = 1440
+ORB_WARMUP_BARS = 60
 
 ORDER_SIZE = 1.0
 ORDER_BOOK_DEPTH_MULT = 10_000.0
@@ -222,6 +236,91 @@ def atr_expansion_warmup_candles(config: AtrExpansionConfig | None = None) -> in
     return max(active.sma_period + active.atr_period, 50)
 
 
+@dataclass(frozen=True, slots=True)
+class EmaTrendFollowConfig:
+    fast_ema_period: int = FAST_EMA_PERIOD
+    slow_ema_period: int = SLOW_EMA_PERIOD
+    min_minutes_between_entries: int = TREND_MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.fast_ema_period <= 0:
+            raise PackABreakoutError("fast_ema_period must be > 0")
+        if self.slow_ema_period <= 0:
+            raise PackABreakoutError("slow_ema_period must be > 0")
+        if self.fast_ema_period >= self.slow_ema_period:
+            raise PackABreakoutError("fast_ema_period must be < slow_ema_period")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
+@dataclass(frozen=True, slots=True)
+class MaCrossoverConfig:
+    fast_sma_period: int = FAST_SMA_PERIOD
+    slow_sma_period: int = SLOW_SMA_PERIOD
+    min_minutes_between_entries: int = TREND_MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.fast_sma_period <= 0:
+            raise PackABreakoutError("fast_sma_period must be > 0")
+        if self.slow_sma_period <= 0:
+            raise PackABreakoutError("slow_sma_period must be > 0")
+        if self.fast_sma_period >= self.slow_sma_period:
+            raise PackABreakoutError("fast_sma_period must be < slow_sma_period")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
+@dataclass(frozen=True, slots=True)
+class OpeningRangeBreakoutConfig:
+    or_start_utc: str = OR_START_UTC
+    or_end_utc: str = OR_END_UTC
+    trade_end_utc: str = TRADE_END_UTC
+    min_minutes_between_entries: int = ORB_MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        _parse_utc_hhmm(self.or_start_utc, field="or_start_utc")
+        or_end = _parse_utc_hhmm(self.or_end_utc, field="or_end_utc")
+        trade_end = _parse_utc_hhmm(self.trade_end_utc, field="trade_end_utc")
+        or_start = _parse_utc_hhmm(self.or_start_utc, field="or_start_utc")
+        if or_end <= or_start:
+            raise PackABreakoutError("or_end_utc must be after or_start_utc")
+        if trade_end <= or_end:
+            raise PackABreakoutError("trade_end_utc must be after or_end_utc")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
+def ema_trend_follow_warmup_candles(
+    config: EmaTrendFollowConfig | None = None,
+) -> int:
+    active = config or EmaTrendFollowConfig()
+    active.validate()
+    return active.slow_ema_period
+
+
+def ma_crossover_warmup_candles(config: MaCrossoverConfig | None = None) -> int:
+    active = config or MaCrossoverConfig()
+    active.validate()
+    return active.slow_sma_period
+
+
+def opening_range_breakout_warmup_candles(
+    config: OpeningRangeBreakoutConfig | None = None,
+) -> int:
+    active = config or OpeningRangeBreakoutConfig()
+    active.validate()
+    return ORB_WARMUP_BARS
+
+
 def _required_float(row: dict[str, Any], key: str) -> float:
     value = row.get(key)
     if value is None or isinstance(value, bool):
@@ -354,6 +453,14 @@ def compute_atr_series(
         smoothed = (smoothed * (period - 1) + tr) / period
         atr[atr_index] = smoothed
     return atr
+
+
+def compute_ema_series(
+    closes: Sequence[float],
+    period: int,
+) -> list[float | None]:
+    """EMA on closed 1m bars using SMA seed (matches core.indicators.trend.EMA)."""
+    return _ema(closes, period)
 
 
 def compute_sma_series(
@@ -532,3 +639,91 @@ def cooldown_allows_entry(
     if last_entry_ts_ms is None:
         return True
     return ts_ms - last_entry_ts_ms >= min_minutes_between_entries * ONE_MINUTE_MS
+
+
+def resolve_candle_ts_ms(row: dict[str, Any]) -> int:
+    """Return candle timestamp in ms from ``ts_ms`` or ``timestamp_ms``."""
+    for key in ("ts_ms", "timestamp_ms"):
+        value = row.get(key)
+        if value is None or isinstance(value, bool):
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError) as exc:
+            raise PackABreakoutError(f"invalid integer field: {key}") from exc
+    raise PackABreakoutError("missing required field: ts_ms or timestamp_ms")
+
+
+def is_bullish_crossover(
+    fast_series: Sequence[float | None],
+    slow_series: Sequence[float | None],
+    index: int,
+) -> bool:
+    if index < 1:
+        return False
+    fast_prev = fast_series[index - 1]
+    fast_curr = fast_series[index]
+    slow_prev = slow_series[index - 1]
+    slow_curr = slow_series[index]
+    if None in (fast_prev, fast_curr, slow_prev, slow_curr):
+        return False
+    return fast_prev <= slow_prev and fast_curr > slow_curr
+
+
+def is_bearish_crossover(
+    fast_series: Sequence[float | None],
+    slow_series: Sequence[float | None],
+    index: int,
+) -> bool:
+    if index < 1:
+        return False
+    fast_prev = fast_series[index - 1]
+    fast_curr = fast_series[index]
+    slow_prev = slow_series[index - 1]
+    slow_curr = slow_series[index]
+    if None in (fast_prev, fast_curr, slow_prev, slow_curr):
+        return False
+    return fast_prev >= slow_prev and fast_curr < slow_curr
+
+
+def _parse_utc_hhmm(value: str, *, field: str) -> int:
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise PackABreakoutError(f"{field} must be HH:MM")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError as exc:
+        raise PackABreakoutError(f"{field} must be HH:MM") from exc
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise PackABreakoutError(f"{field} must be a valid UTC time")
+    return hour * 60 + minute
+
+
+def utc_minutes_of_day(ts_ms: int) -> int:
+    dt = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+    return dt.hour * 60 + dt.minute
+
+
+def utc_day_key(ts_ms: int) -> str:
+    dt = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+    return dt.strftime("%Y-%m-%d")
+
+
+def orb_session_phase(
+    ts_ms: int,
+    *,
+    or_start_utc: str,
+    or_end_utc: str,
+    trade_end_utc: str,
+) -> str:
+    """Return ``opening_range``, ``trading``, or ``closed`` for a UTC timestamp."""
+    minute = utc_minutes_of_day(ts_ms)
+    or_start = _parse_utc_hhmm(or_start_utc, field="or_start_utc")
+    or_end = _parse_utc_hhmm(or_end_utc, field="or_end_utc")
+    trade_end = _parse_utc_hhmm(trade_end_utc, field="trade_end_utc")
+    if or_start <= minute < or_end:
+        return "opening_range"
+    if or_end <= minute < trade_end:
+        return "trading"
+    return "closed"

--- a/docs/contracts/batch_a_funnel_manifest.v1.json
+++ b/docs/contracts/batch_a_funnel_manifest.v1.json
@@ -127,7 +127,7 @@
     {
       "strategy_id": "ema_trend_follow_v1",
       "implementation_mode": "NEW",
-      "implementation_status": "implementation_pending",
+      "implementation_status": "implemented",
       "later_slice": "2c",
       "adapter_id": null,
       "runner_module": "services.validation.ema_trend_follow_backtest_runner",
@@ -151,7 +151,7 @@
     {
       "strategy_id": "ma_crossover_v1",
       "implementation_mode": "NEW",
-      "implementation_status": "implementation_pending",
+      "implementation_status": "implemented",
       "later_slice": "2c",
       "adapter_id": null,
       "runner_module": "services.validation.ma_crossover_backtest_runner",
@@ -258,7 +258,7 @@
     {
       "strategy_id": "opening_range_breakout_v1",
       "implementation_mode": "NEW",
-      "implementation_status": "implementation_pending",
+      "implementation_status": "implemented",
       "later_slice": "2c",
       "adapter_id": null,
       "runner_module": "services.validation.opening_range_breakout_backtest_runner",

--- a/services/validation/ema_trend_follow_backtest_runner.py
+++ b/services/validation/ema_trend_follow_backtest_runner.py
@@ -1,0 +1,169 @@
+"""Single-pass backtest runner for ema_trend_follow_v1 (Pack-A slice 2c)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    EMA_TREND_FOLLOW_STRATEGY_ID,
+    EmaTrendFollowConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    compute_ema_series,
+    cooldown_allows_entry,
+    ema_trend_follow_warmup_candles,
+    is_bearish_crossover,
+    is_bullish_crossover,
+    validate_pack_a_candle_series,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_ema_trend_follow_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: EmaTrendFollowConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass EMA trend-follow backtest returning a report dict."""
+    config = bridge_config or EmaTrendFollowConfig()
+    config.validate()
+    warmup = ema_trend_follow_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    fast_ema = compute_ema_series(closes, config.fast_ema_period)
+    slow_ema = compute_ema_series(closes, config.slow_ema_period)
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+
+        if open_position is None:
+            if (
+                is_bullish_crossover(fast_ema, slow_ema, index)
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("ema_bullish_cross")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif is_bearish_crossover(fast_ema, slow_ema, index):
+            exit_price = close
+            volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+            order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+            fill = sim.simulate_market_order(
+                side="sell",
+                size=ORDER_SIZE,
+                current_price=exit_price,
+                order_book_depth=order_book_depth,
+                volatility=max(volatility, 0.0),
+            )
+            trade_r = (
+                fill.avg_fill_price - open_position["entry_price"]
+            ) / open_position["entry_price"]
+            exit_reasons.append("ema_bearish_cross")
+            trades.append(
+                {
+                    "entry_ts_ms": open_position["entry_ts_ms"],
+                    "exit_ts_ms": ts_ms,
+                    "entry_price": open_position["entry_price"],
+                    "exit_price": fill.avg_fill_price,
+                    "entry_fee": open_position["entry_fee"],
+                    "exit_fee": fill.fees,
+                    "r_return": trade_r,
+                    "reason": "ema_bearish_cross",
+                }
+            )
+            open_position = None
+
+    return build_pack_a_full_report(
+        strategy_id=EMA_TREND_FOLLOW_STRATEGY_ID,
+        source="ema_trend_follow_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "fast_ema_period": config.fast_ema_period,
+            "slow_ema_period": config.slow_ema_period,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "ema_bullish_cross": entry_reasons.count("ema_bullish_cross"),
+            "ema_bearish_cross": exit_reasons.count("ema_bearish_cross"),
+        },
+    )
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=EMA_TREND_FOLLOW_STRATEGY_ID,
+        source="ema_trend_follow_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/services/validation/ma_crossover_backtest_runner.py
+++ b/services/validation/ma_crossover_backtest_runner.py
@@ -1,0 +1,169 @@
+"""Single-pass backtest runner for ma_crossover_v1 (Pack-A slice 2c)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    MA_CROSSOVER_STRATEGY_ID,
+    MaCrossoverConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    compute_sma_series,
+    cooldown_allows_entry,
+    is_bearish_crossover,
+    is_bullish_crossover,
+    ma_crossover_warmup_candles,
+    validate_pack_a_candle_series,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_ma_crossover_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: MaCrossoverConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass SMA crossover backtest returning a report dict."""
+    config = bridge_config or MaCrossoverConfig()
+    config.validate()
+    warmup = ma_crossover_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    fast_sma = compute_sma_series(closes, config.fast_sma_period)
+    slow_sma = compute_sma_series(closes, config.slow_sma_period)
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+
+        if open_position is None:
+            if (
+                is_bullish_crossover(fast_sma, slow_sma, index)
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("sma_bullish_cross")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif is_bearish_crossover(fast_sma, slow_sma, index):
+            exit_price = close
+            volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+            order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+            fill = sim.simulate_market_order(
+                side="sell",
+                size=ORDER_SIZE,
+                current_price=exit_price,
+                order_book_depth=order_book_depth,
+                volatility=max(volatility, 0.0),
+            )
+            trade_r = (
+                fill.avg_fill_price - open_position["entry_price"]
+            ) / open_position["entry_price"]
+            exit_reasons.append("sma_bearish_cross")
+            trades.append(
+                {
+                    "entry_ts_ms": open_position["entry_ts_ms"],
+                    "exit_ts_ms": ts_ms,
+                    "entry_price": open_position["entry_price"],
+                    "exit_price": fill.avg_fill_price,
+                    "entry_fee": open_position["entry_fee"],
+                    "exit_fee": fill.fees,
+                    "r_return": trade_r,
+                    "reason": "sma_bearish_cross",
+                }
+            )
+            open_position = None
+
+    return build_pack_a_full_report(
+        strategy_id=MA_CROSSOVER_STRATEGY_ID,
+        source="ma_crossover_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "fast_sma_period": config.fast_sma_period,
+            "slow_sma_period": config.slow_sma_period,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "sma_bullish_cross": entry_reasons.count("sma_bullish_cross"),
+            "sma_bearish_cross": exit_reasons.count("sma_bearish_cross"),
+        },
+    )
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=MA_CROSSOVER_STRATEGY_ID,
+        source="ma_crossover_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/services/validation/opening_range_breakout_backtest_runner.py
+++ b/services/validation/opening_range_breakout_backtest_runner.py
@@ -1,0 +1,242 @@
+"""Single-pass backtest runner for opening_range_breakout_v1 (Pack-A slice 2c)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    OPENING_RANGE_BREAKOUT_STRATEGY_ID,
+    OpeningRangeBreakoutConfig,
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    cooldown_allows_entry,
+    opening_range_breakout_warmup_candles,
+    orb_session_phase,
+    resolve_candle_ts_ms,
+    utc_day_key,
+    validate_pack_a_candle_series,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_opening_range_breakout_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: OpeningRangeBreakoutConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass UTC opening-range breakout backtest returning a report dict."""
+    config = bridge_config or OpeningRangeBreakoutConfig()
+    config.validate()
+    warmup = opening_range_breakout_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [resolve_candle_ts_ms(c) for c in candles]
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    current_day: str | None = None
+    or_high: float | None = None
+    or_low: float | None = None
+    or_locked = False
+
+    for index, candle in enumerate(candles):
+        close = closes[index]
+        ts_ms = ts_values[index]
+        high = highs[index]
+        low = lows[index]
+        volume = float(candle.get("volume", 0.0))
+        day_key = utc_day_key(ts_ms)
+        phase = orb_session_phase(
+            ts_ms,
+            or_start_utc=config.or_start_utc,
+            or_end_utc=config.or_end_utc,
+            trade_end_utc=config.trade_end_utc,
+        )
+
+        if day_key != current_day:
+            current_day = day_key
+            or_high = None
+            or_low = None
+            or_locked = False
+
+        if phase == "opening_range":
+            or_high = high if or_high is None else max(or_high, high)
+            or_low = low if or_low is None else min(or_low, low)
+            continue
+
+        if phase == "trading" and not or_locked:
+            or_locked = or_high is not None and or_low is not None
+
+        if index < warmup:
+            continue
+
+        if phase == "closed" and open_position is not None:
+            exit_reasons.append("session_end_utc")
+            open_position = _close_position(
+                sim=sim,
+                open_position=open_position,
+                index=index,
+                ts_ms=ts_ms,
+                close=close,
+                highs=highs,
+                lows=lows,
+                volume=volume,
+                trades=trades,
+                reason="session_end_utc",
+            )
+            continue
+
+        if phase != "trading" or not or_locked or or_high is None or or_low is None:
+            continue
+
+        if open_position is None:
+            if (
+                close > or_high
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("orb_upper_break")
+                volatility = abs(high - low) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif close < or_low:
+            exit_reasons.append("orb_lower_break")
+            open_position = _close_position(
+                sim=sim,
+                open_position=open_position,
+                index=index,
+                ts_ms=ts_ms,
+                close=close,
+                highs=highs,
+                lows=lows,
+                volume=volume,
+                trades=trades,
+                reason="orb_lower_break",
+            )
+
+    return build_pack_a_full_report(
+        strategy_id=OPENING_RANGE_BREAKOUT_STRATEGY_ID,
+        source="opening_range_breakout_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "or_start_utc": config.or_start_utc,
+            "or_end_utc": config.or_end_utc,
+            "trade_end_utc": config.trade_end_utc,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "orb_upper_break": entry_reasons.count("orb_upper_break"),
+            "orb_lower_break": exit_reasons.count("orb_lower_break"),
+            "session_end_utc": exit_reasons.count("session_end_utc"),
+        },
+    )
+
+
+def _close_position(
+    *,
+    sim: ExecutionSimulator,
+    open_position: dict[str, Any],
+    index: int,
+    ts_ms: int,
+    close: float,
+    highs: list[float],
+    lows: list[float],
+    volume: float,
+    trades: list[dict[str, Any]],
+    reason: str,
+) -> None:
+    volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+    order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+    fill = sim.simulate_market_order(
+        side="sell",
+        size=ORDER_SIZE,
+        current_price=close,
+        order_book_depth=order_book_depth,
+        volatility=max(volatility, 0.0),
+    )
+    trade_r = (fill.avg_fill_price - open_position["entry_price"]) / open_position[
+        "entry_price"
+    ]
+    trades.append(
+        {
+            "entry_ts_ms": open_position["entry_ts_ms"],
+            "exit_ts_ms": ts_ms,
+            "entry_price": open_position["entry_price"],
+            "exit_price": fill.avg_fill_price,
+            "entry_fee": open_position["entry_fee"],
+            "exit_fee": fill.fees,
+            "r_return": trade_r,
+            "reason": reason,
+        }
+    )
+    return None
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=OPENING_RANGE_BREAKOUT_STRATEGY_ID,
+        source="opening_range_breakout_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/tests/fixtures/arvp/batch_a_scenario_matrix_v1.json
+++ b/tests/fixtures/arvp/batch_a_scenario_matrix_v1.json
@@ -27,13 +27,13 @@
     "bollinger_squeeze_breakout_v1",
     "atr_expansion_v1",
     "range_mean_reversion_v1",
-    "momentum_capture_v1"
-  ],
-  "implementation_pending_strategy_ids": [
+    "momentum_capture_v1",
     "ema_trend_follow_v1",
     "ma_crossover_v1",
-    "roc_breakout_confirm_v1",
     "opening_range_breakout_v1"
+  ],
+  "implementation_pending_strategy_ids": [
+    "roc_breakout_confirm_v1"
   ],
   "canonical_adapter_by_strategy": {
     "breakout_volatility_filter_v1": null,

--- a/tests/unit/contracts/test_batch_a_funnel_manifest_contract.py
+++ b/tests/unit/contracts/test_batch_a_funnel_manifest_contract.py
@@ -82,7 +82,7 @@ def test_registry_matches_manifest_strategy_ids(manifest: dict) -> None:
     assert set(batch_a_strategy_ids()) == manifest_ids
 
 
-def test_slice_2b_runners_executable() -> None:
+def test_slice_2c_runners_executable() -> None:
     assert executable_batch_a_strategy_ids() == frozenset(
         {
             "range_mean_reversion_v1",
@@ -91,9 +91,12 @@ def test_slice_2b_runners_executable() -> None:
             "volatility_breakout_v1",
             "bollinger_squeeze_breakout_v1",
             "atr_expansion_v1",
+            "ema_trend_follow_v1",
+            "ma_crossover_v1",
+            "opening_range_breakout_v1",
         }
     )
-    assert len(pending_batch_a_strategy_ids()) == 4
+    assert pending_batch_a_strategy_ids() == frozenset({"roc_breakout_confirm_v1"})
 
 
 def test_pending_candidates_not_executable() -> None:

--- a/tests/unit/replay/test_batch_a_strategy_registry.py
+++ b/tests/unit/replay/test_batch_a_strategy_registry.py
@@ -23,8 +23,8 @@ def test_registry_lists_all_ten_locked_candidates() -> None:
 def test_only_implemented_runners_are_executable() -> None:
     executable = executable_batch_a_strategy_ids()
     pending = pending_batch_a_strategy_ids()
-    assert len(executable) == 6
-    assert len(pending) == 4
+    assert len(executable) == 9
+    assert len(pending) == 1
     assert executable.isdisjoint(pending)
 
 

--- a/tests/unit/validation/test_ema_trend_follow_backtest_runner.py
+++ b/tests/unit/validation/test_ema_trend_follow_backtest_runner.py
@@ -1,0 +1,71 @@
+"""Tests for ema_trend_follow_v1 backtest runner (#4031 slice 2c)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    FAST_EMA_PERIOD,
+    SLOW_EMA_PERIOD,
+    TREND_MIN_MINUTES_BETWEEN_ENTRIES,
+)
+from services.validation.ema_trend_follow_backtest_runner import (
+    run_ema_trend_follow_backtest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.1) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _ema_crossover_candles() -> list[dict]:
+    rows: list[dict] = []
+    start_ts = 1_700_000_000_000
+    for index in range(120):
+        if index < 60:
+            close = 100.0
+        elif index < 80:
+            close = 100.0 + (index - 59) * 1.5
+        elif index < 95:
+            close = 130.0 - (index - 79) * 2.0
+        else:
+            close = 100.0
+        rows.append(_candle(start_ts + index * 60_000, close))
+    return rows
+
+
+def test_ema_trend_follow_runs_and_closes_trade() -> None:
+    report = run_ema_trend_follow_backtest(
+        _ema_crossover_candles(),
+        code_commit="slice-2c-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "ema_trend_follow_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_ema_trend_follow_frozen_params_in_snapshot() -> None:
+    report = run_ema_trend_follow_backtest(
+        _ema_crossover_candles(),
+        code_commit="slice-2c-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["fast_ema_period"] == FAST_EMA_PERIOD
+    assert snapshot["slow_ema_period"] == SLOW_EMA_PERIOD
+    assert snapshot["min_minutes_between_entries"] == TREND_MIN_MINUTES_BETWEEN_ENTRIES
+    assert snapshot["trade_side_mode"] == "long_only"

--- a/tests/unit/validation/test_ma_crossover_backtest_runner.py
+++ b/tests/unit/validation/test_ma_crossover_backtest_runner.py
@@ -1,0 +1,69 @@
+"""Tests for ma_crossover_v1 backtest runner (#4031 slice 2c)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    FAST_SMA_PERIOD,
+    SLOW_SMA_PERIOD,
+    TREND_MIN_MINUTES_BETWEEN_ENTRIES,
+)
+from services.validation.ma_crossover_backtest_runner import run_ma_crossover_backtest
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.1) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _ma_crossover_candles() -> list[dict]:
+    rows: list[dict] = []
+    start_ts = 1_700_000_000_000
+    for index in range(120):
+        if index < 60:
+            close = 100.0
+        elif index < 80:
+            close = 100.0 + (index - 59) * 2.0
+        elif index < 95:
+            close = 140.0 - (index - 79) * 3.0
+        else:
+            close = 95.0
+        rows.append(_candle(start_ts + index * 60_000, close))
+    return rows
+
+
+def test_ma_crossover_runs_and_closes_trade() -> None:
+    report = run_ma_crossover_backtest(
+        _ma_crossover_candles(),
+        code_commit="slice-2c-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "ma_crossover_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_ma_crossover_frozen_params_in_snapshot() -> None:
+    report = run_ma_crossover_backtest(
+        _ma_crossover_candles(),
+        code_commit="slice-2c-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["fast_sma_period"] == FAST_SMA_PERIOD
+    assert snapshot["slow_sma_period"] == SLOW_SMA_PERIOD
+    assert snapshot["min_minutes_between_entries"] == TREND_MIN_MINUTES_BETWEEN_ENTRIES
+    assert snapshot["trade_side_mode"] == "long_only"

--- a/tests/unit/validation/test_opening_range_breakout_backtest_runner.py
+++ b/tests/unit/validation/test_opening_range_breakout_backtest_runner.py
@@ -1,0 +1,201 @@
+"""Tests for opening_range_breakout_v1 backtest runner (#4031 slice 2c)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    OR_END_UTC,
+    OR_START_UTC,
+    ORB_MIN_MINUTES_BETWEEN_ENTRIES,
+    TRADE_END_UTC,
+    orb_session_phase,
+    utc_day_key,
+)
+from services.validation.opening_range_breakout_backtest_runner import (
+    run_opening_range_breakout_backtest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _utc_ts_ms(year: int, month: int, day: int, hour: int, minute: int = 0) -> int:
+    return int(
+        datetime(year, month, day, hour, minute, tzinfo=timezone.utc).timestamp()
+        * 1000
+    )
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.5) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "timestamp_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _orb_day_candles(
+    *,
+    start_ts_ms: int,
+    or_high: float,
+    or_low: float,
+    breakout_close: float,
+    breakout_offset_minutes: int = 90,
+    hold_until_session_end: bool = False,
+) -> list[dict]:
+    rows: list[dict] = []
+    for minute in range(breakout_offset_minutes + 1):
+        ts_ms = start_ts_ms + minute * 60_000
+        if minute < 60:
+            close = (or_high + or_low) / 2
+            spread = max(or_high - close, close - or_low, 0.1)
+        elif minute < breakout_offset_minutes:
+            close = (or_high + or_low) / 2
+            spread = 0.1
+        else:
+            close = breakout_close
+            spread = 0.1
+        rows.append(_candle(ts_ms, close, spread=spread))
+
+    if hold_until_session_end:
+        session_end_offset = 20 * 60
+        for minute in range(breakout_offset_minutes + 1, session_end_offset + 1):
+            ts_ms = start_ts_ms + minute * 60_000
+            rows.append(_candle(ts_ms, breakout_close))
+    return rows
+
+
+def _orb_fixture_candles() -> list[dict]:
+    warmup_start = _utc_ts_ms(2024, 6, 1, 23, 0)
+    warmup = [
+        _candle(warmup_start + index * 60_000, 100.0) for index in range(60)
+    ]
+    session = _orb_day_candles(
+        start_ts_ms=_utc_ts_ms(2024, 6, 2, 0, 0),
+        or_high=101.0,
+        or_low=99.0,
+        breakout_close=102.5,
+        breakout_offset_minutes=90,
+        hold_until_session_end=True,
+    )
+    return warmup + session
+
+
+def test_opening_range_breakout_runs_and_closes_trade() -> None:
+    report = run_opening_range_breakout_backtest(
+        _orb_fixture_candles(),
+        code_commit="slice-2c-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "opening_range_breakout_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_opening_range_breakout_frozen_params_in_snapshot() -> None:
+    report = run_opening_range_breakout_backtest(
+        _orb_fixture_candles(),
+        code_commit="slice-2c-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["or_start_utc"] == OR_START_UTC
+    assert snapshot["or_end_utc"] == OR_END_UTC
+    assert snapshot["trade_end_utc"] == TRADE_END_UTC
+    assert snapshot["min_minutes_between_entries"] == ORB_MIN_MINUTES_BETWEEN_ENTRIES
+    assert snapshot["trade_side_mode"] == "long_only"
+
+
+def test_orb_midnight_utc_resets_opening_range_per_day() -> None:
+    day_one_start = _utc_ts_ms(2024, 6, 2, 0, 0)
+    day_one = _orb_day_candles(
+        start_ts_ms=day_one_start,
+        or_high=101.0,
+        or_low=99.0,
+        breakout_close=102.5,
+        breakout_offset_minutes=75,
+    )
+    minutes_day_one = len(day_one)
+    day_two_start = day_one_start + minutes_day_one * 60_000
+    while utc_day_key(day_two_start) == utc_day_key(day_one_start):
+        day_two_start += 60_000
+    gap_fill = []
+    cursor = day_one_start + minutes_day_one * 60_000
+    while cursor < day_two_start:
+        gap_fill.append(_candle(cursor, 102.0))
+        cursor += 60_000
+    day_two = _orb_day_candles(
+        start_ts_ms=day_two_start,
+        or_high=50.2,
+        or_low=49.8,
+        breakout_close=50.0,
+        breakout_offset_minutes=75,
+    )
+
+    report = run_opening_range_breakout_backtest(
+        day_one + gap_fill + day_two,
+        code_commit="slice-2c-test",
+    )
+
+    assert report["metrics"]["buy_signals_total"] == 1
+    assert report["thresholds_applied"]["orb_upper_break"] == 1
+
+
+def test_orb_session_end_utc_closes_open_position() -> None:
+    warmup_start = _utc_ts_ms(2024, 6, 1, 23, 0)
+    warmup = [
+        _candle(warmup_start + index * 60_000, 100.0) for index in range(60)
+    ]
+    session = _orb_day_candles(
+        start_ts_ms=_utc_ts_ms(2024, 6, 2, 0, 0),
+        or_high=101.0,
+        or_low=99.0,
+        breakout_close=102.0,
+        breakout_offset_minutes=90,
+        hold_until_session_end=True,
+    )
+
+    report = run_opening_range_breakout_backtest(
+        warmup + session,
+        code_commit="slice-2c-test",
+    )
+
+    assert report["metrics"]["closed_trades_total"] == 1
+    assert report["exit_reasons"] == ["session_end_utc"]
+    assert report["thresholds_applied"]["session_end_utc"] == 1
+
+
+@pytest.mark.parametrize(
+    ("hour", "minute", "expected"),
+    [
+        (0, 30, "opening_range"),
+        (1, 0, "trading"),
+        (12, 0, "trading"),
+        (19, 59, "trading"),
+        (20, 0, "closed"),
+        (23, 0, "closed"),
+    ],
+)
+def test_orb_session_phase_utc_boundaries(
+    hour: int, minute: int, expected: str
+) -> None:
+    ts_ms = _utc_ts_ms(2024, 6, 2, hour, minute)
+    assert (
+        orb_session_phase(
+            ts_ms,
+            or_start_utc=OR_START_UTC,
+            or_end_utc=OR_END_UTC,
+            trade_end_utc=TRADE_END_UTC,
+        )
+        == expected
+    )


### PR DESCRIPTION
## Summary
- Add single-pass Pack-A backtest runners: \ma_trend_follow_v1\ (EMA 20/50 bullish cross), \ma_crossover_v1\ (SMA 20/50 cross), \opening_range_breakout_v1\ (UTC OR 00:00–01:00, trade end 20:00).
- Extend \pack_a_breakout_common\ with EMA/SMA crossover helpers, UTC ORB session utilities, and frozen config dataclasses.
- Mark three strategies \implemented\ in registry + manifest; scenario matrix now shows **9 executable / 1 pending** (\oc_breakout_confirm_v1\ only).

## Test plan
- [x] \pytest tests/unit/validation/test_ema_trend_follow_backtest_runner.py\
- [x] \pytest tests/unit/validation/test_ma_crossover_backtest_runner.py\
- [x] \pytest tests/unit/validation/test_opening_range_breakout_backtest_runner.py\ (incl. midnight UTC + session-end boundary tests)
- [x] \pytest tests/unit/replay/test_batch_a_strategy_registry.py\
- [x] \pytest tests/unit/contracts/test_batch_a_funnel_manifest_contract.py\
- [x] \pytest tests/unit/arvp/test_batch_a_scenario_matrix_contract.py\
- [x] \uff check\ on touched modules

## Delivered
- \services/validation/ema_trend_follow_backtest_runner.py\
- \services/validation/ma_crossover_backtest_runner.py\
- \services/validation/opening_range_breakout_backtest_runner.py\
- Registry/manifest/fixture + contract test updates

## Validation
41 tests passed locally (slice 2c runners + registry + manifest + scenario matrix).

## Non-goals
- ROC runner (slice 2d)
- Batch-A dispatch wiring (slice 2d)
- Stage-A campaign execution

## Remaining uncertainty
- CI full suite not run locally; only targeted unit/contract tests.

Closes #4031 (slice 2c scope).

Made with [Cursor](https://cursor.com)