### PR TITLE
feat(arvp): Batch-A preflight benchmark + coordinator wiring (#4032)

### DIFF
--- a/docs/evidence/arvp_batch_a_campaign_preflight_benchmark.md
+++ b/docs/evidence/arvp_batch_a_campaign_preflight_benchmark.md
@@ -1,0 +1,98 @@
+# ARVP Batch-A Stage-A Campaign Preflight Benchmark (A4)
+
+**Date:** 2026-07-13  
+**Issue:** [#4032](https://github.com/jannekbuengener/Claire_de_Binare/issues/4032)  
+**Source SHA:** `d0a4e72d10fced72a5fb2d2edf1e40f3c80f417a` (gate merge #4058)  
+**Plan:** `arvp-funnel-v1.1-2026-07-13` — GO amendment **A4**  
+**LR:** NO-GO | **`ranking_ready`:** `false`
+
+---
+
+## Scope
+
+Conservative preflight before the locked Stage-A matrix (390 coordinator jobs / 780 scenario runs: 10 strategies × 39 development windows × 2 scenarios).
+
+| Constraint | Value |
+|------------|-------|
+| Max parallel workers (benchmark) | 2 |
+| Scenarios | `baseline`, `pessimistic_execution` |
+| Sample windows | 3 locked development months |
+| Runner families | 4 (2 regime-enriched + 2 non-regime) |
+
+---
+
+## Sample matrix (12 jobs)
+
+| Family | Strategy | Adapter | Regime |
+|--------|----------|---------|--------|
+| Regime / reuse | `momentum_capture_v1` | `momentum_capture_runner_v1` | yes |
+| Regime / reuse | `range_mean_reversion_v1` | `range_mean_reversion_runner_v1` | yes |
+| Breakout | `breakout_volatility_filter_v1` | `batch_a_shadow_runner_v1` | no |
+| Trend | `ema_trend_follow_v1` | `batch_a_shadow_runner_v1` | no |
+
+**Windows:** `binance_1m_month_2017_10`, `binance_1m_month_2017_11`, `binance_1m_month_2018_03`
+
+---
+
+## Timing (live, 2026-07-13)
+
+| Metric | Value |
+|--------|-------|
+| Jobs total | 12 |
+| Jobs PASS | 12 |
+| Jobs FAIL | 0 |
+| Wall clock (2 workers) | 21.37 s |
+| Median job time | 3.252 s |
+| **p95 job time** | **3.677 s** |
+| Max job time | 3.755 s |
+
+---
+
+## Artifacts
+
+| Metric | Value |
+|--------|-------|
+| Total artifact bytes (12 jobs) | 82,211 |
+| Median bytes / job | ~6,850 |
+| **Extrapolated Stage-A artifacts (390 jobs)** | **~2.6 MB** (scenario bundles only; excludes queue/metrics JSON) |
+
+---
+
+## Disk headroom
+
+| Metric | Value |
+|--------|-------|
+| Free disk before benchmark | 65.64 GB |
+| Free disk after benchmark | 65.64 GB |
+| Campaign `min_free_disk_gb` gate | 5.0 GB |
+| Headroom vs extrapolated artifacts | >> adequate |
+
+---
+
+## Campaign duration estimate (conservative)
+
+| Mode | Estimate |
+|------|----------|
+| Sequential coordinator (1 job/cycle) | 390 × 3.677 s p95 ≈ **24 min** replay wall |
+| 2-worker sample benchmark throughput | ~12 min equivalent replay wall |
+| Full matrix scenario runs | **780** (`baseline` + `pessimistic_execution` per job) |
+
+---
+
+## RAM
+
+Process RSS sampling unavailable in the benchmark shell (`psutil` not installed). Replay jobs are short-lived subprocesses; coordinator remains single-process. **No RAM blocker observed** for the 12-job sample at 2-worker concurrency.
+
+---
+
+## Boundaries
+
+- Binance `historical_cross_venue_research` / controlled-lab window bank only
+- No live capital, no promotion, LR **NO-GO**
+- Preflight does not assert survivor counts or gate outcomes
+
+---
+
+## Raw summary
+
+Machine-readable run summary (local, not versioned): `artifacts/evidence/batch_a_preflight_tmp/summary.json`

--- a/tools/arvp_vacation/batch_a_stage_a_manifest.py
+++ b/tools/arvp_vacation/batch_a_stage_a_manifest.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+import yaml
+
 from core.replay.batch_a_strategy_registry import batch_a_strategy_ids
 from core.replay.canonical_json import canonical_hash
 from tools.arvp_vacation.contract import build_job_fingerprint, build_job_id
@@ -21,6 +23,7 @@ from tools.market_data.development_window_selector import (
     DevelopmentSelectionError,
     default_window_bank_manifest_path,
     load_window_bank_manifest,
+    resolve_window_candles_path,
     select_batch_a_development_windows,
 )
 
@@ -237,3 +240,76 @@ def _is_sha256(value: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def build_vacation_coordinator_manifest_payload(
+    *,
+    campaign_id: str,
+    source_sha: str,
+    artifact_root: str = "artifacts/arvp_vacation",
+    manifest_path: Path | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """YAML-ready vacation coordinator manifest for Batch-A Stage-A."""
+    root = repo_root or Path(__file__).resolve().parents[2]
+    bank_path = manifest_path or default_window_bank_manifest_path(root)
+    bank_manifest = load_window_bank_manifest(bank_path, repo_root=root)
+    selection = select_batch_a_development_windows(bank_manifest)
+    windows_by_id = _window_rows_by_id(selection.windows)
+    dataset_roots: list[str] = []
+    for window_id in LOCKED_BATCH_A_DEVELOPMENT_WINDOW_IDS:
+        row = windows_by_id[window_id]
+        spec_path = str(row.get("spec_path") or "").strip()
+        if spec_path:
+            spec = Path(spec_path)
+            if spec.is_absolute():
+                dataset_roots.append(str(spec.parent.relative_to(root)).replace("\\", "/"))
+            else:
+                dataset_roots.append(str(spec.parent).replace("\\", "/"))
+            continue
+        candles_path = resolve_window_candles_path(row, repo_root=root)
+        rel_parent = candles_path.parent
+        if rel_parent.is_absolute():
+            rel_parent = rel_parent.relative_to(root)
+        dataset_roots.append(str(rel_parent).replace("\\", "/"))
+
+    return {
+        "schema_version": "1.0",
+        "campaign_id": campaign_id,
+        "source_sha": source_sha.lower(),
+        "evidence_class": "controlled_lab_evidence",
+        "artifact_root": artifact_root,
+        "dataset_roots": dataset_roots,
+        "strategies": list(batch_a_strategy_ids()),
+        "scenarios": list(STAGE_A_SCENARIOS),
+        "max_job_runtime_seconds": 3600,
+        "max_attempts_per_job": 2,
+        "min_free_disk_gb": 5.0,
+        "allow_paper_jobs": False,
+        "speedup_profile": "instant",
+        "symbol": "BTCUSDT",
+        "batch_a_stage_a": {
+            "development_selection_sha256": selection.selection_sha256,
+            "job_count": EXPECTED_JOB_COUNT,
+            "scenario_run_count": EXPECTED_SCENARIO_RUN_COUNT,
+        },
+    }
+
+
+def write_vacation_coordinator_manifest(
+    path: Path,
+    *,
+    campaign_id: str,
+    source_sha: str,
+    manifest_path: Path | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    payload = build_vacation_coordinator_manifest_payload(
+        campaign_id=campaign_id,
+        source_sha=source_sha,
+        manifest_path=manifest_path,
+        repo_root=repo_root,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return payload

--- a/tools/arvp_vacation/contract.py
+++ b/tools/arvp_vacation/contract.py
@@ -9,6 +9,10 @@ from typing import Any, Callable, Iterable, Mapping, Sequence
 import yaml
 
 from core.replay.canonical_json import canonical_hash
+from core.replay.batch_a_strategy_registry import (
+    BATCH_A_STRATEGY_REGISTRY,
+    executable_batch_a_strategy_ids,
+)
 
 MANIFEST_SCHEMA_VERSION = "1.0"
 QUEUE_STATE_SCHEMA_VERSION = "1.0"
@@ -36,18 +40,33 @@ TERMINAL_JOB_STATUSES = frozenset(
 STRATEGY_ACTIVE = "active"
 STRATEGY_PARKED = "parked_reference"
 
-ALLOWED_STRATEGIES: frozenset[str] = frozenset(
+_LEGACY_STRATEGY_IDS: frozenset[str] = frozenset(
     {
         "donchian_breakout_v1",
         "breakout_trend_filter_v1",
         "primary_breakout_v1",
     }
 )
+_BATCH_A_SHADOW_ADAPTER_ID = "batch_a_shadow_runner_v1"
+
+
+def batch_a_strategy_adapters() -> dict[str, str]:
+    adapters: dict[str, str] = {}
+    for strategy_id in sorted(executable_batch_a_strategy_ids()):
+        record = BATCH_A_STRATEGY_REGISTRY[strategy_id]
+        adapters[strategy_id] = record.adapter_id or _BATCH_A_SHADOW_ADAPTER_ID
+    return adapters
+
+
+ALLOWED_STRATEGIES: frozenset[str] = (
+    _LEGACY_STRATEGY_IDS | executable_batch_a_strategy_ids()
+)
 
 STRATEGY_ADAPTERS: dict[str, str] = {
     "donchian_breakout_v1": "donchian_breakout_runner_v1",
     "breakout_trend_filter_v1": "breakout_trend_filter_runner_v1",
     "primary_breakout_v1": "primary_breakout_runner_v1",
+    **batch_a_strategy_adapters(),
 }
 
 ALLOWED_SCENARIOS: frozenset[str] = frozenset(


### PR DESCRIPTION
## Summary
- A4 preflight evidence: docs/evidence/arvp_batch_a_campaign_preflight_benchmark.md
- Extend vacation contract ALLOWED_STRATEGIES/STRATEGY_ADAPTERS for all 10 Batch-A runners
- Add write_vacation_coordinator_manifest() for 390-job Stage-A matrix

## Test plan
- [x] pytest tests/unit/arvp/test_batch_a_stage_a_manifest.py
- [x] pytest tests/unit/arvp/test_arvp_vacation_mvp.py
- [x] coordinator --preflight-only (390 jobs / 39 datasets)
- [x] 12-job live replay sample (p95 3.677s, 2 workers)

## Boundaries
- ranking_ready=false, LR NO-GO
- No live capital

## Non-goals
- Stage-A campaign execution (running locally post-merge)
- Survivor scoring / Evidence-PR closeout

Made with [Cursor](https://cursor.com)