### PR TITLE
docs(guard): reconcile active env test strategy and metrics surfaces

### DIFF
--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -10,15 +10,16 @@ Nicht exhaustiv; diese Seite zeigt die Canon-Pointer.
 | `TRADING_MODE` | `paper` | Trading-Mode-Auswahl, Execution-Logging | [`core/config/trading_mode.py`](../../core/config/trading_mode.py) |
 | `LIVE_TRADING_CONFIRMED` | unset | Human gate fuer `TRADING_MODE=live` | [`core/config/trading_mode.py`](../../core/config/trading_mode.py) |
 | `MOCK_TRADING` | `true` | Execution-Service waehlt Non-Live statt Live-Executor | [`services/execution/config.py`](../../services/execution/config.py), [`services/execution/service.py`](../../services/execution/service.py) |
-| `MOCK_EXECUTION_MODE` | `simple` | Opt-in fuer expliziten Mock-Pfad: `simple`=`MockExecutor`, `simulator`=`SimulatorExecutor` | [`services/execution/config.py`](../../services/execution/config.py), [`services/execution/service.py`](../../services/execution/service.py), [`services/execution/simulator_executor.py`](../../services/execution/simulator_executor.py) |
-| `SIMULATOR_ORDER_BOOK_DEPTH` / `SIMULATOR_VOLATILITY` | `1000000` / `0.02` | Tuning fuer den market-like, nicht-live Simulator-Pfad | [`services/execution/config.py`](../../services/execution/config.py), [`services/execution/simulator_executor.py`](../../services/execution/simulator_executor.py) |
 | `CDB_CONTROL_BOARD_AUTOMATION_ENABLED` | `false` | Control-Board-Routing und Upsert | [docs/runbooks/control_board_board_as_code.md](../runbooks/control_board_board_as_code.md) |
 | `POSTGRES_SSLMODE` | `prefer` | Postgres-DSN / SSL-Verbindung | [`core/utils/postgres_client.py`](../../core/utils/postgres_client.py), [`infrastructure/tls/TLS_SETUP.md`](../../infrastructure/tls/TLS_SETUP.md) |
 | `SECRETS_PATH` | lokal: `~/Documents/.secrets/.cdb`, CI: `${{ github.workspace }}/.ci-secrets` | Compose, Bootstrap, E2E/Soak | BLUE+RED compose (`compose.blue.yml` / `compose.red.yml`), [`infrastructure/scripts/bootstrap_local.sh`](../../infrastructure/scripts/bootstrap_local.sh), [tests/fixtures/README.md](../../tests/fixtures/README.md) |
 | `CDB_EXTERNAL_TESTS` | off | Opt-in fuer externe Integrations-Tests | [`tests/integration/test_mexc_testnet.py`](../../tests/integration/test_mexc_testnet.py) |
 | `surrealdb_enabled` / `governance_source` | `false` / `git` | SurrealDB-Mirror und Governance-Read-Quelle | [`infrastructure/config/surrealdb/feature-flags.yaml`](../../infrastructure/config/surrealdb/feature-flags.yaml), [docs/surrealdb/rollback-cutover-plan.md](../surrealdb/rollback-cutover-plan.md) |
 
-Safety-Hinweis: `MOCK_EXECUTION_MODE=simulator` wird nur beachtet, wenn `MOCK_TRADING=true` ist. Der Pfad bleibt explizit non-live und schaltet keinen echten Exchange-Zugriff frei.
+`MOCK_EXECUTION_MODE`, `SIMULATOR_ORDER_BOOK_DEPTH` und `SIMULATOR_VOLATILITY`
+sind keine belegten Runtime-Variablen. Es existiert kein aktueller
+`SimulatorExecutor`-Pfad. Solche Flags duerfen erst dokumentiert werden, wenn ein
+Code-/Config-Consumer und ein getesteter Contract vorhanden sind.
 
 ## GitHub-Automation Secrets
 
@@ -52,27 +53,21 @@ Canon-Pointer:
 
 For later Agent-/MCP-readonly discovery, prefer a dedicated DSN secret name:
 
-- `POSTGRES_READONLY_PASSWORD_DSN` - preferred DSN name for a dedicated readonly
-  login such as `cdb_readonly`
-- `POSTGRES_READONLY_PASSWORD` - optional raw password secret if the operator
-  path keeps password and DSN separately
+- `POSTGRES_READONLY_PASSWORD_DSN` - preferred DSN name for a dedicated readonly login such as `cdb_readonly`
+- `POSTGRES_READONLY_PASSWORD` - optional raw password secret if the operator path keeps password and DSN separately
 
 Canonical operator bridge for the login-creation step:
 
 - secret store file: `POSTGRES_READONLY_PASSWORD`
 - temporary operator-shell variable: `CDB_READONLY_PASSWORD`
-- consumer: `psql -v CDB_READONLY_PASSWORD=...` for
-  `infrastructure/database/operator_create_readonly_login.sql`
+- consumer: `psql -v CDB_READONLY_PASSWORD=...` for `infrastructure/database/operator_create_readonly_login.sql`
 
 Guardrails:
 
 - Secret values stay outside the repo in the canonical secret store.
-- Runtime-service credentials such as `claire_user` / `POSTGRES_PASSWORD` are
-  not acceptable for Agent-/MCP-discovery.
-- `CDB_READONLY_PASSWORD` is only a temporary operator bridge variable. The
-  canonical stored secret remains `POSTGRES_READONLY_PASSWORD`.
-- The canonical readonly-login boundary is documented in
-  [`docs/runbooks/postgres_least_privilege_rls.md`](../runbooks/postgres_least_privilege_rls.md).
+- Runtime-service credentials such as `claire_user` / `POSTGRES_PASSWORD` are not acceptable for Agent-/MCP-discovery.
+- `CDB_READONLY_PASSWORD` is only a temporary operator bridge variable. The canonical stored secret remains `POSTGRES_READONLY_PASSWORD`.
+- The canonical readonly-login boundary is documented in [`docs/runbooks/postgres_least_privilege_rls.md`](../runbooks/postgres_least_privilege_rls.md).
 
 ## Wenn du etwas nachschlagen willst
 

--- a/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
+++ b/docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
@@ -109,7 +109,7 @@ Rules:
 - **No DB-Go.** No document in this lab authorises database writes, migrations, or schema changes.
 - **No Risk-/Execution-/Allocation-Go.** No document in this lab overrides risk limits, execution gates, or allocation policies.
 - **Repo canon wins.** The active Claire de Binare repository, its issues, PRs, required checks, governance documents, and live-readiness SSOT override every document in this lab.
-- **CDB governance applies.** All rules from the [CDB Constitution](../knowledge/governance/CDB_CONSTITUTION.md), [CDB Governance](../knowledge/governance/CDB_GOVERNANCE.md), and [CDB Agent Policy](../knowledge/governance/CDB_AGENT_POLICY.md) apply to any activity that moves from lab discussion into repo work.
+- **CDB governance applies.** All rules from the [CDB Constitution](../../knowledge/governance/CDB_CONSTITUTION.md), [CDB Governance](../../knowledge/governance/CDB_GOVERNANCE.md), and [CDB Agent Policy](../../knowledge/governance/CDB_AGENT_POLICY.md) apply to any activity that moves from lab discussion into repo work.
 - **Board stage `trade-capable` is orthogonal.** The Board stage does not imply live-readiness, and lab documents do not change Board stage.
 
 ## Status

--- a/infrastructure/compose/TEST_OVERLAY_README.md
+++ b/infrastructure/compose/TEST_OVERLAY_README.md
@@ -1,460 +1,131 @@
-# Test Overlay - Isolated E2E Test Execution
+# Test Overlay — Isolated E2E Test Execution
 
-**Purpose**: Provides isolated test stack for running E2E tests without affecting development or production data.
-**Status**: Canonical Docker CI lab baseline for 431B (`base.yml + test.yml`).
+**Purpose:** Isolated Docker test stack for E2E validation without using development or production data.  
+**Status:** Canonical Docker CI lab baseline for 431B (`base.yml + test.yml`).
 
----
+## Quick start
 
-## Quick Start
-
-### Run E2E Tests in Isolated Stack
+From the repository root:
 
 ```bash
-# From project root
 cd infrastructure/compose
-
-# Start test stack and run tests (auto-exit when done)
-docker compose -f base.yml -f test.yml up --abort-on-container-exit
-
-# Alternative: Build fresh and run
 docker compose -f base.yml -f test.yml up --build --abort-on-container-exit
 ```
 
-**Expected Output**:
-```
-cdb_test_runner  | ============================================
-cdb_test_runner  | E2E Test Runner Starting...
-cdb_test_runner  | ============================================
-cdb_test_runner  | Waiting for services to be ready...
-cdb_test_runner  | Services Status:
-cdb_test_runner  |   - Redis: cdb_redis_test
-cdb_test_runner  |   - Postgres: cdb_postgres_test
-cdb_test_runner  |   - Risk: cdb_risk_test
-cdb_test_runner  |   - Execution: cdb_execution_test
-cdb_test_runner  | Running E2E tests...
-cdb_test_runner  | ============================= test session starts ==============================
-cdb_test_runner  | collected 66 items / 61 deselected / 5 selected
-cdb_test_runner  |
-cdb_test_runner  | tests/e2e/test_paper_trading_p0.py::test_order_to_execution_flow PASSED  [ 20%]
-cdb_test_runner  | tests/e2e/test_paper_trading_p0.py::test_order_results_schema PASSED     [ 40%]
-cdb_test_runner  | tests/e2e/test_paper_trading_p0.py::test_stream_persistence PASSED       [ 60%]
-cdb_test_runner  | tests/e2e/test_paper_trading_p0.py::test_subscriber_count PASSED         [ 80%]
-cdb_test_runner  | tests/e2e/test_paper_trading_p0.py::test_replay_determinism FAILED       [100%]
-cdb_test_runner  | =========== 1 failed, 4 passed, 61 deselected, 63 warnings in 8.33s ============
-cdb_test_runner  | ============================================
-cdb_test_runner  | E2E Tests Complete!
-cdb_test_runner  | ============================================
-```
+The overlay starts isolated Redis and Postgres services, the Risk and Execution
+test services, and `cdb_test_runner`. It does not authorize or start live trading.
 
-**Known Issues**:
-- `test_replay_determinism` fails on Windows due to charmap encoding bug (pre-existing issue, not a regression)
-- Expected pass rate: 80% (4/5 tests)
+## Current P0 test contract
 
----
+The active P0 source is:
 
-## Architecture
+- [`tests/e2e/test_paper_trading_p0.py`](../../tests/e2e/test_paper_trading_p0.py)
 
-### Overlay Pattern
+The file currently defines **10 E2E tests**. The container command selects E2E
+tests through the `e2e` marker:
 
-The test overlay extends the base infrastructure with test-specific overrides:
-
-```
-base.yml          # Core infrastructure (Redis, Postgres, network)
-  +
-test.yml          # Test overrides (isolated volumes, test runner)
-  =
-Isolated test stack
-```
-
-For 431B, this is the canonical Docker CI lab baseline.
-`base.yml + dev.yml` remains a secondary local/compatibility path and is not the CI-lab default.
-
-### Key Isolation Features
-
-1. **Separate Containers**
-   - `cdb_redis_test` (instead of `cdb_redis`)
-   - `cdb_postgres_test` (instead of `cdb_postgres`)
-
-2. **Isolated Volumes**
-   - `redis_test_data` (not shared with dev/prod)
-   - `postgres_test_data` (not shared with dev/prod)
-
-3. **Test Database**
-   - Database name: `claire_de_binare_test`
-   - Schema loaded from `schema.sql` on init
-   - Migrations applied automatically
-
-4. **Test Runner Service**
-   - Runs pytest with E2E marker
-   - Auto-exits when tests complete
-   - Logs visible in console output
-
----
-
-## Services
-
-### cdb_redis_test
-
-**Override Changes**:
-- Container name: `cdb_redis_test`
-- Volume: `redis_test_data` (isolated)
-- Network: `cdb_test_network` (isolated from dev/prod)
-- All other settings inherited from base.yml
-
-### cdb_postgres_test
-
-**Override Changes**:
-- Container name: `cdb_postgres_test`
-- Volume: `postgres_test_data` (isolated)
-- Database name: `claire_de_binare_test`
-- Healthcheck: Updated to check `claire_de_binare_test` database
-- Network: `cdb_test_network` (isolated from dev/prod)
-- Schema: Loaded from `schema.sql` + migrations
-
-### cdb_risk_test (NEW)
-
-**Purpose**: Risk management service for E2E tests
-
-**Configuration**:
-- Dockerfile: `services/risk/Dockerfile`
-- Environment:
-  - `REDIS_HOST=cdb_redis_test`
-  - `POSTGRES_HOST=cdb_postgres_test`
-  - `E2E_RUN=1`, `E2E_DISABLE_CIRCUIT_BREAKER=1`
-  - `TRADING_MODE=paper`, `DRY_RUN=1`
-  - `LOG_LEVEL=DEBUG`
-- Depends on: Redis + Postgres (healthy)
-- Network: `cdb_test_network`
-
-### cdb_execution_test (NEW)
-
-**Purpose**: Order execution service for E2E tests
-
-**Configuration**:
-- Dockerfile: `services/execution/Dockerfile`
-- Environment:
-  - `REDIS_HOST=cdb_redis_test`
-  - `POSTGRES_HOST=cdb_postgres_test`
-  - `E2E_RUN=1`, `E2E_DISABLE_CIRCUIT_BREAKER=1`
-  - `TRADING_MODE=paper`, `DRY_RUN=1`
-  - `LOG_LEVEL=DEBUG`
-- Depends on: Redis + Postgres (healthy)
-- Network: `cdb_test_network`
-
-### cdb_test_runner (NEW)
-
-**Purpose**: Containerized pytest execution
-
-**Build**:
-- Dockerfile: `infrastructure/compose/Dockerfile.test`
-- Base image: `python:3.12-slim`
-- Dependencies: pytest, psycopg2-binary, all service requirements
-
-**Environment**:
-- `POSTGRES_HOST=cdb_postgres_test`
-- `POSTGRES_DB=claire_de_binare_test`
-- `REDIS_HOST=cdb_redis_test`
-- `E2E_RUN=1` (enables E2E tests)
-- `E2E_DISABLE_CIRCUIT_BREAKER=1` (prevents retries in tests)
-
-**Volumes (Read-Only)**:
-- `/app/core` → Source code
-- `/app/services` → Service modules
-- `/app/tests` → Test suite
-- `/app/infrastructure` → Test fixtures
-
-**Volumes (Writable)**:
-- `/app/logs` → Test execution logs
-
-**Command**:
 ```bash
 pytest -m e2e tests/ -v --tb=short --no-cov -p no:cacheprovider --maxfail=3
 ```
 
----
+Expected result for a healthy stack is a fully green selected E2E run. The old
+five-test example and the expected Windows charmap failure are historical and no
+longer describe the current UTF-8-safe test behavior.
 
-## Usage Patterns
+Do not hard-code a repository-wide collected/deselected count here. That count
+changes whenever unrelated E2E tests are added. The authoritative count for the
+P0 slice is the set of test functions in the active P0 file.
 
-### 1. Quick E2E Test Run
+## Overlay pattern
 
-```bash
-# Start, test, auto-exit
-docker compose -f base.yml -f test.yml up --abort-on-container-exit
+```text
+base.yml          core Redis/Postgres/network services
+  +
+test.yml          isolated test overrides and test runner
+  =
+isolated E2E stack
 ```
 
-### 2. Rebuild Before Testing
+`base.yml + dev.yml` remains a secondary local compatibility path and is not the
+canonical 431B CI-lab path.
+
+## Isolation boundaries
+
+- Test containers use test-specific names and volumes.
+- The test database is `claire_de_binare_test`.
+- Test services use `TRADING_MODE=paper` and `DRY_RUN=1`.
+- `E2E_RUN=1` enables the guarded E2E tests.
+- Test data and volumes are disposable.
+- No live exchange credentials or real-money path is required.
+
+## Main services
+
+| Service | Role |
+|---|---|
+| `cdb_redis_test` | isolated Redis transport |
+| `cdb_postgres_test` | isolated test database |
+| `cdb_risk_test` | Risk service for the test flow |
+| `cdb_execution_test` | paper/non-live Execution service |
+| `cdb_test_runner` | containerized pytest runner |
+
+The concrete service definitions and environment values are authoritative in:
+
+- [`base.yml`](base.yml)
+- [`test.yml`](test.yml)
+- [`Dockerfile.test`](Dockerfile.test)
+
+## Useful commands
+
+Rebuild only the test runner:
 
 ```bash
-# Force rebuild test runner image
 docker compose -f base.yml -f test.yml build --no-cache cdb_test_runner
+```
 
-# Run with fresh image
+Run the stack in the foreground:
+
+```bash
 docker compose -f base.yml -f test.yml up --abort-on-container-exit
 ```
 
-### 3. Keep Stack Running for Debugging
+Inspect the runner:
 
 ```bash
-# Start test stack (don't auto-exit)
-docker compose -f base.yml -f test.yml up -d
-
-# View logs
-docker logs cdb_test_runner -f
-
-# Stop when done
-docker compose -f base.yml -f test.yml down
-```
-
-### 4. Run Specific Tests
-
-Edit `test.yml` line 86 to change pytest command:
-
-```yaml
-# Example: Run only one test
-pytest tests/e2e/test_paper_trading_p0.py::test_order_to_execution_flow -v
-
-# Example: Run with more verbose output
-pytest -m e2e tests/ -vv --tb=long
-```
-
----
-
-## Validation
-
-### Verify Stack Starts Correctly
-
-```bash
-# Start stack
-docker compose -f base.yml -f test.yml up -d
-
-# Check all services healthy
-docker ps --filter "name=cdb_" --format "table {{.Names}}\t{{.Status}}"
-```
-
-**Expected**:
-```
-NAMES                 STATUS
-cdb_test_runner       Up X seconds
-cdb_postgres_test     Up X seconds (healthy)
-cdb_redis_test        Up X seconds (healthy)
-```
-
-### Verify Test Runner Execution
-
-```bash
-# Check test runner logs
 docker logs cdb_test_runner
 ```
 
-**Expected**:
-- "E2E Test Runner Starting..."
-- "Running E2E tests..."
-- pytest output with test results
-- "E2E Tests Complete!"
+Clean the isolated stack and volumes:
 
----
+```bash
+docker compose -f base.yml -f test.yml down -v
+```
 
 ## Troubleshooting
 
-### 1. Network Not Found Error
+When the runner exits before tests execute, check in this order:
 
-**Symptom**:
-```
-ERROR: Network cdb_network declared as external, but could not be found
-```
+1. Redis and Postgres health.
+2. Test service hostnames from `test.yml`.
+3. Secret mounts required by the test stack.
+4. Python dependencies in `Dockerfile.test`.
+5. Full `cdb_test_runner` logs.
 
-**Fix**:
-```bash
-# Create network manually
-docker network create cdb_network
+Do not fix documentation drift by weakening tests or adding runtime behavior.
+Update this file only from current Compose, Dockerfile, and P0-test evidence.
 
-# Secondary fallback only: start dev stack first to create the shared network
-# This is not the canonical 431B CI-lab path.
-docker compose -f base.yml -f dev.yml up -d
-docker compose -f base.yml -f dev.yml down
+## Verification
 
-# Then run test stack
-docker compose -f base.yml -f test.yml up --abort-on-container-exit
-```
-
-### 2. Test Runner Exits Immediately
-
-**Symptom**: `cdb_test_runner` exits with code 0 or 1 before running tests
-
-**Check Logs**:
-```bash
-docker logs cdb_test_runner
-```
-
-**Common Issues**:
-- **Database not ready**: Test runner starts before Postgres healthy
-  - Fix: Check `depends_on` healthchecks in test.yml
-- **Import errors**: Missing Python dependencies
-  - Fix: Rebuild image with `--no-cache`
-- **Connection refused**: Wrong service hostnames
-  - Fix: Verify POSTGRES_HOST=cdb_postgres_test (not cdb_redis_test!)
-
-### 3. Tests Fail with Connection Errors
-
-**Symptom**: Tests fail with `psycopg2.OperationalError: could not connect`
-
-**Debug**:
-```bash
-# Check Postgres is healthy
-docker exec cdb_postgres_test pg_isready -U claire_user -d claire_de_binare_test
-
-# Check network connectivity
-docker exec cdb_test_runner ping -c 3 cdb_postgres_test
-
-# Verify environment variables
-docker exec cdb_test_runner env | grep POSTGRES
-```
-
-### 4. Volume Permission Issues
-
-**Symptom**: `Permission denied` errors in logs directory
-
-**Fix**:
-```bash
-# Ensure logs directory exists and is writable
-mkdir -p logs
-chmod 777 logs  # Or appropriate permissions for your setup
-```
-
----
-
-## Cleanup
-
-### Remove Test Volumes
+Static verification:
 
 ```bash
-# Stop test stack
-docker compose -f base.yml -f test.yml down
-
-# Remove test volumes (deletes all test data!)
-docker volume rm claire_de_binare_redis_test_data
-docker volume rm claire_de_binare_postgres_test_data
+python -m tools.validate_readme_links
 ```
 
-### Remove Test Images
+Runtime verification is optional and must remain isolated:
 
 ```bash
-# Remove test runner image
-docker rmi claire_de_binare-cdb_test_runner:latest
+docker compose -f infrastructure/compose/base.yml \
+  -f infrastructure/compose/test.yml config
 ```
 
-### Full Reset
-
-```bash
-# Stop and remove everything
-docker compose -f base.yml -f test.yml down -v --rmi local
-
-# Verify cleanup
-docker ps -a | grep cdb_test
-docker volume ls | grep test_data
-```
-
----
-
-## CI/CD Integration
-
-### GitHub Actions Example
-
-```yaml
-name: E2E Tests
-
-on: [push, pull_request]
-
-jobs:
-  e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create .env file
-        run: |
-          echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> .env
-          echo "REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}" >> .env
-
-      - name: Run E2E Tests
-        run: |
-          cd infrastructure/compose
-          docker compose -f base.yml -f test.yml up --abort-on-container-exit
-
-      - name: Upload test logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-logs
-          path: logs/
-```
-
----
-
-## Best Practices
-
-1. **Always use test overlay for automated testing**
-   - Never run E2E tests against dev or prod stack
-   - Test volumes are isolated and disposable
-
-2. **Clean volumes between test runs for determinism**
-   - `docker compose -f base.yml -f test.yml down -v`
-   - Ensures fresh database state each run
-
-3. **Use DB fixtures for test data**
-   - See `tests/fixtures/README.md`
-   - Fixtures provide deterministic seed data
-
-4. **Check test runner exit code in CI**
-   - Exit code 0 = all tests passed
-   - Exit code 1 = tests failed
-   - Non-zero exit = test execution error
-
-5. **Review logs after failures**
-   - `docker logs cdb_test_runner`
-   - Test logs in `logs/` directory
-
----
-
-## Related Documentation
-
-- [Test Fixtures](../../tests/fixtures/README.md) - Database fixtures for E2E tests
-- [Test Baseline](../../docs/testing/test_baseline.md) - Test inventory and categories
-- [Markers](../../docs/testing/markers.md) - Pytest marker taxonomy
-
----
-
-## Technical Details
-
-### Environment Variables Required
-
-See `.env` file for all required variables. Key test-specific vars:
-
-| Variable | Value | Purpose |
-|----------|-------|---------|
-| `POSTGRES_HOST` | `cdb_postgres_test` | Test database host |
-| `POSTGRES_DB` | `claire_de_binare_test` | Test database name |
-| `REDIS_HOST` | `cdb_redis_test` | Test Redis host |
-| `E2E_RUN` | `1` | Enable E2E test execution |
-| `E2E_DISABLE_CIRCUIT_BREAKER` | `1` | Disable retries in tests |
-
-### Network Configuration
-
-- Network name: `cdb_network` (external, created by base.yml)
-- Driver: bridge
-- Isolation: All test containers on same network for connectivity
-
-### Volume Mounts
-
-**Source Code (Read-Only)**:
-- Ensures tests run against actual codebase
-- No test execution can modify source
-
-**Logs (Writable)**:
-- Allows test runner to write execution logs
-- Persists even after container exits
-
----
-
-**Status**: ✅ Production-ready (Issue #274)
-**Last Updated**: 2025-12-27
+Rendering Compose configuration does not start containers.

--- a/infrastructure/monitoring/METRICS_MATRIX.md
+++ b/infrastructure/monitoring/METRICS_MATRIX.md
@@ -2,128 +2,119 @@
 
 Repo-backed SSOT for Prometheus-scraped metrics in the Claire de Binare repository.
 
-Scope of this file:
-- inventory and canon only
-- no dashboard spec
-- no operator KPI shortlist
-- no new telemetry
+## Authority
 
-Collection authority:
-- Prometheus scrape plan: `infrastructure/monitoring/prometheus.yml`
-- Runtime/job evidence: `infrastructure/compose/compose.blue.yml`, `infrastructure/compose/compose.red.yml`, `infrastructure/compose/base.yml`, `infrastructure/compose/dev.yml`
-- Metric producer evidence: service code and exporter wiring in the repo
-- Grafana is downstream only and is not a source-of-truth surface for this file
+This file is the authoritative inventory for active scrape jobs and repo-backed
+metric names.
 
-## Ist-Zustand
+Primary evidence:
 
-- Prometheus currently defines 10 scrape jobs in `infrastructure/monitoring/prometheus.yml`.
-- Repo-backed custom `/metrics` producers exist for `cdb_risk`, `cdb_execution`, `cdb_signal`, `cdb_db_writer`, `cdb_ws`, and `cdb_candles`.
-- Repo-backed exporter jobs exist for `cdb_postgres`, `cdb_redis`, and `cdb_cadvisor`.
-- `cdb_paper_runner` exists as a repo-backed runtime service, but it is intentionally not part of the active Prometheus scrape canon because the service only exposes `/health` and `/status`.
-- `cdb_node_exporter` is intentionally not part of the active BLUE+RED runtime canon; `#1528` removed the historical `base.yml` / `dev.yml` wiring and the Prometheus scrape job instead of restoring the exporter.
-- `infrastructure/monitoring/KPI_REFERENCE.md` had become broader than the repo-backed metric surface and is now reduced to a front-door pointer to this file.
+- [`prometheus.yml`](prometheus.yml) — scrape plan
+- [`compose.blue.yml`](../compose/compose.blue.yml) and [`compose.red.yml`](../compose/compose.red.yml) — active runtime wiring
+- [`base.yml`](../compose/base.yml) and [`dev.yml`](../compose/dev.yml) — compatibility/test wiring where still referenced
+- service code and exporter configuration — metric producer evidence
 
-## Scrape Jobs
+[`KPI_REFERENCE.md`](KPI_REFERENCE.md) is only a front-door pointer. It does not
+define additional metric names and must not be used as a parallel KPI canon.
+Grafana dashboards are downstream consumers, not sources of truth.
 
-| job_name | source_service / exporter | scrape_target / endpoint | Runtime evidence | status | Notes |
-|---|---|---|---|---|---|
-| `prometheus` | Prometheus self-scrape | `localhost:9090/metrics` | `infrastructure/monitoring/prometheus.yml` | `aktiv` | Self metrics plus Prometheus-generated `up` |
-| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `services/execution/service.py` | `aktiv` | Manual text/plain metrics endpoint |
-| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `services/signal/service.py` | `aktiv` | Manual text/plain metrics endpoint |
-| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `services/candles/service.py` | `aktiv` | Marked `env=dev` in scrape config |
-| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `services/db_writer/db_writer.py` | `aktiv` | `prometheus_client.start_http_server()` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `services/risk/service.py` | `aktiv` | Manual text/plain metrics endpoint |
-| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `services/ws/service.py` | `aktiv` | `prometheus_client.generate_latest()` |
-| `cdb_postgres` | postgres-exporter | `cdb_postgres_exporter:9187/metrics` | `infrastructure/compose/base.yml`, `infrastructure/compose/compose.red.yml` | `aktiv` | Standard exporter surface; exact collector set not customized in repo |
-| `cdb_redis` | redis-exporter | `cdb_redis_exporter:9121/metrics` | `infrastructure/compose/base.yml`, `infrastructure/compose/compose.red.yml` | `aktiv` | Standard exporter surface; exact collector set not customized in repo |
-| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `infrastructure/compose/base.yml`, `infrastructure/compose/compose.red.yml` | `aktiv` | Container resource metrics |
-Note:
-- Prometheus generates `up{job,instance,...}` for every configured scrape target. To avoid duplicating one row per job, `up` is only called out below where it is the main known signal for a drifted or exporter-backed target.
+## Active scrape jobs
 
-## Metrics Matrix
+| job_name | target | Producer evidence | Status |
+|---|---|---|---|
+| `prometheus` | `localhost:9090/metrics` | Prometheus self-scrape | active |
+| `cdb_execution` | `cdb_execution:8003/metrics` | [`services/execution/service.py`](../../services/execution/service.py) | active |
+| `cdb_signal` | `cdb_signal:8005/metrics` | [`services/signal/service.py`](../../services/signal/service.py) | active |
+| `cdb_candles` | `cdb_candles:8007/metrics` | [`services/candles/service.py`](../../services/candles/service.py) | active |
+| `cdb_db_writer` | `cdb_db_writer:8010/metrics` | [`services/db_writer/db_writer.py`](../../services/db_writer/db_writer.py) | active |
+| `cdb_risk` | `cdb_risk:8002/metrics` | [`services/risk/service.py`](../../services/risk/service.py) | active |
+| `cdb_ws` | `cdb_ws:8000/metrics` | [`services/ws/service.py`](../../services/ws/service.py) | active |
+| `cdb_postgres` | `cdb_postgres_exporter:9187/metrics` | postgres-exporter wiring | active |
+| `cdb_redis` | `cdb_redis_exporter:9121/metrics` | redis-exporter wiring | active |
+| `cdb_cadvisor` | `cdb_cadvisor:8080/metrics` | cAdvisor wiring | active |
 
-### Repo-backed custom service metrics
+`cdb_paper_runner` is not part of the active scrape canon because its current
+service surface exposes health/status endpoints rather than a repo-backed
+Prometheus metrics endpoint. `cdb_node_exporter` is not part of the active
+BLUE+RED runtime canon.
 
-| job_name | source_service / exporter | scrape_target / endpoint | metric_name | type | kurze Bedeutung | class | status | labels | spaetere dashboard_eignung |
-|---|---|---|---|---|---|---|---|---|---|
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `signals_received_total` | `counter` | Count of signals consumed from Redis PubSub | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_approved_total` | `counter` | Orders approved by risk checks and forwarded | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_blocked_total` | `counter` | Orders blocked by risk checks | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_skipped_total` | `counter` | Orders skipped due to qty/parsing edge cases | `mixed/unclear` | `aktiv` | none visible | `unklar` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `circuit_breaker_active` | `gauge` | Circuit breaker state, `1` when tripped | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `order_results_received_total` | `counter` | Count of execution result events processed by risk | `mixed/unclear` | `aktiv` | none visible | `unklar` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `orders_rejected_execution_total` | `counter` | Orders rejected downstream by execution | `mixed/unclear` | `aktiv` | none visible | `kandidat` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_pending_orders_total` | `gauge` | Current number of pending order confirmations | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_total_exposure_value` | `gauge` | Current total notional exposure | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_reduce_only_approved_total` | `counter` | Reduce-only sells approved while over exposure limit | `business` | `aktiv` | none visible | `unklar` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_proactive_unwind_triggered_total` | `counter` | Auto-unwind triggers raised by risk logic | `business` | `aktiv` | none visible | `unklar` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_alerts_generated_total` | `counter` | Alerts published to Redis topic `alerts` | `mixed/unclear` | `aktiv` | none visible | `unklar` |
-| `cdb_risk` | Risk Service | `cdb_risk:8002/metrics` | `risk_kill_switch_active` | `gauge` | Kill-switch state, `1` when trading is halted | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_orders_received_total` | `counter` | Orders received by execution | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_orders_filled_total` | `counter` | Orders filled successfully | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_orders_rejected_total` | `counter` | Orders rejected by execution | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_invalid_payloads_total` | `counter` | Invalid order payloads dropped fail-closed | `mixed/unclear` | `aktiv` | none visible | `unklar` |
-| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_shadow_blocked_total` | `counter` | Orders blocked by shadow-mode gate | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_execution` | Execution Service | `cdb_execution:8003/metrics` | `execution_uptime_seconds` | `gauge` | Service uptime in seconds | `infra` | `aktiv` | none visible | `eher nicht` |
-| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signals_generated_total` | `counter` | Signals emitted by the signal engine | `business` | `aktiv` | none visible | `kandidat` |
-| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signal_engine_status` | `gauge` | Service status, `1` when running | `infra` | `aktiv` | none visible | `unklar` |
-| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signal_processing_latency_ms` | `histogram` | Signal processing latency histogram | `mixed/unclear` | `aktiv` | `le` | `kandidat` |
-| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `signal_errors_total` | `counter` | Signal processing errors by error type | `mixed/unclear` | `aktiv` | `error_type` when present | `kandidat` |
-| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `db_writer_events_processed_total` | `counter` | Persisted Redis events by subscribed channel | `mixed/unclear` | `aktiv` | `channel` | `kandidat` |
-| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `db_writer_events_failed_total` | `counter` | Failed persistence attempts by subscribed channel | `mixed/unclear` | `aktiv` | `channel` | `kandidat` |
-| `cdb_db_writer` | DB Writer | `cdb_db_writer:8010/metrics` | `db_writer_uptime_seconds` | `gauge` | Service uptime in seconds | `infra` | `aktiv` | none visible | `eher nicht` |
-| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `decoded_messages_total` | `counter` | Decoded WebSocket market-data messages | `mixed/unclear` | `aktiv` | none visible | `unklar` |
-| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `decode_errors_total` | `counter` | WebSocket message decode failures | `infra` | `aktiv` | none visible | `kandidat` |
-| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `ws_connected` | `gauge` | WebSocket connection state, `1` when connected | `infra` | `aktiv` | none visible | `kandidat` |
-| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `last_message_ts_ms` | `gauge` | Timestamp of last received message in ms | `infra` | `aktiv` | none visible | `kandidat` |
-| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `redis_publish_total` | `counter` | Market-data publishes to Redis | `mixed/unclear` | `aktiv` | none visible | `unklar` |
-| `cdb_ws` | WebSocket service | `cdb_ws:8000/metrics` | `redis_publish_errors_total` | `counter` | Failed market-data publishes to Redis | `infra` | `aktiv` | none visible | `kandidat` |
-| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candle_trades_processed_total` | `counter` | Raw trades aggregated into candles | `business` | `aktiv` | none visible | `unklar` |
-| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candle_candles_emitted_total` | `counter` | Completed candles emitted by the aggregator | `business` | `aktiv` | none visible | `unklar` |
+## Repo-backed custom metrics
 
-### Exporter-backed and scrape-level families
+### Risk
 
-| job_name | source_service / exporter | scrape_target / endpoint | metric_name | type | kurze Bedeutung | class | status | labels | spaetere dashboard_eignung |
-|---|---|---|---|---|---|---|---|---|---|
-| `prometheus` | Prometheus self-scrape | `localhost:9090/metrics` | `up` | `gauge` | Scrape success for the Prometheus target itself | `infra` | `aktiv` | `job`, `instance`, static target labels | `kandidat` |
-| `prometheus` | Prometheus self-scrape | `localhost:9090/metrics` | `prometheus_*` | `mixed/unclear` | Prometheus server internal metric families; exact subset not enumerated here | `infra` | `unklar` | exporter-defined | `unklar` |
-| `cdb_postgres` | postgres-exporter | `cdb_postgres_exporter:9187/metrics` | `pg_up` | `gauge` | Postgres scrape/connectivity state used by alerts | `infra` | `aktiv` | exporter-defined | `kandidat` |
-| `cdb_postgres` | postgres-exporter | `cdb_postgres_exporter:9187/metrics` | `pg_*` | `mixed/unclear` | Standard postgres-exporter families; exact collector subset not customized in repo | `infra` | `unklar` | exporter-defined | `unklar` |
-| `cdb_redis` | redis-exporter | `cdb_redis_exporter:9121/metrics` | `redis_up` | `gauge` | Redis scrape/connectivity state used by alerts | `infra` | `aktiv` | exporter-defined | `kandidat` |
-| `cdb_redis` | redis-exporter | `cdb_redis_exporter:9121/metrics` | `redis_*` | `mixed/unclear` | Standard redis-exporter families; exact subset not customized in repo | `infra` | `unklar` | exporter-defined | `unklar` |
-| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_cpu_usage_seconds_total` | `counter` | Per-container CPU usage | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
-| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_memory_usage_bytes` | `gauge` | Per-container memory usage | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
-| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_memory_limit_bytes` | `gauge` | Per-container memory limit | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
-| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_restart_count` | `gauge` | Container restart count used by soak/infra alerts | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
-| `cdb_cadvisor` | cAdvisor | `cdb_cadvisor:8080/metrics` | `container_memory_oom_kill_total` | `counter` | OOM kill count per container | `infra` | `aktiv` | cAdvisor container labels | `kandidat` |
-### Documented but not repo-backed as active exports
+- `signals_received_total`
+- `orders_approved_total`
+- `orders_blocked_total`
+- `orders_skipped_total`
+- `circuit_breaker_active`
+- `order_results_received_total`
+- `orders_rejected_execution_total`
+- `risk_pending_orders_total`
+- `risk_total_exposure_value`
+- `risk_reduce_only_approved_total`
+- `risk_proactive_unwind_triggered_total`
+- `risk_alerts_generated_total`
+- `risk_kill_switch_active`
 
-| job_name | source_service / exporter | scrape_target / endpoint | metric_name | type | kurze Bedeutung | class | status | labels | spaetere dashboard_eignung |
-|---|---|---|---|---|---|---|---|---|---|
-| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `latency_samples`, `latency_sum_ms`, `latency_count` | `gauge/counter` | Older names still documented in `KPI_REFERENCE.md`, but current code exports `signal_processing_latency_ms_*` | `deprecated/drift` | `deprecated/drift` | none visible | `eher nicht` |
-| `cdb_signal` | Signal Engine | `cdb_signal:8005/metrics` | `errors_total` | `counter` | Older doc name; current code exports `signal_errors_total` | `deprecated/drift` | `deprecated/drift` | none visible | `eher nicht` |
-| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candles_trades_processed_total`, `candles_emitted_total` | `counter` | Older doc names; current code exports `candle_trades_processed_total` and `candle_candles_emitted_total` | `deprecated/drift` | `deprecated/drift` | none visible | `eher nicht` |
-| `cdb_candles` | Candle Aggregator | `cdb_candles:8007/metrics` | `candles_market_state_updates_total`, `candles_market_state_skipped_total` | `counter` | Stats exist in code, but they are not exported on `/metrics` | `mixed/unclear` | `deprecated/drift` | none visible | `eher nicht` |
+### Execution
 
-## Erkannte Canon- und Dokudrift
+- `execution_orders_received_total`
+- `execution_orders_filled_total`
+- `execution_orders_rejected_total`
+- `execution_invalid_payloads_total`
+- `execution_shadow_blocked_total`
+- `execution_uptime_seconds`
 
-1. `infrastructure/monitoring/KPI_REFERENCE.md` documented Signal metrics with outdated names (`latency_samples`, `latency_sum_ms`, `latency_count`, `errors_total`) while the actual service exports `signal_processing_latency_ms_*` and `signal_errors_total`.
-2. `infrastructure/monitoring/KPI_REFERENCE.md` documented Candle metrics with outdated names (`candles_*`) and extra market-state counters that are tracked in memory but not exposed on `/metrics`.
-3. `#1536` resolved the stale `cdb_paper_runner` scrape by removing the `prometheus.yml` job instead of inventing a fake `/metrics` endpoint for a health/status-only runtime.
-4. `#1528` resolved the `cdb_node_exporter` canon split by removing the stale scrape job and historical `base.yml` / `dev.yml` service wiring to match the active BLUE+RED runtime and `SERVICE_MAPPING.md`.
-5. `infrastructure/monitoring/alerts.yml` is reconciled fail-closed against the current repo-backed metric surface:
-   - retained repo-backed examples: `circuit_breaker_active`, `pg_up`, `redis_up`, `execution_orders_received_total`, `signals_received_total`, `orders_approved_total`, `orders_blocked_total`, `execution_orders_filled_total`, `container_*`
-   - stale/non-repo-backed alert expressions were removed instead of being kept on guessed metric names: `cdb_daily_drawdown_pct`, `cdb_latency_seconds_bucket`, `cdb_errors_total`, `cdb_requests_total`, `cdb_order_processing_seconds`, `cdb_position_utilization_pct`, `cdb_orders_processed_total`, `cdb_signal_queue_length`
-   - `SoakTest_HighMemoryUsage` now uses repo-backed cAdvisor metric `container_memory_limit_bytes` instead of the previously unverified `container_spec_memory_limit_bytes`
-6. `#1537` resolved the front-door compose drift by marking `cdb_paper_runner` active in `infrastructure/compose/COMPOSE_LAYERS.md` to match the repo-backed dev overlay and runtime wiring.
+### Signal
 
-## Schnitt fuer spaetere Grafana- und KPI-Auswahl
+- `signals_generated_total`
+- `signal_engine_status`
+- `signal_processing_latency_ms`
+- `signal_errors_total`
 
-This matrix is intentionally split so the next session can filter without re-inventorying:
-- `business`: trade-path and operator-control metrics that could become candidate KPIs later
-- `infra`: health, scrape, runtime, and exporter metrics
-- `mixed/unclear`: persistence or pipeline metrics that need operator-context decisions later
+### DB Writer
 
-Recommended next step after this file:
-- choose a minimal operator-facing subset from the rows already marked `kandidat`
-- do not add new metrics before that selection is justified against this inventory
+- `db_writer_events_processed_total`
+- `db_writer_events_failed_total`
+- `db_writer_uptime_seconds`
+
+### WebSocket
+
+- `decoded_messages_total`
+- `decode_errors_total`
+- `ws_connected`
+- `last_message_ts_ms`
+- `redis_publish_total`
+- `redis_publish_errors_total`
+
+### Candles
+
+- `candle_trades_processed_total`
+- `candle_candles_emitted_total`
+
+## Exporter-backed families
+
+Exporter families are recorded by stable, repo-used examples rather than an
+invented exhaustive list:
+
+- Prometheus: `up`, `prometheus_*`
+- Postgres exporter: `pg_up`, `pg_*`
+- Redis exporter: `redis_up`, `redis_*`
+- cAdvisor: `container_cpu_usage_seconds_total`, `container_memory_usage_bytes`,
+  `container_memory_limit_bytes`, `container_restart_count`,
+  `container_memory_oom_kill_total`
+
+Exact exporter collector subsets remain exporter-defined unless explicitly
+configured in this repository.
+
+## Maintenance rule
+
+A metric belongs here only when all of the following are present:
+
+1. a repo-backed producer or exporter configuration,
+2. an active or explicitly classified scrape target,
+3. the exact emitted metric name or a clearly marked exporter family.
+
+Do not copy historical KPI names from old documents into this matrix. New
+metrics require code/config evidence first, then this inventory and downstream
+dashboards may be updated.

--- a/tests/fixtures/readme_link_policy.yaml
+++ b/tests/fixtures/readme_link_policy.yaml
@@ -1,12 +1,12 @@
-# README link validation policy (#3994, extended #4037)
+# README link validation policy (#3994, extended #4037 and #4124)
 #
 # Discovery: git ls-files '**/README.md' (automatic, fail-closed for new files)
-# This fixture holds only classification rules and documented exceptions — not
-# a manual inventory of every README path.
+# This fixture holds only classification rules, explicit active non-README
+# surfaces, and documented exceptions.
 
 version: 1
 issue: 3994
-follow_up_issue: 4037
+follow_up_issue: 4124
 
 # Unmatched README paths use this class and are validated (fail-closed).
 default_classification: active
@@ -24,12 +24,12 @@ classification_rules:
       - artifacts/
       - docs/evidence/reports/p5_canary/
 
-# Non-README canon entry points — same offline link rules as active READMEs (#3995).
-# Discovery is explicit (not git ls-files); paths must stay tracked in git.
+# Non-README canon entry points — same offline link rules as active READMEs.
+# Discovery is explicit; every path must stay tracked in git.
 explicit_active_surfaces:
   description: >-
-    Tier-A navigation/status surfaces outside README.md trees; validated by the
-    same engine as active READMEs (tools/validate_readme_links.py).
+    Active navigation, status, operational, strategy, environment, test, and
+    metric surfaces outside README.md trees; validated by the same link engine.
   paths:
     - CURRENT_STATUS.md
     - docs/runbooks/CONTROL_REGISTER.md
@@ -40,6 +40,10 @@ explicit_active_surfaces:
     - docs/onboarding/cdb_glossary.md
     - docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
     - docs/onboarding/repo_brain_context_intelligence.md
+    - docs/strategy/CDB_STRATEGIC_IDEA_LAB.md
+    - docs/env/index.md
+    - infrastructure/compose/TEST_OVERLAY_README.md
+    - infrastructure/monitoring/METRICS_MATRIX.md
 
 # Explicit per-path overrides (use sparingly).
 documented_exceptions: []


### PR DESCRIPTION
## Delivered

- repairs the three Strategic Idea Lab governance links
- removes unimplemented simulator flags and the nonexistent simulator executor path from the active env index
- reconciles the test overlay with the current ten-test P0 file and UTF-8-safe expected behavior
- makes `METRICS_MATRIX.md` the explicit metric SSOT and keeps `KPI_REFERENCE.md` as pointer only
- adds all four active non-README surfaces to the existing explicit link-guard policy

## Analysis

The required analysis and Decision Line were posted on #4124 before implementation.

## Coordination

- the TLS row in `docs/env/index.md` is unchanged
- #4120 remains the owner of the TLS decision
- no Execution, test, monitoring, Compose, TLS, or runtime behavior changed

## Verification

- existing `python -m tools.validate_readme_links` now covers all four surfaces
- branch is five documentation/policy commits ahead of current main
- no new validator or parallel canon was introduced

Closes #4124
Refs #1445