### PR TITLE
feat(arvp): Batch-A slice 2d — ROC runner + full replay dispatch (#4031)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@
 !services/validation/volatility_breakout_backtest_runner.py
 !services/validation/bollinger_squeeze_breakout_backtest_runner.py
 !services/validation/atr_expansion_backtest_runner.py
+!services/validation/ema_trend_follow_backtest_runner.py
+!services/validation/ma_crossover_backtest_runner.py
+!services/validation/opening_range_breakout_backtest_runner.py
+!services/validation/roc_breakout_confirm_backtest_runner.py
 !services/validation/pack_a_backtest_report.py
 !cdb_agent_sdk/tests/**/*.py
 !cdb_agent_sdk/tests/**/*.js

--- a/core/replay/batch_a_strategy_registry.py
+++ b/core/replay/batch_a_strategy_registry.py
@@ -206,7 +206,7 @@ BATCH_A_STRATEGY_REGISTRY: dict[str, BatchAStrategyRecord] = {
     "roc_breakout_confirm_v1": BatchAStrategyRecord(
         strategy_id="roc_breakout_confirm_v1",
         implementation_mode=ImplementationMode.NEW,
-        implementation_status=ImplementationStatus.IMPLEMENTATION_PENDING,
+        implementation_status=ImplementationStatus.IMPLEMENTED,
         later_slice="2d",
         adapter_id=None,
         runner_module="services.validation.roc_breakout_confirm_backtest_runner",

--- a/core/replay/pack_a_breakout_common.py
+++ b/core/replay/pack_a_breakout_common.py
@@ -22,6 +22,7 @@ ATR_EXPANSION_STRATEGY_ID = "atr_expansion_v1"
 EMA_TREND_FOLLOW_STRATEGY_ID = "ema_trend_follow_v1"
 MA_CROSSOVER_STRATEGY_ID = "ma_crossover_v1"
 OPENING_RANGE_BREAKOUT_STRATEGY_ID = "opening_range_breakout_v1"
+ROC_BREAKOUT_CONFIRM_STRATEGY_ID = "roc_breakout_confirm_v1"
 PACK_A_SYMBOL = PRIMARY_BREAKOUT_SYMBOL
 
 ENTRY_CHANNEL_BARS = 20
@@ -58,6 +59,10 @@ OR_END_UTC = "01:00"
 TRADE_END_UTC = "20:00"
 ORB_MIN_MINUTES_BETWEEN_ENTRIES = 1440
 ORB_WARMUP_BARS = 60
+ROC_PERIOD = 12
+ROC_ENTRY_THRESHOLD = 0.005
+ROC_EXIT_THRESHOLD = 0.0
+ROC_MIN_MINUTES_BETWEEN_ENTRIES = 30
 
 ORDER_SIZE = 1.0
 ORDER_BOOK_DEPTH_MULT = 10_000.0
@@ -313,6 +318,37 @@ def ma_crossover_warmup_candles(config: MaCrossoverConfig | None = None) -> int:
     return active.slow_sma_period
 
 
+@dataclass(frozen=True, slots=True)
+class RocBreakoutConfirmConfig:
+    breakout_lookback: int = BREAKOUT_LOOKBACK
+    exit_lookback: int = EXIT_LOOKBACK
+    roc_period: int = ROC_PERIOD
+    roc_entry_threshold: float = ROC_ENTRY_THRESHOLD
+    roc_exit_threshold: float = ROC_EXIT_THRESHOLD
+    min_minutes_between_entries: int = ROC_MIN_MINUTES_BETWEEN_ENTRIES
+    trade_side_mode: str = "long_only"
+
+    def validate(self) -> None:
+        if self.breakout_lookback <= 0:
+            raise PackABreakoutError("breakout_lookback must be > 0")
+        if self.exit_lookback <= 0:
+            raise PackABreakoutError("exit_lookback must be > 0")
+        if self.roc_period <= 0:
+            raise PackABreakoutError("roc_period must be > 0")
+        if self.min_minutes_between_entries < 0:
+            raise PackABreakoutError("min_minutes_between_entries must be >= 0")
+        if self.trade_side_mode != "long_only":
+            raise PackABreakoutError("trade_side_mode must be long_only")
+
+
+def roc_breakout_confirm_warmup_candles(
+    config: RocBreakoutConfirmConfig | None = None,
+) -> int:
+    active = config or RocBreakoutConfirmConfig()
+    active.validate()
+    return max(active.breakout_lookback, active.exit_lookback, active.roc_period)
+
+
 def opening_range_breakout_warmup_candles(
     config: OpeningRangeBreakoutConfig | None = None,
 ) -> int:
@@ -413,6 +449,22 @@ def compute_lowest_low(
     for index in range(len(lows)):
         if index >= lookback:
             result[index] = min(lows[index - lookback : index])
+    return result
+
+
+def compute_roc_series(
+    closes: Sequence[float],
+    period: int,
+) -> list[float | None]:
+    """Rate of change on close: (close[i] - close[i-period]) / close[i-period]."""
+    if period <= 0:
+        raise PackABreakoutError("period must be > 0")
+    result: list[float | None] = [None] * len(closes)
+    for index in range(period, len(closes)):
+        prior_close = closes[index - period]
+        if prior_close <= 0:
+            continue
+        result[index] = (closes[index] - prior_close) / prior_close
     return result
 
 

--- a/docs/strategy/CDB_BATCH_A_FUNNEL_CONTRACT_V1.md
+++ b/docs/strategy/CDB_BATCH_A_FUNNEL_CONTRACT_V1.md
@@ -38,7 +38,7 @@ All parameters are frozen from #4030. No optimization or post-hoc changes.
 | `ema_trend_follow_v1` | implementation_pending | 2c |
 | `ma_crossover_v1` | implementation_pending | 2c |
 | `opening_range_breakout_v1` | implementation_pending | 2c |
-| `roc_breakout_confirm_v1` | implementation_pending | 2d |
+| `roc_breakout_confirm_v1` | **implemented** | 2d |
 | `range_mean_reversion_v1` | **implemented** (reuse) | 2d |
 | `momentum_capture_v1` | **implemented** (reuse) | 2d |
 
@@ -83,10 +83,9 @@ does not compute regime labels.
 
 ## Implementation-pending semantics
 
-`core/replay/batch_a_strategy_registry.py` lists all ten locked IDs.
 Only `range_mean_reversion_v1` and `momentum_capture_v1` are marked
-`implemented` with adapter IDs. Pending IDs must not enter executable replay
-dispatch until their slice lands.
+`implemented` with adapter IDs. All ten Batch-A runners are now executable via
+`strategy_replay_runner` dispatch (slice 2d).
 
 ## Non-goals (slice 2a)
 

--- a/services/validation/roc_breakout_confirm_backtest_runner.py
+++ b/services/validation/roc_breakout_confirm_backtest_runner.py
@@ -1,0 +1,194 @@
+"""Single-pass backtest runner for roc_breakout_confirm_v1 (Pack-A slice 2d)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from core.replay.pack_a_breakout_common import (
+    ORDER_BOOK_DEPTH_MULT,
+    ORDER_SIZE,
+    ROC_BREAKOUT_CONFIRM_STRATEGY_ID,
+    RocBreakoutConfirmConfig,
+    compute_highest_high,
+    compute_lowest_low,
+    compute_roc_series,
+    cooldown_allows_entry,
+    roc_breakout_confirm_warmup_candles,
+    validate_pack_a_candle_series,
+)
+from services.execution.simulator import ExecutionSimulator
+from services.validation.pack_a_backtest_report import (
+    build_pack_a_full_report,
+    build_pack_a_minimal_report,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_roc_breakout_confirm_backtest(
+    candles: list[dict[str, Any]],
+    run_config: dict[str, Any] | None = None,
+    simulator_config: dict[str, Any] | None = None,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+    *,
+    bridge_config: RocBreakoutConfirmConfig | None = None,
+) -> dict[str, Any]:
+    """Single-pass ROC-confirmed breakout backtest returning a report dict."""
+    config = bridge_config or RocBreakoutConfirmConfig()
+    config.validate()
+    warmup = roc_breakout_confirm_warmup_candles(config)
+
+    if not candles:
+        return _build_minimal_report("no_data", code_commit, run_id=run_id)
+    try:
+        validate_pack_a_candle_series(candles)
+    except ValueError as exc:
+        return _build_minimal_report(str(exc), code_commit, run_id=run_id)
+
+    if len(candles) <= warmup:
+        return _build_minimal_report("insufficient_candles", code_commit, run_id=run_id)
+
+    highs = [float(c["high"]) for c in candles]
+    lows = [float(c["low"]) for c in candles]
+    closes = [float(c["close"]) for c in candles]
+    ts_values = [int(c["ts_ms"]) for c in candles]
+
+    highest_high = compute_highest_high(highs, config.breakout_lookback)
+    lowest_low = compute_lowest_low(lows, config.exit_lookback)
+    roc_series = compute_roc_series(closes, config.roc_period)
+
+    sim = ExecutionSimulator(config=simulator_config or {})
+    live_candles = candles[warmup:]
+    trades: list[dict[str, Any]] = []
+    open_position: dict[str, Any] | None = None
+    signals_total = 0
+    last_entry_ts_ms: int | None = None
+    entry_reasons: list[str] = []
+    exit_reasons: list[str] = []
+
+    for offset, candle in enumerate(live_candles):
+        index = warmup + offset
+        close = closes[index]
+        ts_ms = ts_values[index]
+        volume = float(candle.get("volume", 0.0))
+        breakout_level = highest_high[index]
+        exit_level = lowest_low[index]
+        roc_value = roc_series[index]
+
+        if open_position is None:
+            roc_confirms = (
+                roc_value is not None and roc_value > config.roc_entry_threshold
+            )
+            if (
+                breakout_level is not None
+                and close > breakout_level
+                and roc_confirms
+                and cooldown_allows_entry(
+                    ts_ms,
+                    last_entry_ts_ms,
+                    min_minutes_between_entries=config.min_minutes_between_entries,
+                )
+            ):
+                signals_total += 1
+                entry_reasons.append("roc_breakout_entry")
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="buy",
+                    size=ORDER_SIZE,
+                    current_price=close,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                open_position = {
+                    "entry_ts_ms": ts_ms,
+                    "entry_price": fill.avg_fill_price,
+                    "entry_fee": fill.fees,
+                }
+                last_entry_ts_ms = ts_ms
+        elif open_position is not None:
+            channel_exit = exit_level is not None and close < exit_level
+            roc_exit = (
+                roc_value is not None and roc_value < config.roc_exit_threshold
+            )
+            if channel_exit or roc_exit:
+                exit_price = close
+                volatility = abs(highs[index] - lows[index]) / close if close > 0 else 0.0
+                order_book_depth = max(volume * close * ORDER_BOOK_DEPTH_MULT, close)
+                fill = sim.simulate_market_order(
+                    side="sell",
+                    size=ORDER_SIZE,
+                    current_price=exit_price,
+                    order_book_depth=order_book_depth,
+                    volatility=max(volatility, 0.0),
+                )
+                trade_r = (
+                    fill.avg_fill_price - open_position["entry_price"]
+                ) / open_position["entry_price"]
+                if channel_exit and roc_exit:
+                    reason = "lowest_low_and_roc_exit"
+                elif roc_exit:
+                    reason = "roc_exit"
+                else:
+                    reason = "lowest_low_break"
+                exit_reasons.append(reason)
+                trades.append(
+                    {
+                        "entry_ts_ms": open_position["entry_ts_ms"],
+                        "exit_ts_ms": ts_ms,
+                        "entry_price": open_position["entry_price"],
+                        "exit_price": fill.avg_fill_price,
+                        "entry_fee": open_position["entry_fee"],
+                        "exit_fee": fill.fees,
+                        "r_return": trade_r,
+                        "reason": reason,
+                    }
+                )
+                open_position = None
+
+    return build_pack_a_full_report(
+        strategy_id=ROC_BREAKOUT_CONFIRM_STRATEGY_ID,
+        source="roc_breakout_confirm_backtest_runner",
+        candles=candles,
+        trades=trades,
+        signals_total=signals_total,
+        entry_reasons=entry_reasons,
+        exit_reasons=exit_reasons,
+        config_snapshot={
+            "breakout_lookback": config.breakout_lookback,
+            "exit_lookback": config.exit_lookback,
+            "roc_period": config.roc_period,
+            "roc_entry_threshold": config.roc_entry_threshold,
+            "roc_exit_threshold": config.roc_exit_threshold,
+            "min_minutes_between_entries": config.min_minutes_between_entries,
+            "trade_side_mode": config.trade_side_mode,
+            "warmup_candles": warmup,
+            "order_size": ORDER_SIZE,
+            "ranking_ready": False,
+        },
+        warmup=warmup,
+        code_commit=code_commit,
+        run_id=run_id,
+        thresholds_applied={
+            "roc_breakout_entry": entry_reasons.count("roc_breakout_entry"),
+            "lowest_low_break": exit_reasons.count("lowest_low_break"),
+            "roc_exit": exit_reasons.count("roc_exit"),
+            "lowest_low_and_roc_exit": exit_reasons.count("lowest_low_and_roc_exit"),
+        },
+    )
+
+
+def _build_minimal_report(
+    reason: str,
+    code_commit: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return build_pack_a_minimal_report(
+        strategy_id=ROC_BREAKOUT_CONFIRM_STRATEGY_ID,
+        source="roc_breakout_confirm_backtest_runner",
+        reason=reason,
+        code_commit=code_commit,
+        run_id=run_id,
+    )

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -66,6 +66,15 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from core.replay.batch_a_strategy_registry import (
+    BATCH_A_STRATEGY_REGISTRY,
+    batch_a_strategy_ids,
+    get_batch_a_strategy,
+)
+from core.replay.binance_window_bank_adapter import (
+    BinanceWindowBankAdapterError,
+    load_binance_window_dataset,
+)
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
 from core.replay.dataset_provider import (
     DBBackedDatasetProvider,
@@ -162,6 +171,30 @@ from services.validation.donchian_breakout_backtest_runner import (
 from services.validation.breakout_trend_filter_backtest_runner import (
     run_breakout_trend_filter_backtest,
 )
+from services.validation.breakout_volatility_filter_backtest_runner import (
+    run_breakout_volatility_filter_backtest,
+)
+from services.validation.volatility_breakout_backtest_runner import (
+    run_volatility_breakout_backtest,
+)
+from services.validation.bollinger_squeeze_breakout_backtest_runner import (
+    run_bollinger_squeeze_breakout_backtest,
+)
+from services.validation.atr_expansion_backtest_runner import (
+    run_atr_expansion_backtest,
+)
+from services.validation.ema_trend_follow_backtest_runner import (
+    run_ema_trend_follow_backtest,
+)
+from services.validation.ma_crossover_backtest_runner import (
+    run_ma_crossover_backtest,
+)
+from services.validation.opening_range_breakout_backtest_runner import (
+    run_opening_range_breakout_backtest,
+)
+from services.validation.roc_breakout_confirm_backtest_runner import (
+    run_roc_breakout_confirm_backtest,
+)
 from services.validation.strategy_backtest_runner import (
     PrimaryBreakoutBacktestError,
     PrimaryBreakoutBacktestRunConfig,
@@ -172,14 +205,47 @@ from services.validation.strategy_backtest_runner import (
 # ---------------------------------------------------------------------------
 # Supported constants (fail-closed validation anchors)
 # ---------------------------------------------------------------------------
-_SUPPORTED_STRATEGY_IDS: frozenset[str] = frozenset(
+_BATCH_A_SHADOW_ADAPTER_ID = "batch_a_shadow_runner_v1"
+_BINANCE_WINDOW_DATASET_STRATEGIES: frozenset[str] = frozenset(
     {
-        PRIMARY_BREAKOUT_STRATEGY_ID,
-        DONCHIAN_BREAKOUT_STRATEGY_ID,
-        BREAKOUT_TREND_FILTER_STRATEGY_ID,
         RANGE_MEAN_REVERSION_STRATEGY_ID,
         MOMENTUM_CAPTURE_STRATEGY_ID,
     }
+)
+
+def _batch_a_runner_dispatch() -> dict[str, Callable[..., dict[str, Any]]]:
+    """Resolve Batch-A runners at call time so tests can patch module bindings."""
+    return {
+        "breakout_volatility_filter_v1": run_breakout_volatility_filter_backtest,
+        "volatility_breakout_v1": run_volatility_breakout_backtest,
+        "bollinger_squeeze_breakout_v1": run_bollinger_squeeze_breakout_backtest,
+        "atr_expansion_v1": run_atr_expansion_backtest,
+        "ema_trend_follow_v1": run_ema_trend_follow_backtest,
+        "ma_crossover_v1": run_ma_crossover_backtest,
+        "opening_range_breakout_v1": run_opening_range_breakout_backtest,
+        "roc_breakout_confirm_v1": run_roc_breakout_confirm_backtest,
+        RANGE_MEAN_REVERSION_STRATEGY_ID: run_range_mean_reversion_backtest,
+        MOMENTUM_CAPTURE_STRATEGY_ID: run_momentum_capture_backtest,
+    }
+
+
+def _batch_a_adapter_ids() -> frozenset[str]:
+    adapter_ids = {_BATCH_A_SHADOW_ADAPTER_ID}
+    for record in BATCH_A_STRATEGY_REGISTRY.values():
+        if record.adapter_id:
+            adapter_ids.add(record.adapter_id)
+    return frozenset(adapter_ids)
+
+
+_SUPPORTED_STRATEGY_IDS: frozenset[str] = (
+    frozenset(batch_a_strategy_ids())
+    | frozenset(
+        {
+            PRIMARY_BREAKOUT_STRATEGY_ID,
+            DONCHIAN_BREAKOUT_STRATEGY_ID,
+            BREAKOUT_TREND_FILTER_STRATEGY_ID,
+        }
+    )
 )
 _SUPPORTED_SYMBOLS: frozenset[str] = frozenset(
     {
@@ -188,13 +254,11 @@ _SUPPORTED_SYMBOLS: frozenset[str] = frozenset(
         MOMENTUM_CAPTURE_SYMBOL,
     }
 )
-_SUPPORTED_ADAPTER_IDS: frozenset[str] = frozenset(
+_SUPPORTED_ADAPTER_IDS: frozenset[str] = _batch_a_adapter_ids() | frozenset(
     {
         "primary_breakout_runner_v1",
         "donchian_breakout_runner_v1",
         "breakout_trend_filter_runner_v1",
-        "range_mean_reversion_runner_v1",
-        "momentum_capture_runner_v1",
     }
 )
 
@@ -254,6 +318,9 @@ class ARVPReplayConfig:
     db_dataset_window: str | None = None
     """DB-backed dataset window: 'START_TS_MS:END_TS_MS' (epoch millis)."""
 
+    binance_window_id: str | None = None
+    """Binance window-bank id when dataset_source='binance_window'."""
+
     strategy_id: str = _DEFAULT_STRATEGY_ID
     """Strategy identifier. Must be in _SUPPORTED_STRATEGY_IDS."""
 
@@ -305,9 +372,10 @@ class ARVPReplayConfig:
     def validate(self) -> None:
         """Fail-closed config validation. Raises ValueError on any violation."""
         dataset_source = (self.dataset_source or "").strip()
-        if dataset_source not in {"file", "db"}:
+        if dataset_source not in {"file", "db", "binance_window"}:
             raise ValueError(
-                f"dataset_source must be 'file' or 'db', got {self.dataset_source!r}"
+                "dataset_source must be 'file', 'db', or 'binance_window', "
+                f"got {self.dataset_source!r}"
             )
 
         if dataset_source == "file":
@@ -321,7 +389,13 @@ class ARVPReplayConfig:
                     "dataset_source='file' and dataset_source='db' are mutually exclusive: "
                     "db_dataset_window must be None when dataset_source='file'."
                 )
-        else:
+            if self.binance_window_id is not None:
+                raise ValueError(
+                    "dataset_source='file' and dataset_source='binance_window' are "
+                    "mutually exclusive: binance_window_id must be None when "
+                    "dataset_source='file'."
+                )
+        elif dataset_source == "db":
             if (
                 self.db_dataset_window is None
                 or not str(self.db_dataset_window).strip()
@@ -334,9 +408,39 @@ class ARVPReplayConfig:
                     "dataset_source='db' and dataset_source='file' are mutually exclusive: "
                     "input_candles_file must be empty when dataset_source='db'."
                 )
+            if self.binance_window_id is not None:
+                raise ValueError(
+                    "dataset_source='db' and dataset_source='binance_window' are "
+                    "mutually exclusive: binance_window_id must be None when "
+                    "dataset_source='db'."
+                )
 
             # Fail-closed: db_dataset_window must include an explicit window.
             _parse_db_dataset_window(self.db_dataset_window)
+        else:
+            if not self.binance_window_id or not str(self.binance_window_id).strip():
+                raise ValueError(
+                    "dataset_source='binance_window' requires binance_window_id "
+                    "(use --binance-window-id)"
+                )
+            if self.strategy_id not in _BINANCE_WINDOW_DATASET_STRATEGIES:
+                raise ValueError(
+                    "dataset_source='binance_window' is only supported for "
+                    f"{sorted(_BINANCE_WINDOW_DATASET_STRATEGIES)}, "
+                    f"got {self.strategy_id!r}"
+                )
+            if self.input_candles_file:
+                raise ValueError(
+                    "dataset_source='binance_window' and dataset_source='file' are "
+                    "mutually exclusive: input_candles_file must be empty when "
+                    "dataset_source='binance_window'."
+                )
+            if self.db_dataset_window is not None:
+                raise ValueError(
+                    "dataset_source='binance_window' and dataset_source='db' are "
+                    "mutually exclusive: db_dataset_window must be None when "
+                    "dataset_source='binance_window'."
+                )
         if self.strategy_id not in _SUPPORTED_STRATEGY_IDS:
             raise ValueError(
                 f"unsupported strategy_id {self.strategy_id!r}; "
@@ -352,6 +456,7 @@ class ARVPReplayConfig:
                 f"unsupported adapter_id {self.adapter_id!r}; "
                 f"supported: {sorted(_SUPPORTED_ADAPTER_IDS)}"
             )
+        _validate_strategy_adapter_pair(self.strategy_id, self.adapter_id)
         try:
             SchedulerConfig(profile=self.speedup_profile).validate()
         except SchedulerError as exc:
@@ -388,6 +493,28 @@ class ARVPReplayConfig:
 
 
 _DB_DATASET_WINDOW_RE = re.compile(r"^(?P<start>\d+):(?P<end>\d+)$")
+
+
+def _validate_strategy_adapter_pair(strategy_id: str, adapter_id: str) -> None:
+    if strategy_id not in BATCH_A_STRATEGY_REGISTRY:
+        return
+    record = get_batch_a_strategy(strategy_id)
+    if record.adapter_id:
+        if adapter_id != record.adapter_id:
+            raise ValueError(
+                f"adapter_id {adapter_id!r} does not match registry for "
+                f"{strategy_id!r}: expected {record.adapter_id!r}"
+            )
+        return
+    if adapter_id != _BATCH_A_SHADOW_ADAPTER_ID:
+        raise ValueError(
+            f"adapter_id {adapter_id!r} invalid for {strategy_id!r}; "
+            f"expected {_BATCH_A_SHADOW_ADAPTER_ID!r}"
+        )
+
+
+def _is_batch_a_strategy(strategy_id: str) -> bool:
+    return strategy_id in BATCH_A_STRATEGY_REGISTRY
 
 
 def _parse_db_dataset_window(db_dataset_window: str) -> tuple[int, int]:
@@ -603,6 +730,16 @@ def _utc_now_iso_not_before(started_at_utc: str) -> str:
 def _build_provenance_config_snapshot(
     config: ARVPReplayConfig,
 ) -> dict[str, Any]:
+    if config.strategy_id in BATCH_A_STRATEGY_REGISTRY:
+        record = get_batch_a_strategy(config.strategy_id)
+        snapshot = {
+            "order_size": config.order_size,
+            "order_book_depth_multiplier": config.order_book_depth_multiplier,
+            **dict(record.frozen_parameters),
+        }
+        if record.warmup_bars is not None:
+            snapshot["warmup_bars"] = record.warmup_bars
+        return snapshot
     if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
         return {
             "order_size": config.order_size,
@@ -735,6 +872,23 @@ def _load_dataset_result(
                 logging.getLogger(__name__).debug(
                     "conn.close() raised in finally block (ignored)", exc_info=True
                 )
+
+    if dataset_source == "binance_window":
+        window_id = str(config.binance_window_id).strip()
+        try:
+            dataset = load_binance_window_dataset(
+                window_id,
+                warmup_candles=warmup_count,
+            )
+        except BinanceWindowBankAdapterError as exc:
+            raise ReplayRunnerError(str(exc)) from exc
+        return DatasetResult(
+            spec=dataset.dataset_result.spec,
+            candles=dataset.dataset_result.candles,
+            fingerprint=dataset.dataset_result.fingerprint,
+            warmup_count=warmup_count,
+            effective_candle_count=dataset.dataset_result.effective_candle_count,
+        )
 
     raise ReplayRunnerError(f"unsupported dataset_source: {config.dataset_source!r}")
 
@@ -883,6 +1037,10 @@ def _build_pack_a_execution_provenance_id(
 
 
 def _strategy_warmup_count(config: ARVPReplayConfig) -> int:
+    if config.strategy_id in BATCH_A_STRATEGY_REGISTRY:
+        record = get_batch_a_strategy(config.strategy_id)
+        if record.warmup_bars is not None:
+            return record.warmup_bars
     if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
         return RMR_WARMUP_CANDLES
     if config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
@@ -895,6 +1053,8 @@ def _strategy_warmup_count(config: ARVPReplayConfig) -> int:
 
 
 def _is_no_two_pass_determinism_strategy(strategy_id: str) -> bool:
+    if strategy_id in BATCH_A_STRATEGY_REGISTRY:
+        return True
     return strategy_id in {
         RANGE_MEAN_REVERSION_STRATEGY_ID,
         MOMENTUM_CAPTURE_STRATEGY_ID,
@@ -909,6 +1069,14 @@ def _build_execution_provenance_id_for_config(
     *,
     code_commit: str,
 ) -> str:
+    if config.strategy_id in BATCH_A_STRATEGY_REGISTRY:
+        record = get_batch_a_strategy(config.strategy_id)
+        return _build_pack_a_execution_provenance_id(
+            candles,
+            strategy_id=config.strategy_id,
+            code_commit=code_commit,
+            config_payload=dict(record.frozen_parameters),
+        )
     if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
         return _build_rmr_execution_provenance_id(candles, code_commit=code_commit)
     if config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
@@ -962,18 +1130,10 @@ def _run_strategy_backtest(
     run_cfg: PrimaryBreakoutBacktestRunConfig | None = None,
     simulator_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
-        return run_range_mean_reversion_backtest(
+    batch_a_runner = _batch_a_runner_dispatch().get(config.strategy_id)
+    if batch_a_runner is not None:
+        return batch_a_runner(
             candles,
-            run_config=None,
-            simulator_config=simulator_config,
-            code_commit=code_commit,
-            run_id=run_id,
-        )
-    if config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
-        return run_momentum_capture_backtest(
-            candles,
-            run_config=None,
             simulator_config=simulator_config,
             code_commit=code_commit,
             run_id=run_id,
@@ -1186,6 +1346,7 @@ def _write_supplementary_artifacts(
         "dataset_source": config.dataset_source,
         "input_candles_file": config.input_candles_file,
         "db_dataset_window": config.db_dataset_window,
+        "binance_window_id": config.binance_window_id,
         "strategy_id": config.strategy_id,
         "symbol": config.symbol,
         "adapter_id": config.adapter_id,
@@ -1592,7 +1753,7 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dataset-source",
         default="file",
-        choices=("file", "db"),
+        choices=("file", "db", "binance_window"),
         metavar="SOURCE",
         help="Dataset input source. Default: 'file'.",
     )
@@ -1607,6 +1768,12 @@ def _build_argument_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="START_TS_MS:END_TS_MS",
         help="DB-backed dataset window (epoch millis). Required when --dataset-source=db.",
+    )
+    parser.add_argument(
+        "--binance-window-id",
+        default=None,
+        metavar="WINDOW_ID",
+        help="Binance window-bank id. Required when --dataset-source=binance_window.",
     )
     parser.add_argument(
         "--output-dir",
@@ -1940,14 +2107,12 @@ def _run_scenario_group_path(
     output_dir = Path(config.output_directory)
     code_commit = _get_code_commit()
 
-    if config.strategy_id == RANGE_MEAN_REVERSION_STRATEGY_ID:
-        run_single = _make_rmr_run_single_fn(candles, config, code_commit, output_dir)
-    elif config.strategy_id == MOMENTUM_CAPTURE_STRATEGY_ID:
-        run_single = _make_momentum_run_single_fn(candles, config, code_commit, output_dir)
-    elif config.strategy_id in {
+    if config.strategy_id in {
+        RANGE_MEAN_REVERSION_STRATEGY_ID,
+        MOMENTUM_CAPTURE_STRATEGY_ID,
         DONCHIAN_BREAKOUT_STRATEGY_ID,
         BREAKOUT_TREND_FILTER_STRATEGY_ID,
-    }:
+    } or _is_batch_a_strategy(config.strategy_id):
         run_single = _make_pack_a_run_single_fn(candles, config, code_commit, output_dir)
     else:
         run_single = _make_pb_run_single_fn(candles, config, code_commit, output_dir)
@@ -1986,6 +2151,7 @@ def main() -> int:
             input_candles_file=args.input_candles,
             dataset_source=args.dataset_source,
             db_dataset_window=args.db_dataset_window,
+            binance_window_id=args.binance_window_id,
             strategy_id=args.strategy_id,
             symbol=args.symbol,
             adapter_id=args.adapter_id,

--- a/tests/fixtures/arvp/batch_a_scenario_matrix_v1.json
+++ b/tests/fixtures/arvp/batch_a_scenario_matrix_v1.json
@@ -30,11 +30,10 @@
     "momentum_capture_v1",
     "ema_trend_follow_v1",
     "ma_crossover_v1",
-    "opening_range_breakout_v1"
-  ],
-  "implementation_pending_strategy_ids": [
+    "opening_range_breakout_v1",
     "roc_breakout_confirm_v1"
   ],
+  "implementation_pending_strategy_ids": [],
   "canonical_adapter_by_strategy": {
     "breakout_volatility_filter_v1": null,
     "volatility_breakout_v1": null,

--- a/tests/unit/contracts/test_batch_a_funnel_manifest_contract.py
+++ b/tests/unit/contracts/test_batch_a_funnel_manifest_contract.py
@@ -11,6 +11,7 @@ from core.replay.batch_a_strategy_registry import (
     ALREADY_TESTED_STRATEGY_IDS,
     BATCH_A_STRATEGY_REGISTRY,
     ImplementationStatus,
+    assert_batch_a_executable,
     batch_a_strategy_ids,
     executable_batch_a_strategy_ids,
     pending_batch_a_strategy_ids,
@@ -82,21 +83,12 @@ def test_registry_matches_manifest_strategy_ids(manifest: dict) -> None:
     assert set(batch_a_strategy_ids()) == manifest_ids
 
 
-def test_slice_2c_runners_executable() -> None:
-    assert executable_batch_a_strategy_ids() == frozenset(
-        {
-            "range_mean_reversion_v1",
-            "momentum_capture_v1",
-            "breakout_volatility_filter_v1",
-            "volatility_breakout_v1",
-            "bollinger_squeeze_breakout_v1",
-            "atr_expansion_v1",
-            "ema_trend_follow_v1",
-            "ma_crossover_v1",
-            "opening_range_breakout_v1",
-        }
-    )
-    assert pending_batch_a_strategy_ids() == frozenset({"roc_breakout_confirm_v1"})
+def test_all_ten_runners_executable() -> None:
+    assert len(executable_batch_a_strategy_ids()) == 10
+    assert pending_batch_a_strategy_ids() == frozenset()
+    for strategy_id in batch_a_strategy_ids():
+        record = assert_batch_a_executable(strategy_id)
+        assert record.runner_module is not None
 
 
 def test_pending_candidates_not_executable() -> None:

--- a/tests/unit/replay/test_batch_a_strategy_registry.py
+++ b/tests/unit/replay/test_batch_a_strategy_registry.py
@@ -23,8 +23,8 @@ def test_registry_lists_all_ten_locked_candidates() -> None:
 def test_only_implemented_runners_are_executable() -> None:
     executable = executable_batch_a_strategy_ids()
     pending = pending_batch_a_strategy_ids()
-    assert len(executable) == 9
-    assert len(pending) == 1
+    assert len(executable) == 10
+    assert len(pending) == 0
     assert executable.isdisjoint(pending)
 
 
@@ -51,6 +51,10 @@ def test_pending_candidates_cannot_be_executed(strategy_id: str) -> None:
     assert not record.executable
     with pytest.raises(ValueError, match="implementation_pending"):
         assert_batch_a_executable(strategy_id)
+
+
+def test_no_pending_candidates_remain() -> None:
+    assert pending_batch_a_strategy_ids() == frozenset()
 
 
 def test_unknown_strategy_raises_key_error() -> None:

--- a/tests/unit/validation/test_pack_a_replay_dispatch.py
+++ b/tests/unit/validation/test_pack_a_replay_dispatch.py
@@ -1,17 +1,26 @@
-"""Dispatch tests for Pack-A strategy replay wiring."""
+"""Dispatch tests for Pack-A and Batch-A strategy replay wiring."""
 
 from __future__ import annotations
 
 import pytest
 
+from core.replay.batch_a_strategy_registry import batch_a_strategy_ids
 from core.replay.pack_a_breakout_common import (
     BREAKOUT_TREND_FILTER_STRATEGY_ID,
     DONCHIAN_BREAKOUT_STRATEGY_ID,
 )
-from services.validation.strategy_replay_runner import ARVPReplayConfig
+from services.validation.strategy_replay_runner import (
+    ARVPReplayConfig,
+    _BATCH_A_SHADOW_ADAPTER_ID,
+)
+
+pytestmark = pytest.mark.unit
+
+_INPUT_CANDLES = (
+    "artifacts/backtests/primary_breakout_v1/20260418-212643/dataset.candles.json"
+)
 
 
-@pytest.mark.unit
 @pytest.mark.parametrize(
     ("strategy_id", "adapter_id"),
     [
@@ -23,11 +32,54 @@ from services.validation.strategy_replay_runner import ARVPReplayConfig
 def test_pack_a_strategy_ids_validate(strategy_id: str, adapter_id: str) -> None:
     config = ARVPReplayConfig(
         dataset_source="file",
-        input_candles_file="artifacts/backtests/primary_breakout_v1/20260418-212643/dataset.candles.json",
+        input_candles_file=_INPUT_CANDLES,
         strategy_id=strategy_id,
         symbol="BTCUSDT",
         adapter_id=adapter_id,
         scenario_ids=("baseline", "pessimistic_execution", "feed_gap"),
+    )
+    config.validate()
+
+
+@pytest.mark.parametrize("strategy_id", sorted(batch_a_strategy_ids()))
+def test_batch_a_strategy_ids_validate(strategy_id: str) -> None:
+    adapter_id = (
+        "range_mean_reversion_runner_v1"
+        if strategy_id == "range_mean_reversion_v1"
+        else "momentum_capture_runner_v1"
+        if strategy_id == "momentum_capture_v1"
+        else _BATCH_A_SHADOW_ADAPTER_ID
+    )
+    config = ARVPReplayConfig(
+        dataset_source="file",
+        input_candles_file=_INPUT_CANDLES,
+        strategy_id=strategy_id,
+        symbol="BTCUSDT",
+        adapter_id=adapter_id,
+        scenario_ids=("baseline", "pessimistic_execution"),
+    )
+    config.validate()
+
+
+@pytest.mark.parametrize(
+    ("strategy_id", "adapter_id", "binance_window_id"),
+    [
+        ("range_mean_reversion_v1", "range_mean_reversion_runner_v1", "binance_1m_month_2021_01"),
+        ("momentum_capture_v1", "momentum_capture_runner_v1", "binance_1m_month_2021_01"),
+    ],
+)
+def test_batch_a_binance_window_dataset_validates(
+    strategy_id: str,
+    adapter_id: str,
+    binance_window_id: str,
+) -> None:
+    config = ARVPReplayConfig(
+        dataset_source="binance_window",
+        binance_window_id=binance_window_id,
+        strategy_id=strategy_id,
+        symbol="BTCUSDT",
+        adapter_id=adapter_id,
+        scenario_ids=("baseline",),
     )
     config.validate()
 

--- a/tests/unit/validation/test_roc_breakout_confirm_backtest_runner.py
+++ b/tests/unit/validation/test_roc_breakout_confirm_backtest_runner.py
@@ -1,0 +1,85 @@
+"""Tests for roc_breakout_confirm_v1 backtest runner (#4031 slice 2d)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.pack_a_breakout_common import (
+    BREAKOUT_LOOKBACK,
+    EXIT_LOOKBACK,
+    ROC_ENTRY_THRESHOLD,
+    ROC_EXIT_THRESHOLD,
+    ROC_MIN_MINUTES_BETWEEN_ENTRIES,
+    ROC_PERIOD,
+)
+from services.validation.roc_breakout_confirm_backtest_runner import (
+    run_roc_breakout_confirm_backtest,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, close: float, *, spread: float = 0.1) -> dict:
+    return {
+        "symbol": "BTCUSDT",
+        "ts_ms": ts_ms,
+        "open": close,
+        "high": close + spread,
+        "low": close - spread,
+        "close": close,
+        "volume": 1_000.0,
+    }
+
+
+def _roc_breakout_candles() -> list[dict]:
+    rows: list[dict] = []
+    start_ts = 1_700_000_000_000
+    for index in range(90):
+        close = 100.0
+        spread = 0.05
+        if 30 <= index < 55:
+            close = 100.0 + (index - 30) * 0.08
+            spread = 0.08
+        elif index == 55:
+            close = 102.5
+            spread = 0.5
+        elif 56 <= index <= 70:
+            close = 102.5 + (index - 56) * 0.04
+            spread = 0.3
+        elif index == 71:
+            close = 99.0
+            spread = 0.4
+        rows.append(_candle(start_ts + index * 60_000, close, spread=spread))
+    return rows
+
+
+def test_roc_breakout_runs_and_closes_trade() -> None:
+    report = run_roc_breakout_confirm_backtest(
+        _roc_breakout_candles(),
+        code_commit="slice-2d-test",
+    )
+
+    assert report["schema_version"] == "strategy_validation_report.v1"
+    assert report["strategy_id"] == "roc_breakout_confirm_v1"
+    assert report["metrics"]["closed_trades_total"] >= 1
+    assert report["config_snapshot"]["ranking_ready"] is False
+    assert report["metrics"]["ranking_ready"] is False
+    assert report["gate_result"]["ranking_ready"] is False
+
+
+def test_roc_breakout_frozen_params_in_snapshot() -> None:
+    report = run_roc_breakout_confirm_backtest(
+        _roc_breakout_candles(),
+        code_commit="slice-2d-test",
+    )
+    snapshot = report["config_snapshot"]
+
+    assert snapshot["breakout_lookback"] == BREAKOUT_LOOKBACK
+    assert snapshot["exit_lookback"] == EXIT_LOOKBACK
+    assert snapshot["roc_period"] == ROC_PERIOD
+    assert snapshot["roc_entry_threshold"] == ROC_ENTRY_THRESHOLD
+    assert snapshot["roc_exit_threshold"] == ROC_EXIT_THRESHOLD
+    assert (
+        snapshot["min_minutes_between_entries"] == ROC_MIN_MINUTES_BETWEEN_ENTRIES
+    )
+    assert snapshot["trade_side_mode"] == "long_only"

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -275,7 +275,7 @@ class TestARVPReplayConfig:
             dataset_source="s3",
             input_candles_file="candles.json",
         )
-        with pytest.raises(ValueError, match="dataset_source must be 'file' or 'db'"):
+        with pytest.raises(ValueError, match="dataset_source must be 'file', 'db', or 'binance_window'"):
             cfg.validate()
 
     def test_db_dataset_id_field_is_not_supported(self):


### PR DESCRIPTION
## Summary
- Add `roc_breakout_confirm_v1` backtest runner (ROC period 12 on close, breakout lookback 20 / exit 10, frozen registry params).
- Extend `strategy_replay_runner` with dispatch for all ten Batch-A `strategy_id`s, registry-based adapter validation, and `binance_window` dataset source for RMR/Momentum.
- Mark `roc_breakout_confirm_v1` IMPLEMENTED; update registry/contract/fixture tests so all ten runners are executable (0 pending).

## Test plan
- [x] `pytest -q tests/unit/validation/test_roc_breakout_confirm_backtest_runner.py tests/unit/validation/test_pack_a_replay_dispatch.py tests/unit/contracts/test_batch_a_funnel_manifest_contract.py tests/unit/replay/test_batch_a_strategy_registry.py tests/unit/arvp/test_batch_a_scenario_matrix_contract.py tests/unit/validation/test_strategy_replay_runner.py` (142 passed, 1 skipped)
- [x] `ruff check` on touched validation/replay modules

## Non-goals
- Stage-A screening campaign (#4032)
- Runtime BLUE/RED changes
- Parameter optimization or ranking_ready promotion

## Remaining uncertainty
- Binance window replay path validated at config level; full window-bank E2E replay deferred to WP3.

Closes #4031