### PR TITLE
chore(deps): bump python:3.14-slim-trixie digest b877e50→cea0e60

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_PYTHON_DIGEST_D1_cea0e60_2026-07-28.md
+++ b/docs/evidence/security/CDB_SECURITY_PYTHON_DIGEST_D1_cea0e60_2026-07-28.md
@@ -1,0 +1,37 @@
+# Python base digest D1 — `b877e50` → `cea0e60`
+
+**Date:** 2026-07-28  
+**Scope:** `python:3.14-slim-trixie` digest bump in service Dockerfiles  
+**Supersedes Dependabot:** #4134 #4136 #4137 #4138 #4139 #4140 #4142 #4143  
+**Tool:** Trivy 0.72.0 (DB refreshed 2026-07-28), severity HIGH+CRITICAL  
+
+## Images compared
+
+| Role | Ref |
+|---|---|
+| Old | `python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1` |
+| New | `python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6` |
+
+Tag semantic unchanged: `python:3.14-slim-trixie` (no Python major/minor change).
+
+## Vulnerability delta (HIGH/CRITICAL)
+
+| Metric | Count |
+|---|---|
+| Old HIGH/CRITICAL findings | 23 |
+| New HIGH/CRITICAL findings | 23 |
+| Cleared | **0** |
+| Introduced | **0** |
+| Unchanged residual set | 23 |
+
+Residual set includes known upstream-blocked clusters (e.g. `perl-base` CVE-2026-13221 / related, `gzip` CVE-2026-41992, `util-linux` CVE-2026-53615). Tracked under existing security residual issues (#4106, #2932, #3802, …). **No new HIGH/CRITICAL introduced by this digest move.**
+
+## Artifacts (local evidence dir)
+
+- `trivy-d1-old-b877e50.json` / `.txt`
+- `trivy-d1-new-cea0e60.json` / `.txt`
+
+## Boundaries
+
+- No BLUE/RED start, no image push, no productive DB mutation.
+- SKIPPED heavy security stage alone is **not** used as merge evidence; this targeted Trivy delta is the required image proof.

--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -1,6 +1,6 @@
 # Allocation Service - Dockerfile
 
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
 

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile - DB Writer Service
 # Claire de Binare Trading Bot
 
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
 

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -1,6 +1,6 @@
 # Execution Service - Gehärtetes Image
 # Claire de Binare Trading Bot
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1 AS build
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS build
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -27,7 +27,7 @@ RUN python -m venv /venv \
     && /venv/bin/pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2 \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
 

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -1,6 +1,6 @@
 # Regime Service - Dockerfile
 
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
 

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
 

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 ARG CDB_SOURCE_SHA=unknown
 ENV CDB_SOURCE_SHA=${CDB_SOURCE_SHA}

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Owner batch for python slim-trixie digest bump across 8 service Dockerfiles
- Supersedes #4134 #4136 #4137 #4138 #4139 #4140 #4142 #4143

## Delivered
- Digest-only Dockerfile updates + Trivy HIGH/CRITICAL delta evidence (neutral: 0 introduced / 0 cleared)

## Validation
- Local CI fast PASS: `20260728T162041Z_4ad48ed3` @ `3b137c4d6a7749af0073abcc0e0c52c33ed9b12b`
- Targeted Trivy delta: `docs/evidence/security/CDB_SECURITY_PYTHON_DIGEST_D1_cea0e60_2026-07-28.md`
- No image push; no BLUE/RED

## Non-goals
- No Python major/minor change

## Remaining uncertainty
- Residual OS CVEs unchanged (upstream residual issues)

Made with [Cursor](https://cursor.com)