### PR TITLE
chore(deps): bump python:3.14-slim-bookworm digest 4ff4b92→86f975a

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_PYTHON_DIGEST_D2_86f975a_2026-07-28.md
+++ b/docs/evidence/security/CDB_SECURITY_PYTHON_DIGEST_D2_86f975a_2026-07-28.md
@@ -1,0 +1,31 @@
+# Python base digest D2 — `4ff4b92` → `86f975a`
+
+**Date:** 2026-07-28  
+**Scope:** `python:3.14-slim-bookworm` digest bump (candles, reports, compose Dockerfile.test)  
+**Supersedes Dependabot:** #4133 #4135 #4141  
+**Tool:** Trivy 0.72.0, severity HIGH+CRITICAL, scanners=vuln  
+
+## Images compared
+
+| Role | Ref |
+|---|---|
+| Old | `python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9` |
+| New | `python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084d1f1a0a6ef6bcaae871a30` |
+
+OS note: Debian 12.14 → 12.15 under same tag family. Tag semantic unchanged (`python:3.14-slim-bookworm`).
+
+## Vulnerability delta (HIGH/CRITICAL CVE IDs)
+
+| Metric | Count |
+|---|---|
+| Old | 14 |
+| New | 14 |
+| Cleared | **0** |
+| Introduced | **0** |
+
+Neutral digest rebuild; no new HIGH/CRITICAL CVE IDs introduced.
+
+## Boundaries
+
+- No BLUE/RED start, no image push.
+- Targeted Trivy delta is merge evidence (not SKIPPED security stage alone).

--- a/infrastructure/compose/Dockerfile.test
+++ b/infrastructure/compose/Dockerfile.test
@@ -2,7 +2,7 @@
 # Purpose: Run pytest in the canonical 431B base.yml + test.yml CI lab baseline
 # Usage: Built automatically by docker compose with infrastructure/compose/test.yml
 
-FROM python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9
+FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084d1f1a0a6ef6bcaae871a30
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/services/candles/Dockerfile
+++ b/services/candles/Dockerfile
@@ -1,6 +1,6 @@
 # Candle Aggregator Service - Dockerfile
 
-FROM python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9
+FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084d1f1a0a6ef6bcaae871a30
 
 WORKDIR /app
 

--- a/services/reports/Dockerfile
+++ b/services/reports/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9
+FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084d1f1a0a6ef6bcaae871a30
 
 LABEL maintainer="CDB Team"
 LABEL description="Daily Orders Summary Report Service"


### PR DESCRIPTION
## Summary
- Owner batch for python slim-bookworm digest bump (candles, reports, compose Dockerfile.test)
- Supersedes #4133 #4135 #4141

## Delivered
- Digest-only updates + Trivy HIGH/CRITICAL delta (neutral: 0 introduced / 0 cleared)

## Validation
- Local CI fast PASS: `20260728T185727Z_e92b58c5` @ `75bd7fd489bbe12eb35de149c1faedf3dc8ebbfc`
- Targeted Trivy: `docs/evidence/security/CDB_SECURITY_PYTHON_DIGEST_D2_86f975a_2026-07-28.md`

## Non-goals
- No BLUE/RED, no image push

Made with [Cursor](https://cursor.com)