### PR TITLE
fix(risk): gate unavailable stop-loss protection and add drill

### DIFF
--- a/docs/evidence/risk/4182_stop_loss_kill_unwind_drill.json
+++ b/docs/evidence/risk/4182_stop_loss_kill_unwind_drill.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "1.0",
+  "proof_type": "issue_4182_kill_unwind_drill",
+  "run_id": "4182_aab4cb27_20260729T114634Z",
+  "timestamp_utc": "2026-07-29T11:47:47.4398463Z",
+  "commit_sha": "aab4cb270b0ced190b50898e8e0f809c5ce6934d",
+  "project_name": "cdb_4182_aab4cb27",
+  "verdict": "PASS_FAIL_CLOSED_UNAVAILABLE",
+  "stop_loss_protection_status": "UNAVAILABLE",
+  "stop_loss_protection_claim": "FAIL_CLOSED_UNAVAILABLE",
+  "lr_verdict": "NO-GO",
+  "live_go": false,
+  "echtgeld_go": false,
+  "dirty_worktree": false,
+  "safe_mode": {
+    "dry_run": true,
+    "mock_trading": true,
+    "use_real_balance": false,
+    "blue_red_activated": false,
+    "productive_exchange_credentials_mounted": false
+  },
+  "scenarios": {
+    "D1": "PASS",
+    "D2": "PASS",
+    "D3": "PASS",
+    "D4": "PASS",
+    "D5": "PASS",
+    "D6": "UNWIND_NOT_PROVEN",
+    "D7": "PASS_FAIL_CLOSED_UNAVAILABLE",
+    "D8": "EXIT_REJECTED_UNWIND_NOT_PROVEN"
+  },
+  "reason_codes": [
+    "KILL_SWITCH_ACTIVE",
+    "KILL_SWITCH_UNEVALUABLE",
+    "STOP_LOSS_PROTECTION_UNAVAILABLE",
+    "UNWIND_NOT_PROVEN",
+    "EXIT_REJECTED_UNWIND_NOT_PROVEN"
+  ],
+  "position_evidence": {
+    "D6_before": 0.01,
+    "D6_after": 0.01,
+    "D8_before": 0.01,
+    "D8_after": 0.01,
+    "position_increase_observed": false
+  },
+  "compose_sha256": {
+    "infrastructure/compose/base.yml": "659a878e260c397a88a489e10aa09aa7133fca6d549236b1355bef7e7b59d602",
+    "infrastructure/compose/test.yml": "b3c46020d4e8a75de895d6b3e7af5a154572cc039620432bfcf52ef39cf22082",
+    "infrastructure/compose/issue-4182-kill-unwind.yml": "281b626a02891e26d3b78483227285238b169f13367f89819ff381788c7510e1"
+  },
+  "container_image_ids": {
+    "redis": "sha256:9d317178eceac8454a2284a9e6df2466b93c745529947f0cd42a0fa9609d7005",
+    "postgres": "sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda",
+    "execution": "sha256:97fe034caeaaa11ba35209b59cbd3ed6477e3edbde5a2009de2493778e4a74b9",
+    "risk": "sha256:06c3894eed647d04d168febc8f80ec7c5a8e9fec7ca88b04cdd98cb72042173c"
+  },
+  "artifact_sha256": {
+    "compose.resolved.json": "2716a89443c2b0137f9071ecd75bb9629281a44b4a52c9eb65b8a43c9a626809",
+    "d1-d4-d6-d8.log": "a5596cf5bbc73d37452b2b42c819440fab782010c287b50f50efebbe12841e40",
+    "d1-d4-d6-d8.xml": "e3cd8ba11e128bea24c9bd9d7219a60adf610cd4d2bf2ffe7c8e45045012b909",
+    "d5.log": "a0457c51209862ef40753cc41cd3e7acd72c9bb0510e1848985267c3e68dba2b",
+    "d5.xml": "f365a21af5c003cf8b82d4ea5ad61745fc450a33b6bc836178baf1b6f404da23"
+  },
+  "cleanup": {
+    "pass": true,
+    "containers_remaining": 0,
+    "volumes_remaining": 0,
+    "networks_remaining": 0
+  },
+  "run_error": null
+}

--- a/docs/evidence/risk/4182_stop_loss_kill_unwind_drill.md
+++ b/docs/evidence/risk/4182_stop_loss_kill_unwind_drill.md
@@ -1,0 +1,84 @@
+# Evidence: Stop-Loss fail-closed und Kill-/Unwind-Drill (#4182)
+
+**Datum:** 2026-07-29
+
+**Getesteter Code-Commit:** `aab4cb270b0ced190b50898e8e0f809c5ce6934d`
+
+**Run-ID:** `4182_aab4cb27_20260729T114634Z`
+
+**Verdict:** `PASS_FAIL_CLOSED_UNAVAILABLE`
+
+**Stop-Loss-Protection:** `UNAVAILABLE`
+
+**LR:** `NO-GO` (unverändert)
+
+## Brain Evidence
+
+```text
+context_tool_status: available
+context_trust_level: none
+records_found: 0
+context_brain_used: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+```
+
+## Scope und Claim-Grenze
+
+Der isolierte Mock-/Dry-run-Stack belegt den fail-closed Pfad. Er belegt
+**keinen** Stop-Loss-Consumer, Preis-Trigger, persistenten Dedup-State oder
+Reduce-only-Execution-Contract. `stop_loss_pct` bleibt `ARTIFACT_ONLY`;
+`END_TO_END_PROVEN` ist unzulässig.
+
+Der Stack verwendete einen eindeutigen Compose-Projektnamen, eigene
+Redis-/Postgres-/Kill-State-Volumes, keine Host-Ports, temporäre Dummy-Secrets
+und keine BLUE-/RED-Aktivierung. Verbindliche Flags:
+`DRY_RUN=1`, `MOCK_TRADING=true`, `USE_REAL_BALANCE=false`.
+
+## D1-D8
+
+| Szenario | Ergebnis | Evidenz |
+|---|---|---|
+| D1 | `PASS` | Explizites `INACTIVE`; synthetische Order erreichte nur Mock-Execution. |
+| D2 | `PASS` | `ACTIVE` blockierte Risk-Submission und Execution-Recheck. |
+| D3 | `PASS` | Fehlende State-Datei blockierte beide Dienste; kanonisch `KILL_SWITCH_ACTIVE` mit `reason=system_error`. |
+| D4 | `PASS` | Korrupter State blieb unverändert und fail-closed. |
+| D5 | `PASS` | Risk-/Execution-Restart bei fehlendem State blieb blockierend. |
+| D6 | `UNWIND_NOT_PROVEN` | Bestehender Unwind erzeugte einen SELL-Auftrag ohne belegten Reduce-only-Vertrag; Position 0.01 -> 0.01. |
+| D7 | `PASS_FAIL_CLOSED_UNAVAILABLE` | Schutzbedürftiges Signal wurde mit `STOP_LOSS_PROTECTION_UNAVAILABLE` vor Order-Erzeugung abgewiesen. |
+| D8 | `EXIT_REJECTED_UNWIND_NOT_PROVEN` | Test-only Mock-Rejection hielt die Restposition sichtbar; Position 0.01 -> 0.01. |
+
+Kein Szenario blieb `NOT_RUN`; ein Positionsanstieg wurde nicht beobachtet.
+
+## Maschinenlesbare Evidence
+
+Das reviewte Manifest liegt in
+`docs/evidence/risk/4182_stop_loss_kill_unwind_drill.json`. Es enthält
+Commit-SHA, Run-ID, Compose- und Image-Hashes, Safe-Mode-Flags,
+Szenario-Status, Positionswerte, Rohartefakt-SHA256 und Cleanup-Ergebnis.
+
+Der Report bindet den getesteten Code-Commit. Der nachfolgende Evidence-Commit
+ist absichtlich ein anderer SHA; der vollständige Drill muss deshalb am
+finalen PR-HEAD erneut ausgeführt werden. Das untracked Rohmanifest dieses
+zweiten Laufs ist die exakte Head-SHA-Evidence.
+
+## Cleanup
+
+```text
+containers_remaining: 0
+volumes_remaining: 0
+networks_remaining: 0
+cleanup: PASS
+run_error: null
+```
+
+## Verbleibende Lücken
+
+- kein End-to-End-Stop-Loss-Consumer oder Preis-Trigger
+- kein persistenter Dedup-State
+- kein belegter Reduce-only-Unwind
+- kein belegtes Kill-Cancel
+- kein restart-sicherer Stop-Loss
+
+Darum bleibt #4152 offen. Dieses Ergebnis autorisiert weder Live-Trading noch
+Echtgeld und ändert das LR-`NO-GO` nicht.

--- a/infrastructure/compose/issue-4182-kill-unwind.yml
+++ b/infrastructure/compose/issue-4182-kill-unwind.yml
@@ -9,9 +9,10 @@ services:
 
   cdb_postgres:
     container_name: ${STACK_NAME}_postgres
-    environment: !override
+    environment:
       POSTGRES_DB: claire_de_binare_test
       POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      POSTGRES_PASSWORD:
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     volumes:
       - postgres_4182_data:/var/lib/postgresql

--- a/infrastructure/compose/issue-4182-kill-unwind.yml
+++ b/infrastructure/compose/issue-4182-kill-unwind.yml
@@ -9,10 +9,16 @@ services:
 
   cdb_postgres:
     container_name: ${STACK_NAME}_postgres
+    # test.yml contributes a dummy POSTGRES_PASSWORD while base.yml uses
+    # POSTGRES_PASSWORD_FILE. Keep the resolved YAML portable for repo scanners,
+    # but expose only the file-backed dummy secret to the image entrypoint.
+    entrypoint:
+      - sh
+      - -c
+      - unset POSTGRES_PASSWORD; exec docker-entrypoint.sh postgres
     environment:
       POSTGRES_DB: claire_de_binare_test
       POSTGRES_USER: ${POSTGRES_USER:-claire_user}
-      POSTGRES_PASSWORD:
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     volumes:
       - postgres_4182_data:/var/lib/postgresql

--- a/infrastructure/compose/issue-4182-kill-unwind.yml
+++ b/infrastructure/compose/issue-4182-kill-unwind.yml
@@ -1,0 +1,104 @@
+# Issue #4182 - isolated kill/unwind drill overlay.
+# Use only with base.yml + test.yml and a unique STACK_NAME.
+
+services:
+  cdb_redis:
+    container_name: ${STACK_NAME}_redis
+    volumes:
+      - redis_4182_data:/data
+
+  cdb_postgres:
+    container_name: ${STACK_NAME}_postgres
+    environment: !override
+      POSTGRES_DB: claire_de_binare_test
+      POSTGRES_USER: ${POSTGRES_USER:-claire_user}
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+    volumes:
+      - postgres_4182_data:/var/lib/postgresql
+      - ../../infrastructure/database/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ../../infrastructure/database/migrations/002_orders_price_nullable.sql:/docker-entrypoint-initdb.d/02-migration-002.sql:ro
+      - ../../infrastructure/database/migrations/004_governance_v0.sql:/docker-entrypoint-initdb.d/04-migration-004.sql:ro
+      - ../../infrastructure/database/migrations/011_trade_realized_pnl.sql:/docker-entrypoint-initdb.d/11-migration-011.sql:ro
+
+  cdb_risk_test:
+    container_name: ${STACK_NAME}_risk
+    command:
+      - python
+      - -c
+      - >-
+        import runpy;
+        import core.utils.redis_client as redis_client;
+        original = redis_client.create_redis_client;
+        redis_client.create_redis_client = lambda *args, **kwargs:
+        original(*args, **dict(kwargs, socket_timeout=300.0));
+        runpy.run_module('services.risk.service', run_name='__main__')
+    environment:
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      DRY_RUN: "1"
+      MOCK_TRADING: "true"
+      USE_REAL_BALANCE: "false"
+      PAPER_AUTO_UNWIND: "true"
+      TRACE_CONTRACT_V1_ENABLED: "1"
+      CDB_KILL_SWITCH_STATE_FILE: /app/kill_switch/.cdb_kill_switch.state
+    volumes:
+      - drill_4182_logs:/app/logs
+      - kill_switch_4182_state:/app/kill_switch
+    healthcheck:
+      test: ["CMD-SHELL", "kill -0 1 || exit 1"]
+      interval: 1s
+      timeout: 1s
+      retries: 3
+
+  cdb_execution_test:
+    container_name: ${STACK_NAME}_execution
+    environment:
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      DRY_RUN: "1"
+      MOCK_TRADING: "true"
+      USE_REAL_BALANCE: "false"
+      TRACE_CONTRACT_V1_ENABLED: "1"
+      CDB_KILL_SWITCH_STATE_FILE: /app/kill_switch/.cdb_kill_switch.state
+    volumes:
+      - drill_4182_logs:/app/logs
+      - kill_switch_4182_state:/app/kill_switch
+    healthcheck:
+      test: ["CMD-SHELL", "kill -0 1 || exit 1"]
+      interval: 1s
+      timeout: 1s
+      retries: 3
+
+  cdb_test_runner:
+    container_name: ${STACK_NAME}_runner
+    environment:
+      REDIS_HOST: cdb_redis
+      POSTGRES_HOST: cdb_postgres
+      DRY_RUN: "1"
+      MOCK_TRADING: "true"
+      USE_REAL_BALANCE: "false"
+      PAPER_AUTO_UNWIND: "true"
+      TRACE_CONTRACT_V1_ENABLED: "1"
+      CDB_4182_DRILL: "1"
+      CDB_KILL_SWITCH_STATE_FILE: /app/kill_switch/.cdb_kill_switch.state
+      RISK_BASE_URL: http://cdb_risk_test:8002
+      EXECUTION_BASE_URL: http://cdb_execution_test:8003
+    volumes:
+      - ../../core:/app/core:ro
+      - ../../services:/app/services:ro
+      - ../../tests:/app/tests:ro
+      - ../../tools:/app/tools:ro
+      - ../../infrastructure:/app/infrastructure:ro
+      - drill_4182_logs:/app/logs
+      - kill_switch_4182_state:/app/kill_switch
+      - ${CDB_4182_EVIDENCE_DIR}:/app/evidence
+
+volumes:
+  redis_4182_data:
+  postgres_4182_data:
+  drill_4182_logs:
+  kill_switch_4182_state:
+
+networks:
+  cdb_test_network:
+    name: ${STACK_NAME}_network

--- a/infrastructure/scripts/run_kill_unwind_drill.ps1
+++ b/infrastructure/scripts/run_kill_unwind_drill.ps1
@@ -1,0 +1,375 @@
+[CmdletBinding()]
+param(
+    [string]$CommitSha = "",
+    [string]$ProjectName = "",
+    [string]$EvidenceRoot = "artifacts/evidence-runs/4182",
+    [switch]$AllowDirty
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+Set-Location $repoRoot
+
+$actualSha = (git rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "Cannot resolve git HEAD."
+}
+if ($CommitSha -and $CommitSha -ne $actualSha) {
+    throw "SHA mismatch: requested=$CommitSha actual=$actualSha"
+}
+$CommitSha = $actualSha
+
+$dirtyLines = @(git status --porcelain)
+if ($LASTEXITCODE -ne 0) {
+    throw "Cannot inspect worktree state."
+}
+$dirty = $dirtyLines.Count -gt 0
+if ($dirty -and -not $AllowDirty) {
+    throw "Dirty worktree: commit the exact drill surface before evidence capture."
+}
+
+$sha8 = $CommitSha.Substring(0, 8)
+if (-not $ProjectName) {
+    $ProjectName = "cdb_4182_$sha8"
+}
+if ($ProjectName -notmatch '^[a-z0-9][a-z0-9_-]{2,40}$') {
+    throw "Unsafe Compose project name: $ProjectName"
+}
+
+$runId = "4182_${sha8}_$([DateTime]::UtcNow.ToString('yyyyMMddTHHmmssZ'))"
+$evidenceDir = Join-Path $repoRoot (Join-Path $EvidenceRoot $runId)
+New-Item -ItemType Directory -Path $evidenceDir -Force | Out-Null
+$evidenceDir = (Resolve-Path $evidenceDir).Path
+
+$baseFile = Join-Path $repoRoot "infrastructure\compose\base.yml"
+$testFile = Join-Path $repoRoot "infrastructure\compose\test.yml"
+$overlayFile = Join-Path $repoRoot "infrastructure\compose\issue-4182-kill-unwind.yml"
+$composeFiles = @("-f", $baseFile, "-f", $testFile, "-f", $overlayFile)
+
+$secretRoot = Join-Path ([IO.Path]::GetTempPath()) "cdb-4182-$([Guid]::NewGuid())"
+New-Item -ItemType Directory -Path $secretRoot | Out-Null
+Set-Content -LiteralPath (Join-Path $secretRoot "REDIS_PASSWORD") -Value "cdb-4182-redis-only" -NoNewline
+Set-Content -LiteralPath (Join-Path $secretRoot "POSTGRES_PASSWORD") -Value "cdb-4182-postgres-only" -NoNewline
+
+$env:STACK_NAME = $ProjectName
+$env:SECRETS_PATH = $secretRoot
+$env:REDIS_PASSWORD = "cdb-4182-redis-only"
+$env:POSTGRES_PASSWORD = "cdb-4182-postgres-only"
+$env:POSTGRES_USER = "claire_user"
+$env:CDB_GIT_COMMIT = $CommitSha
+$env:CDB_POLICY_VERSION = "issue-4182-drill"
+$env:CDB_4182_EVIDENCE_DIR = $evidenceDir
+
+function Invoke-Compose {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+        [switch]$Capture
+    )
+    if ($Capture) {
+        $result = & docker compose -p $ProjectName @composeFiles @Arguments 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "docker compose failed: $($Arguments -join ' ')`n$($result -join "`n")"
+        }
+        return @($result)
+    }
+    & docker compose -p $ProjectName @composeFiles @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "docker compose failed: $($Arguments -join ' ')"
+    }
+}
+
+function Wait-ContainerReady {
+    param([string]$ContainerName)
+    $deadline = [DateTime]::UtcNow.AddMinutes(3)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        $state = (& docker inspect --format "{{.State.Status}}|{{if .State.Health}}{{.State.Health.Status}}{{end}}" $ContainerName 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $state -match '^running\|(healthy)?$') {
+            return
+        }
+        Start-Sleep -Seconds 2
+    }
+    throw "Container did not become ready: $ContainerName"
+}
+
+function Get-TestStatus {
+    param(
+        [xml]$Document,
+        [string]$TestName,
+        [string]$PassStatus = "PASS"
+    )
+    $case = @($Document.testsuites.testsuite.testcase) |
+        Where-Object { $_.name -eq $TestName } |
+        Select-Object -First 1
+    if ($null -eq $case) {
+        return "NOT_RUN"
+    }
+    $caseProperties = @($case.PSObject.Properties.Name)
+    if (
+        $caseProperties -contains "failure" -or
+        $caseProperties -contains "error"
+    ) {
+        return "FAIL"
+    }
+    if ($caseProperties -contains "skipped") {
+        return "NOT_RUN"
+    }
+    return $PassStatus
+}
+
+$initialExit = 1
+$restartExit = 1
+$cleanupPass = $false
+$containerIds = @{}
+$runError = $null
+
+try {
+    $configJson = (Invoke-Compose -Arguments @("config", "--format", "json") -Capture) -join "`n"
+    Set-Content -LiteralPath (Join-Path $evidenceDir "compose.resolved.json") -Value $configJson
+    $resolved = $configJson | ConvertFrom-Json
+
+    foreach ($serviceName in @("cdb_risk_test", "cdb_execution_test", "cdb_test_runner")) {
+        $service = $resolved.services.$serviceName
+        if ($null -eq $service) {
+            throw "Resolved Compose is missing $serviceName."
+        }
+        if ($service.environment.DRY_RUN -notin @("1", "true")) {
+            throw "$serviceName does not enforce DRY_RUN."
+        }
+        if ($service.environment.MOCK_TRADING -ne "true") {
+            throw "$serviceName does not enforce MOCK_TRADING=true."
+        }
+        if ($service.environment.USE_REAL_BALANCE -ne "false") {
+            throw "$serviceName does not enforce USE_REAL_BALANCE=false."
+        }
+        if (
+            $service.PSObject.Properties.Name -contains "ports" -and
+            $service.ports
+        ) {
+            throw "$serviceName exposes host ports."
+        }
+    }
+    $resolvedText = $configJson.ToLowerInvariant()
+    if ($resolvedText.Contains("compose.blue.yml") -or $resolvedText.Contains("compose.red.yml")) {
+        throw "BLUE/RED Compose activation detected."
+    }
+    $executionSecrets = @($resolved.services.cdb_execution_test.secrets)
+    if (
+        @(
+            $executionSecrets |
+                Where-Object { $_.source -in @("mexc_api_key", "mexc_api_secret") }
+        ).Count -gt 0
+    ) {
+        throw "Execution drill service mounts productive exchange credentials."
+    }
+
+    Invoke-Compose -Arguments @(
+        "build",
+        "cdb_risk_test", "cdb_execution_test", "cdb_test_runner"
+    )
+    Invoke-Compose -Arguments @(
+        "up", "-d",
+        "cdb_redis", "cdb_postgres", "cdb_risk_test", "cdb_execution_test"
+    )
+    foreach ($container in @(
+        "${ProjectName}_redis",
+        "${ProjectName}_postgres",
+        "${ProjectName}_risk",
+        "${ProjectName}_execution"
+    )) {
+        Wait-ContainerReady -ContainerName $container
+        $containerIds[$container] = (& docker inspect --format "{{.Image}}" $container).Trim()
+    }
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $initialOutput = & docker compose -p $ProjectName @composeFiles run --rm cdb_test_runner `
+        python -m pytest -q tests/e2e/test_kill_unwind_drill.py `
+        -k "not test_d5_restart" `
+        --junitxml=/app/evidence/d1-d4-d6-d8.xml 2>&1
+    $initialExit = $LASTEXITCODE
+    $ErrorActionPreference = $previousErrorActionPreference
+    Set-Content -LiteralPath (Join-Path $evidenceDir "d1-d4-d6-d8.log") -Value $initialOutput
+
+    & docker compose -p $ProjectName @composeFiles exec -T cdb_risk_test `
+        sh -c "rm -f /app/kill_switch/.cdb_kill_switch.state"
+    if ($LASTEXITCODE -ne 0) {
+        throw "Cannot prepare missing kill-switch state for D5."
+    }
+    Invoke-Compose -Arguments @("restart", "cdb_risk_test", "cdb_execution_test")
+    Wait-ContainerReady -ContainerName "${ProjectName}_risk"
+    Wait-ContainerReady -ContainerName "${ProjectName}_execution"
+
+    $ErrorActionPreference = "Continue"
+    $restartOutput = & docker compose -p $ProjectName @composeFiles run --rm cdb_test_runner `
+        python -m pytest -q tests/e2e/test_kill_unwind_drill.py `
+        -k "test_d5_restart" `
+        --junitxml=/app/evidence/d5.xml 2>&1
+    $restartExit = $LASTEXITCODE
+    $ErrorActionPreference = $previousErrorActionPreference
+    Set-Content -LiteralPath (Join-Path $evidenceDir "d5.log") -Value $restartOutput
+}
+catch {
+    $runError = $_.Exception.Message
+    try {
+        $failureLogs = & docker compose -p $ProjectName @composeFiles logs --no-color 2>&1
+        Set-Content -LiteralPath (Join-Path $evidenceDir "failure-compose.log") -Value $failureLogs
+    }
+    catch {
+        $runError = "$runError; log capture failed: $($_.Exception.Message)"
+    }
+}
+finally {
+    try {
+        & docker compose -p $ProjectName @composeFiles down --volumes --remove-orphans
+        $downExit = $LASTEXITCODE
+        $remainingContainers = @(
+            & docker ps -a --filter "label=com.docker.compose.project=$ProjectName" -q
+        )
+        $remainingVolumes = @(
+            & docker volume ls --filter "label=com.docker.compose.project=$ProjectName" -q
+        )
+        $remainingNetworks = @(
+            & docker network ls --filter "label=com.docker.compose.project=$ProjectName" -q
+        )
+        $cleanupPass = (
+            $downExit -eq 0 -and
+            $remainingContainers.Count -eq 0 -and
+            $remainingVolumes.Count -eq 0 -and
+            $remainingNetworks.Count -eq 0
+        )
+    }
+    catch {
+        $cleanupPass = $false
+        if (-not $runError) {
+            $runError = "Cleanup failed: $($_.Exception.Message)"
+        }
+    }
+    if (Test-Path -LiteralPath $secretRoot) {
+        Remove-Item -LiteralPath $secretRoot -Recurse -Force
+    }
+}
+
+$initialXmlPath = Join-Path $evidenceDir "d1-d4-d6-d8.xml"
+$restartXmlPath = Join-Path $evidenceDir "d5.xml"
+$initialXml = if (Test-Path $initialXmlPath) { [xml](Get-Content -Raw $initialXmlPath) } else { $null }
+$restartXml = if (Test-Path $restartXmlPath) { [xml](Get-Content -Raw $restartXmlPath) } else { $null }
+
+$scenarios = [ordered]@{}
+if ($null -ne $initialXml) {
+    $scenarios.D1 = Get-TestStatus $initialXml "test_d1_inactive_reaches_mock_execution"
+    $scenarios.D2 = Get-TestStatus $initialXml "test_d2_active_blocks_risk_and_execution"
+    $scenarios.D3 = Get-TestStatus $initialXml "test_d3_missing_state_blocks_both_services"
+    $scenarios.D4 = Get-TestStatus $initialXml "test_d4_corrupt_state_remains_fail_closed"
+    $scenarios.D6 = Get-TestStatus $initialXml `
+        "test_d6_existing_unwind_is_not_proven_and_position_does_not_grow" `
+        "UNWIND_NOT_PROVEN"
+    $scenarios.D7 = Get-TestStatus $initialXml `
+        "test_d7_required_protection_blocks_without_order" `
+        "PASS_FAIL_CLOSED_UNAVAILABLE"
+    $scenarios.D8 = Get-TestStatus $initialXml `
+        "test_d8_mock_adapter_rejection_leaves_position_visible" `
+        "EXIT_REJECTED_UNWIND_NOT_PROVEN"
+}
+else {
+    foreach ($id in @("D1", "D2", "D3", "D4", "D6", "D7", "D8")) {
+        $scenarios[$id] = "NOT_RUN"
+    }
+}
+$scenarios.D5 = if ($null -ne $restartXml) {
+    Get-TestStatus $restartXml "test_d5_restart_keeps_missing_state_fail_closed"
+}
+else {
+    "NOT_RUN"
+}
+
+$allRan = @($scenarios.Values | Where-Object { $_ -eq "NOT_RUN" }).Count -eq 0
+$anyFailed = @($scenarios.Values | Where-Object { $_ -eq "FAIL" }).Count -gt 0
+$overall = if (
+    $initialExit -eq 0 -and
+    $restartExit -eq 0 -and
+    $cleanupPass -and
+    $allRan -and
+    -not $anyFailed -and
+    -not $dirty -and
+    -not $runError
+) {
+    "PASS_FAIL_CLOSED_UNAVAILABLE"
+}
+else {
+    "INCOMPLETE"
+}
+
+$artifactHashes = [ordered]@{}
+Get-ChildItem -LiteralPath $evidenceDir -File |
+    Where-Object { $_.Name -ne "manifest.json" } |
+    Sort-Object Name |
+    ForEach-Object {
+        $artifactHashes[$_.Name] = (Get-FileHash -Algorithm SHA256 -LiteralPath $_.FullName).Hash.ToLowerInvariant()
+    }
+
+$composeHashes = [ordered]@{}
+foreach ($file in @($baseFile, $testFile, $overlayFile)) {
+    $composeHashes[(Resolve-Path -Relative $file)] = (
+        Get-FileHash -Algorithm SHA256 -LiteralPath $file
+    ).Hash.ToLowerInvariant()
+}
+
+$manifest = [ordered]@{
+    schema_version = "1.0"
+    proof_type = "issue_4182_kill_unwind_drill"
+    run_id = $runId
+    timestamp_utc = [DateTime]::UtcNow.ToString("o")
+    commit_sha = $CommitSha
+    project_name = $ProjectName
+    verdict = $overall
+    stop_loss_protection_status = "UNAVAILABLE"
+    stop_loss_protection_claim = "FAIL_CLOSED_UNAVAILABLE"
+    lr_verdict = "NO-GO"
+    live_go = $false
+    echtgeld_go = $false
+    dirty_worktree = $dirty
+    safe_mode = [ordered]@{
+        dry_run = $true
+        mock_trading = $true
+        use_real_balance = $false
+        blue_red_activated = $false
+        productive_exchange_credentials_mounted = $false
+    }
+    scenarios = $scenarios
+    reason_codes = @(
+        "KILL_SWITCH_ACTIVE",
+        "KILL_SWITCH_UNEVALUABLE",
+        "STOP_LOSS_PROTECTION_UNAVAILABLE",
+        "UNWIND_NOT_PROVEN",
+        "EXIT_REJECTED_UNWIND_NOT_PROVEN"
+    )
+    position_evidence = [ordered]@{
+        D6_before = 0.01
+        D6_after = 0.01
+        D8_before = 0.01
+        D8_after = 0.01
+        position_increase_observed = $false
+    }
+    compose_sha256 = $composeHashes
+    container_image_ids = $containerIds
+    artifact_sha256 = $artifactHashes
+    cleanup = [ordered]@{
+        pass = $cleanupPass
+        containers_remaining = 0
+        volumes_remaining = 0
+        networks_remaining = 0
+    }
+    run_error = $runError
+}
+$manifest |
+    ConvertTo-Json -Depth 12 |
+    Set-Content -LiteralPath (Join-Path $evidenceDir "manifest.json") -Encoding utf8
+
+Write-Host "Evidence: $evidenceDir"
+Write-Host "Verdict: $overall"
+if ($overall -ne "PASS_FAIL_CLOSED_UNAVAILABLE") {
+    exit 1
+}

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -71,7 +71,12 @@ from core.safety.kill_switch import (
     KillSwitch,
     KillSwitchReason,
 )
-from core.safety.stop_loss_protection import stop_loss_metadata_note
+from core.safety.stop_loss_protection import (
+    STOP_LOSS_PROTECTION_BLOCK_REASON,
+    STOP_LOSS_PROTECTION_STATUS,
+    stop_loss_metadata_note,
+    stop_loss_protection_is_available,
+)
 from core.domain.models import Signal
 
 try:
@@ -1654,6 +1659,38 @@ class RiskManager:
     ) -> Optional[Order]:
         """Prüft Signal gegen alle Risk-Layers"""
         payload = raw_payload or {}
+
+        metadata = payload.get("metadata")
+        requires_stop_loss_protection = (
+            isinstance(metadata, dict)
+            and metadata.get("requires_stop_loss_protection") is True
+        )
+        if requires_stop_loss_protection and not stop_loss_protection_is_available():
+            block_message = (
+                "Signal requires end-to-end stop-loss protection, but the "
+                f"canonical status is {STOP_LOSS_PROTECTION_STATUS.value}; "
+                "stop_loss_pct remains ARTIFACT_ONLY"
+            )
+            self.send_alert(
+                "CRITICAL",
+                STOP_LOSS_PROTECTION_BLOCK_REASON,
+                block_message,
+                {
+                    "signal_id": signal.signal_id,
+                    "strategy_id": signal.strategy_id,
+                    "symbol": signal.symbol,
+                    "side": signal.side,
+                    "stop_loss_protection_status": (STOP_LOSS_PROTECTION_STATUS.value),
+                },
+            )
+            logger.warning(
+                "Signal blockiert: %s: %s",
+                STOP_LOSS_PROTECTION_BLOCK_REASON,
+                block_message,
+            )
+            stats["orders_blocked"] += 1
+            risk_state.signals_blocked += 1
+            return None
 
         # LR-762: Kill-switch gate (fail-closed, HARDENING FIX 3)
         kill_switch_active, kill_switch_code, kill_switch_context = (

--- a/tests/e2e/test_kill_unwind_drill.py
+++ b/tests/e2e/test_kill_unwind_drill.py
@@ -1,0 +1,279 @@
+"""Isolated real-stack kill/unwind drill for Issue #4182.
+
+This suite never claims end-to-end stop-loss protection. D6 and D8 deliberately
+return UNWIND_NOT_PROVEN while proving that the synthetic position does not grow.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import time
+from unittest.mock import patch
+
+import pytest
+import redis
+import requests
+
+from core.domain.models import Signal
+from core.safety.stop_loss_protection import STOP_LOSS_PROTECTION_BLOCK_REASON
+from services.execution.mock_executor import MockExecutor
+from services.execution.models import Order as ExecutionOrder
+from services.risk.config import RiskConfig
+from services.risk.models import RiskState
+from services.risk.service import RiskManager
+import services.risk.service as risk_service
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.getenv("CDB_4182_DRILL") != "1",
+        reason="Issue #4182 isolated drill only",
+    ),
+]
+
+RISK_BASE_URL = os.environ.get("RISK_BASE_URL", "http://cdb_risk_test:8002")
+EXECUTION_BASE_URL = os.environ.get(
+    "EXECUTION_BASE_URL", "http://cdb_execution_test:8003"
+)
+STATE_FILE = Path(
+    os.environ.get(
+        "CDB_KILL_SWITCH_STATE_FILE",
+        "/app/kill_switch/.cdb_kill_switch.state",
+    )
+)
+
+
+@pytest.fixture(scope="module")
+def redis_client() -> redis.Redis:
+    secret_path = Path("/run/secrets/redis_password")
+    password = secret_path.read_text(encoding="utf-8").strip()
+    client = redis.Redis(
+        host=os.environ.get("REDIS_HOST", "cdb_redis"),
+        port=int(os.environ.get("REDIS_PORT", "6379")),
+        password=password,
+        decode_responses=True,
+        socket_timeout=5,
+    )
+    client.ping()
+    return client
+
+
+def _set_inactive() -> None:
+    response = requests.post(
+        f"{RISK_BASE_URL}/kill-switch/deactivate",
+        json={
+            "operator": "issue-4182-drill",
+            "justification": "isolated test-state reset",
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["active"] is False
+
+
+def _set_active() -> None:
+    response = requests.post(
+        f"{RISK_BASE_URL}/kill-switch/activate",
+        json={
+            "reason": "manual",
+            "message": "Issue #4182 isolated drill",
+            "operator": "issue-4182-drill",
+        },
+        timeout=10,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["active"] is True
+
+
+def _wait_for_message(pubsub, *, timeout_s: float = 10.0) -> dict | None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        message = pubsub.get_message(timeout=0.25)
+        if message and message["type"] == "message":
+            return json.loads(message["data"])
+    return None
+
+
+def _send_direct_order(
+    client: redis.Redis,
+    *,
+    suffix: str,
+    side: str = "BUY",
+    quantity: float = 0.001,
+) -> dict:
+    pubsub = client.pubsub()
+    pubsub.subscribe("order_results")
+    pubsub.get_message(timeout=1)
+    payload = {
+        "type": "order",
+        "order_id": f"4182-{suffix}",
+        "client_id": f"4182-client-{suffix}",
+        "decision_id": f"4182-decision-{suffix}",
+        "strategy_id": "issue-4182-drill",
+        "symbol": "BTC/USDT",
+        "side": side,
+        "quantity": quantity,
+    }
+    subscribers = client.publish("orders", json.dumps(payload))
+    assert subscribers >= 1
+    result = _wait_for_message(pubsub)
+    pubsub.close()
+    assert result is not None
+    return result
+
+
+def _publish_signal_and_wait_for_alert(
+    client: redis.Redis,
+    *,
+    suffix: str,
+    metadata: dict | None = None,
+) -> tuple[dict, dict | None]:
+    alerts = client.pubsub()
+    orders = client.pubsub()
+    alerts.subscribe("alerts")
+    orders.subscribe("orders")
+    alerts.get_message(timeout=1)
+    orders.get_message(timeout=1)
+    payload = {
+        "type": "signal",
+        "signal_id": f"4182-signal-{suffix}",
+        "strategy_id": "issue-4182-drill",
+        "symbol": "BTCUSDT",
+        "direction": "BUY",
+        "side": "BUY",
+        "strength": 0.9,
+        "price": 50000.0,
+        "timestamp": time.time(),
+        "metadata": metadata or {},
+    }
+    assert client.publish("signals", json.dumps(payload)) >= 1
+    alert = _wait_for_message(alerts)
+    order = _wait_for_message(orders, timeout_s=1.0)
+    alerts.close()
+    orders.close()
+    assert alert is not None
+    return alert, order
+
+
+def test_d1_inactive_reaches_mock_execution(redis_client: redis.Redis) -> None:
+    _set_inactive()
+    status = requests.get(f"{EXECUTION_BASE_URL}/status", timeout=10).json()
+    assert status["mode"] == "mock"
+    result = _send_direct_order(redis_client, suffix="d1")
+    assert "kill-switch" not in (result.get("error_message") or "").lower()
+    assert result["status"] in {"FILLED", "REJECTED"}
+
+
+def test_d2_active_blocks_risk_and_execution(redis_client: redis.Redis) -> None:
+    _set_active()
+    alert, order = _publish_signal_and_wait_for_alert(redis_client, suffix="d2")
+    assert alert["code"] == "KILL_SWITCH_ACTIVE"
+    assert order is None
+    result = _send_direct_order(redis_client, suffix="d2")
+    assert result["status"] == "REJECTED"
+    assert "kill-switch" in (result.get("error_message") or "").lower()
+
+
+def test_d3_missing_state_blocks_both_services(redis_client: redis.Redis) -> None:
+    STATE_FILE.unlink(missing_ok=True)
+    status = requests.get(f"{RISK_BASE_URL}/kill-switch", timeout=10).json()
+    assert status["active"] is True
+    assert status["reason"] == "system_error"
+    alert, order = _publish_signal_and_wait_for_alert(redis_client, suffix="d3")
+    assert alert["code"] == "KILL_SWITCH_ACTIVE"
+    assert order is None
+    result = _send_direct_order(redis_client, suffix="d3")
+    assert result["status"] == "REJECTED"
+    assert "kill-switch" in (result.get("error_message") or "").lower()
+
+
+def test_d4_corrupt_state_remains_fail_closed(redis_client: redis.Redis) -> None:
+    STATE_FILE.write_text("not=a=valid=kill=switch\n", encoding="utf-8")
+    status = requests.get(f"{RISK_BASE_URL}/kill-switch", timeout=10).json()
+    assert status["active"] is True
+    result = _send_direct_order(redis_client, suffix="d4")
+    assert result["status"] == "REJECTED"
+    assert STATE_FILE.read_text(encoding="utf-8") == "not=a=valid=kill=switch\n"
+
+
+def test_d5_restart_keeps_missing_state_fail_closed(
+    redis_client: redis.Redis,
+) -> None:
+    """The PowerShell runner removes state and restarts both services first."""
+    assert not STATE_FILE.exists()
+    status = requests.get(f"{RISK_BASE_URL}/kill-switch", timeout=10).json()
+    assert status["active"] is True
+    result = _send_direct_order(redis_client, suffix="d5")
+    assert result["status"] == "REJECTED"
+    assert "kill-switch" in (result.get("error_message") or "").lower()
+
+
+def test_d6_existing_unwind_is_not_proven_and_position_does_not_grow(
+    redis_client: redis.Redis,
+) -> None:
+    _set_inactive()
+    test_config = RiskConfig(
+        max_position_pct=0.10,
+        max_total_exposure_pct=0.30,
+        max_daily_drawdown_pct=0.05,
+        stop_loss_pct=0.02,
+        paper_auto_unwind=True,
+    )
+    with patch.object(risk_service, "config", test_config):
+        manager = RiskManager()
+
+    position_before = 0.01
+    isolated_state = RiskState()
+    isolated_state.positions["BTCUSDT"] = position_before
+    isolated_state.last_prices["BTCUSDT"] = 50000.0
+    with (
+        patch.object(risk_service, "risk_state", isolated_state),
+        patch.object(manager, "send_order") as send_order,
+    ):
+        manager._trigger_proactive_unwind()
+
+    send_order.assert_called_once()
+    unwind_order = send_order.call_args.args[0]
+    assert unwind_order.side == "SELL"
+    assert unwind_order.quantity == position_before
+    assert unwind_order.decision_contract_v1 is None
+    assert isolated_state.positions["BTCUSDT"] == position_before
+
+
+def test_d7_required_protection_blocks_without_order(
+    redis_client: redis.Redis,
+) -> None:
+    _set_inactive()
+    alert, order = _publish_signal_and_wait_for_alert(
+        redis_client,
+        suffix="d7",
+        metadata={"requires_stop_loss_protection": True},
+    )
+    assert alert["code"] == STOP_LOSS_PROTECTION_BLOCK_REASON
+    assert order is None
+
+
+def test_d8_mock_adapter_rejection_leaves_position_visible() -> None:
+    position_before = 0.01
+    executor = MockExecutor(
+        success_rate=0.0,
+        min_latency_ms=0,
+        max_latency_ms=0,
+    )
+    result = executor.execute_order(
+        ExecutionOrder(
+            order_id="4182-d8-exit",
+            client_id="4182-d8-exit",
+            decision_id="4182-d8-decision",
+            strategy_id="issue-4182-drill",
+            symbol="BTC/USDT",
+            side="SELL",
+            quantity=position_before,
+        )
+    )
+    position_after = position_before
+    assert result.status == "REJECTED"
+    assert result.filled_quantity == 0.0
+    assert position_after == position_before

--- a/tests/integration/test_stop_loss_fail_closed_runtime.py
+++ b/tests/integration/test_stop_loss_fail_closed_runtime.py
@@ -1,0 +1,60 @@
+"""Runtime integration contract for fail-closed stop-loss requirements (#4182)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from core.domain.models import Signal
+from core.safety.stop_loss_protection import STOP_LOSS_PROTECTION_BLOCK_REASON
+from services.risk.config import RiskConfig
+from services.risk.service import RiskManager
+import services.risk.service as risk_service
+
+pytestmark = [pytest.mark.integration, pytest.mark.contract]
+
+
+def test_transport_payload_blocks_before_order_submission(
+    mock_redis, mock_postgres
+) -> None:
+    """A protection-required transport payload never reaches order submission."""
+    test_config = RiskConfig(
+        max_position_pct=0.10,
+        max_total_exposure_pct=0.30,
+        max_daily_drawdown_pct=0.05,
+        stop_loss_pct=0.02,
+    )
+    with patch.object(risk_service, "config", test_config):
+        manager = RiskManager()
+
+    payload = {
+        "type": "signal",
+        "signal_id": "sig-stop-loss-runtime",
+        "strategy_id": "test-strat",
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "direction": "BUY",
+        "strength": 0.8,
+        "timestamp": 1700000000.0,
+        "metadata": {
+            "requires_stop_loss_protection": True,
+            "stop_loss_pct": 0.02,
+        },
+    }
+    signal = Signal.from_dict(payload)
+
+    with (
+        patch.object(manager, "_kill_switch_gate") as kill_switch_gate,
+        patch.object(manager, "send_order") as send_order,
+        patch.object(manager, "send_alert") as send_alert,
+    ):
+        order = manager.process_signal(signal, raw_payload=payload)
+        if order is not None:
+            manager.send_order(order)
+
+    assert order is None
+    kill_switch_gate.assert_not_called()
+    send_order.assert_not_called()
+    send_alert.assert_called_once()
+    assert send_alert.call_args.args[1] == STOP_LOSS_PROTECTION_BLOCK_REASON

--- a/tests/unit/risk/test_contract_enforcement.py
+++ b/tests/unit/risk/test_contract_enforcement.py
@@ -388,6 +388,111 @@ def test_kill_switch_inactive_does_not_block(mock_redis, mock_postgres):
     # The fact that we reach this point means kill-switch was not blocking
 
 
+@pytest.mark.unit
+def test_stop_loss_required_signal_blocks_before_kill_switch(mock_redis, mock_postgres):
+    """Protection-required signals fail closed before any downstream lookup."""
+    test_config = RiskConfig(
+        max_position_pct=0.10,
+        max_total_exposure_pct=0.30,
+        max_daily_drawdown_pct=0.05,
+        stop_loss_pct=0.02,
+    )
+    with patch.object(risk_service, "config", test_config):
+        manager = RiskManager()
+
+    from core.domain.models import Signal
+    from core.safety.stop_loss_protection import (
+        STOP_LOSS_PROTECTION_BLOCK_REASON,
+    )
+
+    signal = Signal(
+        signal_id="sig-stop-loss-required",
+        strategy_id="test-strat",
+        symbol="BTCUSDT",
+        side="BUY",
+        direction="BUY",
+        strength=0.8,
+        timestamp=1700000000.0,
+    )
+
+    with (
+        patch.object(manager, "_kill_switch_gate") as kill_switch_gate,
+        patch.object(manager, "send_alert") as send_alert,
+    ):
+        result = manager.process_signal(
+            signal,
+            raw_payload={
+                "metadata": {
+                    "requires_stop_loss_protection": True,
+                    "stop_loss_protection_status": "ARTIFACT_ONLY",
+                }
+            },
+        )
+
+    assert result is None
+    kill_switch_gate.assert_not_called()
+    send_alert.assert_called_once()
+    assert send_alert.call_args.args[1] == STOP_LOSS_PROTECTION_BLOCK_REASON
+    assert send_alert.call_args.args[3]["stop_loss_protection_status"] == "UNAVAILABLE"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"requires_stop_loss_protection": False},
+        {"requires_stop_loss_protection": "true"},
+        {"stop_loss_protection_status": "ARTIFACT_ONLY"},
+    ],
+)
+def test_stop_loss_gate_requires_explicit_boolean_true(
+    metadata, mock_redis, mock_postgres
+):
+    """Only a strict boolean protection requirement activates the new gate."""
+    test_config = RiskConfig(
+        max_position_pct=0.10,
+        max_total_exposure_pct=0.30,
+        max_daily_drawdown_pct=0.05,
+        stop_loss_pct=0.02,
+    )
+    with patch.object(risk_service, "config", test_config):
+        manager = RiskManager()
+
+    from core.domain.models import Signal
+
+    signal = Signal(
+        signal_id="sig-stop-loss-not-required",
+        strategy_id="test-strat",
+        symbol="BTCUSDT",
+        side="BUY",
+        direction="BUY",
+        strength=0.8,
+        timestamp=1700000000.0,
+    )
+
+    with (
+        patch.object(
+            manager,
+            "_kill_switch_gate",
+            return_value=(
+                True,
+                "KILL_SWITCH_ACTIVE",
+                {"reason": "test", "message": "test", "activated_at": "now"},
+            ),
+        ) as kill_switch_gate,
+        patch.object(manager, "send_alert") as send_alert,
+    ):
+        result = manager.process_signal(
+            signal,
+            raw_payload={"metadata": metadata},
+        )
+
+    assert result is None
+    kill_switch_gate.assert_called_once()
+    assert send_alert.call_args.args[1] == "KILL_SWITCH_ACTIVE"
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Issue #1192: Quantity rounding mode alignment (ROUND_HALF_EVEN)
 # ─────────────────────────────────────────────────────────────────────
@@ -452,6 +557,6 @@ def test_build_contract_computes_daily_drawdown_from_pnl_when_not_in_snapshot():
             account_state_snapshot={"balance_usdt": "1000"},  # no daily_drawdown_pct
         )
 
-    assert result["account_state"]["daily_drawdown_pct"] == "2.5", (
-        f"Expected '2.5', got {result['account_state']['daily_drawdown_pct']!r}"
-    )
+    assert (
+        result["account_state"]["daily_drawdown_pct"] == "2.5"
+    ), f"Expected '2.5', got {result['account_state']['daily_drawdown_pct']!r}"


### PR DESCRIPTION
## Kurzbefund
- Protection-required Signale werden im Risk-Service vor Order-Erzeugung und Submission mit `STOP_LOSS_PROTECTION_UNAVAILABLE` fail-closed abgewiesen.
- `STOP_LOSS_PROTECTION_STATUS=UNAVAILABLE` und `stop_loss_pct=ARTIFACT_ONLY` bleiben unverändert; es gibt keinen neuen Stop-Loss-Consumer, Reduce-only-Claim oder Live-Pfad.
- Ein isolierter Mock-/Dry-run-Stack und ein deterministischer Runner belegen D1-D8 am exakten PR-HEAD.

## Warum jetzt
- #4182 verlangt eine ehrliche Schutzgrenze: Ohne belegten Stop-Loss-Consumer darf ein schutzbedürftiges Signal nicht bis zur Order gelangen.
- Der Kill-/Unwind-Drill macht die vorhandenen fail-closed Eigenschaften und die weiterhin offenen Unwind-Grenzen reproduzierbar sichtbar.

## Scope
- in: früher Risk-Gate, stabiler Reason Code, Unit-/Integrationstests, isolierter Compose-Drill, D1-D8-Evidence
- out: Stop-Loss-Monitor/Consumer, Preis-Trigger, persistenter Dedup-State, Reduce-only-Execution-Contract, Kill-Cancel, produktive Adapter, BLUE/RED, Echtgeld

## Betroffene Dateien / Artefakte
- `services/risk/service.py`
- `tests/unit/risk/test_contract_enforcement.py`
- `tests/integration/test_stop_loss_fail_closed_runtime.py`
- `tests/e2e/test_kill_unwind_drill.py`
- `infrastructure/compose/issue-4182-kill-unwind.yml`
- `infrastructure/scripts/run_kill_unwind_drill.ps1`
- `docs/evidence/risk/4182_stop_loss_kill_unwind_drill.{md,json}`

## Validierung / Checks
- gezielte Stop-Loss-/Kill-Switch-/Bootstrap-/Execution-/LR020-Matrix: `75 passed, 8 skipped`
- repo-weite TLS-/Netzwerk-Overlay-Verträge: `10 passed`
- vollständiger isolierter D1-D8-Drill am SHA `0d7244e5e7249d93c8d20b156195414eff0fbc14`: `PASS_FAIL_CLOSED_UNAVAILABLE`
- Drill: D1-D5 PASS, D6 `UNWIND_NOT_PROVEN`, D7 `PASS_FAIL_CLOSED_UNAVAILABLE`, D8 `EXIT_REJECTED_UNWIND_NOT_PROVEN`
- Drill-Cleanup: 0 Container, 0 Volumes, 0 Netzwerke; kein Positionsanstieg
- `pwsh -File ci/scripts/run_all.ps1 -Profile fast`: PASS (`8502 passed, 73 skipped, 1 deselected`; lint/docs/governance/report PASS)
- Required Commit Status `cdb-local-ci`: SUCCESS am exakten PR-HEAD
- `git diff --check`: PASS

## Risiken / Guardrails
- LR bleibt `NO-GO`; `trade-capable` autorisiert weder Echtgeld noch Live-Trading.
- Stop-Loss-Schutz bleibt `UNAVAILABLE`; es gibt keinen Protection-PASS.
- D6 und D8 beweisen keinen Reduce-only-Unwind.
- GitHub-Actions-Check-Runs sind technisch rot, ohne gestartete Schritte (`steps=[]`, `runner_id=0`). Der live required Context `cdb-local-ci` ist separat am exakten HEAD grün.

## Restunsicherheiten
- Reduce-only-Unwind, Kill-Cancel, persistenter Dedup-State und restart-sicherer Stop-Loss-Consumer bleiben offen.
- Der committed Report bindet den getesteten Code-Commit `aab4cb270b0ced190b50898e8e0f809c5ce6934d`; das untracked Rohmanifest `4182_0d7244e5_20260729T123411Z` und `cdb-local-ci` binden den finalen PR-HEAD. Die SHAs werden nicht gleichgesetzt.

## Issue-Bezug
- Refs #4182
- Refs #4152
