### PR TITLE
feat(arvp): Batch-A compact regime_stats.v1 (#4031)

### DIFF
--- a/core/replay/regime_stats.py
+++ b/core/replay/regime_stats.py
@@ -1,0 +1,248 @@
+"""Compact regime evidence aggregation for ARVP Batch-A campaign jobs (#4031 A3).
+
+Streaming/online aggregation from candle ``regime_id`` fields and closed trades.
+Produces schema-versioned ``regime_stats.v1`` artifacts without persisting full
+per-candle step traces.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping
+
+from core.replay.canonical_json import canonical_hash
+
+_SCHEMA_VERSION = "regime_stats.v1"
+_UNKNOWN_REGIME = "UNKNOWN"
+_HVC_REGIME = "HIGH_VOL_CHAOTIC"
+_DOMINANCE_THRESHOLD = Decimal("0.90")
+_MONEY_Q = Decimal("0.00000001")
+_RATE_Q = Decimal("0.00000001")
+
+_REGIME_ID_TO_NAME: dict[int, str] = {
+    0: "TREND",
+    1: "RANGE",
+    2: "HIGH_VOL_CHAOTIC",
+    3: "CRISIS",
+}
+
+
+def normalize_regime_id(raw: object) -> str | None:
+    """Map candle/trade regime context to a stable uppercase string id."""
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip().upper()
+    if isinstance(raw, int) and not isinstance(raw, bool):
+        return _REGIME_ID_TO_NAME.get(raw, _UNKNOWN_REGIME)
+    return None
+
+
+@dataclass
+class _RegimeBucket:
+    candle_count: int = 0
+    entry_trade_count: int = 0
+    exit_trade_count: int = 0
+    gross_pnl_r: Decimal = Decimal("0")
+    net_pnl_r: Decimal = Decimal("0")
+    fees_quote: Decimal = Decimal("0")
+    r_returns: list[Decimal] = field(default_factory=list)
+
+
+class RegimeStatsAggregator:
+    """Online regime counter updated per bar and per closed trade."""
+
+    def __init__(self, *, warmup: int = 0) -> None:
+        if warmup < 0:
+            raise ValueError("warmup must be >= 0")
+        self._warmup = warmup
+        self._buckets: dict[str, _RegimeBucket] = defaultdict(_RegimeBucket)
+        self._ts_to_regime: dict[int, str] = {}
+        self._candles_total = 0
+        self._candles_with_regime = 0
+        self._candles_missing_regime = 0
+
+    def update_bar(self, candle: Mapping[str, Any], *, index: int | None = None) -> None:
+        """Count one candle/step toward its regime bucket."""
+        if index is not None and index < self._warmup:
+            return
+        self._candles_total += 1
+        regime = normalize_regime_id(candle.get("regime_id"))
+        if regime is None:
+            self._candles_missing_regime += 1
+            return
+        self._candles_with_regime += 1
+        self._buckets[regime].candle_count += 1
+        ts_ms = candle.get("ts_ms")
+        if isinstance(ts_ms, int) and not isinstance(ts_ms, bool):
+            self._ts_to_regime[ts_ms] = regime
+
+    def record_trade(self, trade: Mapping[str, Any]) -> None:
+        """Attribute one closed trade to entry/exit regime buckets when derivable."""
+        entry_regime = normalize_regime_id(trade.get("entry_regime_id"))
+        exit_regime = normalize_regime_id(trade.get("exit_regime_id"))
+        if entry_regime is None:
+            entry_regime = self._lookup_regime(trade.get("entry_ts_ms"))
+        if exit_regime is None:
+            exit_regime = self._lookup_regime(trade.get("exit_ts_ms"))
+
+        if entry_regime is not None:
+            self._buckets[entry_regime].entry_trade_count += 1
+        if exit_regime is not None:
+            bucket = self._buckets[exit_regime]
+            bucket.exit_trade_count += 1
+            r_return = _as_decimal(trade.get("r_return"))
+            if r_return is not None:
+                bucket.gross_pnl_r += r_return
+                bucket.r_returns.append(r_return)
+                entry_fee = _as_decimal(trade.get("entry_fee")) or Decimal("0")
+                exit_fee = _as_decimal(trade.get("exit_fee")) or Decimal("0")
+                fees = (entry_fee + exit_fee).quantize(_MONEY_Q)
+                bucket.fees_quote += fees
+                entry_price = _as_decimal(trade.get("entry_price"))
+                order_size = _as_decimal(trade.get("order_size")) or Decimal("1")
+                if entry_price is not None and entry_price > 0:
+                    fee_r = fees / (entry_price * order_size)
+                    bucket.net_pnl_r += (r_return - fee_r).quantize(_RATE_Q)
+
+    def finalize(self) -> dict[str, Any]:
+        """Return deterministic ``regime_stats.v1`` payload (no step trace)."""
+        per_regime = []
+        regimes_with_trades: set[str] = set()
+        for regime_id in sorted(self._buckets):
+            bucket = self._buckets[regime_id]
+            if bucket.entry_trade_count or bucket.exit_trade_count:
+                regimes_with_trades.add(regime_id)
+            expectancy_r: str | None = None
+            if bucket.r_returns:
+                total = sum(bucket.r_returns, Decimal("0"))
+                expectancy_r = str(
+                    (total / Decimal(len(bucket.r_returns))).quantize(_RATE_Q)
+                )
+            segment: dict[str, Any] = {
+                "regime_id": regime_id,
+                "candle_count": bucket.candle_count,
+                "step_count": bucket.candle_count,
+                "entry_trade_count": bucket.entry_trade_count,
+                "exit_trade_count": bucket.exit_trade_count,
+            }
+            if bucket.exit_trade_count:
+                segment["gross_pnl_r"] = str(bucket.gross_pnl_r.quantize(_RATE_Q))
+                segment["net_pnl_r"] = str(bucket.net_pnl_r.quantize(_RATE_Q))
+                segment["fees_quote"] = str(bucket.fees_quote.quantize(_MONEY_Q))
+                if expectancy_r is not None:
+                    segment["expectancy_r"] = expectancy_r
+            per_regime.append(segment)
+
+        diversity = _build_diversity_flags(self._buckets, self._candles_with_regime)
+        coverage = {
+            "candles_total": self._candles_total,
+            "candles_with_regime_id": self._candles_with_regime,
+            "candles_missing_regime_id": self._candles_missing_regime,
+            "regime_id_missing_flag": self._candles_missing_regime > 0,
+        }
+        payload_without_hash = {
+            "schema_version": _SCHEMA_VERSION,
+            "coverage": coverage,
+            "diversity_flags": diversity,
+            "per_regime": per_regime,
+        }
+        payload = {
+            **payload_without_hash,
+            "stats_fingerprint": canonical_hash(payload_without_hash),
+        }
+        _assert_no_trace_keys(payload)
+        return payload
+
+    def _lookup_regime(self, ts_ms: object) -> str | None:
+        if isinstance(ts_ms, int) and not isinstance(ts_ms, bool):
+            return self._ts_to_regime.get(ts_ms)
+        return None
+
+
+def build_regime_stats_from_replay(
+    candles: list[Mapping[str, Any]],
+    trades: list[Mapping[str, Any]],
+    *,
+    warmup: int = 0,
+) -> dict[str, Any]:
+    """Convenience helper: aggregate candles + trades into ``regime_stats.v1``."""
+    aggregator = RegimeStatsAggregator(warmup=warmup)
+    for index, candle in enumerate(candles):
+        aggregator.update_bar(candle, index=index)
+    for trade in trades:
+        aggregator.record_trade(trade)
+    return aggregator.finalize()
+
+
+def regime_scorecard_status_from_stats(regime_stats: Mapping[str, Any] | None) -> str:
+    """Minimal PEP hook: ok when trades span multiple regimes, else unavailable."""
+    if not isinstance(regime_stats, Mapping):
+        return "unavailable"
+    diversity = regime_stats.get("diversity_flags")
+    if not isinstance(diversity, Mapping):
+        return "unavailable"
+    trades_count = diversity.get("regimes_with_trades_count")
+    if isinstance(trades_count, int) and trades_count >= 2:
+        return "ok"
+    return "unavailable"
+
+
+def _build_diversity_flags(
+    buckets: dict[str, _RegimeBucket],
+    candles_with_regime: int,
+) -> dict[str, Any]:
+    regimes_observed = sum(1 for bucket in buckets.values() if bucket.candle_count > 0)
+    regimes_with_trades = sum(
+        1
+        for bucket in buckets.values()
+        if bucket.entry_trade_count or bucket.exit_trade_count
+    )
+    hvc_count = buckets.get(_HVC_REGIME, _RegimeBucket()).candle_count
+    hvc_share = (
+        Decimal(hvc_count) / Decimal(candles_with_regime)
+        if candles_with_regime > 0
+        else Decimal("0")
+    ).quantize(_RATE_Q)
+
+    dominant_regime: str | None = None
+    dominant_share = Decimal("0")
+    if candles_with_regime > 0:
+        for regime_id, bucket in buckets.items():
+            if bucket.candle_count <= 0:
+                continue
+            share = Decimal(bucket.candle_count) / Decimal(candles_with_regime)
+            if share > dominant_share:
+                dominant_share = share
+                dominant_regime = regime_id
+
+    return {
+        "hvc_candle_share": str(hvc_share),
+        "regimes_observed_count": regimes_observed,
+        "regimes_with_trades_count": regimes_with_trades,
+        "single_regime_dominance_flag": dominant_share > _DOMINANCE_THRESHOLD,
+        "dominant_regime_id": dominant_regime,
+        "dominant_regime_share": str(dominant_share.quantize(_RATE_Q)),
+    }
+
+
+def _as_decimal(value: object) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, str):
+        try:
+            return Decimal(value)
+        except (InvalidOperation, ValueError):
+            return None
+    return None
+
+
+def _assert_no_trace_keys(payload: Mapping[str, Any]) -> None:
+    forbidden = ("steps", "trace", "step_trace")
+    for key in forbidden:
+        if key in payload:
+            raise ValueError(f"regime_stats must not include {key!r}")

--- a/services/validation/arvp_candidate_evidence_assembler.py
+++ b/services/validation/arvp_candidate_evidence_assembler.py
@@ -21,6 +21,7 @@ from jsonschema.validators import validator_for
 
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
 
+from core.replay.regime_stats import regime_scorecard_status_from_stats
 from services.validation.profitability_evidence_packet_assembler import (
     _deterministic_json_dumps,
     _sha256_hex,
@@ -479,6 +480,35 @@ def _assess_candidate_rankability(records: Sequence[Mapping[str, Any]]) -> tuple
     return RANKABILITY_RANKABLE, reasons
 
 
+def _regime_scorecard_block_from_records(
+    records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Derive compact PEP regime_scorecard status from job-level regime_stats.v1."""
+    # Full arvp_regime_scorecard artifact wiring remains future work; stats.v1 is
+    # sufficient to mark multi-regime trade coverage for PARTIAL_EVIDENCE paths.
+    for record in records:
+        stats = record.get("regime_stats")
+        status = regime_scorecard_status_from_stats(
+            stats if isinstance(stats, Mapping) else None
+        )
+        if status == "ok":
+            return {
+                "status": "ok",
+                "artifact_ref": None,
+                "summary": (
+                    "Compact regime_stats.v1 shows trades in multiple regimes; "
+                    "full arvp_regime_scorecard artifact not attached."
+                ),
+            }
+    return {
+        "status": "unavailable",
+        "artifact_ref": None,
+        "summary": (
+            "Window-level regime_availability only; no multi-regime trade scorecard measured."
+        ),
+    }
+
+
 def _hashable_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
     excluded = {"generated_at", "content_hash"}
     return {key: value for key, value in packet.items() if key not in excluded}
@@ -645,8 +675,10 @@ def build_candidate_evidence_packet(
         "Top-level gross_return/net_return are descriptive medians of per-window quote PnL, not additive total return."
     )
     limitations.append(
-        "Regime fields describe window-level regime_availability only, not strategy regime performance."
+        "Regime fields describe window-level regime_availability and compact regime_stats when present."
     )
+
+    regime_scorecard_block = _regime_scorecard_block_from_records(records)
 
     packet: dict[str, Any] = {
         "schema_version": "profitability_evidence_packet.v1",
@@ -691,13 +723,7 @@ def build_candidate_evidence_packet(
         "max_drawdown": summary["max_drawdown"],
         "loss_streak": summary["loss_streak"],
         "trade_count": summary["trade_count"],
-        "regime_scorecard": {
-            "status": "unavailable",
-            "artifact_ref": None,
-            "summary": (
-                "Window-level regime_availability only; no strategy regime scorecard measured."
-            ),
-        },
+        "regime_scorecard": regime_scorecard_block,
         "scenario_results": _scenario_results(records),
         "replay_vs_paper_status": "not_run",
         "simulator_drift": "not_assessed",
@@ -738,7 +764,7 @@ def build_candidate_evidence_packet(
             "scenario_ready": True,
             "replay_ready": False,
             "replay_vs_paper_ready": False,
-            "regime_scorecard_ready": False,
+            "regime_scorecard_ready": regime_scorecard_block["status"] == "ok",
             "harvester_refs_ready": True,
             "summary": (
                 "ARVP cross-venue research packet; ranking_inputs_complete=false; "

--- a/services/validation/pack_a_backtest_report.py
+++ b/services/validation/pack_a_backtest_report.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from core.replay.pack_a_breakout_common import ORDER_SIZE
+from core.replay.regime_stats import build_regime_stats_from_replay
 from core.utils.clock import utcnow
 from core.utils.uuid_gen import generate_uuid
 
@@ -83,6 +84,12 @@ def build_pack_a_full_report(
     snapshot.setdefault("warmup_candles", warmup)
     snapshot.setdefault("order_size", ORDER_SIZE)
 
+    regime_stats = build_regime_stats_from_replay(
+        candles,
+        trades,
+        warmup=warmup,
+    )
+
     return {
         "schema_version": "strategy_validation_report.v1",
         "strategy_id": strategy_id,
@@ -133,6 +140,7 @@ def build_pack_a_full_report(
             "status": "NOT_RANKING_READY",
             "ranking_ready": False,
         },
+        "regime_stats": regime_stats,
     }
 
 

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -135,6 +135,7 @@ from core.replay.scenario_harness import (
     ScenarioRunResult,
     ScenarioSpec,
 )
+from core.replay.regime_stats import build_regime_stats_from_replay
 from core.replay.replay_report_builder import (
     build_scenario_comparison_summary,
 )
@@ -1839,12 +1840,32 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_regime_stats_block(
+    backtest_report: dict[str, Any],
+    candles: list[dict[str, Any]] | None = None,
+    *,
+    warmup: int = 0,
+) -> dict[str, Any]:
+    existing = backtest_report.get("regime_stats")
+    if isinstance(existing, dict) and existing.get("schema_version") == "regime_stats.v1":
+        return existing
+    if candles is None:
+        return build_regime_stats_from_replay([], backtest_report.get("trades") or [])
+    return build_regime_stats_from_replay(
+        candles,
+        backtest_report.get("trades") or [],
+        warmup=warmup,
+    )
+
+
 def _write_scenario_metrics_artifact(
     *,
     output_dir: Path,
     config: ARVPReplayConfig,
     spec: ScenarioSpec,
     backtest_report: dict[str, Any],
+    candles: list[dict[str, Any]] | None = None,
+    warmup: int = 0,
 ) -> None:
     if config.scenario_group_id:
         summary_dir = output_dir / config.scenario_group_id
@@ -1857,6 +1878,11 @@ def _write_scenario_metrics_artifact(
         "strategy_id": config.strategy_id,
         "metrics": backtest_report.get("metrics", {}),
         "dataset_summary": backtest_report.get("dataset_summary", {}),
+        "regime_stats": _resolve_regime_stats_block(
+            backtest_report,
+            candles,
+            warmup=warmup,
+        ),
         "ranking_ready": False,
     }
     (summary_dir / f"{spec.scenario_id}_metrics.json").write_text(
@@ -1908,6 +1934,8 @@ def _make_pb_run_single_fn(
                 config=config,
                 spec=spec,
                 backtest_report=backtest_report,
+                candles=scenario_candles,
+                warmup=warmup_count,
             )
             run_id = backtest_report["run_metadata"]["run_id"]
             return ScenarioRunResult(
@@ -2054,6 +2082,8 @@ def _make_pack_a_run_single_fn(
                 config=config,
                 spec=spec,
                 backtest_report=backtest_report,
+                candles=scenario_candles,
+                warmup=warmup_count,
             )
             return ScenarioRunResult(
                 scenario_id=spec.scenario_id,

--- a/tests/fixtures/arvp/candidate_evidence/slice_bundle_manifest.v1.json
+++ b/tests/fixtures/arvp/candidate_evidence/slice_bundle_manifest.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "arvp_candidate_evidence_bundle.v1",
-  "bundle_hash": "60ab9973f898c5819d5f3cb56767ef22f124078416fc9fe1aaff530e5e9f0d80",
+  "bundle_hash": "e4e4b79ad1b0f6d3d6fc3d9f6d16d9c52109357f12bfbbd27072f5051991ab7d",
   "packet_count": 2,
   "source_record_count": 6,
   "candidates": [
@@ -10,12 +10,12 @@
   "packets": [
     {
       "strategy_id": "donchian_breakout_v1",
-      "content_hash": "01e82b7b19bd64bd596084734cd2dab379fc0e9817106ebd3b987ba12fb27162",
+      "content_hash": "3f728fe08dce3c21d3ad34a71f5ad045975eaf95a083818e5f9edf9ca3f227cd",
       "rankability_status": "NOT_RANKABLE"
     },
     {
       "strategy_id": "primary_breakout_v1",
-      "content_hash": "d345626ab5adff01c9e121e1555b10b8aa649a94ae00a2a13e0bbafe124d9de8",
+      "content_hash": "5bc652387e5e007ae400bb88bcc5f9e668759d34f2d84242c019b528cb395eaa",
       "rankability_status": "NOT_RANKABLE"
     }
   ]

--- a/tests/unit/replay/test_regime_stats.py
+++ b/tests/unit/replay/test_regime_stats.py
@@ -1,0 +1,135 @@
+"""Unit tests for core/replay/regime_stats.py (#4031 A3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.replay.canonical_json import canonical_hash
+from core.replay.regime_stats import (
+    RegimeStatsAggregator,
+    build_regime_stats_from_replay,
+    normalize_regime_id,
+    regime_scorecard_status_from_stats,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(ts_ms: int, regime_id: int | str) -> dict[str, object]:
+    return {
+        "ts_ms": ts_ms,
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.5,
+        "volume": 1.0,
+        "regime_id": regime_id,
+    }
+
+
+def _trade(
+    *,
+    entry_ts_ms: int,
+    exit_ts_ms: int,
+    r_return: float = 0.01,
+) -> dict[str, object]:
+    return {
+        "entry_ts_ms": entry_ts_ms,
+        "exit_ts_ms": exit_ts_ms,
+        "entry_price": 100.0,
+        "exit_price": 101.0,
+        "entry_fee": 0.01,
+        "exit_fee": 0.01,
+        "r_return": r_return,
+    }
+
+
+class TestNormalizeRegimeId:
+    def test_numeric_hvc(self) -> None:
+        assert normalize_regime_id(2) == "HIGH_VOL_CHAOTIC"
+
+    def test_string_uppercase(self) -> None:
+        assert normalize_regime_id("trend") == "TREND"
+
+
+class TestRegimeStatsAggregator:
+    def test_deterministic_finalize_hash(self) -> None:
+        candles = [_candle(i * 60_000, i % 3) for i in range(10)]
+        trades = [_trade(entry_ts_ms=120_000, exit_ts_ms=180_000)]
+        first = build_regime_stats_from_replay(candles, trades, warmup=2)
+        second = build_regime_stats_from_replay(candles, trades, warmup=2)
+        assert first == second
+        assert first["stats_fingerprint"] == second["stats_fingerprint"]
+
+    def test_no_steps_trace_in_output(self) -> None:
+        stats = build_regime_stats_from_replay(
+            [_candle(0, 0), _candle(60_000, 1)],
+            [],
+        )
+        assert "steps" not in stats
+        assert "trace" not in stats
+        assert stats["schema_version"] == "regime_stats.v1"
+
+    def test_hvc_dominance_flag_when_over_90_percent_one_regime(self) -> None:
+        candles = [_candle(i * 60_000, 2) for i in range(100)]
+        candles[0] = _candle(0, 1)
+        stats = build_regime_stats_from_replay(candles, [], warmup=0)
+        flags = stats["diversity_flags"]
+        assert flags["hvc_candle_share"] == "0.99000000"
+        assert flags["single_regime_dominance_flag"] is True
+        assert flags["dominant_regime_id"] == "HIGH_VOL_CHAOTIC"
+        assert flags["regimes_observed_count"] == 2
+
+    def test_warmup_excluded_from_candle_counts(self) -> None:
+        candles = [_candle(i * 60_000, 0) for i in range(5)]
+        stats = build_regime_stats_from_replay(candles, [], warmup=3)
+        assert stats["coverage"]["candles_total"] == 2
+
+    def test_trade_regime_attribution_via_timestamps(self) -> None:
+        candles = [
+            _candle(60_000, 0),
+            _candle(120_000, 1),
+            _candle(180_000, 2),
+        ]
+        trades = [_trade(entry_ts_ms=60_000, exit_ts_ms=180_000)]
+        stats = build_regime_stats_from_replay(candles, trades)
+        by_regime = {row["regime_id"]: row for row in stats["per_regime"]}
+        assert by_regime["TREND"]["entry_trade_count"] == 1
+        assert by_regime["HIGH_VOL_CHAOTIC"]["exit_trade_count"] == 1
+        assert stats["diversity_flags"]["regimes_with_trades_count"] == 2
+
+    def test_missing_regime_coverage_flag(self) -> None:
+        candles = [{"ts_ms": 0, "regime_id": 0}, {"ts_ms": 60_000}]
+        stats = build_regime_stats_from_replay(candles, [])
+        assert stats["coverage"]["regime_id_missing_flag"] is True
+        assert stats["coverage"]["candles_missing_regime_id"] == 1
+
+    def test_fingerprint_stable_for_same_payload(self) -> None:
+        agg = RegimeStatsAggregator()
+        agg.update_bar(_candle(0, 0))
+        payload = agg.finalize()
+        assert payload["stats_fingerprint"] == canonical_hash(
+            {
+                "schema_version": payload["schema_version"],
+                "coverage": payload["coverage"],
+                "diversity_flags": payload["diversity_flags"],
+                "per_regime": payload["per_regime"],
+            }
+        )
+
+
+class TestRegimeScorecardStatusHook:
+    def test_ok_when_trades_in_multiple_regimes(self) -> None:
+        stats = {
+            "diversity_flags": {"regimes_with_trades_count": 2},
+        }
+        assert regime_scorecard_status_from_stats(stats) == "ok"
+
+    def test_unavailable_when_single_regime_trades(self) -> None:
+        stats = {
+            "diversity_flags": {"regimes_with_trades_count": 1},
+        }
+        assert regime_scorecard_status_from_stats(stats) == "unavailable"
+
+    def test_unavailable_when_missing(self) -> None:
+        assert regime_scorecard_status_from_stats(None) == "unavailable"

--- a/tools/arvp_vacation/strategy_metric_extraction.py
+++ b/tools/arvp_vacation/strategy_metric_extraction.py
@@ -313,6 +313,10 @@ def extract_scenario_record(
             continue
         record[field] = _resolve_metric_value(metrics, field)
 
+    regime_stats = payload.get("regime_stats")
+    if isinstance(regime_stats, dict):
+        record["regime_stats"] = regime_stats
+
     return record
 
 


### PR DESCRIPTION
## Summary
- Add \core/replay/regime_stats.py\ with \RegimeStatsAggregator\ for online per-bar aggregation from candle \egime_id\ (no \steps[]\ trace persisted).
- Emit schema-versioned \egime_stats.v1\ in Pack-A backtest reports and \strategy_replay_runner\ scenario metrics alongside \scenario_metrics\.
- Propagate compact stats through ARVP metric extraction; minimal PEP \egime_scorecard.status\ hook when trades span multiple regimes.

## Test plan
- [x] \pytest tests/unit/replay/test_regime_stats.py\ (12 passed)
- [x] \pytest tests/unit/validation/test_pack_a_replay_dispatch.py\ (16 passed)
- [x] \pytest tests/unit/arvp/test_candidate_evidence_assembly.py\ (8 passed, 1 skipped)
- [x] \uff check\ on touched files

Closes #4031

Made with [Cursor](https://cursor.com)