### PR TITLE
chore(deps): bump prometheus-client, ruff, aiohttp

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ mypy==2.3.0
 
 # Code Quality
 black==26.5.1
-ruff==0.15.21
+ruff==0.16.0
 
 # Security Scanning
 bandit==1.9.4
@@ -30,7 +30,7 @@ werkzeug>=3.1.8  # Security: CVE fixes
 psycopg2-binary==2.9.12
 requests==2.34.2
 cryptography==49.0.0
-aiohttp>=3.14.1
+aiohttp>=3.14.3
 python-dateutil==2.8.2
 tabulate==0.10.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 # Signal Engine - Requirements
 # Utilities
 # Web Framework
-aiohttp>=3.14.1
+aiohttp>=3.14.3
 cryptography==49.0.0
 flask==3.1.3
 werkzeug>=3.1.8  # Security: Fix CVEs in Dependabot alerts #339
@@ -24,6 +24,6 @@ python-dateutil==2.8.2
 python-dotenv==1.2.2
 python-json-logger==4.1.0
 numpy>=1.26.0
-prometheus_client==0.25.0
+prometheus_client==0.26.0
 redis==8.0.1
 requests==2.34.2


### PR DESCRIPTION
## Summary
- Owner batch for Python dependency bumps
- `prometheus_client` 0.25.0 → 0.26.0
- `ruff` 0.15.21 → 0.16.0
- `aiohttp` ≥3.14.1 → ≥3.14.3
- Supersedes #4155, #4156, #4157

## Delivered
- requirements.txt / requirements-dev.txt pin updates only

## Validation
- Local CI fast PASS: run_id `20260728T151237Z_960bd387`, SHA `0647a61acdb6b7772d1f846dbb38d718a2f8bcd9`, dirty=false
- Lint stage PASS under ruff 0.16 constraint (no mass reformatting)
- Required evidence: `cdb-local-ci`

## Non-goals
- No ML/RL deps, no format mass-changes, no runtime config changes

## Remaining uncertainty
- Hosted Actions under billing lock (#4167)

Made with [Cursor](https://cursor.com)