### PR TITLE
feat(ci): add fail-closed Dependabot classifier

### DIFF
--- a/.github/dependabot-autopilot-allowlist.yml
+++ b/.github/dependabot-autopilot-allowlist.yml
@@ -1,0 +1,19 @@
+schema_version: 1
+default_mode: report_only
+
+defaults:
+  unknown_package: HOLD
+  unknown_ecosystem: HOLD
+  additional_file: HOLD
+  github_actions: HOLD
+  docker: HOLD
+  runtime_dependency: HOLD
+
+entries:
+  pip:
+    ruff:
+      dependency_type: direct:development
+      allowed_update_types:
+        - version-update:semver-patch
+      allowed_files:
+        - requirements-dev.txt

--- a/.github/scripts/dependabot_autopilot_classifier.py
+++ b/.github/scripts/dependabot_autopilot_classifier.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Fail-closed Dependabot autopilot classifier (pure decision core, no I/O)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+Classification = Literal["ELIGIBLE", "HOLD"]
+Action = Literal["REPORT_ONLY", "MERGE_CANDIDATE", "HOLD"]
+
+SUPPORTED_SCHEMA_VERSION = 1
+DEFAULT_BASE_BRANCH = "main"
+DEFAULT_HEAD_PREFIX = "dependabot/"
+
+DEPENDABOT_AUTHOR_LOGINS = frozenset(
+    {
+        "dependabot[bot]",
+        "app/dependabot",
+    }
+)
+
+MANUAL_REVIEW_LABELS = frozenset(
+    {
+        "dependencies:manual-review",
+        "manual-approval",
+        "status:blocked",
+    }
+)
+
+REQUIRED_CHECK_NAMES = (
+    "ci (Unit/Integration + Lint gesammelt)",
+    "policy-gate",
+)
+
+SUCCESS_CHECK_STATUSES = frozenset({"success", "completed"})
+
+CONTROL_PLANE_PREFIXES = (
+    ".github/workflows/",
+    ".github/dependabot.yml",
+    ".github/CONTROL_PLANE.md",
+    ".github/pull_request_template.md",
+)
+
+DOCKER_PATH_MARKERS = (
+    "/dockerfile",
+    "docker-compose",
+    "compose/",
+    "infrastructure/compose/",
+)
+
+RUNTIME_REQUIREMENT_MARKERS = (
+    "requirements.txt",
+    "services/",
+)
+
+GITHUB_ACTIONS_ECOSYSTEMS = frozenset({"github-actions", "github_actions"})
+
+DOCKER_ECOSYSTEMS = frozenset({"docker", "docker-compose", "docker_compose"})
+
+PATCH_UPDATE_TYPE = "version-update:semver-patch"
+MINOR_UPDATE_TYPE = "version-update:semver-minor"
+MAJOR_UPDATE_TYPE = "version-update:semver-major"
+
+REASON_ELIGIBLE = "ELIGIBLE_ALLOWLISTED_PATCH"
+REASON_REPORT_ONLY = "REPORT_ONLY"
+REASON_AUTOMERGE_DISABLED = "AUTOMERGE_DISABLED"
+REASON_AUTHOR = "AUTHOR_NOT_DEPENDABOT"
+REASON_BASE = "BASE_BRANCH_NOT_ALLOWED"
+REASON_HEAD = "HEAD_BRANCH_NOT_DEPENDABOT"
+REASON_DRAFT = "PR_IS_DRAFT"
+REASON_MANUAL_REVIEW = "MANUAL_REVIEW_REQUIRED"
+REASON_COMMIT_COUNT = "COMMIT_COUNT_NOT_ONE"
+REASON_COMMIT_AUTHOR = "COMMIT_AUTHOR_NOT_DEPENDABOT"
+REASON_DIFF = "DIFF_NOT_VERIFIED"
+REASON_FILE = "CHANGED_FILE_NOT_ALLOWED"
+REASON_CONTROL_PLANE = "CONTROL_PLANE_CHANGE"
+REASON_METADATA = "METADATA_INCOMPLETE"
+REASON_UPDATE_TYPE = "UPDATE_TYPE_NOT_PATCH"
+REASON_DEP_TYPE = "DEPENDENCY_TYPE_NOT_ALLOWED"
+REASON_PACKAGE = "PACKAGE_NOT_ALLOWLISTED"
+REASON_ECOSYSTEM = "ECOSYSTEM_NOT_ALLOWED"
+REASON_RANGE = "RANGE_CHANGE"
+REASON_DATE_VERSION = "DATE_VERSION_UNSUPPORTED"
+REASON_POLICY = "POLICY_INVALID"
+REASON_CHECK_MISSING = "REQUIRED_CHECK_MISSING"
+REASON_CHECK_FAIL = "REQUIRED_CHECK_NOT_SUCCESS"
+REASON_BRANCH = "BRANCH_NOT_CURRENT"
+REASON_MERGE_STATE = "MERGE_STATE_NOT_CLEAN"
+REASON_API = "API_ERROR"
+REASON_RUNTIME = "RUNTIME_DEPENDENCY_CHANGE"
+REASON_DOCKER = "DOCKER_CHANGE"
+REASON_ACTIONS = "GITHUB_ACTIONS_CHANGE"
+
+HOLD_EVALUATION_ORDER = (
+    REASON_POLICY,
+    REASON_API,
+    REASON_AUTHOR,
+    REASON_BASE,
+    REASON_HEAD,
+    REASON_DRAFT,
+    REASON_MANUAL_REVIEW,
+    REASON_COMMIT_COUNT,
+    REASON_COMMIT_AUTHOR,
+    REASON_DIFF,
+    REASON_METADATA,
+    REASON_RANGE,
+    REASON_DATE_VERSION,
+    REASON_UPDATE_TYPE,
+    REASON_CONTROL_PLANE,
+    REASON_ACTIONS,
+    REASON_DOCKER,
+    REASON_RUNTIME,
+    REASON_ECOSYSTEM,
+    REASON_PACKAGE,
+    REASON_DEP_TYPE,
+    REASON_FILE,
+    REASON_CHECK_MISSING,
+    REASON_CHECK_FAIL,
+    REASON_BRANCH,
+    REASON_MERGE_STATE,
+)
+
+
+@dataclass(frozen=True)
+class RequiredCheckFact:
+    name: str
+    status: str
+
+
+@dataclass(frozen=True)
+class DependabotAutopilotFacts:
+    pr_author: str
+    base_branch: str
+    head_branch: str
+    is_draft: bool
+    labels: tuple[str, ...]
+    head_sha: str
+    commit_count: int
+    commit_authors: tuple[str, ...]
+    changed_files: tuple[str, ...]
+    required_checks: tuple[RequiredCheckFact, ...]
+    branch_is_current: bool
+    merge_state: str
+    ecosystem: str
+    package_name: str
+    dependency_type: str
+    update_type: str
+    current_version: str
+    target_version: str
+    metadata_complete: bool
+    diff_verified: bool
+    range_change: bool
+    date_versioned: bool
+    api_error: bool
+    execution_mode: str
+    kill_switch_enabled: bool
+
+
+@dataclass(frozen=True)
+class AllowlistPackageRule:
+    dependency_type: str
+    allowed_update_types: frozenset[str]
+    allowed_files: frozenset[str]
+
+
+@dataclass(frozen=True)
+class AllowlistPolicy:
+    schema_version: int
+    default_mode: str
+    entries: Mapping[str, Mapping[str, AllowlistPackageRule]]
+    defaults: Mapping[str, str]
+    valid: bool
+    validation_errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    classification: Classification
+    action: Action
+    merge_authorized: bool
+    reason_codes: tuple[str, ...]
+    human_summary: str
+
+
+def _normalize_login(value: str) -> str:
+    login = (value or "").strip().lower()
+    if login.startswith("app/"):
+        return login
+    return login
+
+
+def _is_dependabot_login(login: str) -> bool:
+    normalized = _normalize_login(login)
+    return normalized in {_normalize_login(item) for item in DEPENDABOT_AUTHOR_LOGINS}
+
+
+def _path_is_control_plane(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    return any(
+        normalized.startswith(prefix.lower()) for prefix in CONTROL_PLANE_PREFIXES
+    )
+
+
+def _path_is_docker_surface(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    if "dockerfile" in normalized:
+        return True
+    return any(marker in normalized for marker in DOCKER_PATH_MARKERS)
+
+
+def _path_is_runtime_surface(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    if normalized == "requirements.txt":
+        return True
+    return normalized.startswith("services/") and normalized.endswith(
+        ("requirements.txt", "/requirements.txt")
+    )
+
+
+def _is_date_version(value: str) -> bool:
+    text = (value or "").strip()
+    if not text:
+        return False
+    parts = text.split(".")
+    if len(parts) != 3:
+        return False
+    return all(part.isdigit() for part in parts) and len(parts[0]) == 4
+
+
+def _ordered_unique(codes: Sequence[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for code in codes:
+        if code in seen:
+            continue
+        seen.add(code)
+        ordered.append(code)
+    return tuple(ordered)
+
+
+def _sort_hold_codes(codes: Sequence[str]) -> tuple[str, ...]:
+    rank = {code: index for index, code in enumerate(HOLD_EVALUATION_ORDER)}
+    return tuple(
+        sorted(_ordered_unique(codes), key=lambda code: rank.get(code, len(rank)))
+    )
+
+
+def parse_allowlist_policy(raw: Mapping[str, Any] | None) -> AllowlistPolicy:
+    errors: list[str] = []
+    if raw is None:
+        return AllowlistPolicy(
+            0, "report_only", {}, {}, False, ("policy payload missing",)
+        )
+
+    schema_version = raw.get("schema_version")
+    if schema_version != SUPPORTED_SCHEMA_VERSION:
+        errors.append(f"unsupported schema_version: {schema_version!r}")
+
+    default_mode = str(raw.get("default_mode", "report_only")).strip() or "report_only"
+    defaults_raw = raw.get("defaults") or {}
+    if not isinstance(defaults_raw, Mapping):
+        errors.append("defaults must be a mapping")
+
+    defaults: dict[str, str] = {}
+    if isinstance(defaults_raw, Mapping):
+        for key, value in defaults_raw.items():
+            defaults[str(key)] = str(value)
+
+    entries_raw = raw.get("entries") or {}
+    if not isinstance(entries_raw, Mapping):
+        errors.append("entries must be a mapping")
+        entries_raw = {}
+
+    parsed_entries: dict[str, dict[str, AllowlistPackageRule]] = {}
+    seen_rules: set[tuple[str, str]] = set()
+
+    for ecosystem, packages in entries_raw.items():
+        if not isinstance(packages, Mapping):
+            errors.append(f"entries.{ecosystem} must be a mapping")
+            continue
+        eco_key = str(ecosystem)
+        parsed_entries.setdefault(eco_key, {})
+        for package_name, rule_raw in packages.items():
+            if not isinstance(rule_raw, Mapping):
+                errors.append(f"entries.{eco_key}.{package_name} must be a mapping")
+                continue
+            pkg_key = str(package_name)
+            dedupe_key = (eco_key, pkg_key)
+            if dedupe_key in seen_rules:
+                errors.append(f"duplicate allowlist rule for {eco_key}/{pkg_key}")
+                continue
+            seen_rules.add(dedupe_key)
+
+            dependency_type = str(rule_raw.get("dependency_type", "")).strip()
+            if not dependency_type:
+                errors.append(
+                    f"entries.{eco_key}.{pkg_key}.dependency_type is required"
+                )
+
+            update_types_raw = rule_raw.get("allowed_update_types")
+            if not isinstance(update_types_raw, list) or not update_types_raw:
+                errors.append(
+                    f"entries.{eco_key}.{pkg_key}.allowed_update_types must be a non-empty list"
+                )
+                update_types: list[str] = []
+            else:
+                update_types = [str(item) for item in update_types_raw]
+
+            files_raw = rule_raw.get("allowed_files")
+            if not isinstance(files_raw, list) or not files_raw:
+                errors.append(
+                    f"entries.{eco_key}.{pkg_key}.allowed_files must be a non-empty list"
+                )
+                allowed_files: list[str] = []
+            else:
+                allowed_files = [str(item) for item in files_raw]
+
+            parsed_entries[eco_key][pkg_key] = AllowlistPackageRule(
+                dependency_type=dependency_type,
+                allowed_update_types=frozenset(update_types),
+                allowed_files=frozenset(allowed_files),
+            )
+
+    valid = not errors and bool(parsed_entries)
+    if not parsed_entries and not errors:
+        errors.append("entries must contain at least one package rule")
+
+    return AllowlistPolicy(
+        schema_version=int(schema_version or 0),
+        default_mode=default_mode,
+        entries=parsed_entries,
+        defaults=defaults,
+        valid=valid,
+        validation_errors=tuple(errors),
+    )
+
+
+def _lookup_package_rule(
+    policy: AllowlistPolicy, ecosystem: str, package_name: str
+) -> AllowlistPackageRule | None:
+    eco_rules = policy.entries.get(ecosystem)
+    if eco_rules is None:
+        return None
+    return eco_rules.get(package_name)
+
+
+def _collect_hold_reasons(
+    facts: DependabotAutopilotFacts, policy: AllowlistPolicy
+) -> list[str]:
+    reasons: list[str] = []
+
+    if not policy.valid:
+        reasons.append(REASON_POLICY)
+        return reasons
+
+    if facts.api_error:
+        reasons.append(REASON_API)
+
+    if not _is_dependabot_login(facts.pr_author):
+        reasons.append(REASON_AUTHOR)
+
+    if facts.base_branch != DEFAULT_BASE_BRANCH:
+        reasons.append(REASON_BASE)
+
+    if not facts.head_branch.startswith(DEFAULT_HEAD_PREFIX):
+        reasons.append(REASON_HEAD)
+
+    if facts.is_draft:
+        reasons.append(REASON_DRAFT)
+
+    label_set = {label.lower() for label in facts.labels}
+    if label_set.intersection({label.lower() for label in MANUAL_REVIEW_LABELS}):
+        reasons.append(REASON_MANUAL_REVIEW)
+
+    if facts.commit_count != 1:
+        reasons.append(REASON_COMMIT_COUNT)
+
+    if facts.commit_count > 0 and not all(
+        _is_dependabot_login(author) for author in facts.commit_authors
+    ):
+        reasons.append(REASON_COMMIT_AUTHOR)
+
+    if not facts.diff_verified:
+        reasons.append(REASON_DIFF)
+
+    if not facts.metadata_complete:
+        reasons.append(REASON_METADATA)
+
+    if facts.range_change:
+        reasons.append(REASON_RANGE)
+
+    if facts.date_versioned:
+        reasons.append(REASON_DATE_VERSION)
+
+    update_type = (facts.update_type or "").strip()
+    if update_type in {MINOR_UPDATE_TYPE, MAJOR_UPDATE_TYPE}:
+        reasons.append(REASON_UPDATE_TYPE)
+    elif update_type != PATCH_UPDATE_TYPE:
+        reasons.append(REASON_UPDATE_TYPE)
+
+    changed_files = [path.replace("\\", "/") for path in facts.changed_files]
+    if any(_path_is_control_plane(path) for path in changed_files):
+        reasons.append(REASON_CONTROL_PLANE)
+
+    ecosystem = (facts.ecosystem or "").strip().lower()
+    if ecosystem in GITHUB_ACTIONS_ECOSYSTEMS or any(
+        path.startswith(".github/workflows/") for path in changed_files
+    ):
+        reasons.append(REASON_ACTIONS)
+
+    if ecosystem in DOCKER_ECOSYSTEMS or any(
+        _path_is_docker_surface(path) for path in changed_files
+    ):
+        reasons.append(REASON_DOCKER)
+
+    if any(_path_is_runtime_surface(path) for path in changed_files):
+        reasons.append(REASON_RUNTIME)
+
+    package_rule = _lookup_package_rule(policy, ecosystem, facts.package_name)
+    if package_rule is None:
+        if (
+            policy.defaults.get("unknown_ecosystem", "HOLD") == "HOLD"
+            and ecosystem not in policy.entries
+        ):
+            reasons.append(REASON_ECOSYSTEM)
+        if policy.defaults.get("unknown_package", "HOLD") == "HOLD":
+            reasons.append(REASON_PACKAGE)
+    else:
+        if facts.dependency_type != package_rule.dependency_type:
+            reasons.append(REASON_DEP_TYPE)
+        if update_type not in package_rule.allowed_update_types:
+            reasons.append(REASON_UPDATE_TYPE)
+        if changed_files and not all(
+            path in package_rule.allowed_files for path in changed_files
+        ):
+            reasons.append(REASON_FILE)
+        if len(changed_files) != len(package_rule.allowed_files):
+            reasons.append(REASON_FILE)
+
+    check_status_by_name = {
+        check.name: (check.status or "").strip().lower()
+        for check in facts.required_checks
+    }
+    for required_name in REQUIRED_CHECK_NAMES:
+        status = check_status_by_name.get(required_name)
+        if status is None:
+            reasons.append(REASON_CHECK_MISSING)
+            continue
+        if status not in SUCCESS_CHECK_STATUSES:
+            reasons.append(REASON_CHECK_FAIL)
+
+    if not facts.branch_is_current:
+        reasons.append(REASON_BRANCH)
+
+    merge_state = (facts.merge_state or "").strip().upper()
+    if merge_state != "CLEAN":
+        reasons.append(REASON_MERGE_STATE)
+
+    return reasons
+
+
+def _build_summary(
+    classification: Classification,
+    action: Action,
+    merge_authorized: bool,
+    reason_codes: Sequence[str],
+    facts: DependabotAutopilotFacts,
+) -> str:
+    pkg = facts.package_name or "unknown-package"
+    eco = facts.ecosystem or "unknown-ecosystem"
+    if classification == "HOLD":
+        primary = reason_codes[0] if reason_codes else REASON_POLICY
+        return (
+            f"HOLD for {eco}/{pkg}: {primary} "
+            f"(head={facts.head_branch}, checks={len(facts.required_checks)})"
+        )
+    merge_hint = "merge authorized" if merge_authorized else "merge not authorized"
+    return (
+        f"ELIGIBLE {eco}/{pkg} patch via {action.lower().replace('_', ' ')}; "
+        f"{merge_hint}"
+    )
+
+
+def classify_dependabot_pr(
+    facts: DependabotAutopilotFacts,
+    policy: AllowlistPolicy,
+) -> ClassificationResult:
+    """Pure fail-closed classifier. Same inputs always yield the same decision."""
+    hold_reasons = _collect_hold_reasons(facts, policy)
+    if hold_reasons:
+        codes = _sort_hold_codes(hold_reasons)
+        return ClassificationResult(
+            classification="HOLD",
+            action="HOLD",
+            merge_authorized=False,
+            reason_codes=codes,
+            human_summary=_build_summary("HOLD", "HOLD", False, codes, facts),
+        )
+
+    reason_codes: list[str] = [REASON_ELIGIBLE]
+    execution_mode = (
+        facts.execution_mode or policy.default_mode or "report_only"
+    ).strip()
+    if execution_mode == "report_only":
+        reason_codes.append(REASON_REPORT_ONLY)
+        return ClassificationResult(
+            classification="ELIGIBLE",
+            action="REPORT_ONLY",
+            merge_authorized=False,
+            reason_codes=_ordered_unique(reason_codes),
+            human_summary=_build_summary(
+                "ELIGIBLE", "REPORT_ONLY", False, reason_codes, facts
+            ),
+        )
+
+    if not facts.kill_switch_enabled:
+        reason_codes.append(REASON_AUTOMERGE_DISABLED)
+        return ClassificationResult(
+            classification="ELIGIBLE",
+            action="REPORT_ONLY",
+            merge_authorized=False,
+            reason_codes=_ordered_unique(reason_codes),
+            human_summary=_build_summary(
+                "ELIGIBLE", "REPORT_ONLY", False, reason_codes, facts
+            ),
+        )
+
+    return ClassificationResult(
+        classification="ELIGIBLE",
+        action="MERGE_CANDIDATE",
+        merge_authorized=True,
+        reason_codes=_ordered_unique(reason_codes),
+        human_summary=_build_summary(
+            "ELIGIBLE", "MERGE_CANDIDATE", True, reason_codes, facts
+        ),
+    )
+
+
+def load_allowlist_policy_from_mapping(raw: Mapping[str, Any]) -> AllowlistPolicy:
+    """Parse and validate an allowlist mapping."""
+    return parse_allowlist_policy(raw)

--- a/.github/scripts/dependabot_autopilot_classifier.py
+++ b/.github/scripts/dependabot_autopilot_classifier.py
@@ -93,6 +93,7 @@ REASON_RUNTIME = "RUNTIME_DEPENDENCY_CHANGE"
 REASON_DOCKER = "DOCKER_CHANGE"
 REASON_ACTIONS = "GITHUB_ACTIONS_CHANGE"
 REASON_FACTS_INVALID = "FACTS_INVALID"
+FACTS_INVALID_SUMMARY = "HOLD: FACTS_INVALID"
 REASON_EXECUTION_MODE = "EXECUTION_MODE_INVALID"
 REASON_HEAD_SHA = "HEAD_SHA_INVALID"
 REASON_VERSION_TRANSITION = "VERSION_TRANSITION_INVALID"
@@ -730,21 +731,27 @@ def _build_summary(
     )
 
 
+def _facts_invalid_hold_result() -> ClassificationResult:
+    return ClassificationResult(
+        classification="HOLD",
+        action="HOLD",
+        merge_authorized=False,
+        reason_codes=(REASON_FACTS_INVALID,),
+        human_summary=FACTS_INVALID_SUMMARY,
+    )
+
+
 def classify_dependabot_pr(
     facts: DependabotAutopilotFacts,
     policy: AllowlistPolicy,
 ) -> ClassificationResult:
     """Pure fail-closed classifier. Same inputs always yield the same decision."""
+    if not isinstance(facts, DependabotAutopilotFacts):
+        return _facts_invalid_hold_result()
+
     fact_errors = _validate_facts(facts)
     if fact_errors:
-        codes = (REASON_FACTS_INVALID,)
-        return ClassificationResult(
-            classification="HOLD",
-            action="HOLD",
-            merge_authorized=False,
-            reason_codes=codes,
-            human_summary=_build_summary("HOLD", "HOLD", False, codes, facts),
-        )
+        return _facts_invalid_hold_result()
 
     hold_reasons = _collect_hold_reasons(facts, policy)
     if hold_reasons:

--- a/.github/scripts/dependabot_autopilot_classifier.py
+++ b/.github/scripts/dependabot_autopilot_classifier.py
@@ -44,13 +44,9 @@ CHECK_STATUS_COMPLETED = "COMPLETED"
 CHECK_CONCLUSION_SUCCESS = "SUCCESS"
 
 HEAD_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SEMVER_TRIPLET_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
-CONTROL_PLANE_PREFIXES = (
-    ".github/workflows/",
-    ".github/dependabot.yml",
-    ".github/CONTROL_PLANE.md",
-    ".github/pull_request_template.md",
-)
+POLICY_DEFAULT_MODE = "report_only"
 
 DOCKER_PATH_MARKERS = (
     "/dockerfile",
@@ -215,10 +211,10 @@ def _normalize_check_token(value: str) -> str:
 
 
 def _path_is_control_plane(path: str) -> bool:
+    if not isinstance(path, str):
+        return True
     normalized = path.replace("\\", "/").lower()
-    return any(
-        normalized.startswith(prefix.lower()) for prefix in CONTROL_PLANE_PREFIXES
-    )
+    return normalized.startswith(".github/")
 
 
 def _path_is_docker_surface(path: str) -> bool:
@@ -253,16 +249,10 @@ def _parse_semver_triplet(value: str) -> tuple[int, int, int] | None:
     text = (value or "").strip()
     if not text or _is_date_version(text):
         return None
-    parts = text.split(".")
-    if len(parts) != 3:
+    match = SEMVER_TRIPLET_PATTERN.fullmatch(text)
+    if match is None:
         return None
-    try:
-        major, minor, patch = (int(part) for part in parts)
-    except ValueError:
-        return None
-    if major < 0 or minor < 0 or patch < 0:
-        return None
-    return major, minor, patch
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
 
 
 def _version_transition_valid(current_version: str, target_version: str) -> bool:
@@ -319,12 +309,9 @@ def _sort_hold_codes(codes: Sequence[str]) -> tuple[str, ...]:
 
 
 def _safe_schema_version(value: Any) -> int | None:
-    if isinstance(value, bool):
+    if type(value) is not int:
         return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
+    return value
 
 
 def _validate_default_mapping(defaults: Mapping[str, str], errors: list[str]) -> None:
@@ -379,9 +366,13 @@ def parse_allowlist_policy(raw: Mapping[str, Any] | None) -> AllowlistPolicy:
     if schema_version != SUPPORTED_SCHEMA_VERSION:
         errors.append(f"unsupported schema_version: {schema_version_raw!r}")
 
-    default_mode = str(raw.get("default_mode", "report_only")).strip() or "report_only"
-    if default_mode not in ALLOWED_EXECUTION_MODES:
-        errors.append(f"default_mode must be one of {sorted(ALLOWED_EXECUTION_MODES)}")
+    default_mode = raw.get("default_mode", POLICY_DEFAULT_MODE)
+    if default_mode != POLICY_DEFAULT_MODE:
+        errors.append(
+            f"default_mode must be {POLICY_DEFAULT_MODE!r} in schema v1; "
+            f"got {default_mode!r}"
+        )
+        default_mode = POLICY_DEFAULT_MODE
 
     defaults_raw = raw.get("defaults") or {}
     if not isinstance(defaults_raw, Mapping):
@@ -542,7 +533,7 @@ def _validate_facts(facts: DependabotAutopilotFacts) -> list[str]:
             if not isinstance(check, RequiredCheckFact):
                 reasons.append(REASON_FACTS_INVALID)
                 break
-            if not check.name.strip():
+            if not isinstance(check.name, str) or not check.name.strip():
                 reasons.append(REASON_FACTS_INVALID)
                 break
             if not isinstance(check.status, str) or not isinstance(
@@ -550,8 +541,11 @@ def _validate_facts(facts: DependabotAutopilotFacts) -> list[str]:
             ):
                 reasons.append(REASON_FACTS_INVALID)
                 break
+            if not check.status.strip() or not check.conclusion.strip():
+                reasons.append(REASON_FACTS_INVALID)
+                break
 
-    return _ordered_unique(reasons)  # type: ignore[return-value]
+    return list(_ordered_unique(reasons))
 
 
 def _execution_mode_valid(mode: str) -> bool:
@@ -601,7 +595,7 @@ def _evaluate_required_checks(
 def _collect_hold_reasons(
     facts: DependabotAutopilotFacts, policy: AllowlistPolicy
 ) -> list[str]:
-    reasons = list(_validate_facts(facts))
+    reasons: list[str] = []
 
     if not policy.valid:
         reasons.append(REASON_POLICY)
@@ -741,6 +735,17 @@ def classify_dependabot_pr(
     policy: AllowlistPolicy,
 ) -> ClassificationResult:
     """Pure fail-closed classifier. Same inputs always yield the same decision."""
+    fact_errors = _validate_facts(facts)
+    if fact_errors:
+        codes = (REASON_FACTS_INVALID,)
+        return ClassificationResult(
+            classification="HOLD",
+            action="HOLD",
+            merge_authorized=False,
+            reason_codes=codes,
+            human_summary=_build_summary("HOLD", "HOLD", False, codes, facts),
+        )
+
     hold_reasons = _collect_hold_reasons(facts, policy)
     if hold_reasons:
         codes = _sort_hold_codes(hold_reasons)

--- a/.github/scripts/dependabot_autopilot_classifier.py
+++ b/.github/scripts/dependabot_autopilot_classifier.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence
 
@@ -12,6 +13,12 @@ Action = Literal["REPORT_ONLY", "MERGE_CANDIDATE", "HOLD"]
 SUPPORTED_SCHEMA_VERSION = 1
 DEFAULT_BASE_BRANCH = "main"
 DEFAULT_HEAD_PREFIX = "dependabot/"
+
+ALLOWED_EXECUTION_MODES = frozenset({"report_only", "phase1"})
+ALLOWED_DEFAULT_VALUES = frozenset({"HOLD"})
+SCHEMA_V1_ECOSYSTEM = "pip"
+SCHEMA_V1_DEPENDENCY_TYPE = "direct:development"
+SCHEMA_V1_UPDATE_TYPE = "version-update:semver-patch"
 
 DEPENDABOT_AUTHOR_LOGINS = frozenset(
     {
@@ -33,7 +40,10 @@ REQUIRED_CHECK_NAMES = (
     "policy-gate",
 )
 
-SUCCESS_CHECK_STATUSES = frozenset({"success", "completed"})
+CHECK_STATUS_COMPLETED = "COMPLETED"
+CHECK_CONCLUSION_SUCCESS = "SUCCESS"
+
+HEAD_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 
 CONTROL_PLANE_PREFIXES = (
     ".github/workflows/",
@@ -49,13 +59,7 @@ DOCKER_PATH_MARKERS = (
     "infrastructure/compose/",
 )
 
-RUNTIME_REQUIREMENT_MARKERS = (
-    "requirements.txt",
-    "services/",
-)
-
 GITHUB_ACTIONS_ECOSYSTEMS = frozenset({"github-actions", "github_actions"})
-
 DOCKER_ECOSYSTEMS = frozenset({"docker", "docker-compose", "docker_compose"})
 
 PATCH_UPDATE_TYPE = "version-update:semver-patch"
@@ -85,15 +89,22 @@ REASON_DATE_VERSION = "DATE_VERSION_UNSUPPORTED"
 REASON_POLICY = "POLICY_INVALID"
 REASON_CHECK_MISSING = "REQUIRED_CHECK_MISSING"
 REASON_CHECK_FAIL = "REQUIRED_CHECK_NOT_SUCCESS"
+REASON_CHECK_AMBIGUOUS = "REQUIRED_CHECK_AMBIGUOUS"
 REASON_BRANCH = "BRANCH_NOT_CURRENT"
 REASON_MERGE_STATE = "MERGE_STATE_NOT_CLEAN"
 REASON_API = "API_ERROR"
 REASON_RUNTIME = "RUNTIME_DEPENDENCY_CHANGE"
 REASON_DOCKER = "DOCKER_CHANGE"
 REASON_ACTIONS = "GITHUB_ACTIONS_CHANGE"
+REASON_FACTS_INVALID = "FACTS_INVALID"
+REASON_EXECUTION_MODE = "EXECUTION_MODE_INVALID"
+REASON_HEAD_SHA = "HEAD_SHA_INVALID"
+REASON_VERSION_TRANSITION = "VERSION_TRANSITION_INVALID"
 
 HOLD_EVALUATION_ORDER = (
+    REASON_FACTS_INVALID,
     REASON_POLICY,
+    REASON_EXECUTION_MODE,
     REASON_API,
     REASON_AUTHOR,
     REASON_BASE,
@@ -102,10 +113,12 @@ HOLD_EVALUATION_ORDER = (
     REASON_MANUAL_REVIEW,
     REASON_COMMIT_COUNT,
     REASON_COMMIT_AUTHOR,
+    REASON_HEAD_SHA,
     REASON_DIFF,
     REASON_METADATA,
     REASON_RANGE,
     REASON_DATE_VERSION,
+    REASON_VERSION_TRANSITION,
     REASON_UPDATE_TYPE,
     REASON_CONTROL_PLANE,
     REASON_ACTIONS,
@@ -115,6 +128,7 @@ HOLD_EVALUATION_ORDER = (
     REASON_PACKAGE,
     REASON_DEP_TYPE,
     REASON_FILE,
+    REASON_CHECK_AMBIGUOUS,
     REASON_CHECK_MISSING,
     REASON_CHECK_FAIL,
     REASON_BRANCH,
@@ -126,6 +140,7 @@ HOLD_EVALUATION_ORDER = (
 class RequiredCheckFact:
     name: str
     status: str
+    conclusion: str
 
 
 @dataclass(frozen=True)
@@ -195,6 +210,10 @@ def _is_dependabot_login(login: str) -> bool:
     return normalized in {_normalize_login(item) for item in DEPENDABOT_AUTHOR_LOGINS}
 
 
+def _normalize_check_token(value: str) -> str:
+    return (value or "").strip().upper()
+
+
 def _path_is_control_plane(path: str) -> bool:
     normalized = path.replace("\\", "/").lower()
     return any(
@@ -225,7 +244,60 @@ def _is_date_version(value: str) -> bool:
     parts = text.split(".")
     if len(parts) != 3:
         return False
-    return all(part.isdigit() for part in parts) and len(parts[0]) == 4
+    if not all(part.isdigit() for part in parts):
+        return False
+    return len(parts[0]) == 4 and int(parts[0]) >= 1900
+
+
+def _parse_semver_triplet(value: str) -> tuple[int, int, int] | None:
+    text = (value or "").strip()
+    if not text or _is_date_version(text):
+        return None
+    parts = text.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        major, minor, patch = (int(part) for part in parts)
+    except ValueError:
+        return None
+    if major < 0 or minor < 0 or patch < 0:
+        return None
+    return major, minor, patch
+
+
+def _version_transition_valid(current_version: str, target_version: str) -> bool:
+    if _is_date_version(current_version) or _is_date_version(target_version):
+        return False
+    current = _parse_semver_triplet(current_version)
+    target = _parse_semver_triplet(target_version)
+    if current is None or target is None:
+        return False
+    if current[0] != target[0] or current[1] != target[1]:
+        return False
+    return target[2] > current[2]
+
+
+def _is_valid_head_sha(value: str) -> bool:
+    return bool(HEAD_SHA_PATTERN.match((value or "").strip().lower()))
+
+
+def _is_safe_allowlist_path(path: str) -> bool:
+    normalized = (path or "").strip()
+    if not normalized:
+        return False
+    if "\\" in normalized:
+        return False
+    if normalized.startswith("/"):
+        return False
+    if ".." in normalized.split("/"):
+        return False
+    if _path_is_control_plane(normalized):
+        return False
+    if _path_is_docker_surface(normalized):
+        return False
+    if _path_is_runtime_surface(normalized):
+        return False
+    return True
 
 
 def _ordered_unique(codes: Sequence[str]) -> tuple[str, ...]:
@@ -246,6 +318,50 @@ def _sort_hold_codes(codes: Sequence[str]) -> tuple[str, ...]:
     )
 
 
+def _safe_schema_version(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _validate_default_mapping(defaults: Mapping[str, str], errors: list[str]) -> None:
+    for key in ("unknown_package", "unknown_ecosystem", "additional_file"):
+        raw = defaults.get(key, "HOLD")
+        if raw not in ALLOWED_DEFAULT_VALUES:
+            errors.append(f"defaults.{key} must be HOLD in schema v1")
+    for key, value in defaults.items():
+        if value not in ALLOWED_DEFAULT_VALUES:
+            errors.append(f"defaults.{key} has unsupported value {value!r}")
+
+
+def _validate_schema_v1_package_rule(
+    eco_key: str,
+    pkg_key: str,
+    dependency_type: str,
+    update_types: Sequence[str],
+    allowed_files: Sequence[str],
+    errors: list[str],
+) -> None:
+    if eco_key != SCHEMA_V1_ECOSYSTEM:
+        errors.append(f"entries.{eco_key} is not allowed in schema v1")
+    if dependency_type != SCHEMA_V1_DEPENDENCY_TYPE:
+        errors.append(
+            f"entries.{eco_key}.{pkg_key}.dependency_type must be "
+            f"{SCHEMA_V1_DEPENDENCY_TYPE!r}"
+        )
+    if set(update_types) != {SCHEMA_V1_UPDATE_TYPE}:
+        errors.append(
+            f"entries.{eco_key}.{pkg_key}.allowed_update_types must contain only "
+            f"{SCHEMA_V1_UPDATE_TYPE!r}"
+        )
+    for path in allowed_files:
+        if not _is_safe_allowlist_path(path):
+            errors.append(f"entries.{eco_key}.{pkg_key}.allowed_files has unsafe path")
+
+
 def parse_allowlist_policy(raw: Mapping[str, Any] | None) -> AllowlistPolicy:
     errors: list[str] = []
     if raw is None:
@@ -253,11 +369,20 @@ def parse_allowlist_policy(raw: Mapping[str, Any] | None) -> AllowlistPolicy:
             0, "report_only", {}, {}, False, ("policy payload missing",)
         )
 
-    schema_version = raw.get("schema_version")
+    if not isinstance(raw, Mapping):
+        return AllowlistPolicy(
+            0, "report_only", {}, {}, False, ("policy payload must be a mapping",)
+        )
+
+    schema_version_raw = raw.get("schema_version")
+    schema_version = _safe_schema_version(schema_version_raw)
     if schema_version != SUPPORTED_SCHEMA_VERSION:
-        errors.append(f"unsupported schema_version: {schema_version!r}")
+        errors.append(f"unsupported schema_version: {schema_version_raw!r}")
 
     default_mode = str(raw.get("default_mode", "report_only")).strip() or "report_only"
+    if default_mode not in ALLOWED_EXECUTION_MODES:
+        errors.append(f"default_mode must be one of {sorted(ALLOWED_EXECUTION_MODES)}")
+
     defaults_raw = raw.get("defaults") or {}
     if not isinstance(defaults_raw, Mapping):
         errors.append("defaults must be a mapping")
@@ -266,9 +391,15 @@ def parse_allowlist_policy(raw: Mapping[str, Any] | None) -> AllowlistPolicy:
     if isinstance(defaults_raw, Mapping):
         for key, value in defaults_raw.items():
             defaults[str(key)] = str(value)
+    _validate_default_mapping(defaults, errors)
 
-    entries_raw = raw.get("entries") or {}
-    if not isinstance(entries_raw, Mapping):
+    entries_raw = raw.get("entries")
+    if isinstance(entries_raw, list):
+        errors.append("entries must be a mapping")
+        entries_raw = {}
+    elif entries_raw is None:
+        entries_raw = {}
+    elif not isinstance(entries_raw, Mapping):
         errors.append("entries must be a mapping")
         entries_raw = {}
 
@@ -281,6 +412,8 @@ def parse_allowlist_policy(raw: Mapping[str, Any] | None) -> AllowlistPolicy:
             continue
         eco_key = str(ecosystem)
         parsed_entries.setdefault(eco_key, {})
+        if not packages:
+            errors.append(f"entries.{eco_key} must contain at least one package rule")
         for package_name, rule_raw in packages.items():
             if not isinstance(rule_raw, Mapping):
                 errors.append(f"entries.{eco_key}.{package_name} must be a mapping")
@@ -316,24 +449,113 @@ def parse_allowlist_policy(raw: Mapping[str, Any] | None) -> AllowlistPolicy:
             else:
                 allowed_files = [str(item) for item in files_raw]
 
+            if schema_version == SUPPORTED_SCHEMA_VERSION:
+                _validate_schema_v1_package_rule(
+                    eco_key,
+                    pkg_key,
+                    dependency_type,
+                    update_types,
+                    allowed_files,
+                    errors,
+                )
+
             parsed_entries[eco_key][pkg_key] = AllowlistPackageRule(
                 dependency_type=dependency_type,
                 allowed_update_types=frozenset(update_types),
                 allowed_files=frozenset(allowed_files),
             )
 
-    valid = not errors and bool(parsed_entries)
-    if not parsed_entries and not errors:
-        errors.append("entries must contain at least one package rule")
+    package_rule_count = sum(len(pkgs) for pkgs in parsed_entries.values())
+    if package_rule_count == 0:
+        errors.append("entries must contain at least one valid package rule")
 
+    valid = not errors and package_rule_count > 0
     return AllowlistPolicy(
-        schema_version=int(schema_version or 0),
+        schema_version=schema_version if schema_version is not None else 0,
         default_mode=default_mode,
         entries=parsed_entries,
         defaults=defaults,
         valid=valid,
         validation_errors=tuple(errors),
     )
+
+
+def _validate_facts(facts: DependabotAutopilotFacts) -> list[str]:
+    reasons: list[str] = []
+
+    required_strings = (
+        facts.pr_author,
+        facts.base_branch,
+        facts.head_branch,
+        facts.head_sha,
+        facts.merge_state,
+        facts.ecosystem,
+        facts.package_name,
+        facts.dependency_type,
+        facts.update_type,
+        facts.current_version,
+        facts.target_version,
+        facts.execution_mode,
+    )
+    if any(
+        not isinstance(value, str) or not value.strip() for value in required_strings
+    ):
+        reasons.append(REASON_FACTS_INVALID)
+
+    bool_fields = (
+        facts.is_draft,
+        facts.metadata_complete,
+        facts.diff_verified,
+        facts.range_change,
+        facts.date_versioned,
+        facts.api_error,
+        facts.branch_is_current,
+        facts.kill_switch_enabled,
+    )
+    if any(not isinstance(value, bool) for value in bool_fields):
+        reasons.append(REASON_FACTS_INVALID)
+
+    if not isinstance(facts.commit_count, int) or isinstance(facts.commit_count, bool):
+        reasons.append(REASON_FACTS_INVALID)
+    elif facts.commit_count < 0:
+        reasons.append(REASON_FACTS_INVALID)
+
+    if not isinstance(facts.labels, tuple) or any(
+        not isinstance(label, str) for label in facts.labels
+    ):
+        reasons.append(REASON_FACTS_INVALID)
+
+    if not isinstance(facts.commit_authors, tuple) or any(
+        not isinstance(author, str) for author in facts.commit_authors
+    ):
+        reasons.append(REASON_FACTS_INVALID)
+
+    if not isinstance(facts.changed_files, tuple) or any(
+        not isinstance(path, str) for path in facts.changed_files
+    ):
+        reasons.append(REASON_FACTS_INVALID)
+
+    if not isinstance(facts.required_checks, tuple):
+        reasons.append(REASON_FACTS_INVALID)
+    else:
+        for check in facts.required_checks:
+            if not isinstance(check, RequiredCheckFact):
+                reasons.append(REASON_FACTS_INVALID)
+                break
+            if not check.name.strip():
+                reasons.append(REASON_FACTS_INVALID)
+                break
+            if not isinstance(check.status, str) or not isinstance(
+                check.conclusion, str
+            ):
+                reasons.append(REASON_FACTS_INVALID)
+                break
+
+    return _ordered_unique(reasons)  # type: ignore[return-value]
+
+
+def _execution_mode_valid(mode: str) -> bool:
+    return (mode or "").strip() in ALLOWED_EXECUTION_MODES
 
 
 def _lookup_package_rule(
@@ -345,14 +567,51 @@ def _lookup_package_rule(
     return eco_rules.get(package_name)
 
 
+def _evaluate_required_checks(
+    checks: Sequence[RequiredCheckFact],
+) -> list[str]:
+    reasons: list[str] = []
+    grouped: dict[str, list[tuple[str, str]]] = {
+        name: [] for name in REQUIRED_CHECK_NAMES
+    }
+
+    for check in checks:
+        name = (check.name or "").strip()
+        if name not in REQUIRED_CHECK_NAMES:
+            continue
+        status = _normalize_check_token(check.status)
+        conclusion = _normalize_check_token(check.conclusion)
+        grouped[name].append((status, conclusion))
+
+    for required_name in REQUIRED_CHECK_NAMES:
+        entries = grouped[required_name]
+        if not entries:
+            reasons.append(REASON_CHECK_MISSING)
+            continue
+        if len(entries) != 1:
+            reasons.append(REASON_CHECK_AMBIGUOUS)
+            continue
+        status, conclusion = entries[0]
+        if status != CHECK_STATUS_COMPLETED or conclusion != CHECK_CONCLUSION_SUCCESS:
+            reasons.append(REASON_CHECK_FAIL)
+
+    return reasons
+
+
 def _collect_hold_reasons(
     facts: DependabotAutopilotFacts, policy: AllowlistPolicy
 ) -> list[str]:
-    reasons: list[str] = []
+    reasons = list(_validate_facts(facts))
 
     if not policy.valid:
         reasons.append(REASON_POLICY)
-        return reasons
+        return _ordered_unique(reasons)  # type: ignore[return-value]
+
+    execution_mode = (facts.execution_mode or "").strip()
+    if not _execution_mode_valid(execution_mode):
+        reasons.append(REASON_EXECUTION_MODE)
+    if not _execution_mode_valid(policy.default_mode):
+        reasons.append(REASON_EXECUTION_MODE)
 
     if facts.api_error:
         reasons.append(REASON_API)
@@ -376,10 +635,13 @@ def _collect_hold_reasons(
     if facts.commit_count != 1:
         reasons.append(REASON_COMMIT_COUNT)
 
-    if facts.commit_count > 0 and not all(
-        _is_dependabot_login(author) for author in facts.commit_authors
-    ):
+    if len(facts.commit_authors) != 1:
         reasons.append(REASON_COMMIT_AUTHOR)
+    elif not _is_dependabot_login(facts.commit_authors[0]):
+        reasons.append(REASON_COMMIT_AUTHOR)
+
+    if not _is_valid_head_sha(facts.head_sha):
+        reasons.append(REASON_HEAD_SHA)
 
     if not facts.diff_verified:
         reasons.append(REASON_DIFF)
@@ -390,8 +652,15 @@ def _collect_hold_reasons(
     if facts.range_change:
         reasons.append(REASON_RANGE)
 
-    if facts.date_versioned:
+    if (
+        facts.date_versioned
+        or _is_date_version(facts.current_version)
+        or _is_date_version(facts.target_version)
+    ):
         reasons.append(REASON_DATE_VERSION)
+
+    if not _version_transition_valid(facts.current_version, facts.target_version):
+        reasons.append(REASON_VERSION_TRANSITION)
 
     update_type = (facts.update_type or "").strip()
     if update_type in {MINOR_UPDATE_TYPE, MAJOR_UPDATE_TYPE}:
@@ -419,13 +688,8 @@ def _collect_hold_reasons(
 
     package_rule = _lookup_package_rule(policy, ecosystem, facts.package_name)
     if package_rule is None:
-        if (
-            policy.defaults.get("unknown_ecosystem", "HOLD") == "HOLD"
-            and ecosystem not in policy.entries
-        ):
-            reasons.append(REASON_ECOSYSTEM)
-        if policy.defaults.get("unknown_package", "HOLD") == "HOLD":
-            reasons.append(REASON_PACKAGE)
+        reasons.append(REASON_ECOSYSTEM)
+        reasons.append(REASON_PACKAGE)
     else:
         if facts.dependency_type != package_rule.dependency_type:
             reasons.append(REASON_DEP_TYPE)
@@ -438,17 +702,7 @@ def _collect_hold_reasons(
         if len(changed_files) != len(package_rule.allowed_files):
             reasons.append(REASON_FILE)
 
-    check_status_by_name = {
-        check.name: (check.status or "").strip().lower()
-        for check in facts.required_checks
-    }
-    for required_name in REQUIRED_CHECK_NAMES:
-        status = check_status_by_name.get(required_name)
-        if status is None:
-            reasons.append(REASON_CHECK_MISSING)
-            continue
-        if status not in SUCCESS_CHECK_STATUSES:
-            reasons.append(REASON_CHECK_FAIL)
+    reasons.extend(_evaluate_required_checks(facts.required_checks))
 
     if not facts.branch_is_current:
         reasons.append(REASON_BRANCH)
@@ -457,7 +711,7 @@ def _collect_hold_reasons(
     if merge_state != "CLEAN":
         reasons.append(REASON_MERGE_STATE)
 
-    return reasons
+    return list(_ordered_unique(reasons))
 
 
 def _build_summary(
@@ -499,9 +753,7 @@ def classify_dependabot_pr(
         )
 
     reason_codes: list[str] = [REASON_ELIGIBLE]
-    execution_mode = (
-        facts.execution_mode or policy.default_mode or "report_only"
-    ).strip()
+    execution_mode = (facts.execution_mode or "").strip()
     if execution_mode == "report_only":
         reason_codes.append(REASON_REPORT_ONLY)
         return ClassificationResult(
@@ -514,7 +766,7 @@ def classify_dependabot_pr(
             ),
         )
 
-    if not facts.kill_switch_enabled:
+    if facts.kill_switch_enabled is not True:
         reason_codes.append(REASON_AUTOMERGE_DISABLED)
         return ClassificationResult(
             classification="ELIGIBLE",

--- a/tests/unit/github/test_dependabot_autopilot_classifier.py
+++ b/tests/unit/github/test_dependabot_autopilot_classifier.py
@@ -32,6 +32,8 @@ Facts = classifier.DependabotAutopilotFacts
 RequiredCheckFact = classifier.RequiredCheckFact
 Policy = classifier.parse_allowlist_policy
 
+VALID_HEAD_SHA = "b366010aa9cbcfca440497dc64b6c8746c50ff55"
+
 
 def _load_policy() -> classifier.AllowlistPolicy:
     raw = yaml.safe_load(ALLOWLIST_PATH.read_text(encoding="utf-8"))
@@ -39,16 +41,20 @@ def _load_policy() -> classifier.AllowlistPolicy:
 
 
 def _checks(
-    *, policy_ok: bool = True, ci_ok: bool = True
+    *,
+    policy_status: str = "COMPLETED",
+    policy_conclusion: str = "SUCCESS",
+    ci_status: str = "COMPLETED",
+    ci_conclusion: str = "SUCCESS",
 ) -> tuple[RequiredCheckFact, ...]:
-    checks = [
-        RequiredCheckFact("policy-gate", "success" if policy_ok else "failure"),
+    return (
+        RequiredCheckFact("policy-gate", policy_status, policy_conclusion),
         RequiredCheckFact(
             "ci (Unit/Integration + Lint gesammelt)",
-            "success" if ci_ok else "pending",
+            ci_status,
+            ci_conclusion,
         ),
-    ]
-    return tuple(checks)
+    )
 
 
 def _facts(**overrides: object) -> Facts:
@@ -58,7 +64,7 @@ def _facts(**overrides: object) -> Facts:
         "head_branch": "dependabot/pip/ruff-0.15.21",
         "is_draft": False,
         "labels": (),
-        "head_sha": "abc123",
+        "head_sha": VALID_HEAD_SHA,
         "commit_count": 1,
         "commit_authors": ("dependabot[bot]",),
         "changed_files": ("requirements-dev.txt",),
@@ -119,7 +125,7 @@ def test_phase1_with_kill_switch_true_yields_merge_candidate_only() -> None:
 
 def test_major_update_holds() -> None:
     result = classifier.classify_dependabot_pr(
-        _facts(update_type="version-update:semver-major"),
+        _facts(update_type="version-update:semver-major", target_version="1.0.0"),
         _load_policy(),
     )
 
@@ -129,7 +135,7 @@ def test_major_update_holds() -> None:
 
 def test_minor_update_holds() -> None:
     result = classifier.classify_dependabot_pr(
-        _facts(update_type="version-update:semver-minor"),
+        _facts(update_type="version-update:semver-minor", target_version="0.16.0"),
         _load_policy(),
     )
 
@@ -146,9 +152,24 @@ def test_range_change_holds() -> None:
     assert classifier.REASON_RANGE in result.reason_codes
 
 
-def test_date_version_holds() -> None:
+def test_date_version_boolean_holds() -> None:
     result = classifier.classify_dependabot_pr(
         _facts(date_versioned=True, target_version="2026.7.10"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_DATE_VERSION in result.reason_codes
+
+
+def test_date_version_detected_without_boolean_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            date_versioned=False,
+            current_version="2026.6.4",
+            target_version="2026.7.10",
+            package_name="mcp-server-time",
+        ),
         _load_policy(),
     )
 
@@ -258,9 +279,39 @@ def test_two_commits_hold() -> None:
     assert classifier.REASON_COMMIT_COUNT in result.reason_codes
 
 
+def test_zero_commits_hold() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(commit_count=0, commit_authors=()),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_COMMIT_COUNT in result.reason_codes
+
+
+def test_empty_commit_authors_with_single_commit_count_hold() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(commit_count=1, commit_authors=()),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_COMMIT_AUTHOR in result.reason_codes
+
+
+def test_two_commit_authors_with_single_commit_count_hold() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(commit_count=1, commit_authors=("dependabot[bot]", "human")),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_COMMIT_AUTHOR in result.reason_codes
+
+
 def test_human_commit_author_holds() -> None:
     result = classifier.classify_dependabot_pr(
-        _facts(commit_authors=("dependabot[bot]", "jannekbuengener")),
+        _facts(commit_authors=("dependabot[bot]", "jannekbuengener"), commit_count=2),
         _load_policy(),
     )
 
@@ -300,7 +351,9 @@ def test_incomplete_metadata_holds() -> None:
 
 def test_missing_required_check_holds() -> None:
     result = classifier.classify_dependabot_pr(
-        _facts(required_checks=(RequiredCheckFact("policy-gate", "success"),)),
+        _facts(
+            required_checks=(RequiredCheckFact("policy-gate", "COMPLETED", "SUCCESS"),)
+        ),
         _load_policy(),
     )
 
@@ -308,14 +361,54 @@ def test_missing_required_check_holds() -> None:
     assert classifier.REASON_CHECK_MISSING in result.reason_codes
 
 
-def test_failed_required_check_holds() -> None:
+def test_completed_with_failure_conclusion_holds() -> None:
     result = classifier.classify_dependabot_pr(
-        _facts(required_checks=_checks(ci_ok=False)),
+        _facts(
+            required_checks=_checks(
+                ci_status="COMPLETED",
+                ci_conclusion="FAILURE",
+            )
+        ),
         _load_policy(),
     )
 
     assert result.classification == "HOLD"
     assert classifier.REASON_CHECK_FAIL in result.reason_codes
+
+
+def test_in_progress_with_success_conclusion_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            required_checks=_checks(
+                ci_status="IN_PROGRESS",
+                ci_conclusion="SUCCESS",
+            )
+        ),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_CHECK_FAIL in result.reason_codes
+
+
+def test_duplicate_required_check_with_conflicting_results_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            required_checks=(
+                RequiredCheckFact("policy-gate", "COMPLETED", "SUCCESS"),
+                RequiredCheckFact("policy-gate", "COMPLETED", "FAILURE"),
+                RequiredCheckFact(
+                    "ci (Unit/Integration + Lint gesammelt)",
+                    "COMPLETED",
+                    "SUCCESS",
+                ),
+            )
+        ),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_CHECK_AMBIGUOUS in result.reason_codes
 
 
 def test_branch_not_current_holds() -> None:
@@ -359,12 +452,81 @@ def test_unknown_package_holds() -> None:
     assert classifier.REASON_PACKAGE in result.reason_codes
 
 
+def test_unknown_package_allow_default_cannot_override_hold() -> None:
+    policy = Policy(
+        {
+            "schema_version": 1,
+            "default_mode": "report_only",
+            "defaults": {"unknown_package": "ALLOW"},
+            "entries": {
+                "pip": {
+                    "ruff": {
+                        "dependency_type": "direct:development",
+                        "allowed_update_types": ["version-update:semver-patch"],
+                        "allowed_files": ["requirements-dev.txt"],
+                    }
+                }
+            },
+        }
+    )
+    assert policy.valid is False
+    result = classifier.classify_dependabot_pr(
+        _facts(package_name="not-listed"),
+        policy,
+    )
+    assert result.classification == "HOLD"
+    assert classifier.REASON_POLICY in result.reason_codes
+
+
 def test_invalid_allowlist_holds() -> None:
     invalid = Policy({"schema_version": 99, "entries": {}})
     result = classifier.classify_dependabot_pr(_facts(), invalid)
 
     assert result.classification == "HOLD"
     assert classifier.REASON_POLICY in result.reason_codes
+
+
+def test_non_numeric_schema_version_does_not_raise() -> None:
+    invalid = Policy({"schema_version": "invalid", "entries": []})
+    assert invalid.valid is False
+    result = classifier.classify_dependabot_pr(_facts(), invalid)
+    assert result.classification == "HOLD"
+    assert classifier.REASON_POLICY in result.reason_codes
+
+
+def test_empty_ecosystem_mapping_is_policy_invalid() -> None:
+    invalid = Policy(
+        {
+            "schema_version": 1,
+            "default_mode": "report_only",
+            "defaults": {"unknown_package": "HOLD", "unknown_ecosystem": "HOLD"},
+            "entries": {"pip": {}},
+        }
+    )
+    assert invalid.valid is False
+    result = classifier.classify_dependabot_pr(_facts(), invalid)
+    assert result.classification == "HOLD"
+    assert classifier.REASON_POLICY in result.reason_codes
+
+
+def test_unsafe_allowlist_path_is_policy_invalid() -> None:
+    invalid = Policy(
+        {
+            "schema_version": 1,
+            "default_mode": "report_only",
+            "defaults": {"unknown_package": "HOLD", "unknown_ecosystem": "HOLD"},
+            "entries": {
+                "pip": {
+                    "ruff": {
+                        "dependency_type": "direct:development",
+                        "allowed_update_types": ["version-update:semver-patch"],
+                        "allowed_files": [".github/workflows/ci.yml"],
+                    }
+                }
+            },
+        }
+    )
+    assert invalid.valid is False
 
 
 def test_manual_review_label_holds() -> None:
@@ -385,6 +547,83 @@ def test_draft_pr_holds() -> None:
 
     assert result.classification == "HOLD"
     assert classifier.REASON_DRAFT in result.reason_codes
+
+
+def test_unknown_execution_mode_with_kill_switch_true_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(execution_mode="auto", kill_switch_enabled=True),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_EXECUTION_MODE in result.reason_codes
+    assert result.action == "HOLD"
+    assert result.merge_authorized is False
+
+
+def test_string_kill_switch_value_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(kill_switch_enabled="false", execution_mode="phase1"),  # type: ignore[arg-type]
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_FACTS_INVALID in result.reason_codes
+
+
+def test_invalid_head_sha_empty_holds() -> None:
+    result = classifier.classify_dependabot_pr(_facts(head_sha=""), _load_policy())
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_HEAD_SHA in result.reason_codes
+
+
+def test_invalid_head_sha_short_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(head_sha="abc123"), _load_policy()
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_HEAD_SHA in result.reason_codes
+
+
+def test_identical_version_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(current_version="0.15.21", target_version="0.15.21"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_VERSION_TRANSITION in result.reason_codes
+
+
+def test_downgrade_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(current_version="0.15.21", target_version="0.15.20"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_VERSION_TRANSITION in result.reason_codes
+
+
+def test_non_consecutive_patch_bump_remains_eligible() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(current_version="0.15.20", target_version="0.15.22"),
+        _load_policy(),
+    )
+
+    assert result.classification == "ELIGIBLE"
+
+
+def test_wrong_minor_patch_jump_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(current_version="0.15.20", target_version="0.16.1"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_VERSION_TRANSITION in result.reason_codes
 
 
 def test_repeated_evaluation_is_deterministic() -> None:

--- a/tests/unit/github/test_dependabot_autopilot_classifier.py
+++ b/tests/unit/github/test_dependabot_autopilot_classifier.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+import yaml
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".github"
+    / "scripts"
+    / "dependabot_autopilot_classifier.py"
+)
+ALLOWLIST_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".github"
+    / "dependabot-autopilot-allowlist.yml"
+)
+
+SPEC = importlib.util.spec_from_file_location(
+    "dependabot_autopilot_classifier", SCRIPT_PATH
+)
+assert SPEC is not None
+classifier = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = classifier
+assert SPEC.loader is not None
+SPEC.loader.exec_module(classifier)
+
+Facts = classifier.DependabotAutopilotFacts
+RequiredCheckFact = classifier.RequiredCheckFact
+Policy = classifier.parse_allowlist_policy
+
+
+def _load_policy() -> classifier.AllowlistPolicy:
+    raw = yaml.safe_load(ALLOWLIST_PATH.read_text(encoding="utf-8"))
+    return Policy(raw)
+
+
+def _checks(
+    *, policy_ok: bool = True, ci_ok: bool = True
+) -> tuple[RequiredCheckFact, ...]:
+    checks = [
+        RequiredCheckFact("policy-gate", "success" if policy_ok else "failure"),
+        RequiredCheckFact(
+            "ci (Unit/Integration + Lint gesammelt)",
+            "success" if ci_ok else "pending",
+        ),
+    ]
+    return tuple(checks)
+
+
+def _facts(**overrides: object) -> Facts:
+    base = {
+        "pr_author": "dependabot[bot]",
+        "base_branch": "main",
+        "head_branch": "dependabot/pip/ruff-0.15.21",
+        "is_draft": False,
+        "labels": (),
+        "head_sha": "abc123",
+        "commit_count": 1,
+        "commit_authors": ("dependabot[bot]",),
+        "changed_files": ("requirements-dev.txt",),
+        "required_checks": _checks(),
+        "branch_is_current": True,
+        "merge_state": "CLEAN",
+        "ecosystem": "pip",
+        "package_name": "ruff",
+        "dependency_type": "direct:development",
+        "update_type": "version-update:semver-patch",
+        "current_version": "0.15.20",
+        "target_version": "0.15.21",
+        "metadata_complete": True,
+        "diff_verified": True,
+        "range_change": False,
+        "date_versioned": False,
+        "api_error": False,
+        "execution_mode": "report_only",
+        "kill_switch_enabled": False,
+    }
+    base.update(overrides)
+    return Facts(**base)
+
+
+def test_allowlisted_ruff_patch_report_only_is_eligible_not_merge_authorized() -> None:
+    result = classifier.classify_dependabot_pr(_facts(), _load_policy())
+
+    assert result.classification == "ELIGIBLE"
+    assert result.action == "REPORT_ONLY"
+    assert result.merge_authorized is False
+    assert classifier.REASON_ELIGIBLE in result.reason_codes
+    assert classifier.REASON_REPORT_ONLY in result.reason_codes
+
+
+def test_kill_switch_false_prevents_merge_authorization_in_phase_mode() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(execution_mode="phase1", kill_switch_enabled=False),
+        _load_policy(),
+    )
+
+    assert result.classification == "ELIGIBLE"
+    assert result.action == "REPORT_ONLY"
+    assert result.merge_authorized is False
+    assert classifier.REASON_AUTOMERGE_DISABLED in result.reason_codes
+
+
+def test_phase1_with_kill_switch_true_yields_merge_candidate_only() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(execution_mode="phase1", kill_switch_enabled=True),
+        _load_policy(),
+    )
+
+    assert result.classification == "ELIGIBLE"
+    assert result.action == "MERGE_CANDIDATE"
+    assert result.merge_authorized is True
+    assert classifier.REASON_ELIGIBLE in result.reason_codes
+
+
+def test_major_update_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(update_type="version-update:semver-major"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_UPDATE_TYPE in result.reason_codes
+
+
+def test_minor_update_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(update_type="version-update:semver-minor"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_UPDATE_TYPE in result.reason_codes
+
+
+def test_range_change_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(range_change=True), _load_policy()
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_RANGE in result.reason_codes
+
+
+def test_date_version_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(date_versioned=True, target_version="2026.7.10"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_DATE_VERSION in result.reason_codes
+
+
+def test_docker_update_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            ecosystem="docker",
+            package_name="postgres",
+            changed_files=("services/risk/Dockerfile",),
+            dependency_type="direct:production",
+            update_type="version-update:semver-patch",
+        ),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_DOCKER in result.reason_codes
+
+
+def test_database_compose_update_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            ecosystem="docker-compose",
+            package_name="postgres",
+            changed_files=("infrastructure/compose/docker-compose.yml",),
+            dependency_type="direct:production",
+            update_type="version-update:semver-patch",
+        ),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_DOCKER in result.reason_codes
+
+
+def test_runtime_requirements_txt_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            package_name="redis",
+            changed_files=("requirements.txt",),
+            dependency_type="direct:production",
+        ),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_RUNTIME in result.reason_codes
+
+
+def test_github_actions_update_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            ecosystem="github-actions",
+            package_name="actions/stale",
+            changed_files=(".github/workflows/stale.yml",),
+            dependency_type="direct:production",
+            update_type="version-update:semver-patch",
+        ),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_ACTIONS in result.reason_codes
+
+
+def test_non_dependabot_author_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(pr_author="jannekbuengener"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_AUTHOR in result.reason_codes
+
+
+def test_wrong_base_branch_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(base_branch="develop"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_BASE in result.reason_codes
+
+
+def test_wrong_head_branch_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(head_branch="feature/ruff-bump"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_HEAD in result.reason_codes
+
+
+def test_two_commits_hold() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(commit_count=2),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_COMMIT_COUNT in result.reason_codes
+
+
+def test_human_commit_author_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(commit_authors=("dependabot[bot]", "jannekbuengener")),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_COMMIT_AUTHOR in result.reason_codes
+
+
+def test_additional_changed_file_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(changed_files=("requirements-dev.txt", "pyproject.toml")),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_FILE in result.reason_codes
+
+
+def test_diff_not_verified_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(diff_verified=False),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_DIFF in result.reason_codes
+
+
+def test_incomplete_metadata_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(metadata_complete=False),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_METADATA in result.reason_codes
+
+
+def test_missing_required_check_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(required_checks=(RequiredCheckFact("policy-gate", "success"),)),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_CHECK_MISSING in result.reason_codes
+
+
+def test_failed_required_check_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(required_checks=_checks(ci_ok=False)),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_CHECK_FAIL in result.reason_codes
+
+
+def test_branch_not_current_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(branch_is_current=False),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_BRANCH in result.reason_codes
+
+
+@pytest.mark.parametrize("merge_state", ["BEHIND", "BLOCKED", "DIRTY", "UNKNOWN"])
+def test_non_clean_merge_state_holds(merge_state: str) -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(merge_state=merge_state),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_MERGE_STATE in result.reason_codes
+
+
+def test_api_error_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(api_error=True),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_API in result.reason_codes
+
+
+def test_unknown_package_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(package_name="unknown-package"),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_PACKAGE in result.reason_codes
+
+
+def test_invalid_allowlist_holds() -> None:
+    invalid = Policy({"schema_version": 99, "entries": {}})
+    result = classifier.classify_dependabot_pr(_facts(), invalid)
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_POLICY in result.reason_codes
+
+
+def test_manual_review_label_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(labels=("dependencies:manual-review",)),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_MANUAL_REVIEW in result.reason_codes
+
+
+def test_draft_pr_holds() -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(is_draft=True),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_DRAFT in result.reason_codes
+
+
+def test_repeated_evaluation_is_deterministic() -> None:
+    policy = _load_policy()
+    facts = _facts()
+    first = classifier.classify_dependabot_pr(facts, policy)
+    second = classifier.classify_dependabot_pr(facts, policy)
+
+    assert first == second
+
+
+def test_anonymized_live_regression_fixture_two_commits_holds() -> None:
+    """Mirrors live #4049: ruff patch + merge commit + behind merge state."""
+    result = classifier.classify_dependabot_pr(
+        _facts(
+            head_branch="dependabot/pip/ruff-0.15.21",
+            commit_count=2,
+            commit_authors=("dependabot[bot]", "jannekbuengener"),
+            changed_files=("requirements-dev.txt",),
+            branch_is_current=False,
+            merge_state="BEHIND",
+        ),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_COMMIT_COUNT in result.reason_codes
+    assert classifier.REASON_COMMIT_AUTHOR in result.reason_codes
+    assert classifier.REASON_BRANCH in result.reason_codes
+    assert classifier.REASON_MERGE_STATE in result.reason_codes

--- a/tests/unit/github/test_dependabot_autopilot_classifier.py
+++ b/tests/unit/github/test_dependabot_autopilot_classifier.py
@@ -576,6 +576,7 @@ def test_invalid_head_sha_empty_holds() -> None:
 
     assert result.classification == "HOLD"
     assert result.reason_codes == (classifier.REASON_FACTS_INVALID,)
+    assert result.human_summary == classifier.FACTS_INVALID_SUMMARY
 
 
 def test_invalid_head_sha_short_holds() -> None:
@@ -714,6 +715,44 @@ def test_malformed_facts_fail_closed_without_exception(overrides: dict) -> None:
     assert result.action == "HOLD"
     assert result.merge_authorized is False
     assert result.reason_codes == (classifier.REASON_FACTS_INVALID,)
+    assert result.human_summary == classifier.FACTS_INVALID_SUMMARY
+
+
+INVALID_FACTS_TOP_LEVEL_CASES = [
+    pytest.param({"required_checks": None}, id="required_checks_none"),  # type: ignore[dict-item]
+    pytest.param({"labels": None}, id="labels_none"),  # type: ignore[dict-item]
+    pytest.param({"changed_files": None}, id="changed_files_none"),  # type: ignore[dict-item]
+    pytest.param({"package_name": 123}, id="package_name_int"),  # type: ignore[dict-item]
+]
+
+
+@pytest.mark.parametrize("overrides", INVALID_FACTS_TOP_LEVEL_CASES)
+def test_invalid_fact_fields_use_constant_summary(overrides: dict) -> None:
+    result = classifier.classify_dependabot_pr(_facts(**overrides), _load_policy())
+
+    assert result.classification == "HOLD"
+    assert result.action == "HOLD"
+    assert result.merge_authorized is False
+    assert result.reason_codes == (classifier.REASON_FACTS_INVALID,)
+    assert result.human_summary == classifier.FACTS_INVALID_SUMMARY
+    assert "123" not in result.human_summary
+    assert "None" not in result.human_summary
+
+
+@pytest.mark.parametrize(
+    "facts_value",
+    [None, {}],
+)
+def test_non_dependabot_autopilot_facts_use_constant_summary(
+    facts_value: object,
+) -> None:
+    result = classifier.classify_dependabot_pr(facts_value, _load_policy())  # type: ignore[arg-type]
+
+    assert result.classification == "HOLD"
+    assert result.action == "HOLD"
+    assert result.merge_authorized is False
+    assert result.reason_codes == (classifier.REASON_FACTS_INVALID,)
+    assert result.human_summary == classifier.FACTS_INVALID_SUMMARY
 
 
 def test_policy_default_mode_phase1_is_invalid() -> None:

--- a/tests/unit/github/test_dependabot_autopilot_classifier.py
+++ b/tests/unit/github/test_dependabot_autopilot_classifier.py
@@ -575,7 +575,7 @@ def test_invalid_head_sha_empty_holds() -> None:
     result = classifier.classify_dependabot_pr(_facts(head_sha=""), _load_policy())
 
     assert result.classification == "HOLD"
-    assert classifier.REASON_HEAD_SHA in result.reason_codes
+    assert result.reason_codes == (classifier.REASON_FACTS_INVALID,)
 
 
 def test_invalid_head_sha_short_holds() -> None:
@@ -654,3 +654,172 @@ def test_anonymized_live_regression_fixture_two_commits_holds() -> None:
     assert classifier.REASON_COMMIT_AUTHOR in result.reason_codes
     assert classifier.REASON_BRANCH in result.reason_codes
     assert classifier.REASON_MERGE_STATE in result.reason_codes
+
+
+MALFORMED_FACT_CASES = [
+    pytest.param({"pr_author": 123}, id="pr_author_int"),
+    pytest.param({"labels": (123,)}, id="labels_int"),
+    pytest.param({"changed_files": (123,)}, id="changed_files_int"),
+    pytest.param({"commit_authors": (None,)}, id="commit_authors_none"),  # type: ignore[list-item]
+    pytest.param(
+        {
+            "required_checks": (
+                RequiredCheckFact(None, "COMPLETED", "SUCCESS"),  # type: ignore[arg-type]
+                RequiredCheckFact(
+                    "ci (Unit/Integration + Lint gesammelt)",
+                    "COMPLETED",
+                    "SUCCESS",
+                ),
+            )
+        },
+        id="required_check_name_none",
+    ),
+    pytest.param(
+        {
+            "required_checks": (
+                RequiredCheckFact("policy-gate", 123, "SUCCESS"),  # type: ignore[arg-type]
+                RequiredCheckFact(
+                    "ci (Unit/Integration + Lint gesammelt)",
+                    "COMPLETED",
+                    "SUCCESS",
+                ),
+            )
+        },
+        id="required_check_status_int",
+    ),
+    pytest.param(
+        {
+            "required_checks": (
+                RequiredCheckFact("policy-gate", "COMPLETED", []),  # type: ignore[arg-type]
+                RequiredCheckFact(
+                    "ci (Unit/Integration + Lint gesammelt)",
+                    "COMPLETED",
+                    "SUCCESS",
+                ),
+            )
+        },
+        id="required_check_conclusion_list",
+    ),
+    pytest.param({"execution_mode": None}, id="execution_mode_none"),  # type: ignore[dict-item]
+    pytest.param({"kill_switch_enabled": "true"}, id="kill_switch_string"),  # type: ignore[dict-item]
+    pytest.param({"commit_count": True}, id="commit_count_bool"),  # type: ignore[dict-item]
+]
+
+
+@pytest.mark.parametrize("overrides", MALFORMED_FACT_CASES)
+def test_malformed_facts_fail_closed_without_exception(overrides: dict) -> None:
+    result = classifier.classify_dependabot_pr(_facts(**overrides), _load_policy())
+
+    assert result.classification == "HOLD"
+    assert result.action == "HOLD"
+    assert result.merge_authorized is False
+    assert result.reason_codes == (classifier.REASON_FACTS_INVALID,)
+
+
+def test_policy_default_mode_phase1_is_invalid() -> None:
+    policy = Policy(
+        {
+            "schema_version": 1,
+            "default_mode": "phase1",
+            "defaults": {"unknown_package": "HOLD", "unknown_ecosystem": "HOLD"},
+            "entries": {
+                "pip": {
+                    "ruff": {
+                        "dependency_type": "direct:development",
+                        "allowed_update_types": ["version-update:semver-patch"],
+                        "allowed_files": ["requirements-dev.txt"],
+                    }
+                }
+            },
+        }
+    )
+    assert policy.valid is False
+    result = classifier.classify_dependabot_pr(_facts(), policy)
+    assert result.classification == "HOLD"
+    assert classifier.REASON_POLICY in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "schema_version",
+    [1.2, True, "1"],
+)
+def test_non_integer_schema_version_is_policy_invalid(schema_version: object) -> None:
+    policy = Policy(
+        {
+            "schema_version": schema_version,
+            "default_mode": "report_only",
+            "defaults": {"unknown_package": "HOLD", "unknown_ecosystem": "HOLD"},
+            "entries": {
+                "pip": {
+                    "ruff": {
+                        "dependency_type": "direct:development",
+                        "allowed_update_types": ["version-update:semver-patch"],
+                        "allowed_files": ["requirements-dev.txt"],
+                    }
+                }
+            },
+        }
+    )
+    assert policy.valid is False
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".github/scripts/example.py",
+        ".github/actions/example/action.yml",
+        ".github/workflows/ci.yml",
+    ],
+)
+def test_changed_file_under_dot_github_is_control_plane_hold(path: str) -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(changed_files=(path,)),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_CONTROL_PLANE in result.reason_codes
+
+
+@pytest.mark.parametrize(
+    "current_version,target_version",
+    [
+        ("+1.2.3", "1.2.4"),
+        ("1.-2.3", "1.2.4"),
+        ("1.2", "1.2.3"),
+        ("1.2.3.4", "1.2.5"),
+        ("1..3", "1.2.4"),
+        ("v1.2.3", "1.2.4"),
+        ("0.15.21", "0.15.21"),
+    ],
+)
+def test_invalid_semver_transition_holds(
+    current_version: str, target_version: str
+) -> None:
+    result = classifier.classify_dependabot_pr(
+        _facts(current_version=current_version, target_version=target_version),
+        _load_policy(),
+    )
+
+    assert result.classification == "HOLD"
+    assert classifier.REASON_VERSION_TRANSITION in result.reason_codes
+
+
+def test_allowlist_rejects_dot_github_scripts_path() -> None:
+    policy = Policy(
+        {
+            "schema_version": 1,
+            "default_mode": "report_only",
+            "defaults": {"unknown_package": "HOLD", "unknown_ecosystem": "HOLD"},
+            "entries": {
+                "pip": {
+                    "ruff": {
+                        "dependency_type": "direct:development",
+                        "allowed_update_types": ["version-update:semver-patch"],
+                        "allowed_files": [".github/scripts/example.py"],
+                    }
+                }
+            },
+        }
+    )
+    assert policy.valid is False


### PR DESCRIPTION
## Summary

Slice S0 for #4061: deterministic fail-closed Dependabot classifier, versioned phase-1 allowlist, and unit tests. No workflow, GitHub API adapter, or merge execution.

## Decision Contract

- **Input:** Normalized `DependabotAutopilotFacts` + validated `AllowlistPolicy` (no network, no subprocess, no writes).
- **Output:** `ClassificationResult` with `classification`, `action`, `merge_authorized`, stable `reason_codes`, `human_summary`.
- **Separation:** Risk classification vs execution authorization — `ELIGIBLE` in `report_only` mode keeps `merge_authorized=false`.
- **Phase 1 allowlist:** `pip` / `ruff` / patch-only / `requirements-dev.txt` only.
- **Global denies:** GitHub Actions, Docker/DB/runtime surfaces, control-plane paths, range/date versions, non-patch updates.

## Brain Evidence

```text
brain_source: repo-only
brain_status: not-used
tools_or_queries:
  - gh issue view 4061, gh pr list dedupe (no existing S0 PR)
  - gh pr view 4049 (live regression facts for anonymized fixture)
  - pytest 33 passed; ruff clean; black formatted
records_or_results:
  - context_search: not re-run (repo-only implementation slice)
repo_crosscheck:
  - tests/unit/github/test_docker_runtime_rebuild_followup_scanner.py importlib pattern
  - issue #4061 S0 contract
limitations:
  - No SurrealDB records; classifier not yet wired to API adapter (later slices)
```

## Validation

```bash
python -m pytest -q tests/unit/github/test_dependabot_autopilot_classifier.py  # 33 passed
python -m ruff check .github/scripts/dependabot_autopilot_classifier.py tests/unit/github/test_dependabot_autopilot_classifier.py
python -m black --check .github/scripts/dependabot_autopilot_classifier.py tests/unit/github/test_dependabot_autopilot_classifier.py
git diff --check
```

## Security Boundaries

- No GitHub writes, merge calls, secrets, or PR mutations in this slice.
- LR remains NO-GO; no runtime/trading changes.

## Non-goals

- No workflow (S1), no kill-switch variable (S3), no governance doc sync (S2).
- Does not close #4061.
- Does not touch #4060 or existing Dependabot PRs.

## Known limitations

- Allowlist loaded by future adapter; tests parse YAML directly.
- `execution_mode=phase1` + `kill_switch_enabled=true` yields `MERGE_CANDIDATE` only — no merge performed here.
- Live #4049 anonymized fixture confirms HOLD for merge commit + BEHIND state.

Refs #4061
