### PR TITLE
fix(security): promote scan-cleared Prometheus image pin

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,7 +4,7 @@ name: Security Scan
 # Issue #97: Trivy Container Scanning
 on:
   push:
-    branches: [main]
+    branches: [main, fix/security-alert-cluster-4072-4081]
   # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
   # RESTORED (#3659): billing recovery complete, trigger re-enabled
   schedule:
@@ -37,11 +37,11 @@ jobs:
         include:
           - image: redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
             scan_name: redis
-          - image: postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
+          - image: postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
             scan_name: postgres
-          - image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+          - image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
             scan_name: prometheus
-          - image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
+          - image: grafana/grafana:13.1.0-ubuntu@sha256:41b0dc13bb4f6a63ae2facb6112bfa40db59c797e0b70f9d6795d838de04537b
             scan_name: grafana
       fail-fast: false
 
@@ -248,7 +248,7 @@ jobs:
       matrix:
         image:
           - redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
-          - postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
+          - postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
       fail-fast: false
 
     env:
@@ -408,5 +408,5 @@ jobs:
 #
 # 4. For manual scans:
 #    docker scout cves redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005 --only-severities critical,high
-#    docker scout cves postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda --only-severities critical,high
+#    docker scout cves postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15 --only-severities critical,high
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,7 +4,7 @@ name: Security Scan
 # Issue #97: Trivy Container Scanning
 on:
   push:
-    branches: [main, fix/security-alert-cluster-4072-4081]
+    branches: [main]
   # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
   # RESTORED (#3659): billing recovery complete, trigger re-enabled
   schedule:
@@ -37,11 +37,11 @@ jobs:
         include:
           - image: redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
             scan_name: redis
-          - image: postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+          - image: postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
             scan_name: postgres
           - image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
             scan_name: prometheus
-          - image: grafana/grafana:13.1.0-ubuntu@sha256:41b0dc13bb4f6a63ae2facb6112bfa40db59c797e0b70f9d6795d838de04537b
+          - image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
             scan_name: grafana
       fail-fast: false
 
@@ -248,7 +248,7 @@ jobs:
       matrix:
         image:
           - redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005
-          - postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+          - postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
       fail-fast: false
 
     env:
@@ -408,5 +408,5 @@ jobs:
 #
 # 4. For manual scans:
 #    docker scout cves redis:8.8.0-alpine@sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005 --only-severities critical,high
-#    docker scout cves postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15 --only-severities critical,high
+#    docker scout cves postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda --only-severities critical,high
 

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -56,7 +56,7 @@ services:
       - cdb_network
 
   cdb_prometheus:
-    image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:

--- a/infrastructure/compose/compose.prometheus-v3.yml
+++ b/infrastructure/compose/compose.prometheus-v3.yml
@@ -4,11 +4,11 @@
 #
 # Scope:
 # - Adds an optional parallel Prometheus v3 canary service
-# - Does not change default runtime service cdb_prometheus (v3.13.0)
+# - Does not change default runtime service cdb_prometheus (v3.13.1)
 
 services:
   cdb_prometheus_v3:
-    image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
     container_name: cdb_prometheus_v3
     restart: unless-stopped
     profiles:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -93,7 +93,7 @@ services:
   # ==================== MONITORING ====================
 
   cdb_prometheus:
-    image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary

Promotes only the base-image candidate that cleared its tracked CVE in a dedicated Trivy/SARIF validation run:

- Prometheus: `v3.13.0` → `v3.13.1` (digest pinned)
- Synchronizes the canonical pin across the security workflow, shared compose base, RED stack, and v3 canary overlay.
- Leaves Postgres and Grafana unchanged because their candidate images still report the tracked vulnerabilities.

## Validation evidence

Security Scan run: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/29350997266

Branch SARIF result for the candidate batch:

| Candidate | Result |
|---|---|
| Prometheus v3.13.1 | CVE-2026-39822 absent |
| Postgres 18.4-alpine digest 9a8afca… | CVE-2026-33630 and CVE-2026-39822 still present |
| Grafana 13.1.0-ubuntu | CVE-2026-39822 still present; additional Zipkin plugin occurrence observed |

The final diff retains only the Prometheus candidate. The temporary validation branch trigger was removed.

## Boundaries

- No Code Scanning alert dismissal.
- No direct `main` write.
- No live/runtime deployment.
- LR remains NO-GO.
- Postgres/Grafana remain tracked as unresolved/upstream-dependent.

Refs #2513 #2933 #4054 #4055 #3755 #4072 #4073 #4074 #4075 #4076 #4077