### PR TITLE
fix(skills): repair mirror assets and validate links

### DIFF
--- a/.claude/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
+++ b/.claude/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
@@ -1,0 +1,17 @@
+# CDB Decision Surface Matrix
+
+Use this matrix before issuing a verdict.
+
+| Surface | Primary question | Canon anchor | Typical failure mode |
+|---|---|---|---|
+| Stage-System | Is a Board-stage claim or transition justified? | `#1445`, newest weekly comment, `#1492` when relevant, `docs/runbooks/CONTROL_REGISTER.md` | Stage is silently promoted into LR |
+| LR-System | Is a live-readiness claim justified? | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | `CURRENT_STATUS.md` is misread as LR authority |
+| Repo/Engineering-Status | Is the repo, PR, or engineering ledger claim justified? | `CURRENT_STATUS.md` | closed issue or merged code is overstated as broader proof |
+| Runtime/Operator-Reality | Is the system operable or fail-closed in practice? | current runbooks, committed artifacts, direct runtime evidence | dashboards or stories substitute for technical checks |
+| CI/Workflow-Reality | Is a workflow, gate, or ruleset claim justified? | workflows, rulesets, current GitHub state | green status hides skipped or soft-failed gates |
+| Data-contract/persistence-reality | Is a field or metadata claim proven end-to-end? | producer, consumer, tests, persisted artifacts | one layer mentions a field and the rest is assumed |
+| Documentation/reporting quality | Is the defect only phrasing or actually technical? | report text plus the canon it references | reporting artifact is inflated into system defect |
+
+Rule:
+- If more than one surface is involved, separate them.
+- Never let one verdict class overwrite another surface.

--- a/.claude/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
+++ b/.claude/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
@@ -1,0 +1,48 @@
+# CDB Issue Comment Patterns
+
+Use short issue-ready comments after the gate verdict is stable.
+
+## PASS WITH EXPLICIT LIMITS
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: PASS WITH EXPLICIT LIMITS
+
+Why:
+- Direct evidence: <artifact>
+- Limits: <explicit residual>
+- Not upgraded: <surface that remains unchanged>
+
+Next move:
+- <one concrete action>
+```
+
+## NON-BLOCKING GAP
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: NON-BLOCKING GAP
+
+Why:
+- The core claim is supportable for this surface.
+- Residual gap: <explicit gap>
+- This does not block: <named surface>
+
+Next move:
+- <one concrete action>
+```
+
+## BLOCKED
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: BLOCKED
+
+Why:
+- Missing or ambiguous proof: <artifact or contract gap>
+- Blocking system: <surface>
+- No fake PASS issued.
+
+Next move:
+- <one concrete action>
+```

--- a/.claude/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
+++ b/.claude/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
@@ -1,0 +1,26 @@
+# CDB Verdict Classes
+
+Use exactly one primary verdict.
+
+## PASS
+Use only when the claim is directly supported by the relevant canon and evidence.
+
+## PASS WITH EXPLICIT LIMITS
+Use when the claim is acceptable only with named boundaries that must stay visible.
+
+## NON-BLOCKING GAP
+Use when a real gap exists, but it does not block the decision surface under review.
+Keep the residual explicit.
+
+## BLOCKED
+Use when a required condition, proof basis, or source-of-truth boundary is unresolved.
+Do not soften this into narrative.
+
+## OUT OF SCOPE
+Use when the finding is real but not part of the current decision surface.
+Do not silently absorb it into the verdict.
+
+## Fast checks
+- If proof depends on memory, use `BLOCKED` or `NON-BLOCKING GAP`.
+- If Stage is acceptable but LR is still `NO-GO`, do not use `PASS` for LR.
+- If code is fixed but closure proof is incomplete, prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`.

--- a/.claude/skills/gh-fix-ci/SKILL.md
+++ b/.claude/skills/gh-fix-ci/SKILL.md
@@ -54,7 +54,7 @@ python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --lines 200
 
 ## Check Status Handling
 
-Based on [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md) findings:
+Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md) findings:
 
 ### Polling Behavior (only with `--wait` flag)
 - **Poll Statuses:** `IN_PROGRESS`, `QUEUED`, `PENDING`
@@ -370,7 +370,7 @@ Exit code: 2
 
 ## References
 
-- **Discovery Report:** [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md)
+- **Discovery Report:** [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md)
 - **CDB Repository:** https://github.com/jannekbuengener/Claire_de_Binare
 - **GitHub CLI Docs:** https://cli.github.com/manual/
 

--- a/.codex/cdb_skills/gh-fix-ci/SKILL.md
+++ b/.codex/cdb_skills/gh-fix-ci/SKILL.md
@@ -54,7 +54,7 @@ python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --lines 200
 
 ## Check Status Handling
 
-Based on [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md) findings:
+Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md) findings:
 
 ### Polling Behavior (only with `--wait` flag)
 - **Poll Statuses:** `IN_PROGRESS`, `QUEUED`, `PENDING`
@@ -370,7 +370,7 @@ Exit code: 2
 
 ## References
 
-- **Discovery Report:** [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md)
+- **Discovery Report:** [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md)
 - **CDB Repository:** https://github.com/jannekbuengener/Claire_de_Binare
 - **GitHub CLI Docs:** https://cli.github.com/manual/
 

--- a/.cursor/skills/gh-fix-ci/SKILL.md
+++ b/.cursor/skills/gh-fix-ci/SKILL.md
@@ -54,7 +54,7 @@ python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --lines 200
 
 ## Check Status Handling
 
-Based on [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md) findings:
+Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md) findings:
 
 ### Polling Behavior (only with `--wait` flag)
 - **Poll Statuses:** `IN_PROGRESS`, `QUEUED`, `PENDING`
@@ -370,7 +370,7 @@ Exit code: 2
 
 ## References
 
-- **Discovery Report:** [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md)
+- **Discovery Report:** [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md)
 - **CDB Repository:** https://github.com/jannekbuengener/Claire_de_Binare
 - **GitHub CLI Docs:** https://cli.github.com/manual/
 

--- a/.opencode/skills/gh-fix-ci/SKILL.md
+++ b/.opencode/skills/gh-fix-ci/SKILL.md
@@ -54,7 +54,7 @@ python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --lines 200
 
 ## Check Status Handling
 
-Based on [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md) findings:
+Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md) findings:
 
 ### Polling Behavior (only with `--wait` flag)
 - **Poll Statuses:** `IN_PROGRESS`, `QUEUED`, `PENDING`
@@ -370,7 +370,7 @@ Exit code: 2
 
 ## References
 
-- **Discovery Report:** [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md)
+- **Discovery Report:** [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md)
 - **CDB Repository:** https://github.com/jannekbuengener/Claire_de_Binare
 - **GitHub CLI Docs:** https://cli.github.com/manual/
 

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -132,11 +132,13 @@ gelistet werden.
   umgestellt werden.
 - Drift-Erkennung gehoert zum `cdb-drift-reconcile`-Workflow.
 
-### 8.1 Skill Surface Mirror Drift Guard (Issue #3643)
+### 8.1 Skill Surface Mirror Drift Guard (Issue #3643, erweitert #4122)
 
 Der Drift-Guard `tools/validate_skill_surface_mirror.py` prueft Canon-Body
-gegen alle erwarteten Adapter (Header ignoriert). Er ist read-only, macht
-keine Datei-, Netzwerk-, GitHub-, DB- oder MCP-Aktionen.
+gegen alle erwarteten Adapter (Header ignoriert), lokale Markdown-Links in
+`SKILL.md`, Markdown-Anchors bei Fragmenten sowie Mirror-Paritaet fuer
+skill-lokale Assets. Er ist read-only, macht keine Datei-, Netzwerk-,
+GitHub-, DB- oder MCP-Aktionen.
 
 ```bash
 python tools/validate_skill_surface_mirror.py          # human report
@@ -148,14 +150,42 @@ python tools/validate_skill_surface_mirror.py --skill <name>
 - Prueft Body-Parity **und** den Pflicht-Header (`mirrored-from-canon` +
   korrekte Canon-Quelle je Adapter, siehe §7); ein Body-Match mit fehlendem
   Header ist Drift.
+- Prueft zusaetzlich (#4122): relative lokale Linkziele (Datei/Verzeichnis),
+  relevante fehlende Markdown-Anchors, Root-Escape ausserhalb des Repos,
+  Mirror-Existenz und Inhaltsparitaet fuer skill-lokale referenzierte Assets.
+- Fehlerklassen u. a.: `MISSING_LOCAL_TARGET`, `MISSING_MIRRORED_ASSET`,
+  `ASSET_CONTENT_DRIFT`, `MISSING_ANCHOR`, `PATH_ESCAPES_REPO_ROOT`,
+  `INVALID_ASSET_CLASS`, `INVALID_EXCEPTION` (mit Datei/Zeile wo sinnvoll).
 - **Pflicht:** Nach jeder Aenderung an `docs/skills/<name>/SKILL.md` den
   Drift-Guard laufen lassen und Adapter nachziehen, bevor die Session als
   vollstaendig abgeschlossen gilt. Bei `DRIFT_FOUND` re-mirror im Scope oder
   dedupliziertes Re-Mirror-Follow-up-Issue anlegen (kein Auto-Merge ohne gruene
   Required Checks).
 - Dokumentierte Ausnahmen (kein Drift): `cdb-onboarding` (codex-only Alias),
-  `gh-fix-ci` Canon-Extras (`META.yaml`/`evals.json`/`scripts/`; nur `SKILL.md`
-  wird verglichen), `.claude/skills/*.skill`, `.gemini/skills/`.
+  `gh-fix-ci` Canon-Extras (`META.yaml`/`evals.json`/`scripts/`),
+  `.claude/skills/*.skill`, `.gemini/skills/`.
+
+### 8.2 Skill Asset Classes (Issue #4122)
+
+Lokale Verweise aus `SKILL.md` werden einer Asset-Klasse zugeordnet:
+
+| Klasse | Regel | Beispiele |
+|---|---|---|
+| `mirrored` | Relativ aus `SKILL.md` verlinkt und unter dem Skill-Verzeichnis aufgeloest → muss auf Canon **und** allen aktiven (nicht excludierten) Adaptern existieren; Inhalt nach Text-Normalisierung identisch | `references/*.md` |
+| `canon_only` | Nur unter `docs/skills/<name>/`; Adapter spiegeln sie nicht; **keine** skill-lokalen relativen `SKILL.md`-Links darauf (stattdessen expliziter Canon-Pfad) | `META.yaml`, `evals.json`, `scripts/`, `DISCOVERY_REPORT.md` |
+| `external` | `https:` / `http:` / `mailto:` — lokal nicht aufgeloest, kein Netzabruf | externe URLs |
+| `excluded` | dokumentierte Surface-Ausnahme mit Reason | `cdb-onboarding` non-codex |
+
+Regeln:
+
+- Canon-first: Assets zuerst unter `docs/skills/<name>/` korrigieren, dann auf
+  Adapter spiegeln (kein abweichender Mirror-Inhalt).
+- Relative Links auf `canon_only`-Pfade sind ungueltig (`INVALID_ASSET_CLASS`),
+  weil Body-Paritaet sonst tote Adapter-Links erzwingt.
+- Links ausserhalb des Skill-Verzeichnisses, aber innerhalb des Repo-Roots,
+  werden nur auf Existenz (und ggf. Anchor) je Quelldatei geprueft — keine
+  Mirror-Pflicht.
+- Leere Platzhalter nur zur Validator-Beruhigung sind verboten.
 
 ## 9. Skill-Neuanlage-Workflow
 
@@ -164,9 +194,12 @@ python tools/validate_skill_surface_mirror.py --skill <name>
    Vertrag: [`SKILL_META_SCHEMA.md`](SKILL_META_SCHEMA.md);
    Starter: [`_templates/META.yaml`](_templates/META.yaml),
    [`_templates/evals.json`](_templates/evals.json).
-   Meta-Artefakte bleiben canon-only (Adapter spiegeln nur `SKILL.md`).
+   Meta-Artefakte und andere `canon_only`-Dateien bleiben im Canon.
+   Relativ aus `SKILL.md` verlinkte skill-lokale Assets (z. B. `references/`)
+   sind `mirrored` und muessen mitgespiegelt werden (Abschnitt 8.2).
 3. Surface-Adapter-Header (Abschnitt 7) in der kanonischen Datei setzen.
-4. Mirror auf alle aktiven Surfaces (Abschnitt 4).
+4. Mirror auf alle aktiven Surfaces (Abschnitt 4): `SKILL.md` plus alle
+   `mirrored` Assets.
 5. `.claude/skills/cdb-<name>.skill` Index anlegen, falls Claude relevant.
 6. Eintrag in `AGENTS.md` Skill-Tabelle (root pointer).
 7. Eintrag in Surface-READMEs der aktiven Surfaces.
@@ -291,7 +324,7 @@ Canon-Body (minus Header). Verifiziert durch
 | cdb-external-docs | Y | sync | sync | sync | sync | — |
 | cdb-ci-cd-guard | Y | sync | sync | sync | sync | — |
 | ctb-docker-stack | Y | sync | sync | sync | sync | — |
-| gh-fix-ci | Y | sync | sync | sync | sync | canon-only: META.yaml, evals.json, scripts/ |
+| gh-fix-ci | Y | sync | sync | sync | sync | canon-only: META.yaml, evals.json, scripts/, DISCOVERY_REPORT.md (Canon-Pfad-Link) |
 | gh-address-comments | Y | sync | sync | sync | sync | — |
 | cdb-github-api-ops | Y | sync | sync | sync | sync | — |
 | surrealql | Y | sync | sync | sync | sync | — |
@@ -303,7 +336,8 @@ Canon-Body (minus Header). Verifiziert durch
 | Skill | Abweichung | Begruendung |
 |---|---|---|
 | `cdb-onboarding` | Nur Codex-Adapter | Duenner Alias auf `onboarding`; andere Surfaces nutzen `onboarding` direkt |
-| `gh-fix-ci` | Zusatzartefakte nur im Canon-Verzeichnis | `META.yaml`, `evals.json`, `scripts/` sind Canon-Erweiterungen; Adapter erhalten nur `SKILL.md` |
+| `gh-fix-ci` | Canon-Extras canon-only | `META.yaml`, `evals.json`, `scripts/`, `DISCOVERY_REPORT.md` bleiben `canon_only`; `SKILL.md` verlinkt den Discovery Report ueber den expliziten Canon-Pfad `../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md` (#4122) |
+| `cdb-contract-evidence-gatekeeper` | `references/` gespiegelt | Die drei Reference-Dateien sind `mirrored` Assets und muessen auf Canon und allen aktiven Adaptern liegen (#4122) |
 | `.claude/skills/*.skill` | Nicht gespiegelt | Paket-/Aliasflaeche; out of scope #3639 |
 | `.gemini/skills/` | Nicht gespiegelt | Eingeschraenkter Surface; kein CDB-Domain-Mirror |
 

--- a/docs/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
+++ b/docs/skills/cdb-contract-evidence-gatekeeper/references/CDB_DECISION_SURFACE_MATRIX.md
@@ -1,0 +1,17 @@
+# CDB Decision Surface Matrix
+
+Use this matrix before issuing a verdict.
+
+| Surface | Primary question | Canon anchor | Typical failure mode |
+|---|---|---|---|
+| Stage-System | Is a Board-stage claim or transition justified? | `#1445`, newest weekly comment, `#1492` when relevant, `docs/runbooks/CONTROL_REGISTER.md` | Stage is silently promoted into LR |
+| LR-System | Is a live-readiness claim justified? | `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` | `CURRENT_STATUS.md` is misread as LR authority |
+| Repo/Engineering-Status | Is the repo, PR, or engineering ledger claim justified? | `CURRENT_STATUS.md` | closed issue or merged code is overstated as broader proof |
+| Runtime/Operator-Reality | Is the system operable or fail-closed in practice? | current runbooks, committed artifacts, direct runtime evidence | dashboards or stories substitute for technical checks |
+| CI/Workflow-Reality | Is a workflow, gate, or ruleset claim justified? | workflows, rulesets, current GitHub state | green status hides skipped or soft-failed gates |
+| Data-contract/persistence-reality | Is a field or metadata claim proven end-to-end? | producer, consumer, tests, persisted artifacts | one layer mentions a field and the rest is assumed |
+| Documentation/reporting quality | Is the defect only phrasing or actually technical? | report text plus the canon it references | reporting artifact is inflated into system defect |
+
+Rule:
+- If more than one surface is involved, separate them.
+- Never let one verdict class overwrite another surface.

--- a/docs/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
+++ b/docs/skills/cdb-contract-evidence-gatekeeper/references/CDB_ISSUE_COMMENT_PATTERNS.md
@@ -1,0 +1,48 @@
+# CDB Issue Comment Patterns
+
+Use short issue-ready comments after the gate verdict is stable.
+
+## PASS WITH EXPLICIT LIMITS
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: PASS WITH EXPLICIT LIMITS
+
+Why:
+- Direct evidence: <artifact>
+- Limits: <explicit residual>
+- Not upgraded: <surface that remains unchanged>
+
+Next move:
+- <one concrete action>
+```
+
+## NON-BLOCKING GAP
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: NON-BLOCKING GAP
+
+Why:
+- The core claim is supportable for this surface.
+- Residual gap: <explicit gap>
+- This does not block: <named surface>
+
+Next move:
+- <one concrete action>
+```
+
+## BLOCKED
+```md
+Decision surface: <surface>
+Claim under review: <claim>
+Verdict: BLOCKED
+
+Why:
+- Missing or ambiguous proof: <artifact or contract gap>
+- Blocking system: <surface>
+- No fake PASS issued.
+
+Next move:
+- <one concrete action>
+```

--- a/docs/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
+++ b/docs/skills/cdb-contract-evidence-gatekeeper/references/CDB_VERDICT_CLASSES.md
@@ -1,0 +1,26 @@
+# CDB Verdict Classes
+
+Use exactly one primary verdict.
+
+## PASS
+Use only when the claim is directly supported by the relevant canon and evidence.
+
+## PASS WITH EXPLICIT LIMITS
+Use when the claim is acceptable only with named boundaries that must stay visible.
+
+## NON-BLOCKING GAP
+Use when a real gap exists, but it does not block the decision surface under review.
+Keep the residual explicit.
+
+## BLOCKED
+Use when a required condition, proof basis, or source-of-truth boundary is unresolved.
+Do not soften this into narrative.
+
+## OUT OF SCOPE
+Use when the finding is real but not part of the current decision surface.
+Do not silently absorb it into the verdict.
+
+## Fast checks
+- If proof depends on memory, use `BLOCKED` or `NON-BLOCKING GAP`.
+- If Stage is acceptable but LR is still `NO-GO`, do not use `PASS` for LR.
+- If code is fixed but closure proof is incomplete, prefer `PASS WITH EXPLICIT LIMITS` or `NON-BLOCKING GAP`.

--- a/docs/skills/gh-fix-ci/SKILL.md
+++ b/docs/skills/gh-fix-ci/SKILL.md
@@ -54,7 +54,7 @@ python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --lines 200
 
 ## Check Status Handling
 
-Based on [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md) findings:
+Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md) findings:
 
 ### Polling Behavior (only with `--wait` flag)
 - **Poll Statuses:** `IN_PROGRESS`, `QUEUED`, `PENDING`
@@ -370,7 +370,7 @@ Exit code: 2
 
 ## References
 
-- **Discovery Report:** [DISCOVERY_REPORT.md](./DISCOVERY_REPORT.md)
+- **Discovery Report:** [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md)
 - **CDB Repository:** https://github.com/jannekbuengener/Claire_de_Binare
 - **GitHub CLI Docs:** https://cli.github.com/manual/
 

--- a/tests/unit/tools/test_validate_skill_surface_mirror.py
+++ b/tests/unit/tools/test_validate_skill_surface_mirror.py
@@ -80,7 +80,9 @@ def test_strip_header_no_header_is_noop() -> None:
 
 def test_normalize_body_ignores_header_and_line_endings() -> None:
     canon = CANON_HEADER.format(name="x") + "line one\nline two\n"
-    adapter = ADAPTER_HEADER.format(name="x", surface="cursor") + "line one\r\nline two\r\n"
+    adapter = (
+        ADAPTER_HEADER.format(name="x", surface="cursor") + "line one\r\nline two\r\n"
+    )
     assert guard.normalize_body(canon) == guard.normalize_body(adapter)
 
 
@@ -226,7 +228,9 @@ def test_report_has_required_json_fields(tmp_path: Path) -> None:
         assert field in report
 
 
-def test_main_exit_code_pass(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_main_exit_code_pass(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     _make_skill(tmp_path, "cdb-alpha")
     code = guard.main(["--repo-root", str(tmp_path), "--json"])
     assert code == 0
@@ -262,10 +266,11 @@ def test_main_blocked_json_emits_status(
 
 
 def test_real_repo_skill_surfaces_are_in_sync() -> None:
-    """CI gate: real canon skills must match their adapters (Issue #3643).
+    """CI gate: real canon skills must match their adapters (Issues #3643/#4122).
 
     Fails if a canon `docs/skills/<name>/SKILL.md` was changed without
-    re-mirroring the `.opencode`/`.cursor`/`.codex`/`.claude` adapters.
+    re-mirroring the `.opencode`/`.cursor`/`.codex`/`.claude` adapters,
+    or if skill-local linked assets / anchors are broken.
     """
     report = guard.run(guard.REPO_ROOT_DEFAULT)
     assert report["status"] == "PASS", (
@@ -273,3 +278,202 @@ def test_real_repo_skill_surfaces_are_in_sync() -> None:
         f"mismatches={report['mismatches']} missing={report['missing']}"
     )
     assert report["canon_count"] >= 1
+
+
+# --- Issue #4122: local links, assets, anchors ---
+
+
+def _body_with_links(name: str, extra: str) -> str:
+    return f"---\nname: {name}\n---\n\n# {name}\n\n{extra}\n"
+
+
+def test_pass_valid_relative_file_and_external_url(tmp_path: Path) -> None:
+    name = "cdb-link-ok"
+    extra = (
+        "See [ref](references/note.md) and [ext](https://example.com/docs).\n"
+        "Also [mail](mailto:ops@example.com).\n"
+    )
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    note = "# Note\n\n## Detail Section\n\nbody\n"
+    for surface in ("canon", "opencode", "cursor", "codex", "claude"):
+        skill_dir = (
+            tmp_path / "docs" / "skills" / name
+            if surface == "canon"
+            else _adapter_path(tmp_path, surface, name).parent
+        )
+        _write(skill_dir / "references" / "note.md", note)
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "PASS", report["mismatches"]
+
+
+def test_pass_valid_subdirectory_link(tmp_path: Path) -> None:
+    name = "cdb-dir-ok"
+    extra = "Browse [refs](references/).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    for surface in ("canon", "opencode", "cursor", "codex", "claude"):
+        skill_dir = (
+            tmp_path / "docs" / "skills" / name
+            if surface == "canon"
+            else _adapter_path(tmp_path, surface, name).parent
+        )
+        (skill_dir / "references").mkdir(parents=True, exist_ok=True)
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "PASS", report["mismatches"]
+
+
+def test_pass_valid_markdown_anchor(tmp_path: Path) -> None:
+    name = "cdb-anchor-ok"
+    extra = "Jump to [detail](references/note.md#detail-section).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    note = "# Note\n\n## Detail Section\n\nbody\n"
+    for surface in ("canon", "opencode", "cursor", "codex", "claude"):
+        skill_dir = (
+            tmp_path / "docs" / "skills" / name
+            if surface == "canon"
+            else _adapter_path(tmp_path, surface, name).parent
+        )
+        _write(skill_dir / "references" / "note.md", note)
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "PASS", report["mismatches"]
+
+
+def test_drift_missing_local_file(tmp_path: Path) -> None:
+    name = "cdb-missing-file"
+    extra = "See [gone](references/missing.md).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "DRIFT_FOUND"
+    kinds = {m["kind"] for m in report["mismatches"]}
+    assert "MISSING_LOCAL_TARGET" in kinds or "MISSING_MIRRORED_ASSET" in kinds
+
+
+def test_drift_missing_local_directory(tmp_path: Path) -> None:
+    name = "cdb-missing-dir"
+    extra = "Browse [refs](references/).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "DRIFT_FOUND"
+    assert any(m["kind"] == "MISSING_LOCAL_TARGET" for m in report["mismatches"])
+
+
+def test_drift_missing_anchor(tmp_path: Path) -> None:
+    name = "cdb-missing-anchor"
+    extra = "Jump to [x](references/note.md#does-not-exist).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    note = "# Note\n\n## Other Heading\n\nbody\n"
+    for surface in ("canon", "opencode", "cursor", "codex", "claude"):
+        skill_dir = (
+            tmp_path / "docs" / "skills" / name
+            if surface == "canon"
+            else _adapter_path(tmp_path, surface, name).parent
+        )
+        _write(skill_dir / "references" / "note.md", note)
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "DRIFT_FOUND"
+    assert any(m["kind"] == "MISSING_ANCHOR" for m in report["mismatches"])
+
+
+def test_drift_invalid_asset_class_canon_only_relative_link(tmp_path: Path) -> None:
+    name = "gh-fix-ci"
+    extra = "See [meta](./META.yaml).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    _write(tmp_path / "docs" / "skills" / name / "META.yaml", "meta: true\n")
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "DRIFT_FOUND"
+    assert any(m["kind"] == "INVALID_ASSET_CLASS" for m in report["mismatches"])
+
+
+def test_drift_missing_mirrored_asset_on_adapter(tmp_path: Path) -> None:
+    name = "cdb-asset-gap"
+    extra = "See [ref](references/note.md).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    note = "# Note\n\nbody\n"
+    # Canon + three adapters have the asset; claude does not.
+    for surface in ("canon", "opencode", "cursor", "codex"):
+        skill_dir = (
+            tmp_path / "docs" / "skills" / name
+            if surface == "canon"
+            else _adapter_path(tmp_path, surface, name).parent
+        )
+        _write(skill_dir / "references" / "note.md", note)
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "DRIFT_FOUND"
+    assert any(
+        m["kind"] in {"MISSING_MIRRORED_ASSET", "MISSING_LOCAL_TARGET"}
+        and m.get("surface") == "claude"
+        for m in report["mismatches"]
+    )
+
+
+def test_drift_mirrored_asset_content_drift(tmp_path: Path) -> None:
+    name = "cdb-asset-drift"
+    extra = "See [ref](references/note.md).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    for surface in ("canon", "opencode", "cursor", "codex", "claude"):
+        skill_dir = (
+            tmp_path / "docs" / "skills" / name
+            if surface == "canon"
+            else _adapter_path(tmp_path, surface, name).parent
+        )
+        content = "# Note\n\ncanon\n" if surface == "canon" else "# Note\n\ndrift\n"
+        _write(skill_dir / "references" / "note.md", content)
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "DRIFT_FOUND"
+    assert any(m["kind"] == "ASSET_CONTENT_DRIFT" for m in report["mismatches"])
+
+
+def test_drift_path_escapes_repo_root(tmp_path: Path) -> None:
+    name = "cdb-escape"
+    extra = "See [outside](../../../../../../etc/passwd).\n"
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "DRIFT_FOUND"
+    assert any(m["kind"] == "PATH_ESCAPES_REPO_ROOT" for m in report["mismatches"])
+
+
+def test_gh_fix_ci_canon_only_extras_still_pass_without_mirror(tmp_path: Path) -> None:
+    """META/evals/scripts remain canon-only and must not force adapter copies."""
+    _make_skill(tmp_path, "gh-fix-ci")
+    _write(tmp_path / "docs" / "skills" / "gh-fix-ci" / "META.yaml", "meta: true\n")
+    _write(tmp_path / "docs" / "skills" / "gh-fix-ci" / "evals.json", "{}\n")
+    _write(
+        tmp_path / "docs" / "skills" / "gh-fix-ci" / "scripts" / "run.sh",
+        "echo hi\n",
+    )
+    report = guard.run(tmp_path, skill_filter="gh-fix-ci")
+    assert report["status"] == "PASS", report["mismatches"]
+
+
+def test_gh_fix_ci_explicit_canon_path_to_discovery_passes(tmp_path: Path) -> None:
+    """Canon-path link to DISCOVERY_REPORT is allowed; no adapter mirror required."""
+    name = "gh-fix-ci"
+    extra = (
+        "Based on [DISCOVERY_REPORT.md]"
+        "(../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md).\n"
+    )
+    _make_skill(tmp_path, name, body=_body_with_links(name, extra))
+    _write(
+        tmp_path / "docs" / "skills" / "gh-fix-ci" / "DISCOVERY_REPORT.md",
+        "# Discovery\n",
+    )
+    report = guard.run(tmp_path, skill_filter=name)
+    assert report["status"] == "PASS", report["mismatches"]
+    assert not any(m["kind"] == "MISSING_MIRRORED_ASSET" for m in report["mismatches"])
+
+
+def test_github_slug_and_duplicate_headings() -> None:
+    md = "# Hello World\n\n## Hello World\n\n## Detail Section\n"
+    anchors = guard.collect_heading_anchors(md)
+    assert "hello-world" in anchors
+    assert "hello-world-1" in anchors
+    assert "detail-section" in anchors
+
+
+def test_invalid_exception_unknown_surface(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        guard.EXCLUDED_ADAPTERS,
+        "cdb-onboarding",
+        {"not-a-surface": "bad"},
+    )
+    mismatches = guard.validate_exclusion_tables()
+    assert any(m["kind"] == "INVALID_EXCEPTION" for m in mismatches)

--- a/tools/validate_skill_surface_mirror.py
+++ b/tools/validate_skill_surface_mirror.py
@@ -9,8 +9,9 @@ PR #3637). Surface adapters mirror those bodies to:
 - ``.claude/skills/<name>/SKILL.md``
 
 This validator compares each canon skill body against its expected adapters
-(ignoring the surface header block) and reports drift. It never modifies files
-and performs no network / GitHub / DB / MCP actions.
+(ignoring the surface header block), checks local markdown links / anchors,
+and enforces mirror parity for skill-local assets referenced from SKILL.md.
+It never modifies files and performs no network / GitHub / DB / MCP actions.
 
 Usage:
     python tools/validate_skill_surface_mirror.py
@@ -20,10 +21,10 @@ Usage:
 
 Exit codes:
     0 - PASS (no drift)
-    1 - DRIFT_FOUND (body mismatch or missing expected adapter)
+    1 - DRIFT_FOUND (body/header/link/asset mismatch or missing adapter)
     2 - BLOCKED (missing canon tree, unknown skill, parse/usage error)
 
-Issue: #3643
+Issues: #3643, #4122
 """
 
 from __future__ import annotations
@@ -32,8 +33,9 @@ import argparse
 import json
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterable
+from urllib.parse import unquote, urlparse
 
 REPO_ROOT_DEFAULT = Path(__file__).resolve().parent.parent
 
@@ -57,18 +59,39 @@ EXCLUDED_ADAPTERS: dict[str, dict[str, str]] = {
     },
 }
 
+# Skill-local paths that stay canon-only (Issue #4122). Relative SKILL.md links
+# to these paths are invalid because adapters would not resolve them.
+# Values are POSIX-style relative paths under the skill directory.
+CANON_ONLY_ASSETS: dict[str, frozenset[str]] = {
+    "gh-fix-ci": frozenset(
+        {
+            "META.yaml",
+            "evals.json",
+            "scripts",
+            "DISCOVERY_REPORT.md",
+        }
+    ),
+}
+
+# Schemes that are never resolved against the local filesystem.
+EXTERNAL_SCHEMES = frozenset({"http", "https", "mailto", "http+unix"})
+
 # Surfaces/paths intentionally out of scope for this mirror check.
 # Documented for transparency; not compared, not treated as drift.
 OUT_OF_SCOPE_NOTES: list[str] = [
-    "`gh-fix-ci` canon extras (META.yaml, evals.json, scripts/) are canon-only; "
-    "only SKILL.md bodies are compared.",
+    "`gh-fix-ci` canon extras (META.yaml, evals.json, scripts/, "
+    "DISCOVERY_REPORT.md) are canon-only; SKILL.md must link DISCOVERY_REPORT "
+    "via the explicit canon path (#4122).",
     "`.claude/skills/*.skill` package/alias files are out of scope.",
     "`.gemini/skills/` is a restricted surface; no CDB domain mirror expected.",
     "`.codex/cdb_skills/.system/` is out of scope.",
+    "External http(s)/mailto links are classified but not fetched (no network).",
 ]
 
 _HEADER_RE = re.compile(r"^\ufeff?\s*<!--.*?-->\s*", flags=re.DOTALL)
 _HEADER_BLOCK_RE = re.compile(r"^\ufeff?\s*<!--(.*?)-->", flags=re.DOTALL)
+_MD_LINK_RE = re.compile(r"(?<!!)\[([^\]]*)\]\(([^)]+)\)")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", flags=re.MULTILINE)
 
 # Adapters must declare they are mirrored from canon (Registry §7).
 MIRRORED_MARKER = "mirrored-from-canon"
@@ -120,14 +143,22 @@ def normalize_body(text: str) -> str:
     return "\n".join(lines).strip()
 
 
+def normalize_asset_bytes(data: bytes) -> bytes:
+    """Normalize asset bytes for cross-surface parity (text line endings)."""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return text.encode("utf-8")
+
+
 def find_canon_skills(repo_root: Path) -> list[str]:
     """Return sorted canon skill names discovered under docs/skills/*/SKILL.md."""
     canon_dir = repo_root / "docs" / "skills"
     if not canon_dir.is_dir():
         raise DriftCheckError(f"canon directory not found: {canon_dir}")
-    names = sorted(
-        p.parent.name for p in canon_dir.glob("*/SKILL.md") if p.is_file()
-    )
+    names = sorted(p.parent.name for p in canon_dir.glob("*/SKILL.md") if p.is_file())
     if not names:
         raise DriftCheckError(f"no canon skills found under {canon_dir}/*/SKILL.md")
     return names
@@ -138,11 +169,406 @@ def exclusion_reason(skill: str, surface: str) -> str | None:
     return EXCLUDED_ADAPTERS.get(skill, {}).get(surface)
 
 
+def skill_dir_for_surface(repo_root: Path, skill: str, surface: str) -> Path:
+    """Return the skill directory path for canon or an adapter surface."""
+    if surface == "canon":
+        return repo_root / "docs" / "skills" / skill
+    return (repo_root / SURFACES[surface].format(name=skill)).parent
+
+
 def _read_text(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:  # pragma: no cover - defensive
         raise DriftCheckError(f"cannot read {path}: {exc}") from exc
+
+
+def _read_bytes(path: Path) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as exc:  # pragma: no cover - defensive
+        raise DriftCheckError(f"cannot read {path}: {exc}") from exc
+
+
+def github_slug(heading: str) -> str:
+    """Approximate GitHub / CommonMark heading slug used in this repo."""
+    text = heading.strip().lower()
+    # Drop markdown emphasis/code markers commonly seen in headings.
+    text = re.sub(r"[`*_~]", "", text)
+    # Keep word chars, spaces, and hyphens; drop other punctuation.
+    text = re.sub(r"[^\w\s\-]", "", text, flags=re.UNICODE)
+    text = re.sub(r"\s+", "-", text.strip())
+    text = re.sub(r"-{2,}", "-", text)
+    return text
+
+
+def collect_heading_anchors(markdown: str) -> set[str]:
+    """Return the set of heading anchors for a markdown document."""
+    anchors: set[str] = set()
+    seen: dict[str, int] = {}
+    for match in _HEADING_RE.finditer(markdown):
+        base = github_slug(match.group(2))
+        if not base:
+            continue
+        count = seen.get(base, 0)
+        seen[base] = count + 1
+        anchors.add(base if count == 0 else f"{base}-{count}")
+    return anchors
+
+
+def _is_canon_only_rel(skill: str, rel_posix: str) -> bool:
+    """True if rel_posix is a documented canon-only asset path for the skill."""
+    allowed = CANON_ONLY_ASSETS.get(skill, frozenset())
+    if not allowed:
+        return False
+    parts = PurePosixPath(rel_posix).parts
+    if not parts:
+        return False
+    # Exact file match or anything under a canon-only directory (e.g. scripts/).
+    if parts[0] in allowed:
+        return True
+    return rel_posix in allowed
+
+
+def _is_skill_local_link_path(path_part: str) -> bool:
+    """True when the written link path stays under the skill dir (no ``..``)."""
+    if not path_part:
+        return False
+    return ".." not in PurePosixPath(path_part).parts
+
+
+def iter_markdown_links(text: str) -> list[tuple[int, str, str]]:
+    """Yield (1-based line, link_text, raw_target) for markdown links in text."""
+    results: list[tuple[int, str, str]] = []
+    for match in _MD_LINK_RE.finditer(text):
+        line_no = text.count("\n", 0, match.start()) + 1
+        raw = match.group(2).strip()
+        # Angle-bracket autolinks / titles: take first token before whitespace/title.
+        if raw.startswith("<") and ">" in raw:
+            raw = raw[1 : raw.index(">")].strip()
+        else:
+            raw = raw.split()[0] if raw else raw
+            if (raw.startswith('"') and raw.endswith('"')) or (
+                raw.startswith("'") and raw.endswith("'")
+            ):
+                raw = raw[1:-1]
+        results.append((line_no, match.group(1), raw))
+    return results
+
+
+def _classify_link_target(raw_target: str) -> tuple[str, str, str]:
+    """Return (kind, path_part, fragment) for a markdown link target.
+
+    kind is one of: external | empty | local
+    """
+    if not raw_target or raw_target == "#":
+        return "empty", "", ""
+    parsed = urlparse(raw_target)
+    if parsed.scheme and parsed.scheme.lower() in EXTERNAL_SCHEMES:
+        return "external", "", ""
+    if parsed.scheme and parsed.scheme.lower() not in {"", "file"}:
+        # Unknown / disallowed scheme — treat as external (not locally resolved).
+        return "external", "", ""
+    # urlparse("references/foo.md#bar") puts path in path; fragment separate.
+    # urlparse("./a.md") works; Windows paths are not expected in skill links.
+    path_part = unquote(parsed.path or "")
+    # Handle targets that are fragment-only (#anchor).
+    if raw_target.startswith("#"):
+        return "local", "", unquote(parsed.fragment or raw_target[1:])
+    fragment = unquote(parsed.fragment or "")
+    # Drop query for local resolution (external queries already handled).
+    return "local", path_part, fragment
+
+
+def check_local_links(
+    *,
+    repo_root: Path,
+    skill: str,
+    surface: str,
+    skill_md_path: Path,
+    text: str,
+) -> list[dict]:
+    """Validate local markdown links in one SKILL.md file."""
+    mismatches: list[dict] = []
+    skill_dir = skill_md_path.parent
+    repo_root_resolved = repo_root.resolve()
+    rel_skill_md = skill_md_path.relative_to(repo_root).as_posix()
+
+    for line_no, _link_text, raw_target in iter_markdown_links(text):
+        kind, path_part, fragment = _classify_link_target(raw_target)
+        if kind in {"external", "empty"}:
+            continue
+
+        if path_part == "" and fragment:
+            # Same-file anchor.
+            anchors = collect_heading_anchors(strip_header(text))
+            if fragment not in anchors:
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": rel_skill_md,
+                        "kind": "MISSING_ANCHOR",
+                        "line": line_no,
+                        "target": raw_target,
+                        "reason": (f"anchor '#{fragment}' not found in {rel_skill_md}"),
+                    }
+                )
+            continue
+
+        # Resolve relative to the source file directory (POSIX-neutral).
+        resolved = (skill_md_path.parent / Path(path_part)).resolve()
+        try:
+            resolved.relative_to(repo_root_resolved)
+        except ValueError:
+            mismatches.append(
+                {
+                    "skill": skill,
+                    "surface": surface,
+                    "path": rel_skill_md,
+                    "kind": "PATH_ESCAPES_REPO_ROOT",
+                    "line": line_no,
+                    "target": raw_target,
+                    "reason": (f"local link resolves outside repo root: {raw_target}"),
+                }
+            )
+            continue
+
+        # Skill-local relative path (for asset-class checks).
+        try:
+            rel_to_skill = resolved.relative_to(skill_dir.resolve()).as_posix()
+            inside_skill = True
+        except ValueError:
+            rel_to_skill = ""
+            inside_skill = False
+
+        # Skill-local relative links (no "..") to canon-only assets are invalid
+        # because body parity would leave adapters with dead links. Explicit
+        # repo-relative canon paths (with "..") remain allowed.
+        if (
+            inside_skill
+            and _is_skill_local_link_path(path_part)
+            and _is_canon_only_rel(skill, rel_to_skill)
+        ):
+            mismatches.append(
+                {
+                    "skill": skill,
+                    "surface": surface,
+                    "path": rel_skill_md,
+                    "kind": "INVALID_ASSET_CLASS",
+                    "line": line_no,
+                    "target": raw_target,
+                    "reason": (
+                        f"skill-local relative link to canon-only asset "
+                        f"'{rel_to_skill}' is not allowed in SKILL.md "
+                        f"(use explicit canon path or reclassify as mirrored)"
+                    ),
+                }
+            )
+            continue
+
+        expects_dir = path_part.endswith("/")
+        if expects_dir:
+            if not resolved.is_dir():
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": rel_skill_md,
+                        "kind": "MISSING_LOCAL_TARGET",
+                        "line": line_no,
+                        "target": raw_target,
+                        "reason": (f"missing directory for link target: {raw_target}"),
+                    }
+                )
+            continue
+
+        if not resolved.exists():
+            mismatches.append(
+                {
+                    "skill": skill,
+                    "surface": surface,
+                    "path": rel_skill_md,
+                    "kind": "MISSING_LOCAL_TARGET",
+                    "line": line_no,
+                    "target": raw_target,
+                    "reason": f"missing local target for link: {raw_target}",
+                }
+            )
+            continue
+
+        if resolved.is_dir():
+            # Directory linked without trailing slash — still valid existence.
+            continue
+
+        if fragment and resolved.suffix.lower() in {".md", ".markdown"}:
+            try:
+                target_text = _read_text(resolved)
+            except DriftCheckError as exc:
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": rel_skill_md,
+                        "kind": "MISSING_LOCAL_TARGET",
+                        "line": line_no,
+                        "target": raw_target,
+                        "reason": str(exc),
+                    }
+                )
+                continue
+            anchors = collect_heading_anchors(target_text)
+            if fragment not in anchors:
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": rel_skill_md,
+                        "kind": "MISSING_ANCHOR",
+                        "line": line_no,
+                        "target": raw_target,
+                        "reason": (
+                            f"anchor '#{fragment}' not found in "
+                            f"{resolved.relative_to(repo_root_resolved).as_posix()}"
+                        ),
+                    }
+                )
+
+    return mismatches
+
+
+def collect_mirrored_asset_rels(
+    skill: str, canon_text: str, canon_md: Path
+) -> set[str]:
+    """Return skill-relative asset paths that must be mirrored across surfaces."""
+    mirrored: set[str] = set()
+    skill_dir = canon_md.parent.resolve()
+    for _line, _text, raw_target in iter_markdown_links(canon_text):
+        kind, path_part, _fragment = _classify_link_target(raw_target)
+        if kind != "local" or not path_part:
+            continue
+        resolved = (canon_md.parent / Path(path_part)).resolve()
+        try:
+            rel = resolved.relative_to(skill_dir).as_posix()
+        except ValueError:
+            continue
+        if rel in {"", "."} or rel == "SKILL.md":
+            continue
+        if _is_canon_only_rel(skill, rel):
+            continue
+        mirrored.add(rel)
+    return mirrored
+
+
+def check_mirrored_assets(
+    *,
+    repo_root: Path,
+    skill: str,
+    asset_rels: set[str],
+) -> list[dict]:
+    """Ensure skill-local mirrored assets exist on all active surfaces with parity."""
+    mismatches: list[dict] = []
+    if not asset_rels:
+        return mismatches
+
+    surfaces_to_check = ["canon"] + [
+        surface for surface in SURFACES if exclusion_reason(skill, surface) is None
+    ]
+
+    for rel in sorted(asset_rels):
+        payloads: dict[str, bytes | None] = {}
+        for surface in surfaces_to_check:
+            skill_dir = skill_dir_for_surface(repo_root, skill, surface)
+            asset_path = skill_dir / Path(rel)
+            if not asset_path.exists():
+                payloads[surface] = None
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": (
+                            asset_path.relative_to(repo_root).as_posix()
+                            if asset_path.is_relative_to(repo_root)
+                            else str(asset_path)
+                        ),
+                        "kind": "MISSING_MIRRORED_ASSET",
+                        "line": None,
+                        "target": rel,
+                        "reason": (
+                            f"mirrored asset missing on surface '{surface}': {rel}"
+                        ),
+                    }
+                )
+                continue
+            if asset_path.is_dir():
+                # Directory presence is enough; children linked separately.
+                payloads[surface] = b"__DIR__"
+                continue
+            payloads[surface] = normalize_asset_bytes(_read_bytes(asset_path))
+
+        present = {s: data for s, data in payloads.items() if data is not None}
+        if len(present) < 2:
+            continue
+        # Compare all present surfaces to the first present payload.
+        baseline_surface, baseline = next(iter(present.items()))
+        for surface, data in present.items():
+            if surface == baseline_surface:
+                continue
+            if data != baseline:
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": (
+                            skill_dir_for_surface(repo_root, skill, surface) / Path(rel)
+                        )
+                        .relative_to(repo_root)
+                        .as_posix(),
+                        "kind": "ASSET_CONTENT_DRIFT",
+                        "line": None,
+                        "target": rel,
+                        "reason": (
+                            f"mirrored asset content drifts vs '{baseline_surface}': "
+                            f"{rel}"
+                        ),
+                    }
+                )
+    return mismatches
+
+
+def validate_exclusion_tables() -> list[dict]:
+    """Return INVALID_EXCEPTION mismatches for undocumented exclusion surfaces."""
+    mismatches: list[dict] = []
+    for skill, surfaces in EXCLUDED_ADAPTERS.items():
+        for surface, reason in surfaces.items():
+            if surface not in SURFACES:
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": "tools/validate_skill_surface_mirror.py",
+                        "kind": "INVALID_EXCEPTION",
+                        "line": None,
+                        "target": surface,
+                        "reason": (
+                            f"EXCLUDED_ADAPTERS references unknown surface "
+                            f"'{surface}' (reason={reason!r})"
+                        ),
+                    }
+                )
+            if not str(reason).strip():
+                mismatches.append(
+                    {
+                        "skill": skill,
+                        "surface": surface,
+                        "path": "tools/validate_skill_surface_mirror.py",
+                        "kind": "INVALID_EXCEPTION",
+                        "line": None,
+                        "target": surface,
+                        "reason": f"empty exclusion reason for {skill}/{surface}",
+                    }
+                )
+    return mismatches
 
 
 def check_skill(repo_root: Path, skill: str) -> dict:
@@ -151,12 +577,23 @@ def check_skill(repo_root: Path, skill: str) -> dict:
     if not canon_path.is_file():
         raise DriftCheckError(f"canon file missing for skill '{skill}': {canon_path}")
 
-    canon_body = normalize_body(_read_text(canon_path))
+    canon_text = _read_text(canon_path)
+    canon_body = normalize_body(canon_text)
 
     mismatches: list[dict] = []
     missing: list[dict] = []
     excluded: list[dict] = []
     adapter_count = 0
+
+    mismatches.extend(
+        check_local_links(
+            repo_root=repo_root,
+            skill=skill,
+            surface="canon",
+            skill_md_path=canon_path,
+            text=canon_text,
+        )
+    )
 
     for surface, template in SURFACES.items():
         rel = template.format(name=skill)
@@ -193,6 +630,24 @@ def check_skill(repo_root: Path, skill: str) -> dict:
                     "reason": head_reason,
                 }
             )
+        mismatches.extend(
+            check_local_links(
+                repo_root=repo_root,
+                skill=skill,
+                surface=surface,
+                skill_md_path=adapter_path,
+                text=adapter_text,
+            )
+        )
+
+    asset_rels = collect_mirrored_asset_rels(skill, canon_text, canon_path)
+    mismatches.extend(
+        check_mirrored_assets(
+            repo_root=repo_root,
+            skill=skill,
+            asset_rels=asset_rels,
+        )
+    )
 
     return {
         "skill": skill,
@@ -219,6 +674,9 @@ def run(repo_root: Path, skill_filter: str | None = None) -> dict:
     missing: list[dict] = []
     excluded: list[dict] = []
     adapter_count = 0
+
+    # Validate exclusion table once per run (not per skill filter miss).
+    mismatches.extend(validate_exclusion_tables())
 
     for skill in canon_skills:
         result = check_skill(repo_root, skill)
@@ -264,7 +722,14 @@ def format_human(report: dict) -> str:
         for m in mismatches:
             kind = m.get("kind", "")
             tag = f"DRIFT/{kind}" if kind else "DRIFT"
-            lines.append(f"  - {tag} {m['skill']} [{m['surface']}] {m['path']}: {m['reason']}")
+            line = m.get("line")
+            line_bit = f":L{line}" if line is not None else ""
+            target = m.get("target")
+            target_bit = f" target={target!r}" if target else ""
+            lines.append(
+                f"  - {tag} {m['skill']} [{m.get('surface', '?')}] "
+                f"{m.get('path', '?')}{line_bit}{target_bit}: {m['reason']}"
+            )
     else:
         lines.append("  - none")
 
@@ -298,7 +763,10 @@ def format_human(report: dict) -> str:
 
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Read-only drift guard for CDB skill surface mirrors (Issue #3643).",
+        description=(
+            "Read-only drift guard for CDB skill surface mirrors "
+            "(Issues #3643, #4122)."
+        ),
     )
     parser.add_argument(
         "--repo-root",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4122

## Problem

`tools/validate_skill_surface_mirror.py` reported PASS while skill-local markdown links pointed at missing assets. Live analysis on `main` @ `2a352079` confirmed 14 dangling links: 6 for `cdb-contract-evidence-gatekeeper` references (canon + Claude) and 8 for `gh-fix-ci` `./DISCOVERY_REPORT.md` on adapters.

## Live Findings

| Cluster | Count | Evidence |
|---|---|---|
| Gatekeeper `references/*` | 6 | Missing under `docs/skills/...` and `.claude/...`; present/byte-identical on cursor/codex/opencode |
| `gh-fix-ci` DISCOVERY_REPORT | 8 | 2 link sites × 4 adapters; file exists only under canon |
| Prior validator | PASS | Body/header only; no asset/link checks |

No prior open PR/branch for #4122. No overlapping open PR on skill/validator files.

## Context Evidence

```text
context_source: unavailable
context_status: not-used
context_brain_attempted: true
context_brain_used: false
context_available: false
repo_fallback_used: true
repo_fallback_reason: unavailable
context_tool_status: absent
context_trust_level: none
records_found: none
```

Issue analysis comment could not be posted (`gh issue comment` → GraphQL: Resource not accessible by integration). Decision lines are recorded here instead.

## Canon and Mirror Model

- SSOT: `docs/skills/<name>/SKILL.md`
- Adapters: `.opencode/skills`, `.cursor/skills`, `.codex/cdb_skills`, `.claude/skills` (manual mirror + validator)
- Asset classes (#4122):
  - `mirrored`: skill-local relative links (e.g. gatekeeper `references/*`)
  - `canon_only`: `gh-fix-ci` `META.yaml`, `evals.json`, `scripts/`, `DISCOVERY_REPORT.md`
  - `external`: http(s)/mailto (not fetched)
  - `excluded`: documented surface exclusions (`cdb-onboarding`)

## Dangling Links Repaired

1. **Gatekeeper (6):** copied `references/{CDB_DECISION_SURFACE_MATRIX,CDB_VERDICT_CLASSES,CDB_ISSUE_COMMENT_PATTERNS}.md` into canon and Claude from existing cursor copies (content unchanged, SHA-identical across surfaces).
2. **gh-fix-ci (8):** retargeted both `SKILL.md` links from `./DISCOVERY_REPORT.md` to explicit canon path `../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.md` on canon + all adapters. Adapter file copies were intentionally not created (secret-scanner blocked env-var *names* in that document; canon-path link satisfies existence on every surface).

## Asset Classes

Documented in `docs/skills/SKILL_SURFACE_REGISTRY.md` §8.2 and enforced in the validator (`CANON_ONLY_ASSETS`, mirror parity for skill-local linked assets).

## Validator Hardening

`tools/validate_skill_surface_mirror.py` now also checks:
- local relative file/directory targets
- markdown anchors (GitHub-like slugs, duplicate headings)
- mirrored asset existence + content drift
- repo-root escape
- skill-local relative links to canon-only assets (`INVALID_ASSET_CLASS`)
- invalid exclusion table entries

Error classes include file path and line number where applicable. Exit code `1` on real failures. No rule loosening.

## Tests

- Extended `tests/unit/tools/test_validate_skill_surface_mirror.py` (positive/negative fixtures)
- Existing contract tests in `tests/unit/agents/test_skill_surface_adapter_drift_contract.py`

## Validation Evidence

```text
Commit: 13544785992d0e3e898ba7389ddc827b0205bf1f
python3 tools/validate_skill_surface_mirror.py → PASS (29 canon / 113 adapters / 0 mismatches)
pytest -q tests/unit/tools/test_validate_skill_surface_mirror.py \
  tests/unit/agents/test_skill_surface_adapter_drift_contract.py → 40 passed
ruff check (touched py) → All checks passed
black --check (touched py) → clean
git diff --check → clean
```

### GitHub Actions (infra, not change failure)

All PR checks failed without steps (`steps: []`, ~2–3s). Annotation on
`ci (Unit/Integration + Lint gesammelt)`:

> The job was not started because your account is locked due to a billing issue.

Run: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/30496567271  
Classification: **billing/infrastructure blocker** — not a test failure of this diff. Local validation remains authoritative for this Draft-PR delivery.

## Changed Files

- `tools/validate_skill_surface_mirror.py`
- `tests/unit/tools/test_validate_skill_surface_mirror.py`
- `docs/skills/SKILL_SURFACE_REGISTRY.md`
- `docs/skills/cdb-contract-evidence-gatekeeper/references/*` (+ Claude mirrors)
- `docs/skills/gh-fix-ci/SKILL.md` (+ adapter remirrors)

## Parallel-Agent Boundaries

- No `.github/workflows/**` changes (#4163)
- No GitLab surface work (#4121)
- No CURRENT_STATUS / CONTROL_REGISTER / LR edits
- No merge / no ready-for-review / issue not closed manually

## Known Limitations

- Issue comment via `gh` blocked by integration permissions in this environment
- Anchor checks are scoped to skill `SKILL.md` local links only (not repo-wide README link tool)
- `CDB.AGENT.LIST.json` / `CDB.AGENT.RULESET.md` remain absent (pre-existing; out of scope)
- GitHub Actions billing lock blocks remote CI green until account unlocked

## Follow-up Issues

None created. Optional later: restore issue analysis comment posting permissions; broader README-link anchor policy outside skills; unlock GH Actions billing.

## Restunsicherheiten

- Remote required checks cannot be proven green while billing lock persists
- After billing unlock: rerun checks; no code change expected for this PR unless a real failure appears

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-830d844e-dfda-499a-834b-c9400688879d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-830d844e-dfda-499a-834b-c9400688879d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

