### PR TITLE
docs(arvp): lock five-candidate Batch B

### DIFF
--- a/docs/contracts/batch_b_funnel_manifest.v1.json
+++ b/docs/contracts/batch_b_funnel_manifest.v1.json
@@ -1,0 +1,172 @@
+{
+  "schema_version": "batch_b_funnel_manifest.v1",
+  "batch_id": "batch_b_established_strategy_funnel_v1",
+  "source_issue": "#4069",
+  "parent_control_issue": "#1900",
+  "predecessor_funnel": "#4029",
+  "readiness_source": "docs/evidence/arvp_batch_b_readiness_4065.md",
+  "lock_evidence": "docs/evidence/arvp_batch_b_readiness_lock_4069.md",
+  "lock_status": "BATCH_B_LOCKED",
+  "lock_scope": "candidate_identity_hypothesis_and_dedupe_boundaries_only",
+  "execution_authorized": false,
+  "implementation_authorized": false,
+  "lr_status": "NO-GO",
+  "ranking_ready": false,
+  "evidence_class": "historical_cross_venue_research",
+  "development_selection": {
+    "source_ref": "docs/contracts/batch_a_funnel_manifest.v1.json#/development_selection",
+    "venue": "binance",
+    "symbol": "BTCUSDT",
+    "timeframe": "1m",
+    "purpose": "development",
+    "overlap_class": "monthly",
+    "window_count": 39,
+    "selection_sha256": "3e9ed68736b51fecb299d228c856be80a597cb1dc72fcba595453b856b58bd52"
+  },
+  "stage_a_plan": {
+    "status": "planned_not_authorized",
+    "scenarios": [
+      "baseline",
+      "pessimistic_execution"
+    ],
+    "candidate_count": 5,
+    "window_count": 39,
+    "scenario_count": 2,
+    "planned_scenario_runs": 390
+  },
+  "candidates": [
+    {
+      "strategy_id": "hh_hl_continuation_v1",
+      "longlist_rank": 7,
+      "family": "trend_following",
+      "implementation_mode": "NEW",
+      "implementation_status": "spec_required",
+      "runner_module": null,
+      "hypothesis_boundary": "Enter continuation only from confirmed rising swing-high and swing-low structure; invalidate on structural higher-low failure.",
+      "dedupe_boundary": "Price-structure continuation, not moving-average trend following and not channel breakout.",
+      "required_data": [
+        "open",
+        "high",
+        "low",
+        "close"
+      ],
+      "lookahead_guard": "Swing points must be confirmed using data available at the decision timestamp; no future-bar relabeling."
+    },
+    {
+      "strategy_id": "rsi_momentum_v1",
+      "longlist_rank": 26,
+      "family": "momentum",
+      "implementation_mode": "NEW",
+      "implementation_status": "spec_required",
+      "runner_module": null,
+      "hypothesis_boundary": "Use RSI as a continuation/burst threshold, never as an oversold mean-reversion entry.",
+      "dedupe_boundary": "No price-channel breakout and no ATR-sized directional-candle trigger; distinct from roc_breakout_confirm_v1 and momentum_capture_v1.",
+      "required_data": [
+        "open",
+        "high",
+        "low",
+        "close"
+      ],
+      "lookahead_guard": "RSI must use closed candles only."
+    },
+    {
+      "strategy_id": "high_vol_avoidance_v1",
+      "longlist_rank": 10,
+      "family": "volatility_filter",
+      "implementation_mode": "NEW",
+      "implementation_status": "spec_required",
+      "runner_module": null,
+      "hypothesis_boundary": "Filter-only overlay that blocks entries during chaotic high volatility; it does not generate an alpha entry.",
+      "dedupe_boundary": "Measures activity compression and avoided friction, not volatility breakout or ATR expansion alpha.",
+      "required_data": [
+        "open",
+        "high",
+        "low",
+        "close"
+      ],
+      "lookahead_guard": "Volatility state must be computed from closed candles only."
+    },
+    {
+      "strategy_id": "range_bound_reversion_v1",
+      "longlist_rank": 19,
+      "family": "mean_reversion",
+      "implementation_mode": "NEW",
+      "implementation_status": "spec_required",
+      "runner_module": null,
+      "hypothesis_boundary": "Fade confirmed structural range edges and exit at the range midpoint or structural invalidation.",
+      "dedupe_boundary": "Support/resistance geometry only; no rolling z-score and no Bollinger-band normalized-distance trigger.",
+      "required_data": [
+        "open",
+        "high",
+        "low",
+        "close"
+      ],
+      "lookahead_guard": "Range edges must be confirmed without future bars and frozen for each decision."
+    },
+    {
+      "strategy_id": "mtf_1m_entry_5m_trend_v1",
+      "longlist_rank": 5,
+      "family": "multi_timeframe",
+      "implementation_mode": "NEW",
+      "implementation_status": "spec_required",
+      "runner_module": null,
+      "hypothesis_boundary": "A direction from the last completed derived 5m bar gates a separately specified 1m entry trigger.",
+      "dedupe_boundary": "Exactly one 5m bias layer plus 1m trigger; no 15m hierarchy and no generic htf_bias_ltf_trigger_v1.",
+      "required_data": [
+        "open",
+        "high",
+        "low",
+        "close",
+        "timestamp_ms"
+      ],
+      "lookahead_guard": "At a 1m decision timestamp, only fully closed 5m aggregates may be consumed."
+    }
+  ],
+  "dedupe_resolutions": [
+    {
+      "strategy_id": "bollinger_mean_reversion_v1",
+      "decision": "EXCLUDED_NEAR_DUPLICATE",
+      "compared_against": "range_mean_reversion_v1",
+      "rationale": "Bollinger normalized distance is materially equivalent to rolling mean/standard-deviation z-score logic already screened in Batch A."
+    },
+    {
+      "strategy_id": "htf_bias_ltf_trigger_v1",
+      "decision": "DEFERRED_OVERLAPPING_MTF",
+      "compared_against": "mtf_1m_entry_5m_trend_v1",
+      "rationale": "The lower-complexity rank-5 1m+5m candidate occupies the MTF lane; 5m/15m hierarchy is deferred until it can justify incremental information."
+    }
+  ],
+  "hard_exclusions": {
+    "batch_a_strategy_ids": [
+      "breakout_volatility_filter_v1",
+      "volatility_breakout_v1",
+      "ema_trend_follow_v1",
+      "ma_crossover_v1",
+      "range_mean_reversion_v1",
+      "bollinger_squeeze_breakout_v1",
+      "roc_breakout_confirm_v1",
+      "opening_range_breakout_v1",
+      "atr_expansion_v1",
+      "momentum_capture_v1"
+    ],
+    "campaign_3990_strategy_ids": [
+      "donchian_breakout_v1",
+      "breakout_trend_filter_v1",
+      "primary_breakout_v1"
+    ],
+    "deferred_domains": [
+      "multi_symbol",
+      "spread_liquidity_filter",
+      "regime_switch",
+      "strategy_gearbox"
+    ]
+  },
+  "safety_boundaries": [
+    "LR NO-GO — no live capital, paper promotion, or strategy promotion",
+    "Candidate lock does not authorize implementation or campaign execution",
+    "ranking_ready=false",
+    "Binance historical cross-venue research only; not MEXC same-venue confirmation",
+    "No parameter optimization in the readiness-lock slice"
+  ],
+  "next_gate": "BATCH_B_IMPLEMENTATION_DUAL_GO"
+}

--- a/docs/evidence/arvp_batch_b_readiness_lock_4069.md
+++ b/docs/evidence/arvp_batch_b_readiness_lock_4069.md
@@ -1,0 +1,95 @@
+# ARVP Batch-B Readiness Lock (#4069)
+
+**Parent:** [#1900](https://github.com/jannekbuengener/Claire_de_Binare/issues/1900)  
+**Predecessor:** [#4029](https://github.com/jannekbuengener/Claire_de_Binare/issues/4029) — terminal no-survivors funnel  
+**Technical correction:** [#4065](https://github.com/jannekbuengener/Claire_de_Binare/issues/4065) / PR #4068  
+**Decision:** `BATCH_B_LOCKED` — candidate identity, hypothesis boundaries, and dedupe boundaries only  
+**Execution:** **not authorized**  
+**LR:** **NO-GO** · `ranking_ready=false`
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+context_tool_status: available
+context_trust_level: none
+records_found: none
+```
+
+The Context Brain briefing returned no DB-backed evidence records. All decisions below are therefore traceable to live GitHub state and versioned repository evidence only.
+
+## Input truth
+
+- Batch-A recompute after #4065: 726/780 rankable records, **0 survivors**.
+- Batch-A result is terminal for its ten candidates; no unchanged repeat is allowed.
+- The #3990 three-strategy campaign is also excluded unchanged.
+- Readiness source: `docs/evidence/arvp_batch_b_readiness_4065.md`.
+- Longlist source: `docs/evidence/arvp_strategy_longlist_deep_research_3746.md`.
+- Development selection is reused by reference: 39 non-overlapping Binance BTCUSDT 1m monthly windows, SHA-256 `3e9ed68736b51fecb299d228c856be80a597cb1dc72fcba595453b856b58bd52`.
+
+## Dedupe resolution
+
+| Candidate | Compared with | Decision | Material boundary |
+|---|---|---|---|
+| `bollinger_mean_reversion_v1` | Batch-A `range_mean_reversion_v1` | **EXCLUDED_NEAR_DUPLICATE** | Bollinger distance is rolling mean/std-dev normalization and does not add a sufficiently distinct hypothesis |
+| `range_bound_reversion_v1` | Batch-A `range_mean_reversion_v1` | **LOCKED** | Confirmed structural support/resistance edges; no z-score or Bollinger trigger |
+| `mtf_1m_entry_5m_trend_v1` | `htf_bias_ltf_trigger_v1` | **LOCKED** | One completed-5m bias layer plus separate 1m trigger |
+| `htf_bias_ltf_trigger_v1` | `mtf_1m_entry_5m_trend_v1` | **DEFERRED_OVERLAPPING_MTF** | Additional 15m hierarchy is complexity without proven incremental information |
+
+## Final locked Batch B
+
+| # | strategy_id | Rank | Family | Frozen distinction |
+|---:|---|---:|---|---|
+| 1 | `hh_hl_continuation_v1` | 7 | Trend | Confirmed swing structure; neither MA nor channel breakout |
+| 2 | `rsi_momentum_v1` | 26 | Momentum | RSI continuation/burst, never oversold mean reversion |
+| 3 | `high_vol_avoidance_v1` | 10 | Volatility filter | Filter-only; blocks chaotic-vol entries and makes no alpha claim |
+| 4 | `range_bound_reversion_v1` | 19 | Mean reversion | Structural range-edge fade; no normalized-distance trigger |
+| 5 | `mtf_1m_entry_5m_trend_v1` | 5 | Multi-timeframe | Last completed 5m bar gates a separately specified 1m entry |
+
+The count is evidence-driven rather than forced to 6–8. It preserves five distinct hypothesis lanes after removing tested and overlapping candidates.
+
+## Stage-A planning arithmetic
+
+| Dimension | Count |
+|---|---:|
+| Locked candidates | 5 |
+| Development windows | 39 |
+| Scenarios | 2 (`baseline`, `pessimistic_execution`) |
+| Planned scenario runs | **390** |
+
+This is a planning count only. No runner, queue, replay, or campaign is created or started by this lock.
+
+## Excluded and deferred
+
+- Hard excluded: all ten Batch-A candidates and the three #3990 candidates.
+- Near-duplicate excluded: `bollinger_mean_reversion_v1`.
+- MTF deferred: `htf_bias_ltf_trigger_v1`.
+- Domain deferred: multi-symbol, spread/liquidity filter, regime-switch, and Strategy Gearbox (#205).
+
+## Lock semantics
+
+`BATCH_B_LOCKED` means:
+
+1. Candidate identities cannot change silently.
+2. Hypothesis and dedupe boundaries are normative for the next spec slice.
+3. Numeric parameters, runners, adapters, and campaign artifacts remain absent.
+4. Any candidate substitution requires reopening #4069 or a superseding decision with evidence.
+5. Implementation and execution require a separate explicit Dual-GO.
+
+## Acceptance readback
+
+- [x] Dedupe matrix with evidence
+- [x] Excluded/deferred list
+- [x] Versioned Batch-B lock manifest
+- [x] Five-candidate count justified without size forcing
+- [x] LR NO-GO and no-promotion boundary explicit
+- [x] No runner implementation or campaign start
+
+**Exit gate:** `BATCH_B_LOCKED`  
+**Next gate:** `BATCH_B_IMPLEMENTATION_DUAL_GO`

--- a/tests/unit/contracts/test_batch_b_funnel_manifest_contract.py
+++ b/tests/unit/contracts/test_batch_b_funnel_manifest_contract.py
@@ -1,0 +1,104 @@
+"""Contract tests for the docs-only Batch-B readiness lock (#4069)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MANIFEST_PATH = REPO_ROOT / "docs/contracts/batch_b_funnel_manifest.v1.json"
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+EXPECTED_IDS = {
+    "hh_hl_continuation_v1",
+    "rsi_momentum_v1",
+    "high_vol_avoidance_v1",
+    "range_bound_reversion_v1",
+    "mtf_1m_entry_5m_trend_v1",
+}
+
+
+@pytest.fixture
+def manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_locks_exactly_five_unique_candidates(manifest: dict) -> None:
+    ids = [row["strategy_id"] for row in manifest["candidates"]]
+    assert len(ids) == 5
+    assert len(set(ids)) == 5
+    assert set(ids) == EXPECTED_IDS
+
+
+def test_lock_is_docs_only_and_fail_closed(manifest: dict) -> None:
+    assert manifest["lock_status"] == "BATCH_B_LOCKED"
+    assert manifest["execution_authorized"] is False
+    assert manifest["implementation_authorized"] is False
+    assert manifest["ranking_ready"] is False
+    assert manifest["lr_status"] == "NO-GO"
+    assert manifest["next_gate"] == "BATCH_B_IMPLEMENTATION_DUAL_GO"
+
+
+def test_stage_a_plan_arithmetic_is_consistent(manifest: dict) -> None:
+    plan = manifest["stage_a_plan"]
+    assert plan["status"] == "planned_not_authorized"
+    assert plan["candidate_count"] == len(manifest["candidates"])
+    assert plan["planned_scenario_runs"] == (
+        plan["candidate_count"] * plan["window_count"] * plan["scenario_count"]
+    )
+    assert plan["planned_scenario_runs"] == 390
+
+
+def test_development_selection_reuses_locked_monthly_window_set(manifest: dict) -> None:
+    selection = manifest["development_selection"]
+    assert selection["window_count"] == 39
+    assert selection["overlap_class"] == "monthly"
+    assert selection["purpose"] == "development"
+    assert (
+        selection["selection_sha256"]
+        == "3e9ed68736b51fecb299d228c856be80a597cb1dc72fcba595453b856b58bd52"
+    )
+
+
+def test_all_candidates_require_spec_and_have_no_runner(manifest: dict) -> None:
+    for candidate in manifest["candidates"]:
+        assert candidate["implementation_status"] == "spec_required"
+        assert candidate["runner_module"] is None
+        assert candidate["hypothesis_boundary"]
+        assert candidate["dedupe_boundary"]
+        assert candidate["lookahead_guard"]
+
+
+def test_mean_reversion_lane_excludes_bollinger_near_duplicate(
+    manifest: dict,
+) -> None:
+    resolutions = {
+        row["strategy_id"]: row["decision"]
+        for row in manifest["dedupe_resolutions"]
+    }
+    assert resolutions["bollinger_mean_reversion_v1"] == "EXCLUDED_NEAR_DUPLICATE"
+    assert "range_bound_reversion_v1" in EXPECTED_IDS
+
+
+def test_mtf_lane_is_single_and_closed_bar_only(manifest: dict) -> None:
+    by_id = {row["strategy_id"]: row for row in manifest["candidates"]}
+    mtf = by_id["mtf_1m_entry_5m_trend_v1"]
+    assert "fully closed 5m aggregates" in mtf["lookahead_guard"]
+    assert "htf_bias_ltf_trigger_v1" not in EXPECTED_IDS
+
+
+def test_filter_lane_makes_no_alpha_entry_claim(manifest: dict) -> None:
+    by_id = {row["strategy_id"]: row for row in manifest["candidates"]}
+    high_vol = by_id["high_vol_avoidance_v1"]
+    assert high_vol["family"] == "volatility_filter"
+    assert "does not generate an alpha entry" in high_vol["hypothesis_boundary"]
+
+
+def test_batch_a_and_3990_candidates_are_disjoint(manifest: dict) -> None:
+    locked = EXPECTED_IDS
+    hard = manifest["hard_exclusions"]
+    assert locked.isdisjoint(hard["batch_a_strategy_ids"])
+    assert locked.isdisjoint(hard["campaign_3990_strategy_ids"])


### PR DESCRIPTION
## Summary

Closes #4069 with a docs-only Batch-B readiness lock.

- Locks five evidence-distinct strategy candidates.
- Resolves the remaining mean-reversion and multi-timeframe dedupe questions.
- Adds a versioned manifest plus contract tests.
- Keeps implementation, runners, queue generation, and campaign execution explicitly unauthorized.

## Locked candidate set

1. `hh_hl_continuation_v1`
2. `rsi_momentum_v1`
3. `high_vol_avoidance_v1`
4. `range_bound_reversion_v1`
5. `mtf_1m_entry_5m_trend_v1`

## Dedupe decisions

- `bollinger_mean_reversion_v1`: excluded as a near-duplicate of the already screened rolling z-score mean-reversion lane.
- `htf_bias_ltf_trigger_v1`: deferred because the lower-complexity rank-5 1m+5m candidate occupies the Batch-B MTF lane.

## Planning boundary

The manifest records 5 candidates × 39 development windows × 2 scenarios = 390 planned scenario runs. This PR does not create or execute those runs.

`execution_authorized=false`  
`implementation_authorized=false`  
`ranking_ready=false`  
LR remains `NO-GO`.

## Validation

- Manifest JSON parse and invariant checks: pass.
- Candidate uniqueness/exact-set contract: pass.
- Planning arithmetic and safety flags: pass.
- Python contract-test syntax compilation: pass.
- Full repository CI: pending on this PR.

## Brain Evidence

`brain_source=repo-only`; Context Brain returned no usable records, so the decision is traced only to live GitHub state and versioned repository evidence.

Refs #1900 #4029 #4065 #4068.