### PR TITLE
docs(agents): align autonomous merge capability and CI handoff

### DIFF
--- a/.claude/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.claude/skills/cdb-ci-cd-guard/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-ci-cd-guard/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -37,6 +37,14 @@ disable-model-invocation: true
 - No silent stub or mock path on protected refs.
 - Missing critical secrets on protected refs must fail closed.
 - Without explicit approval, default to audit plus fix plan rather than mutation.
+- The sole live merge-relevant required context is `cdb-local-ci` (a Commit
+  Status, not a Check Run). Verify live with `gh api`; do not hardcode a
+  required-checks list from memory. Hosted Actions check-runs are
+  advisory/safety-relevant only (migration #4169).
+- Autonomous squash merge is capability-based (see
+  `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+  merge), not agent-type-based. `--admin` is never a valid bypass for a
+  missing/red `cdb-local-ci`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.claude/skills/cdb-drift-reconcile/SKILL.md
+++ b/.claude/skills/cdb-drift-reconcile/SKILL.md
@@ -2,10 +2,9 @@
 Canonical Skill Source: docs/skills/cdb-drift-reconcile/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
-
 ---
 name: cdb-drift-reconcile
 description: >
@@ -99,7 +98,9 @@ report `skill surface drift unknown`.
 
 **Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
 canon within the current scope, or create a deduplicated re-mirror follow-up issue
-and hand off. Never auto-merge without green required checks.
+and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
+exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
+merge remains capability-based when those gates are proven.
 
 ## Classification Rules
 

--- a/.claude/skills/cdb-github-api-ops/SKILL.md
+++ b/.claude/skills/cdb-github-api-ops/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -159,7 +159,8 @@ collection_errors:
 | Comment on issue/PR | Only if Plan-GO explicitly allows it |
 | Create issue/PR | Only if Plan-GO explicitly allows it |
 | Label/milestone changes | Only if Plan-GO explicitly allows it |
-| Merge/rebase/push | Separate scope, never automatic |
+| Rebase/push | Only if Plan-GO explicitly allows it |
+| Squash merge (`gh pr merge --squash --delete-branch`) | Autonomous only when every capability gate in `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous merge is proven for the exact PR head (task allows autonomous merge, PR in scope/mergeable, no blocking reviews, local Fast-CI PASS bound to head, main unchanged since validation, `cdb-local-ci` SUCCESS on exact head, session can perform the merge). Capability-based, not agent-type-based. `--admin` is never a substitute for missing/red `cdb-local-ci`. If any gate is unproven: report `DONE_PR_OPEN_MERGE_HANDOFF` naming the exact missing capability — do not loop, do not force. |
 | Repo settings/admin | Separate scope, never automatic |
 | Branch protection changes | Separate scope, never automatic |
 
@@ -169,6 +170,10 @@ When a write seems necessary but no approved scope exists:
 2. Report what needs writing and why.
 3. Propose the write as a follow-up with explicit Human-GO.
 4. Do NOT execute the write.
+
+For the merge row specifically: an unproven capability gate is a
+`DONE_PR_OPEN_MERGE_HANDOFF` report, not a STOP-and-ask — the PR stays open
+and the missing capability is named for the next session/human to close.
 
 ## Hard rules
 

--- a/.claude/skills/cdb-issue-to-session-plan/SKILL.md
+++ b/.claude/skills/cdb-issue-to-session-plan/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-issue-to-session-plan/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -49,6 +49,14 @@ Use this after `cdb-control-intake` when the next concrete unit of work is one s
    - Rank the issue inside the current stage and weekly context.
    - Name guardrails, blockers, and explicit non-goals.
    - Break the work into a short, ordered session plan with concrete next steps.
+   - If the plan ends in a PR, name the expected close state honestly:
+     autonomous squash merge only when the full capability gate in
+     `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+     merge is provable for the exact head; otherwise plan for
+     `DONE_PR_OPEN_MERGE_HANDOFF`, not a silent assumption of merge.
+   - If the plan spans multiple sequential PRs on the same base (a merge
+     wave), state that each merge requires a rebase + full revalidation
+     against the just-merged main before the next merge is attempted.
    - Mark all unresolved assumptions as unconfirmed.
 
 ## Interpretation Rules

--- a/.claude/skills/cdb-operator/SKILL.md
+++ b/.claude/skills/cdb-operator/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/cdb-operator/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-operator
-description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates. Autonomous squash-merge is allowed only when the full capability gate (docs/runbooks/merge_policy_ci_gate.md) is proven for the exact PR head; otherwise honest DONE_PR_OPEN_MERGE_HANDOFF, never --admin.
 compatibility: opencode
 metadata:
   project: claire-de-binare
@@ -30,9 +30,23 @@ Use this skill when working on Claire_de_Binare with OpenCode.
 5. Pull GitHub issue and PR state live.
 6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
 7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
-8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+8. Do not write, commit, push, comment, label, or close without explicit human GO.
+9. Merge is capability-based, not agent-type-based: after Plan-GO, a squash
+   merge (`gh pr merge <PR> --squash --delete-branch`) is autonomous and
+   allowed only when every capability gate in
+   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+   merge is proven for the exact PR head (task allows autonomous merge, PR
+   in scope/mergeable/no blocking reviews, local Fast-CI PASS bound to head,
+   main unchanged since validation, `cdb-local-ci` SUCCESS on exact head,
+   session can perform the merge). `--admin` is never a substitute for a
+   missing `cdb-local-ci`. If any gate is unproven: report
+   `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
+   loop or force.
 
 ## Stop conditions
 
-Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red
+`cdb-local-ci` (the sole required merge context; Hosted Actions red is
+advisory), a capability gate unproven for merge, scope growth, or any
+live-readiness/echtgeld implication.
 

--- a/.claude/skills/cdb-session-close/SKILL.md
+++ b/.claude/skills/cdb-session-close/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -78,7 +78,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If push is not done, say so explicitly in the rest status.
    - If the issue state should change, describe the correct next state rather than claiming it changed when it did not.
    - If the work is still local-only, make that explicit in the issue-facing close-out instead of implying landed or review-ready state.
-   - If a PR was merged during this session, proceed to step 6. If no PR exists or the PR is still open, skip steps 6–7 and record `pending main-verification` or `n.a.` in the rest status.
+   - If a PR was merged during this session, proceed to step 6. If no PR
+     exists: skip steps 6–7. If the PR is still open because this session
+     could not prove the autonomous-merge capability gate (missing
+     `statuses:write`, unbound evidence, auth/publisher block): record
+     `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
+     skip steps 6–7. Do not use `--admin` and do not loop retries.
 6. Verify delivery on `main` — only when a PR was merged in this session:
 
    ```bash
@@ -103,6 +108,10 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
    - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
+   - After squash merge with `--delete-branch`: do **not** re-push or
+     recreate the deleted remote branch (anti-repush). Local `[gone]`
+     tracking refs may remain historical; clean them with `git fetch
+     --prune` / `git branch -d` only when unambiguous.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:

--- a/.claude/skills/cdb-session-start/SKILL.md
+++ b/.claude/skills/cdb-session-start/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-start/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -68,7 +68,7 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it |
+   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
    | Old local worktree from a prior session | Do not read as implicit active progress |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
@@ -188,6 +188,10 @@ Establish a verified, fail-closed starting state before any repo work begins.
    - Scope stated: what is IN, what is OUT.
    - Closure semantics confirmed: `Closes #N` (full delivery) vs. `Refs #N`
      (partial or scoped delivery).
+   - If the session may end in an autonomous merge, note that capability
+     (not agent type) gates it; see `docs/runbooks/merge_policy_ci_gate.md`
+     § Capability-based autonomous merge. Missing capability at close time
+     is `DONE_PR_OPEN_MERGE_HANDOFF`, not a blocker to starting session work.
 
 ## Fail-Closed Rules
 

--- a/.claude/skills/gh-fix-ci/SKILL.md
+++ b/.claude/skills/gh-fix-ci/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/gh-fix-ci/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 # gh-fix-ci - GitHub CI Failure Inspector
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Status:** Active
 **Canonical Location:** `docs/skills/gh-fix-ci/`
 
@@ -79,24 +79,63 @@ Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.m
 
 ## Required Checks for CDB
 
-Based on branch protection rules for `main`:
+**SSOT:** `docs/runbooks/merge_policy_ci_gate.md`.
+Live branch protection on `main` requires **exactly one** merge-relevant
+context:
 
-1. **ci (Unit/Integration + Lint gesammelt)** - Python tests, Ruff, Black, mypy
-2. **validate-branch-name** - Branch naming policy
-3. **gitleaks (Secrets-Alarm)** - Secret detection
-4. **trivy (kritische CVEs/Supply-Chain)** - Container CVE scan
-5. **Check Core Duplicates** - Prevents duplicate `core/` directories
-6. **Check Delivery Gate** - Enforces `DELIVERY_APPROVED.yaml` gate
-7. **guard** - repository canon consistency check
-8. **E2E Happy Path** - Full integration test (Redis, Postgres, Docker Compose)
+- **`cdb-local-ci`** — a GitHub **Commit Status** (not a Check Run) published
+  by the local Fast-CI status publisher for the exact PR head SHA. Verify
+  live with `gh api`, not from any hardcoded list (including this one).
+
+Since migration #4169, hosted GitHub Actions check-runs — `ci (Unit/Integration + Lint gesammelt)`,
+`validate-branch-name`, `gitleaks (Secrets-Alarm)`, `trivy (kritische CVEs/Supply-Chain)`,
+`Check Core Duplicates`, `Check Delivery Gate`, `guard`, `E2E Happy Path`, and
+similar — are **advisory/safety-relevant only**. They remain useful signal
+(lint, tests, security, governance, E2E) and should be inspected and fixed
+when red, but their status alone does **not** gate merge and does not need
+to be "8/8 present" for merge eligibility.
+
+### Failure classification (used by this skill)
+
+- `MERGE_READY` — `cdb-local-ci` SUCCESS on the exact PR head SHA. PR is
+  merge-eligible regardless of Hosted Actions state (surface Hosted Actions
+  findings as advisory only).
+- `REQUIRED_STATUS_MISSING` — `cdb-local-ci` absent or stale for the exact
+  head SHA. Not merge-eligible; needs a local Fast-CI run + publish, or a
+  capable session to do so.
+- `CODE_FAILURE` — a check (local Fast-CI stage or Hosted Actions job) fails
+  due to an actual code/test/lint/type issue. Fixable in-repo.
+  `--check` name filtering (e.g. `--check "ci (Unit"`) still works for
+  Hosted Actions advisory triage.
+- `HOSTED_ACTIONS_INFRA_BLOCK` — Hosted Actions run is red/blocked due to
+  billing, runner lock, `action_required` approval gate, or similar
+  infrastructure condition unrelated to code correctness. Report distinctly
+  from `CODE_FAILURE`; does not block merge if `cdb-local-ci` is SUCCESS.
+- `AUTH_PUBLISHER_BLOCK` — the session cannot read/verify `cdb-local-ci` or
+  (if attempting to publish) cannot authenticate with sufficient scope. See
+  Auth Preflight below.
 
 ### Conditional Checks
 
-Some required checks may not be present on every PR due to workflow path filters:
+Some Hosted Actions checks may not be present on every PR due to workflow
+path filters:
 
 - **E2E Happy Path**: Ergänzender E2E-Workflow; kein branch-protected Required Check.
-- The script reports these as "not triggered" rather than failures
-- Output format: `[OK] All required checks passed (7/7 present, 1 not triggered)`
+- The script reports these as "not triggered" rather than failures.
+- Output format: `[OK] Hosted Actions advisory checks: 7/7 present, 1 not triggered (cdb-local-ci: SUCCESS)`
+
+### Auth Preflight
+
+Before relying on any check result, verify the identity/token can actually
+read live status:
+
+1. `gh auth status` — confirm an authenticated identity.
+2. `gh api repos/<owner>/<repo>/commits/<head_sha>/status` — confirm
+   `cdb-local-ci` is readable for the exact PR head SHA (billing/lock
+   conditions on Hosted Actions do not affect this read).
+3. If step 2 fails with an auth/permission error, classify as
+   `AUTH_PUBLISHER_BLOCK`, not `REQUIRED_STATUS_MISSING` — these have
+   different remediations (fix auth vs. run+publish local CI).
 
 ---
 
@@ -158,39 +197,42 @@ Failing Checks (2/15):
 
 ### Human-Readable Summary (Default)
 ```
-PR #807: docs(lr): add LR-007 Shadow Mode status tracking
-Branch: docs/lr-007-status-tracking
-Status: 13 passed, 2 in_progress, 0 failed
+PR #807: jannekbuengener/Claire_de_Binare
+Status: 13 passed, 0 failed, 2 in_progress
 
-✅ All required checks passed (8/8)
+[OK] Required merge context is SUCCESS: MERGE_READY (1/1)
 
-Passing Checks:
-- ci (Unit/Integration + Lint gesammelt) ✅
-- validate-branch-name ✅
-- gitleaks (Secrets-Alarm) ✅
-...
+[ADVISORY] 1 Hosted Actions check(s) red (does not block merge if cdb-local-ci is SUCCESS):
+  - trivy (kritische CVEs/Supply-Chain)
+```
 
-In Progress:
-- trivy (kritische CVEs/Supply-Chain) ⏳ (elapsed: 45s)
+Missing/red required context is reported instead as:
+```
+[FAIL] Required merge context missing on this head SHA: REQUIRED_STATUS_MISSING
+   Missing: cdb-local-ci
+```
+or
+```
+[FAIL] Required merge context failed/red (1/1): BLOCKED_REQUIRED_STATUS
+  - cdb-local-ci
 ```
 
 ### JSON Output (with `--json`)
 ```json
 {
   "pr_number": 807,
-  "pr_title": "docs(lr): add LR-007 Shadow Mode status tracking",
-  "branch": "docs/lr-007-status-tracking",
-  "total_checks": 15,
-  "passed": 13,
-  "failed": 0,
-  "in_progress": 2,
-  "skipped": 0,
-  "failing_checks": [],
-  "required_checks_status": {
-    "ci (Unit/Integration + Lint gesammelt)": "SUCCESS",
-    "validate-branch-name": "SUCCESS",
-    ...
-  }
+  "repo": "jannekbuengener/Claire_de_Binare",
+  "summary": {
+    "total": 15,
+    "passed": 13,
+    "failed": 0,
+    "in_progress": 2,
+    "skipped": 0,
+    "required_checks_status": {
+      "cdb-local-ci": "SUCCESS"
+    }
+  },
+  "failing_checks": []
 }
 ```
 
@@ -377,5 +419,5 @@ Exit code: 2
 ---
 
 **Created:** 2026-02-08
-**Last Updated:** 2026-02-08
+**Last Updated:** 2026-07-30
 **Maintainer:** Claude Code (Session Lead)

--- a/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
+++ b/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-ci-cd-guard/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -37,6 +37,14 @@ disable-model-invocation: true
 - No silent stub or mock path on protected refs.
 - Missing critical secrets on protected refs must fail closed.
 - Without explicit approval, default to audit plus fix plan rather than mutation.
+- The sole live merge-relevant required context is `cdb-local-ci` (a Commit
+  Status, not a Check Run). Verify live with `gh api`; do not hardcode a
+  required-checks list from memory. Hosted Actions check-runs are
+  advisory/safety-relevant only (migration #4169).
+- Autonomous squash merge is capability-based (see
+  `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+  merge), not agent-type-based. `--admin` is never a valid bypass for a
+  missing/red `cdb-local-ci`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
+++ b/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
@@ -2,10 +2,9 @@
 Canonical Skill Source: docs/skills/cdb-drift-reconcile/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
-
 ---
 name: cdb-drift-reconcile
 description: >
@@ -99,7 +98,9 @@ report `skill surface drift unknown`.
 
 **Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
 canon within the current scope, or create a deduplicated re-mirror follow-up issue
-and hand off. Never auto-merge without green required checks.
+and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
+exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
+merge remains capability-based when those gates are proven.
 
 ## Classification Rules
 

--- a/.codex/cdb_skills/cdb-github-api-ops/SKILL.md
+++ b/.codex/cdb_skills/cdb-github-api-ops/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -159,7 +159,8 @@ collection_errors:
 | Comment on issue/PR | Only if Plan-GO explicitly allows it |
 | Create issue/PR | Only if Plan-GO explicitly allows it |
 | Label/milestone changes | Only if Plan-GO explicitly allows it |
-| Merge/rebase/push | Separate scope, never automatic |
+| Rebase/push | Only if Plan-GO explicitly allows it |
+| Squash merge (`gh pr merge --squash --delete-branch`) | Autonomous only when every capability gate in `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous merge is proven for the exact PR head (task allows autonomous merge, PR in scope/mergeable, no blocking reviews, local Fast-CI PASS bound to head, main unchanged since validation, `cdb-local-ci` SUCCESS on exact head, session can perform the merge). Capability-based, not agent-type-based. `--admin` is never a substitute for missing/red `cdb-local-ci`. If any gate is unproven: report `DONE_PR_OPEN_MERGE_HANDOFF` naming the exact missing capability — do not loop, do not force. |
 | Repo settings/admin | Separate scope, never automatic |
 | Branch protection changes | Separate scope, never automatic |
 
@@ -169,6 +170,10 @@ When a write seems necessary but no approved scope exists:
 2. Report what needs writing and why.
 3. Propose the write as a follow-up with explicit Human-GO.
 4. Do NOT execute the write.
+
+For the merge row specifically: an unproven capability gate is a
+`DONE_PR_OPEN_MERGE_HANDOFF` report, not a STOP-and-ask — the PR stays open
+and the missing capability is named for the next session/human to close.
 
 ## Hard rules
 

--- a/.codex/cdb_skills/cdb-issue-to-session-plan/SKILL.md
+++ b/.codex/cdb_skills/cdb-issue-to-session-plan/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-issue-to-session-plan/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -49,6 +49,14 @@ Use this after `cdb-control-intake` when the next concrete unit of work is one s
    - Rank the issue inside the current stage and weekly context.
    - Name guardrails, blockers, and explicit non-goals.
    - Break the work into a short, ordered session plan with concrete next steps.
+   - If the plan ends in a PR, name the expected close state honestly:
+     autonomous squash merge only when the full capability gate in
+     `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+     merge is provable for the exact head; otherwise plan for
+     `DONE_PR_OPEN_MERGE_HANDOFF`, not a silent assumption of merge.
+   - If the plan spans multiple sequential PRs on the same base (a merge
+     wave), state that each merge requires a rebase + full revalidation
+     against the just-merged main before the next merge is attempted.
    - Mark all unresolved assumptions as unconfirmed.
 
 ## Interpretation Rules

--- a/.codex/cdb_skills/cdb-operator/SKILL.md
+++ b/.codex/cdb_skills/cdb-operator/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/cdb-operator/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-operator
-description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates. Autonomous squash-merge is allowed only when the full capability gate (docs/runbooks/merge_policy_ci_gate.md) is proven for the exact PR head; otherwise honest DONE_PR_OPEN_MERGE_HANDOFF, never --admin.
 compatibility: opencode
 metadata:
   project: claire-de-binare
@@ -30,9 +30,23 @@ Use this skill when working on Claire_de_Binare with OpenCode.
 5. Pull GitHub issue and PR state live.
 6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
 7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
-8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+8. Do not write, commit, push, comment, label, or close without explicit human GO.
+9. Merge is capability-based, not agent-type-based: after Plan-GO, a squash
+   merge (`gh pr merge <PR> --squash --delete-branch`) is autonomous and
+   allowed only when every capability gate in
+   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+   merge is proven for the exact PR head (task allows autonomous merge, PR
+   in scope/mergeable/no blocking reviews, local Fast-CI PASS bound to head,
+   main unchanged since validation, `cdb-local-ci` SUCCESS on exact head,
+   session can perform the merge). `--admin` is never a substitute for a
+   missing `cdb-local-ci`. If any gate is unproven: report
+   `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
+   loop or force.
 
 ## Stop conditions
 
-Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red
+`cdb-local-ci` (the sole required merge context; Hosted Actions red is
+advisory), a capability gate unproven for merge, scope growth, or any
+live-readiness/echtgeld implication.
 

--- a/.codex/cdb_skills/cdb-session-close/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-close/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -78,7 +78,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If push is not done, say so explicitly in the rest status.
    - If the issue state should change, describe the correct next state rather than claiming it changed when it did not.
    - If the work is still local-only, make that explicit in the issue-facing close-out instead of implying landed or review-ready state.
-   - If a PR was merged during this session, proceed to step 6. If no PR exists or the PR is still open, skip steps 6–7 and record `pending main-verification` or `n.a.` in the rest status.
+   - If a PR was merged during this session, proceed to step 6. If no PR
+     exists: skip steps 6–7. If the PR is still open because this session
+     could not prove the autonomous-merge capability gate (missing
+     `statuses:write`, unbound evidence, auth/publisher block): record
+     `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
+     skip steps 6–7. Do not use `--admin` and do not loop retries.
 6. Verify delivery on `main` — only when a PR was merged in this session:
 
    ```bash
@@ -103,6 +108,10 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
    - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
+   - After squash merge with `--delete-branch`: do **not** re-push or
+     recreate the deleted remote branch (anti-repush). Local `[gone]`
+     tracking refs may remain historical; clean them with `git fetch
+     --prune` / `git branch -d` only when unambiguous.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:

--- a/.codex/cdb_skills/cdb-session-start/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-start/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-start/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -68,7 +68,7 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it |
+   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
    | Old local worktree from a prior session | Do not read as implicit active progress |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
@@ -188,6 +188,10 @@ Establish a verified, fail-closed starting state before any repo work begins.
    - Scope stated: what is IN, what is OUT.
    - Closure semantics confirmed: `Closes #N` (full delivery) vs. `Refs #N`
      (partial or scoped delivery).
+   - If the session may end in an autonomous merge, note that capability
+     (not agent type) gates it; see `docs/runbooks/merge_policy_ci_gate.md`
+     § Capability-based autonomous merge. Missing capability at close time
+     is `DONE_PR_OPEN_MERGE_HANDOFF`, not a blocker to starting session work.
 
 ## Fail-Closed Rules
 

--- a/.codex/cdb_skills/gh-fix-ci/SKILL.md
+++ b/.codex/cdb_skills/gh-fix-ci/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/gh-fix-ci/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 # gh-fix-ci - GitHub CI Failure Inspector
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Status:** Active
 **Canonical Location:** `docs/skills/gh-fix-ci/`
 
@@ -79,24 +79,63 @@ Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.m
 
 ## Required Checks for CDB
 
-Based on branch protection rules for `main`:
+**SSOT:** `docs/runbooks/merge_policy_ci_gate.md`.
+Live branch protection on `main` requires **exactly one** merge-relevant
+context:
 
-1. **ci (Unit/Integration + Lint gesammelt)** - Python tests, Ruff, Black, mypy
-2. **validate-branch-name** - Branch naming policy
-3. **gitleaks (Secrets-Alarm)** - Secret detection
-4. **trivy (kritische CVEs/Supply-Chain)** - Container CVE scan
-5. **Check Core Duplicates** - Prevents duplicate `core/` directories
-6. **Check Delivery Gate** - Enforces `DELIVERY_APPROVED.yaml` gate
-7. **guard** - repository canon consistency check
-8. **E2E Happy Path** - Full integration test (Redis, Postgres, Docker Compose)
+- **`cdb-local-ci`** — a GitHub **Commit Status** (not a Check Run) published
+  by the local Fast-CI status publisher for the exact PR head SHA. Verify
+  live with `gh api`, not from any hardcoded list (including this one).
+
+Since migration #4169, hosted GitHub Actions check-runs — `ci (Unit/Integration + Lint gesammelt)`,
+`validate-branch-name`, `gitleaks (Secrets-Alarm)`, `trivy (kritische CVEs/Supply-Chain)`,
+`Check Core Duplicates`, `Check Delivery Gate`, `guard`, `E2E Happy Path`, and
+similar — are **advisory/safety-relevant only**. They remain useful signal
+(lint, tests, security, governance, E2E) and should be inspected and fixed
+when red, but their status alone does **not** gate merge and does not need
+to be "8/8 present" for merge eligibility.
+
+### Failure classification (used by this skill)
+
+- `MERGE_READY` — `cdb-local-ci` SUCCESS on the exact PR head SHA. PR is
+  merge-eligible regardless of Hosted Actions state (surface Hosted Actions
+  findings as advisory only).
+- `REQUIRED_STATUS_MISSING` — `cdb-local-ci` absent or stale for the exact
+  head SHA. Not merge-eligible; needs a local Fast-CI run + publish, or a
+  capable session to do so.
+- `CODE_FAILURE` — a check (local Fast-CI stage or Hosted Actions job) fails
+  due to an actual code/test/lint/type issue. Fixable in-repo.
+  `--check` name filtering (e.g. `--check "ci (Unit"`) still works for
+  Hosted Actions advisory triage.
+- `HOSTED_ACTIONS_INFRA_BLOCK` — Hosted Actions run is red/blocked due to
+  billing, runner lock, `action_required` approval gate, or similar
+  infrastructure condition unrelated to code correctness. Report distinctly
+  from `CODE_FAILURE`; does not block merge if `cdb-local-ci` is SUCCESS.
+- `AUTH_PUBLISHER_BLOCK` — the session cannot read/verify `cdb-local-ci` or
+  (if attempting to publish) cannot authenticate with sufficient scope. See
+  Auth Preflight below.
 
 ### Conditional Checks
 
-Some required checks may not be present on every PR due to workflow path filters:
+Some Hosted Actions checks may not be present on every PR due to workflow
+path filters:
 
 - **E2E Happy Path**: Ergänzender E2E-Workflow; kein branch-protected Required Check.
-- The script reports these as "not triggered" rather than failures
-- Output format: `[OK] All required checks passed (7/7 present, 1 not triggered)`
+- The script reports these as "not triggered" rather than failures.
+- Output format: `[OK] Hosted Actions advisory checks: 7/7 present, 1 not triggered (cdb-local-ci: SUCCESS)`
+
+### Auth Preflight
+
+Before relying on any check result, verify the identity/token can actually
+read live status:
+
+1. `gh auth status` — confirm an authenticated identity.
+2. `gh api repos/<owner>/<repo>/commits/<head_sha>/status` — confirm
+   `cdb-local-ci` is readable for the exact PR head SHA (billing/lock
+   conditions on Hosted Actions do not affect this read).
+3. If step 2 fails with an auth/permission error, classify as
+   `AUTH_PUBLISHER_BLOCK`, not `REQUIRED_STATUS_MISSING` — these have
+   different remediations (fix auth vs. run+publish local CI).
 
 ---
 
@@ -158,39 +197,42 @@ Failing Checks (2/15):
 
 ### Human-Readable Summary (Default)
 ```
-PR #807: docs(lr): add LR-007 Shadow Mode status tracking
-Branch: docs/lr-007-status-tracking
-Status: 13 passed, 2 in_progress, 0 failed
+PR #807: jannekbuengener/Claire_de_Binare
+Status: 13 passed, 0 failed, 2 in_progress
 
-✅ All required checks passed (8/8)
+[OK] Required merge context is SUCCESS: MERGE_READY (1/1)
 
-Passing Checks:
-- ci (Unit/Integration + Lint gesammelt) ✅
-- validate-branch-name ✅
-- gitleaks (Secrets-Alarm) ✅
-...
+[ADVISORY] 1 Hosted Actions check(s) red (does not block merge if cdb-local-ci is SUCCESS):
+  - trivy (kritische CVEs/Supply-Chain)
+```
 
-In Progress:
-- trivy (kritische CVEs/Supply-Chain) ⏳ (elapsed: 45s)
+Missing/red required context is reported instead as:
+```
+[FAIL] Required merge context missing on this head SHA: REQUIRED_STATUS_MISSING
+   Missing: cdb-local-ci
+```
+or
+```
+[FAIL] Required merge context failed/red (1/1): BLOCKED_REQUIRED_STATUS
+  - cdb-local-ci
 ```
 
 ### JSON Output (with `--json`)
 ```json
 {
   "pr_number": 807,
-  "pr_title": "docs(lr): add LR-007 Shadow Mode status tracking",
-  "branch": "docs/lr-007-status-tracking",
-  "total_checks": 15,
-  "passed": 13,
-  "failed": 0,
-  "in_progress": 2,
-  "skipped": 0,
-  "failing_checks": [],
-  "required_checks_status": {
-    "ci (Unit/Integration + Lint gesammelt)": "SUCCESS",
-    "validate-branch-name": "SUCCESS",
-    ...
-  }
+  "repo": "jannekbuengener/Claire_de_Binare",
+  "summary": {
+    "total": 15,
+    "passed": 13,
+    "failed": 0,
+    "in_progress": 2,
+    "skipped": 0,
+    "required_checks_status": {
+      "cdb-local-ci": "SUCCESS"
+    }
+  },
+  "failing_checks": []
 }
 ```
 
@@ -377,5 +419,5 @@ Exit code: 2
 ---
 
 **Created:** 2026-02-08
-**Last Updated:** 2026-02-08
+**Last Updated:** 2026-07-30
 **Maintainer:** Claude Code (Session Lead)

--- a/.cursor/rules/CDB-Checks-and-Merge-Rule.mdc
+++ b/.cursor/rules/CDB-Checks-and-Merge-Rule.mdc
@@ -4,34 +4,126 @@ alwaysApply: true
 
 Red, missing, stale, or pending required checks are not a reason to stop and ask Jannek.
 
+The only merge-relevant required context for `main` is `cdb-local-ci` (a Commit
+Status, not a Check Run), exact PR head SHA. SSOT:
+`docs/runbooks/merge_policy_ci_gate.md`. Verify live with `gh api` — do not
+rely on stale tables. Hosted GitHub Actions check-runs (including any
+`ci`/`policy-gate` workflow content) are advisory/safety-relevant but are
+**not** the required merge gate. Hosted Actions red due to billing/runner
+lock is an infra condition, not a code failure, and must not be conflated
+with a missing/red `cdb-local-ci`.
+
 If required checks are red, missing, stale, or pending:
-1. Inspect live check status and logs.
-2. Identify the cause.
+1. Inspect live check status and logs (`gh api` for the live required context;
+   Hosted Actions logs for advisory failures).
+2. Identify the cause; classify as code failure vs. Hosted-Actions
+   infra block vs. required-status-missing vs. auth/publisher block.
 3. Update the branch if needed.
-4. Rerun checks if useful.
+4. Rerun checks / republish `cdb-local-ci` if useful and the session has the
+   capability to do so.
 5. Apply small in-scope fixes if the cause is inside the approved plan.
 6. Recheck.
-7. Merge only when required checks are green.
+7. Merge only after live `cdb-local-ci` SUCCESS on the exact PR head SHA.
 
 If the failure cannot be fixed within the approved scope:
 - do not expand scope silently
-- document HOLD/BLOCKED
+- document HOLD/BLOCKED with the correct status (see below)
 - dedupe existing issues
 - create a follow-up issue if needed
 - link the finding in the final report
 - continue independent approved work where possible
 
-When merge is explicitly allowed by the approved plan, merge autonomously if all criteria are true:
+## Capability-based autonomous merge
+
+Autonomous squash merge is capability-based, not agent-type-based. Any
+session — local or cloud — may autonomously squash-merge a PR when ALL of
+the following are proven true:
+
+1. Task allows `autonomous_regular_merge_allowed` for this scope.
+2. PR is fully in approved scope, not draft, and mergeable.
+3. No blocking reviews, unresolved scope/governance blockers, or
+   `CHANGES_REQUESTED` state.
+4. Full local Fast-CI PASS for the exact PR head SHA.
+5. Evidence is bound to the exact PR head SHA (no stale/other-SHA evidence).
+6. Validated `main` is unchanged since validation (no drift since evidence
+   was produced).
+7. `cdb-local-ci` shows SUCCESS as a live Commit Status on the exact PR head
+   SHA (verified via `gh api`, not inferred).
+8. The session can perform a regular squash merge (`statuses:write`/merge
+   permission available), and can publish `cdb-local-ci` itself if it is
+   still missing and the session holds evidence to do so.
+
+Command: `gh pr merge <PR> --squash --delete-branch`.
+
+Forbidden, always:
+- `--admin` as a bypass for a missing/red/stale `cdb-local-ci`. `--admin` is
+  never a substitute for the required live status.
+- Fake-green claims (asserting a status without live `gh api` verification).
+- Merging an untested head (evidence bound to a different SHA than the
+  current PR head).
+- Looping the same failing merge attempt without new evidence or a changed
+  hypothesis.
+
+## Missing capability → honest handoff, not admin merge, not loops
+
+If the session lacks any capability gate above (e.g. no `statuses:write`, no
+verifiable identity, no bound evidence, auth/publisher blocked), do **not**
+fall back to `--admin` and do **not** loop retries. Instead:
+
+- Leave the PR open in its current, correctly-described state.
+- Report status `DONE_PR_OPEN_MERGE_HANDOFF`: PR is ready or near-ready, but
+  this session cannot complete the merge itself; the concrete missing
+  capability and the exact next command for a capable session/human are
+  documented in the report.
+- Do not silently retry the same blocked path.
+
+## Merge waves and anti-repush
+
+When merging multiple PRs in sequence ("merge waves"): rebase the next PR
+onto the updated `main` and fully revalidate (`cdb-local-ci` SUCCESS on the
+new head) after each merge before merging the next one. Do not batch-merge
+on stale evidence from before the wave started.
+
+After a squash merge with `--delete-branch`: do not automatically re-push,
+recreate, or resurrect the deleted remote branch (no anti-repush violation).
+If further work is needed on that topic, open a new branch explicitly.
+
+## Status taxonomy
+
+Use these statuses precisely (see `CDB-Final-Report-Rule.mdc` for the full
+report contract):
+
+- `DONE_MERGED_CLOSED` — merge verified live on `main` (commit present,
+  PR closed as merged); only after live verification, never assumed.
+- `DONE_PR_OPEN_MERGE_HANDOFF` — PR ready/near-ready, capability gate not
+  fully met by this session; honest handoff with concrete next step.
+- `DONE_PR_OPEN` — PR open, not yet merge-eligible (e.g. still under
+  validation or intentionally left for review).
+- `BLOCKED_LOCAL_VALIDATION` — local Fast-CI or evidence generation failed.
+- `BLOCKED_REQUIRED_STATUS` — `cdb-local-ci` missing/red/stale on the exact
+  head SHA.
+- `BLOCKED_AUTH_PUBLISHER` — session cannot publish/verify `cdb-local-ci` or
+  cannot authenticate for the merge action.
+- `HOLD_SCOPE_OR_REVIEW` — scope, governance, or unresolved review blocker.
+- `HOLD_MAIN_OR_HEAD_DRIFT` — validated `main` or PR head changed since
+  evidence was produced; revalidation required before merge.
+
+Autonomous merge criteria, restated as a checklist:
 1. PR belongs to approved scope.
 2. Diff matches the plan and has no unauthorized scope growth.
-3. All required checks are green.
-4. Non-required checks are green, skipped with explanation, or documented as non-blocking.
-5. No blocking reviews, unresolved blocker threads, or CHANGES_REQUESTED state.
+3. `cdb-local-ci` is SUCCESS on the exact PR head SHA (live, via `gh api`).
+4. Hosted Actions advisory checks are green, skipped with explanation, or
+   documented as non-blocking infra (billing/lock ≠ code failure).
+5. No blocking reviews, unresolved blocker threads, or CHANGES_REQUESTED.
 6. PR is not draft and not HOLD/BLOCKED.
 7. Branch is mergeable or has been updated in scope.
 8. No secrets, sensitive values, or token leaks were introduced.
-9. No safety, LR, live/echtgeld, productive DB, MCP mutation, or BLUE/RED boundary is bypassed.
-10. PR body or final report includes Delivered, Validation, Non-goals, and Remaining uncertainty.
+9. No safety, LR, live/echtgeld, productive DB, MCP mutation, or BLUE/RED
+   boundary is bypassed.
+10. PR body or final report includes Delivered, Validation, Non-goals, and
+    Remaining uncertainty.
 
-Do not ask “Should I merge?” when the merge criteria are satisfied.
-Instead: merge, then report the evidence.
+Do not ask "Should I merge?" when the capability gate and merge criteria are
+satisfied. Instead: merge, then report the evidence (`DONE_MERGED_CLOSED`).
+If the capability gate is not satisfied: hand off honestly
+(`DONE_PR_OPEN_MERGE_HANDOFF`) instead of looping or using `--admin`.

--- a/.cursor/rules/CDB-Final-Report-Rule.mdc
+++ b/.cursor/rules/CDB-Final-Report-Rule.mdc
@@ -7,7 +7,26 @@ For CDB work, finish with a compact evidence-based report.
 Use this structure:
 
 Status:
-- DONE_MERGED | DONE_NO_PR | HOLD | BLOCKED | PARTIAL
+- One of: `DONE_MERGED_CLOSED` | `DONE_PR_OPEN_MERGE_HANDOFF` | `DONE_PR_OPEN` |
+  `DONE_NO_PR` | `BLOCKED_LOCAL_VALIDATION` | `BLOCKED_REQUIRED_STATUS` |
+  `BLOCKED_AUTH_PUBLISHER` | `HOLD_SCOPE_OR_REVIEW` | `HOLD_MAIN_OR_HEAD_DRIFT` |
+  `HOLD` | `BLOCKED` | `PARTIAL`
+
+Status rules:
+- `DONE_MERGED_CLOSED` requires live verification that the PR is merged on
+  `main` (commit present via `gh api`/`git log`, PR state closed as merged).
+  Never report a merged/`DONE_MERGED` status from a queued or assumed merge.
+- `DONE_PR_OPEN_MERGE_HANDOFF` is the honest result when the PR is
+  ready/near-ready but this session could not prove the full autonomous-merge
+  capability gate (see `CDB-Checks-and-Merge-Rule.mdc`). State the exact
+  missing capability and the next command for a capable session/human.
+  `--admin` is never used to convert this into `DONE_MERGED_CLOSED`.
+- `BLOCKED_REQUIRED_STATUS` means `cdb-local-ci` is missing/red/stale on the
+  exact PR head SHA — the only merge-relevant required context.
+- `BLOCKED_AUTH_PUBLISHER` means the session cannot authenticate or publish
+  the required status itself.
+- `HOLD_MAIN_OR_HEAD_DRIFT` means validated `main` or the PR head changed
+  since evidence was produced; revalidate before merging.
 
 Scope:
 - <what was approved>
@@ -17,6 +36,9 @@ Delivered:
 
 Validation:
 - <commands, checks, tests, PR checks, or live GitHub evidence>
+- For any merge claim: the exact `gh api`/`gh pr view` evidence that
+  `cdb-local-ci` was SUCCESS on the exact head SHA, and that the merge
+  landed on `main`.
 
 GitHub/Repo State:
 - <issues, PRs, branch, commit, merge status>
@@ -25,7 +47,7 @@ Boundaries:
 - <LR/live/echtgeld/secrets/DB/MCP/runtime impact>
 
 Follow-ups:
-- <created or existing issues, or “none”>
+- <created or existing issues, or "none">
 
 Limitations:
 - <what remains unproven or intentionally untouched>

--- a/.cursor/rules/CDB-Plan-GO-Autonomy-Rule.mdc
+++ b/.cursor/rules/CDB-Plan-GO-Autonomy-Rule.mdc
@@ -24,17 +24,40 @@ After Plan-GO:
 Allowed after Plan-GO, if explicitly inside scope:
 - review PRs
 - inspect diffs
-- check required checks
+- check required checks (live `cdb-local-ci` via `gh api`; see
+  `CDB-Checks-and-Merge-Rule.mdc`)
 - update branches
-- rerun checks
+- rerun checks / republish `cdb-local-ci` if capable
 - implement small in-scope fixes
 - commit and push
 - resolve review threads
 - post comments
 - apply or remove labels
 - close issues
-- merge PRs
+- merge PRs autonomously when the capability gate in
+  `CDB-Checks-and-Merge-Rule.mdc` is fully satisfied
 - create deduplicated follow-up issues
 - report final status
 
 This is not a blank check. Productive DB writes, MCP mutations, BLUE/RED runtime changes, LR/live/echtgeld actions, secret handling, and scope expansion still require their own explicit scope or gate.
+
+## Merge capability, not agent type
+
+Plan-GO authorizes autonomous merge for **any** session — local or cloud —
+that proves the full capability gate defined in
+`CDB-Checks-and-Merge-Rule.mdc` (scope, no blockers, `cdb-local-ci` SUCCESS
+on exact head, unchanged validated `main`, and the ability to perform the
+merge itself). Merge authority is never granted or withheld based on which
+agent surface is running; it is granted only when the gate is proven.
+
+If a session lacks a capability (e.g. no `statuses:write`, no verifiable
+identity, evidence not bound to the exact head): do not use `--admin` as a
+substitute, and do not loop the same blocked attempt. Report
+`DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and the next
+command for a capable session/human, then continue other approved,
+independent work.
+
+`DONE_MERGED` (or the more precise `DONE_MERGED_CLOSED`) may only be reported
+after live verification that the PR is actually merged on `main` (commit
+present, PR state closed/merged) — never assumed from a queued or in-flight
+merge command.

--- a/.cursor/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.cursor/skills/cdb-ci-cd-guard/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-ci-cd-guard/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -37,6 +37,14 @@ disable-model-invocation: true
 - No silent stub or mock path on protected refs.
 - Missing critical secrets on protected refs must fail closed.
 - Without explicit approval, default to audit plus fix plan rather than mutation.
+- The sole live merge-relevant required context is `cdb-local-ci` (a Commit
+  Status, not a Check Run). Verify live with `gh api`; do not hardcode a
+  required-checks list from memory. Hosted Actions check-runs are
+  advisory/safety-relevant only (migration #4169).
+- Autonomous squash merge is capability-based (see
+  `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+  merge), not agent-type-based. `--admin` is never a valid bypass for a
+  missing/red `cdb-local-ci`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.cursor/skills/cdb-drift-reconcile/SKILL.md
+++ b/.cursor/skills/cdb-drift-reconcile/SKILL.md
@@ -2,10 +2,9 @@
 Canonical Skill Source: docs/skills/cdb-drift-reconcile/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
-
 ---
 name: cdb-drift-reconcile
 description: >
@@ -99,7 +98,9 @@ report `skill surface drift unknown`.
 
 **Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
 canon within the current scope, or create a deduplicated re-mirror follow-up issue
-and hand off. Never auto-merge without green required checks.
+and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
+exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
+merge remains capability-based when those gates are proven.
 
 ## Classification Rules
 

--- a/.cursor/skills/cdb-github-api-ops/SKILL.md
+++ b/.cursor/skills/cdb-github-api-ops/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -159,7 +159,8 @@ collection_errors:
 | Comment on issue/PR | Only if Plan-GO explicitly allows it |
 | Create issue/PR | Only if Plan-GO explicitly allows it |
 | Label/milestone changes | Only if Plan-GO explicitly allows it |
-| Merge/rebase/push | Separate scope, never automatic |
+| Rebase/push | Only if Plan-GO explicitly allows it |
+| Squash merge (`gh pr merge --squash --delete-branch`) | Autonomous only when every capability gate in `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous merge is proven for the exact PR head (task allows autonomous merge, PR in scope/mergeable, no blocking reviews, local Fast-CI PASS bound to head, main unchanged since validation, `cdb-local-ci` SUCCESS on exact head, session can perform the merge). Capability-based, not agent-type-based. `--admin` is never a substitute for missing/red `cdb-local-ci`. If any gate is unproven: report `DONE_PR_OPEN_MERGE_HANDOFF` naming the exact missing capability — do not loop, do not force. |
 | Repo settings/admin | Separate scope, never automatic |
 | Branch protection changes | Separate scope, never automatic |
 
@@ -169,6 +170,10 @@ When a write seems necessary but no approved scope exists:
 2. Report what needs writing and why.
 3. Propose the write as a follow-up with explicit Human-GO.
 4. Do NOT execute the write.
+
+For the merge row specifically: an unproven capability gate is a
+`DONE_PR_OPEN_MERGE_HANDOFF` report, not a STOP-and-ask — the PR stays open
+and the missing capability is named for the next session/human to close.
 
 ## Hard rules
 

--- a/.cursor/skills/cdb-issue-to-session-plan/SKILL.md
+++ b/.cursor/skills/cdb-issue-to-session-plan/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-issue-to-session-plan/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -49,6 +49,14 @@ Use this after `cdb-control-intake` when the next concrete unit of work is one s
    - Rank the issue inside the current stage and weekly context.
    - Name guardrails, blockers, and explicit non-goals.
    - Break the work into a short, ordered session plan with concrete next steps.
+   - If the plan ends in a PR, name the expected close state honestly:
+     autonomous squash merge only when the full capability gate in
+     `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+     merge is provable for the exact head; otherwise plan for
+     `DONE_PR_OPEN_MERGE_HANDOFF`, not a silent assumption of merge.
+   - If the plan spans multiple sequential PRs on the same base (a merge
+     wave), state that each merge requires a rebase + full revalidation
+     against the just-merged main before the next merge is attempted.
    - Mark all unresolved assumptions as unconfirmed.
 
 ## Interpretation Rules

--- a/.cursor/skills/cdb-operator/SKILL.md
+++ b/.cursor/skills/cdb-operator/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/cdb-operator/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-operator
-description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates. Autonomous squash-merge is allowed only when the full capability gate (docs/runbooks/merge_policy_ci_gate.md) is proven for the exact PR head; otherwise honest DONE_PR_OPEN_MERGE_HANDOFF, never --admin.
 compatibility: opencode
 metadata:
   project: claire-de-binare
@@ -30,9 +30,23 @@ Use this skill when working on Claire_de_Binare with OpenCode.
 5. Pull GitHub issue and PR state live.
 6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
 7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
-8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+8. Do not write, commit, push, comment, label, or close without explicit human GO.
+9. Merge is capability-based, not agent-type-based: after Plan-GO, a squash
+   merge (`gh pr merge <PR> --squash --delete-branch`) is autonomous and
+   allowed only when every capability gate in
+   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+   merge is proven for the exact PR head (task allows autonomous merge, PR
+   in scope/mergeable/no blocking reviews, local Fast-CI PASS bound to head,
+   main unchanged since validation, `cdb-local-ci` SUCCESS on exact head,
+   session can perform the merge). `--admin` is never a substitute for a
+   missing `cdb-local-ci`. If any gate is unproven: report
+   `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
+   loop or force.
 
 ## Stop conditions
 
-Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red
+`cdb-local-ci` (the sole required merge context; Hosted Actions red is
+advisory), a capability gate unproven for merge, scope growth, or any
+live-readiness/echtgeld implication.
 

--- a/.cursor/skills/cdb-session-close/SKILL.md
+++ b/.cursor/skills/cdb-session-close/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -78,7 +78,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If push is not done, say so explicitly in the rest status.
    - If the issue state should change, describe the correct next state rather than claiming it changed when it did not.
    - If the work is still local-only, make that explicit in the issue-facing close-out instead of implying landed or review-ready state.
-   - If a PR was merged during this session, proceed to step 6. If no PR exists or the PR is still open, skip steps 6–7 and record `pending main-verification` or `n.a.` in the rest status.
+   - If a PR was merged during this session, proceed to step 6. If no PR
+     exists: skip steps 6–7. If the PR is still open because this session
+     could not prove the autonomous-merge capability gate (missing
+     `statuses:write`, unbound evidence, auth/publisher block): record
+     `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
+     skip steps 6–7. Do not use `--admin` and do not loop retries.
 6. Verify delivery on `main` — only when a PR was merged in this session:
 
    ```bash
@@ -103,6 +108,10 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
    - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
+   - After squash merge with `--delete-branch`: do **not** re-push or
+     recreate the deleted remote branch (anti-repush). Local `[gone]`
+     tracking refs may remain historical; clean them with `git fetch
+     --prune` / `git branch -d` only when unambiguous.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:

--- a/.cursor/skills/cdb-session-start/SKILL.md
+++ b/.cursor/skills/cdb-session-start/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-start/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -68,7 +68,7 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it |
+   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
    | Old local worktree from a prior session | Do not read as implicit active progress |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
@@ -188,6 +188,10 @@ Establish a verified, fail-closed starting state before any repo work begins.
    - Scope stated: what is IN, what is OUT.
    - Closure semantics confirmed: `Closes #N` (full delivery) vs. `Refs #N`
      (partial or scoped delivery).
+   - If the session may end in an autonomous merge, note that capability
+     (not agent type) gates it; see `docs/runbooks/merge_policy_ci_gate.md`
+     § Capability-based autonomous merge. Missing capability at close time
+     is `DONE_PR_OPEN_MERGE_HANDOFF`, not a blocker to starting session work.
 
 ## Fail-Closed Rules
 

--- a/.cursor/skills/gh-fix-ci/SKILL.md
+++ b/.cursor/skills/gh-fix-ci/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/gh-fix-ci/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 # gh-fix-ci - GitHub CI Failure Inspector
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Status:** Active
 **Canonical Location:** `docs/skills/gh-fix-ci/`
 
@@ -79,24 +79,63 @@ Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.m
 
 ## Required Checks for CDB
 
-Based on branch protection rules for `main`:
+**SSOT:** `docs/runbooks/merge_policy_ci_gate.md`.
+Live branch protection on `main` requires **exactly one** merge-relevant
+context:
 
-1. **ci (Unit/Integration + Lint gesammelt)** - Python tests, Ruff, Black, mypy
-2. **validate-branch-name** - Branch naming policy
-3. **gitleaks (Secrets-Alarm)** - Secret detection
-4. **trivy (kritische CVEs/Supply-Chain)** - Container CVE scan
-5. **Check Core Duplicates** - Prevents duplicate `core/` directories
-6. **Check Delivery Gate** - Enforces `DELIVERY_APPROVED.yaml` gate
-7. **guard** - repository canon consistency check
-8. **E2E Happy Path** - Full integration test (Redis, Postgres, Docker Compose)
+- **`cdb-local-ci`** — a GitHub **Commit Status** (not a Check Run) published
+  by the local Fast-CI status publisher for the exact PR head SHA. Verify
+  live with `gh api`, not from any hardcoded list (including this one).
+
+Since migration #4169, hosted GitHub Actions check-runs — `ci (Unit/Integration + Lint gesammelt)`,
+`validate-branch-name`, `gitleaks (Secrets-Alarm)`, `trivy (kritische CVEs/Supply-Chain)`,
+`Check Core Duplicates`, `Check Delivery Gate`, `guard`, `E2E Happy Path`, and
+similar — are **advisory/safety-relevant only**. They remain useful signal
+(lint, tests, security, governance, E2E) and should be inspected and fixed
+when red, but their status alone does **not** gate merge and does not need
+to be "8/8 present" for merge eligibility.
+
+### Failure classification (used by this skill)
+
+- `MERGE_READY` — `cdb-local-ci` SUCCESS on the exact PR head SHA. PR is
+  merge-eligible regardless of Hosted Actions state (surface Hosted Actions
+  findings as advisory only).
+- `REQUIRED_STATUS_MISSING` — `cdb-local-ci` absent or stale for the exact
+  head SHA. Not merge-eligible; needs a local Fast-CI run + publish, or a
+  capable session to do so.
+- `CODE_FAILURE` — a check (local Fast-CI stage or Hosted Actions job) fails
+  due to an actual code/test/lint/type issue. Fixable in-repo.
+  `--check` name filtering (e.g. `--check "ci (Unit"`) still works for
+  Hosted Actions advisory triage.
+- `HOSTED_ACTIONS_INFRA_BLOCK` — Hosted Actions run is red/blocked due to
+  billing, runner lock, `action_required` approval gate, or similar
+  infrastructure condition unrelated to code correctness. Report distinctly
+  from `CODE_FAILURE`; does not block merge if `cdb-local-ci` is SUCCESS.
+- `AUTH_PUBLISHER_BLOCK` — the session cannot read/verify `cdb-local-ci` or
+  (if attempting to publish) cannot authenticate with sufficient scope. See
+  Auth Preflight below.
 
 ### Conditional Checks
 
-Some required checks may not be present on every PR due to workflow path filters:
+Some Hosted Actions checks may not be present on every PR due to workflow
+path filters:
 
 - **E2E Happy Path**: Ergänzender E2E-Workflow; kein branch-protected Required Check.
-- The script reports these as "not triggered" rather than failures
-- Output format: `[OK] All required checks passed (7/7 present, 1 not triggered)`
+- The script reports these as "not triggered" rather than failures.
+- Output format: `[OK] Hosted Actions advisory checks: 7/7 present, 1 not triggered (cdb-local-ci: SUCCESS)`
+
+### Auth Preflight
+
+Before relying on any check result, verify the identity/token can actually
+read live status:
+
+1. `gh auth status` — confirm an authenticated identity.
+2. `gh api repos/<owner>/<repo>/commits/<head_sha>/status` — confirm
+   `cdb-local-ci` is readable for the exact PR head SHA (billing/lock
+   conditions on Hosted Actions do not affect this read).
+3. If step 2 fails with an auth/permission error, classify as
+   `AUTH_PUBLISHER_BLOCK`, not `REQUIRED_STATUS_MISSING` — these have
+   different remediations (fix auth vs. run+publish local CI).
 
 ---
 
@@ -158,39 +197,42 @@ Failing Checks (2/15):
 
 ### Human-Readable Summary (Default)
 ```
-PR #807: docs(lr): add LR-007 Shadow Mode status tracking
-Branch: docs/lr-007-status-tracking
-Status: 13 passed, 2 in_progress, 0 failed
+PR #807: jannekbuengener/Claire_de_Binare
+Status: 13 passed, 0 failed, 2 in_progress
 
-✅ All required checks passed (8/8)
+[OK] Required merge context is SUCCESS: MERGE_READY (1/1)
 
-Passing Checks:
-- ci (Unit/Integration + Lint gesammelt) ✅
-- validate-branch-name ✅
-- gitleaks (Secrets-Alarm) ✅
-...
+[ADVISORY] 1 Hosted Actions check(s) red (does not block merge if cdb-local-ci is SUCCESS):
+  - trivy (kritische CVEs/Supply-Chain)
+```
 
-In Progress:
-- trivy (kritische CVEs/Supply-Chain) ⏳ (elapsed: 45s)
+Missing/red required context is reported instead as:
+```
+[FAIL] Required merge context missing on this head SHA: REQUIRED_STATUS_MISSING
+   Missing: cdb-local-ci
+```
+or
+```
+[FAIL] Required merge context failed/red (1/1): BLOCKED_REQUIRED_STATUS
+  - cdb-local-ci
 ```
 
 ### JSON Output (with `--json`)
 ```json
 {
   "pr_number": 807,
-  "pr_title": "docs(lr): add LR-007 Shadow Mode status tracking",
-  "branch": "docs/lr-007-status-tracking",
-  "total_checks": 15,
-  "passed": 13,
-  "failed": 0,
-  "in_progress": 2,
-  "skipped": 0,
-  "failing_checks": [],
-  "required_checks_status": {
-    "ci (Unit/Integration + Lint gesammelt)": "SUCCESS",
-    "validate-branch-name": "SUCCESS",
-    ...
-  }
+  "repo": "jannekbuengener/Claire_de_Binare",
+  "summary": {
+    "total": 15,
+    "passed": 13,
+    "failed": 0,
+    "in_progress": 2,
+    "skipped": 0,
+    "required_checks_status": {
+      "cdb-local-ci": "SUCCESS"
+    }
+  },
+  "failing_checks": []
 }
 ```
 
@@ -377,5 +419,5 @@ Exit code: 2
 ---
 
 **Created:** 2026-02-08
-**Last Updated:** 2026-02-08
+**Last Updated:** 2026-07-30
 **Maintainer:** Claude Code (Session Lead)

--- a/.github/CONTROL_PLANE.md
+++ b/.github/CONTROL_PLANE.md
@@ -37,10 +37,17 @@ mehr.
 
 ## Merge-Vertrag
 
-Die merge-relevanten Check-Kontexte sind:
+SSOT: [`docs/runbooks/merge_policy_ci_gate.md`](../docs/runbooks/merge_policy_ci_gate.md).
+Der einzige merge-relevante Required Context auf `main` ist `cdb-local-ci`
+(Commit Status, lokaler Publisher, exakter PR-Head-SHA) — live verifizieren
+via `gh api`, nicht aus dieser Datei ableiten.
 
-- `ci (Unit/Integration + Lint gesammelt)` aus `ci.yml`
-- `policy-gate` aus `policy-gate.yml`
+`ci (Unit/Integration + Lint gesammelt)` aus `ci.yml` und `policy-gate` aus
+`policy-gate.yml` sind Hosted-GitHub-Actions-Inhalte, die als
+Safety-/Advisory-Signal nützlich bleiben, seit Migration #4169 aber **nicht
+mehr** branch-protection-required sind. Ein rotes Hosted-Actions-Billing-
+oder Runner-Lock ist eine Infrastruktur-Bedingung, kein Code-Fehler, und
+ersetzt nicht die Prüfung von `cdb-local-ci`.
 
 Workflow-Dateien ohne dokumentierten operativen Zweck werden nicht als
 Deprecation-Stub aufbewahrt, sondern zusammen mit Tests und aktueller Doku

--- a/.github/scripts/dependabot_autopilot_classifier.py
+++ b/.github/scripts/dependabot_autopilot_classifier.py
@@ -35,10 +35,12 @@ MANUAL_REVIEW_LABELS = frozenset(
     }
 )
 
-REQUIRED_CHECK_NAMES = (
-    "ci (Unit/Integration + Lint gesammelt)",
-    "policy-gate",
-)
+REQUIRED_CHECK_NAMES = ("cdb-local-ci",)
+"""Live required merge context (Commit Status, not Check Run).
+
+SSOT: docs/runbooks/merge_policy_ci_gate.md; live baseline snapshot at
+docs/evidence/reports/REQUIRED_CHECK_CONTEXTS_BASELINE_main.json.
+"""
 
 CHECK_STATUS_COMPLETED = "COMPLETED"
 CHECK_CONCLUSION_SUCCESS = "SUCCESS"

--- a/.github/scripts/dependabot_autopilot_report.py
+++ b/.github/scripts/dependabot_autopilot_report.py
@@ -25,16 +25,18 @@ DEFAULT_ALLOWLIST = REPO_ROOT / ".github" / "dependabot-autopilot-allowlist.yml"
 DEPENDABOT_LOGINS = frozenset({"dependabot[bot]", "app/dependabot"})
 DEPENDABOT_HEAD_PREFIX = "dependabot/"
 
-REQUIRED_CHECK_NAMES = (
-    "ci (Unit/Integration + Lint gesammelt)",
-    "policy-gate",
-)
+REQUIRED_CHECK_NAMES = ("cdb-local-ci",)
+"""Live required merge context per docs/runbooks/merge_policy_ci_gate.md.
+
+`cdb-local-ci` is a Commit Status (not a Check Run) published by the local
+Fast-CI publisher. Hosted GitHub Actions check-runs remain advisory only and
+are not consulted here."""
 
 ALLOWED_GET_ENDPOINT = re.compile(
     r"^repos/[^/]+/[^/]+/"
     r"(?:"
     r"pulls(?:/\d+(?:/(?:files|commits))?)?"
-    r"|commits/[0-9a-f]{40}/check-runs"
+    r"|commits/[0-9a-f]{40}/status"
     r"|compare/[0-9a-f]{40}\.\.\.[0-9a-f]{40}"
     r")$"
 )
@@ -129,11 +131,11 @@ def _merge_paginated_payload(documents: Sequence[Any]) -> Any:
             merged.extend(doc)
         return merged
 
-    if all(isinstance(doc, Mapping) and "check_runs" in doc for doc in documents):
-        merged_runs: list[Any] = []
+    if all(isinstance(doc, Mapping) and "statuses" in doc for doc in documents):
+        merged_statuses: list[Any] = []
         for doc in documents:
-            merged_runs.extend(doc.get("check_runs") or [])
-        return merged_runs
+            merged_statuses.extend(doc.get("statuses") or [])
+        return merged_statuses
 
     return documents[-1]
 
@@ -185,8 +187,8 @@ class SubprocessGhTransport:
                 f"malformed gh api paginated JSON for {endpoint}: {exc}"
             ) from exc
         payload = _merge_paginated_payload(documents)
-        if isinstance(payload, Mapping) and "check_runs" in payload:
-            return payload.get("check_runs") or []
+        if isinstance(payload, Mapping) and "statuses" in payload:
+            return payload.get("statuses") or []
         return payload
 
 
@@ -485,15 +487,31 @@ def _normalize_merge_state(raw: str | None) -> str:
     return "UNKNOWN"
 
 
-def _normalize_check_runs(check_runs: Sequence[Mapping[str, Any]]) -> list[Any]:
+_STATUS_STATE_MAP: dict[str, tuple[str, str]] = {
+    "success": ("COMPLETED", "SUCCESS"),
+    "failure": ("COMPLETED", "FAILURE"),
+    "error": ("COMPLETED", "FAILURE"),
+    "pending": ("IN_PROGRESS", "PENDING"),
+}
+
+
+def _normalize_required_check_facts(
+    statuses: Sequence[Mapping[str, Any]],
+) -> list[Any]:
+    """Map Commit Status entries (`context`/`state`) to RequiredCheckFact.
+
+    `cdb-local-ci` is published as a GitHub Commit Status, not a Check Run,
+    so the live payload shape differs from hosted Actions check-runs
+    (`context`/`state` instead of `name`/`status`/`conclusion`).
+    """
     classifier = _load_classifier_module()
     facts: list[Any] = []
-    for run in check_runs:
-        name = str(run.get("name") or "").strip()
+    for entry in statuses:
+        name = str(entry.get("context") or "").strip()
         if name not in REQUIRED_CHECK_NAMES:
             continue
-        status = str(run.get("status") or "").strip().upper()
-        conclusion = str(run.get("conclusion") or "").strip().upper()
+        state = str(entry.get("state") or "").strip().lower()
+        status, conclusion = _STATUS_STATE_MAP.get(state, ("UNKNOWN", "UNKNOWN"))
         facts.append(classifier.RequiredCheckFact(name, status, conclusion))
     return facts
 
@@ -617,15 +635,17 @@ def _build_facts_for_pull(
     file_items = files if isinstance(files, list) else []
     patch_facts = _merge_patch_facts(file_items)
 
-    check_runs: list[Mapping[str, Any]] = []
+    required_check_entries: list[Mapping[str, Any]] = []
     if head_sha:
         try:
             payload = transport.get_json(
-                f"repos/{repo}/commits/{head_sha}/check-runs",
+                f"repos/{repo}/commits/{head_sha}/status",
                 params={"per_page": "100"},
             )
             if isinstance(payload, list):
-                check_runs = [item for item in payload if isinstance(item, Mapping)]
+                required_check_entries = [
+                    item for item in payload if isinstance(item, Mapping)
+                ]
         except GitHubApiError:
             api_error = True
 
@@ -690,7 +710,7 @@ def _build_facts_for_pull(
         commit_count=len(commit_items),
         commit_authors=tuple(commit_authors),
         changed_files=tuple(patch_facts.get("changed_files") or ()),
-        required_checks=tuple(_normalize_check_runs(check_runs)),
+        required_checks=tuple(_normalize_required_check_facts(required_check_entries)),
         branch_is_current=branch_is_current,
         merge_state=merge_state,
         ecosystem=ecosystem,

--- a/.github/workflows/cdb-dependabot-autopilot.yml
+++ b/.github/workflows/cdb-dependabot-autopilot.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  checks: read
+  statuses: read
 
 concurrency:
   group: cdb-dependabot-autopilot-${{ github.ref || github.run_id }}

--- a/.opencode/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.opencode/skills/cdb-ci-cd-guard/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-ci-cd-guard/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -37,6 +37,14 @@ disable-model-invocation: true
 - No silent stub or mock path on protected refs.
 - Missing critical secrets on protected refs must fail closed.
 - Without explicit approval, default to audit plus fix plan rather than mutation.
+- The sole live merge-relevant required context is `cdb-local-ci` (a Commit
+  Status, not a Check Run). Verify live with `gh api`; do not hardcode a
+  required-checks list from memory. Hosted Actions check-runs are
+  advisory/safety-relevant only (migration #4169).
+- Autonomous squash merge is capability-based (see
+  `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+  merge), not agent-type-based. `--admin` is never a valid bypass for a
+  missing/red `cdb-local-ci`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.opencode/skills/cdb-drift-reconcile/SKILL.md
+++ b/.opencode/skills/cdb-drift-reconcile/SKILL.md
@@ -2,10 +2,9 @@
 Canonical Skill Source: docs/skills/cdb-drift-reconcile/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
-
 ---
 name: cdb-drift-reconcile
 description: >
@@ -99,7 +98,9 @@ report `skill surface drift unknown`.
 
 **Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
 canon within the current scope, or create a deduplicated re-mirror follow-up issue
-and hand off. Never auto-merge without green required checks.
+and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
+exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
+merge remains capability-based when those gates are proven.
 
 ## Classification Rules
 

--- a/.opencode/skills/cdb-github-api-ops/SKILL.md
+++ b/.opencode/skills/cdb-github-api-ops/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -159,7 +159,8 @@ collection_errors:
 | Comment on issue/PR | Only if Plan-GO explicitly allows it |
 | Create issue/PR | Only if Plan-GO explicitly allows it |
 | Label/milestone changes | Only if Plan-GO explicitly allows it |
-| Merge/rebase/push | Separate scope, never automatic |
+| Rebase/push | Only if Plan-GO explicitly allows it |
+| Squash merge (`gh pr merge --squash --delete-branch`) | Autonomous only when every capability gate in `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous merge is proven for the exact PR head (task allows autonomous merge, PR in scope/mergeable, no blocking reviews, local Fast-CI PASS bound to head, main unchanged since validation, `cdb-local-ci` SUCCESS on exact head, session can perform the merge). Capability-based, not agent-type-based. `--admin` is never a substitute for missing/red `cdb-local-ci`. If any gate is unproven: report `DONE_PR_OPEN_MERGE_HANDOFF` naming the exact missing capability — do not loop, do not force. |
 | Repo settings/admin | Separate scope, never automatic |
 | Branch protection changes | Separate scope, never automatic |
 
@@ -169,6 +170,10 @@ When a write seems necessary but no approved scope exists:
 2. Report what needs writing and why.
 3. Propose the write as a follow-up with explicit Human-GO.
 4. Do NOT execute the write.
+
+For the merge row specifically: an unproven capability gate is a
+`DONE_PR_OPEN_MERGE_HANDOFF` report, not a STOP-and-ask — the PR stays open
+and the missing capability is named for the next session/human to close.
 
 ## Hard rules
 

--- a/.opencode/skills/cdb-issue-to-session-plan/SKILL.md
+++ b/.opencode/skills/cdb-issue-to-session-plan/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-issue-to-session-plan/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -49,6 +49,14 @@ Use this after `cdb-control-intake` when the next concrete unit of work is one s
    - Rank the issue inside the current stage and weekly context.
    - Name guardrails, blockers, and explicit non-goals.
    - Break the work into a short, ordered session plan with concrete next steps.
+   - If the plan ends in a PR, name the expected close state honestly:
+     autonomous squash merge only when the full capability gate in
+     `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+     merge is provable for the exact head; otherwise plan for
+     `DONE_PR_OPEN_MERGE_HANDOFF`, not a silent assumption of merge.
+   - If the plan spans multiple sequential PRs on the same base (a merge
+     wave), state that each merge requires a rebase + full revalidation
+     against the just-merged main before the next merge is attempted.
    - Mark all unresolved assumptions as unconfirmed.
 
 ## Interpretation Rules

--- a/.opencode/skills/cdb-operator/SKILL.md
+++ b/.opencode/skills/cdb-operator/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/cdb-operator/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-operator
-description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates. Autonomous squash-merge is allowed only when the full capability gate (docs/runbooks/merge_policy_ci_gate.md) is proven for the exact PR head; otherwise honest DONE_PR_OPEN_MERGE_HANDOFF, never --admin.
 compatibility: opencode
 metadata:
   project: claire-de-binare
@@ -30,9 +30,23 @@ Use this skill when working on Claire_de_Binare with OpenCode.
 5. Pull GitHub issue and PR state live.
 6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
 7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
-8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+8. Do not write, commit, push, comment, label, or close without explicit human GO.
+9. Merge is capability-based, not agent-type-based: after Plan-GO, a squash
+   merge (`gh pr merge <PR> --squash --delete-branch`) is autonomous and
+   allowed only when every capability gate in
+   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+   merge is proven for the exact PR head (task allows autonomous merge, PR
+   in scope/mergeable/no blocking reviews, local Fast-CI PASS bound to head,
+   main unchanged since validation, `cdb-local-ci` SUCCESS on exact head,
+   session can perform the merge). `--admin` is never a substitute for a
+   missing `cdb-local-ci`. If any gate is unproven: report
+   `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
+   loop or force.
 
 ## Stop conditions
 
-Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red
+`cdb-local-ci` (the sole required merge context; Hosted Actions red is
+advisory), a capability gate unproven for merge, scope growth, or any
+live-readiness/echtgeld implication.
 

--- a/.opencode/skills/cdb-session-close/SKILL.md
+++ b/.opencode/skills/cdb-session-close/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -78,7 +78,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If push is not done, say so explicitly in the rest status.
    - If the issue state should change, describe the correct next state rather than claiming it changed when it did not.
    - If the work is still local-only, make that explicit in the issue-facing close-out instead of implying landed or review-ready state.
-   - If a PR was merged during this session, proceed to step 6. If no PR exists or the PR is still open, skip steps 6–7 and record `pending main-verification` or `n.a.` in the rest status.
+   - If a PR was merged during this session, proceed to step 6. If no PR
+     exists: skip steps 6–7. If the PR is still open because this session
+     could not prove the autonomous-merge capability gate (missing
+     `statuses:write`, unbound evidence, auth/publisher block): record
+     `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
+     skip steps 6–7. Do not use `--admin` and do not loop retries.
 6. Verify delivery on `main` — only when a PR was merged in this session:
 
    ```bash
@@ -103,6 +108,10 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
    - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
+   - After squash merge with `--delete-branch`: do **not** re-push or
+     recreate the deleted remote branch (anti-repush). Local `[gone]`
+     tracking refs may remain historical; clean them with `git fetch
+     --prune` / `git branch -d` only when unambiguous.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:

--- a/.opencode/skills/cdb-session-start/SKILL.md
+++ b/.opencode/skills/cdb-session-start/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-session-start/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -68,7 +68,7 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it |
+   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
    | Old local worktree from a prior session | Do not read as implicit active progress |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
@@ -188,6 +188,10 @@ Establish a verified, fail-closed starting state before any repo work begins.
    - Scope stated: what is IN, what is OUT.
    - Closure semantics confirmed: `Closes #N` (full delivery) vs. `Refs #N`
      (partial or scoped delivery).
+   - If the session may end in an autonomous merge, note that capability
+     (not agent type) gates it; see `docs/runbooks/merge_policy_ci_gate.md`
+     § Capability-based autonomous merge. Missing capability at close time
+     is `DONE_PR_OPEN_MERGE_HANDOFF`, not a blocker to starting session work.
 
 ## Fail-Closed Rules
 

--- a/.opencode/skills/gh-fix-ci/SKILL.md
+++ b/.opencode/skills/gh-fix-ci/SKILL.md
@@ -2,12 +2,12 @@
 Canonical Skill Source: docs/skills/gh-fix-ci/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 # gh-fix-ci - GitHub CI Failure Inspector
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Status:** Active
 **Canonical Location:** `docs/skills/gh-fix-ci/`
 
@@ -79,24 +79,63 @@ Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.m
 
 ## Required Checks for CDB
 
-Based on branch protection rules for `main`:
+**SSOT:** `docs/runbooks/merge_policy_ci_gate.md`.
+Live branch protection on `main` requires **exactly one** merge-relevant
+context:
 
-1. **ci (Unit/Integration + Lint gesammelt)** - Python tests, Ruff, Black, mypy
-2. **validate-branch-name** - Branch naming policy
-3. **gitleaks (Secrets-Alarm)** - Secret detection
-4. **trivy (kritische CVEs/Supply-Chain)** - Container CVE scan
-5. **Check Core Duplicates** - Prevents duplicate `core/` directories
-6. **Check Delivery Gate** - Enforces `DELIVERY_APPROVED.yaml` gate
-7. **guard** - repository canon consistency check
-8. **E2E Happy Path** - Full integration test (Redis, Postgres, Docker Compose)
+- **`cdb-local-ci`** — a GitHub **Commit Status** (not a Check Run) published
+  by the local Fast-CI status publisher for the exact PR head SHA. Verify
+  live with `gh api`, not from any hardcoded list (including this one).
+
+Since migration #4169, hosted GitHub Actions check-runs — `ci (Unit/Integration + Lint gesammelt)`,
+`validate-branch-name`, `gitleaks (Secrets-Alarm)`, `trivy (kritische CVEs/Supply-Chain)`,
+`Check Core Duplicates`, `Check Delivery Gate`, `guard`, `E2E Happy Path`, and
+similar — are **advisory/safety-relevant only**. They remain useful signal
+(lint, tests, security, governance, E2E) and should be inspected and fixed
+when red, but their status alone does **not** gate merge and does not need
+to be "8/8 present" for merge eligibility.
+
+### Failure classification (used by this skill)
+
+- `MERGE_READY` — `cdb-local-ci` SUCCESS on the exact PR head SHA. PR is
+  merge-eligible regardless of Hosted Actions state (surface Hosted Actions
+  findings as advisory only).
+- `REQUIRED_STATUS_MISSING` — `cdb-local-ci` absent or stale for the exact
+  head SHA. Not merge-eligible; needs a local Fast-CI run + publish, or a
+  capable session to do so.
+- `CODE_FAILURE` — a check (local Fast-CI stage or Hosted Actions job) fails
+  due to an actual code/test/lint/type issue. Fixable in-repo.
+  `--check` name filtering (e.g. `--check "ci (Unit"`) still works for
+  Hosted Actions advisory triage.
+- `HOSTED_ACTIONS_INFRA_BLOCK` — Hosted Actions run is red/blocked due to
+  billing, runner lock, `action_required` approval gate, or similar
+  infrastructure condition unrelated to code correctness. Report distinctly
+  from `CODE_FAILURE`; does not block merge if `cdb-local-ci` is SUCCESS.
+- `AUTH_PUBLISHER_BLOCK` — the session cannot read/verify `cdb-local-ci` or
+  (if attempting to publish) cannot authenticate with sufficient scope. See
+  Auth Preflight below.
 
 ### Conditional Checks
 
-Some required checks may not be present on every PR due to workflow path filters:
+Some Hosted Actions checks may not be present on every PR due to workflow
+path filters:
 
 - **E2E Happy Path**: Ergänzender E2E-Workflow; kein branch-protected Required Check.
-- The script reports these as "not triggered" rather than failures
-- Output format: `[OK] All required checks passed (7/7 present, 1 not triggered)`
+- The script reports these as "not triggered" rather than failures.
+- Output format: `[OK] Hosted Actions advisory checks: 7/7 present, 1 not triggered (cdb-local-ci: SUCCESS)`
+
+### Auth Preflight
+
+Before relying on any check result, verify the identity/token can actually
+read live status:
+
+1. `gh auth status` — confirm an authenticated identity.
+2. `gh api repos/<owner>/<repo>/commits/<head_sha>/status` — confirm
+   `cdb-local-ci` is readable for the exact PR head SHA (billing/lock
+   conditions on Hosted Actions do not affect this read).
+3. If step 2 fails with an auth/permission error, classify as
+   `AUTH_PUBLISHER_BLOCK`, not `REQUIRED_STATUS_MISSING` — these have
+   different remediations (fix auth vs. run+publish local CI).
 
 ---
 
@@ -158,39 +197,42 @@ Failing Checks (2/15):
 
 ### Human-Readable Summary (Default)
 ```
-PR #807: docs(lr): add LR-007 Shadow Mode status tracking
-Branch: docs/lr-007-status-tracking
-Status: 13 passed, 2 in_progress, 0 failed
+PR #807: jannekbuengener/Claire_de_Binare
+Status: 13 passed, 0 failed, 2 in_progress
 
-✅ All required checks passed (8/8)
+[OK] Required merge context is SUCCESS: MERGE_READY (1/1)
 
-Passing Checks:
-- ci (Unit/Integration + Lint gesammelt) ✅
-- validate-branch-name ✅
-- gitleaks (Secrets-Alarm) ✅
-...
+[ADVISORY] 1 Hosted Actions check(s) red (does not block merge if cdb-local-ci is SUCCESS):
+  - trivy (kritische CVEs/Supply-Chain)
+```
 
-In Progress:
-- trivy (kritische CVEs/Supply-Chain) ⏳ (elapsed: 45s)
+Missing/red required context is reported instead as:
+```
+[FAIL] Required merge context missing on this head SHA: REQUIRED_STATUS_MISSING
+   Missing: cdb-local-ci
+```
+or
+```
+[FAIL] Required merge context failed/red (1/1): BLOCKED_REQUIRED_STATUS
+  - cdb-local-ci
 ```
 
 ### JSON Output (with `--json`)
 ```json
 {
   "pr_number": 807,
-  "pr_title": "docs(lr): add LR-007 Shadow Mode status tracking",
-  "branch": "docs/lr-007-status-tracking",
-  "total_checks": 15,
-  "passed": 13,
-  "failed": 0,
-  "in_progress": 2,
-  "skipped": 0,
-  "failing_checks": [],
-  "required_checks_status": {
-    "ci (Unit/Integration + Lint gesammelt)": "SUCCESS",
-    "validate-branch-name": "SUCCESS",
-    ...
-  }
+  "repo": "jannekbuengener/Claire_de_Binare",
+  "summary": {
+    "total": 15,
+    "passed": 13,
+    "failed": 0,
+    "in_progress": 2,
+    "skipped": 0,
+    "required_checks_status": {
+      "cdb-local-ci": "SUCCESS"
+    }
+  },
+  "failing_checks": []
 }
 ```
 
@@ -377,5 +419,5 @@ Exit code: 2
 ---
 
 **Created:** 2026-02-08
-**Last Updated:** 2026-02-08
+**Last Updated:** 2026-07-30
 **Maintainer:** Claude Code (Session Lead)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,11 +184,13 @@ Coverage target: 80% on `core/` and `services/` (enforced by `make test-coverage
 
 ### CI / Branch Protection
 
-- Required checks: `ci (Unit/Integration + Lint gesammelt)` + `policy-gate`
+- Required merge context (SSOT: `docs/runbooks/merge_policy_ci_gate.md`, verify live via `gh api`): `cdb-local-ci` (Commit Status, exact PR head SHA) — the only branch-protection-required context on `main`.
+- `ci (Unit/Integration + Lint gesammelt)` + `policy-gate` (Hosted Actions) remain advisory/safety-relevant but are not branch-protection-required since migration #4169.
 - `policy-gate` categorizes PRs; core/service PRs need label `allow-core-change` or `manual-approval`
 - `strict: true` — branch must be up-to-date with main before merge
 - Bot review threads (Sourcery, Copilot) must be resolved before merge
 - Runner: `ci.yml` runs on `ubuntu-latest` (GitHub-hosted); self-hosted runners decommissioned from active CI per #3575; historical labels defined in `infrastructure/actions-runner/`
+- Autonomous squash merge is capability-based (see `.cursor/rules/CDB-Checks-and-Merge-Rule.mdc`): allowed once `cdb-local-ci` SUCCESS is proven live on the exact PR head SHA; `--admin` is never a substitute for a missing/red required status.
 
 ### Key Governance Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,10 +191,15 @@ pytest tests/e2e/ -v -m e2e
 Merge contract on `main` (SSOT:
 [`docs/runbooks/merge_policy_ci_gate.md`](docs/runbooks/merge_policy_ci_gate.md)):
 
-| Check | Source |
-|-------|--------|
-| `ci (Unit/Integration + Lint gesammelt)` | `.github/workflows/ci.yml` |
-| `policy-gate` | `.github/workflows/policy-gate.yml` |
+| Check | Source | Type |
+|-------|--------|------|
+| `cdb-local-ci` | Local CI Status Publisher | Commit Status (the only merge-relevant required context) |
+
+`ci (Unit/Integration + Lint gesammelt)` (`.github/workflows/ci.yml`) and
+`policy-gate` (`.github/workflows/policy-gate.yml`) are Hosted GitHub
+Actions content. They remain useful advisory/safety signals (lint, tests,
+scope policy) but are **not** branch-protection-required since migration
+#4169. Verify the live required context with `gh api`, not this table.
 
 Inside the CI gate: `ruff check .`, unit/integration tests, and Black on changed
 Python under `services/` and `tests/`. Coverage >= 80% applies when running

--- a/ci/README.md
+++ b/ci/README.md
@@ -15,6 +15,11 @@ Lokale, Docker-fähige CI-Ausführungsschicht für Claire_de_Binare.
   (`tools/ci/policy_gate_local.py`) ist Publish-Pflicht für `cdb-local-ci`.
 - Lokales CodeQL/SARIF ersetzt **nicht** den GitHub Security-Tab.
 - LR bleibt **NO-GO**. Kein BLUE/RED als Default-CI. Kein GHCR-Push.
+- Autonomous merge is capability-based (any session, not agent-type-based):
+  see [`docs/runbooks/merge_policy_ci_gate.md`](../docs/runbooks/merge_policy_ci_gate.md)
+  § Capability-based Autonomous Merge. `cdb-local-ci` SUCCESS on the exact PR
+  head SHA is the required merge context; missing capability → honest
+  `DONE_PR_OPEN_MERGE_HANDOFF`, never `--admin`.
 
 ## Preferred Windows front door
 

--- a/docs/ci/ACTION_REQUIRED_RUNBOOK.md
+++ b/docs/ci/ACTION_REQUIRED_RUNBOOK.md
@@ -23,7 +23,12 @@ Evidence anchors from triage:
 2. Check for the approval banner (`Approval required`).
 3. Click `Approve and run` (or equivalent approval button).
 4. Verify jobs are created and start running (no longer `jobs=[]`).
-5. Verify required context emission on the PR, especially `ci (Unit/Integration + Lint gesammelt)`.
+5. Verify the required context on the PR head: `cdb-local-ci` (the sole
+   branch-protection-required Commit Status; SSOT:
+   [`merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md)). Hosted
+   Actions contexts like `ci (Unit/Integration + Lint gesammelt)` are
+   advisory only — approving their run does not by itself satisfy the merge
+   gate.
 
 Important:
 - Approve only; do not post or expose secret values.
@@ -65,7 +70,9 @@ Decision tree:
 ## E) Maintainer Checklist (Daily Ops)
 - If a PR run is `action_required`:
   - 1) Approve run.
-  - 2) Confirm required context is emitted: `ci (Unit/Integration + Lint gesammelt)`.
+  - 2) Confirm the actual required merge context is live-green on the exact
+       PR head SHA: `cdb-local-ci` (verify via `gh api`). Hosted Actions
+       context emission alone is advisory evidence, not the merge gate.
   - 3) If recurring, review governance settings using MODE 1 vs MODE 2.
 
 ## F) Do / Don't

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -19,14 +19,26 @@
 
 ## Kanonischer PR-Merge-Vertrag
 
-| Workflow | Check-Kontext | Trigger |
-|---|---|---|
-| [`ci.yml`](../../.github/workflows/ci.yml) | `ci (Unit/Integration + Lint gesammelt)` | `pull_request`, gefilterter `push` |
-| [`policy-gate.yml`](../../.github/workflows/policy-gate.yml) | `policy-gate` | `pull_request` |
+SSOT: [`merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md). Der
+einzige merge-relevante Required Context auf `main` ist `cdb-local-ci`
+(Commit Status, lokaler Publisher, exakter PR-Head-SHA), live verifizierbar
+via `gh api`.
 
-Die frühere parallele Legacy-Pipeline wurde entfernt. Es gibt nur noch einen
-kanonischen CI-Pfad; Diagnose, Branch Protection und Dokumentation müssen sich
-auf die beiden Check-Kontexte oben beziehen.
+| Quelle | Check-Kontext | Typ |
+|---|---|---|
+| Local CI Status Publisher | `cdb-local-ci` | Commit Status |
+
+| Workflow | Rolle | Trigger |
+|---|---|---|
+| [`ci.yml`](../../.github/workflows/ci.yml) | Hosted Actions, advisory | `pull_request`, gefilterter `push` |
+| [`policy-gate.yml`](../../.github/workflows/policy-gate.yml) | Hosted Actions, advisory | `pull_request` |
+
+`ci.yml` und `policy-gate.yml` sind seit Migration #4169 **nicht mehr**
+branch-protection-required. Sie bleiben als Workflow-Inhalt / Safety-Gates
+nützlich (Hosted-Actions-Signal), ersetzen aber nicht `cdb-local-ci`. Ein
+rotes/blockiertes Hosted-Actions-Billing-/Runner-Lock ist eine
+Infrastruktur-Bedingung, kein Code-Fehler, und darf nicht mit einem
+fehlenden/roten `cdb-local-ci` verwechselt werden.
 
 ## Ergänzende Prüfungen
 
@@ -39,12 +51,13 @@ auf die beiden Check-Kontexte oben beziehen.
 | Audit | `required-checks-audit.yml`, `governance-audit.yml` |
 
 Diese Prüfungen können Fehler oder Findings liefern, sind aber keine
-Ersatzquelle für die beiden branch-protected Check-Kontexte.
+Ersatzquelle für den einzigen branch-protected Check-Kontext `cdb-local-ci`.
 
 ## Einstieg bei Fehlern
 
-1. Betroffenen Check-Kontext und Commit-SHA bestimmen.
-2. Job- und Step-Logs des konkreten Runs lesen.
+1. `cdb-local-ci` live für den exakten PR-Head-SHA prüfen (`gh api`), nicht
+   aus veralteten Tabellen ableiten.
+2. Job- und Step-Logs des konkreten Runs (Hosted Actions, advisory) lesen.
 3. [Merge-Policy-Runbook](../runbooks/merge_policy_ci_gate.md) anwenden.
 4. Bei Inventar- oder Trigger-Drift das
    [Workflow-Register](../runbooks/GITHUB_WORKFLOW_REGISTER.md) prüfen.

--- a/docs/ci/local-status-publisher.md
+++ b/docs/ci/local-status-publisher.md
@@ -103,6 +103,28 @@ pwsh -File ci/scripts/publish_status.ps1 -Command dry-run -EvidenceDir ci/artifa
   -PrNumber <n>
 ```
 
+## Identity preflight and handoff when `statuses:write` is missing
+
+Before attempting `publish`, a session should preflight its own capability
+rather than discover the failure mid-merge attempt:
+
+1. `gh auth status` — confirm an authenticated identity exists.
+2. Confirm a usable token per the resolution order above
+   (`GITHUB_TOKEN` → `GH_TOKEN` → `gh auth token`).
+3. Attempt `python -m ci.publisher dry-run ...` first; a dry-run failure due
+   to insufficient scope (no Commit-statuses write) surfaces as a clear
+   `REJECT:` without mutating anything.
+
+If the preflight shows the session cannot write the required Commit Status
+(no `statuses:write`-capable token, no authenticated identity, or the token
+owner lacks permission on this repo): do not fall back to `--admin` merge
+and do not loop retries. Report `DONE_PR_OPEN_MERGE_HANDOFF` /
+`BLOCKED_AUTH_PUBLISHER` (see
+[`merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md) §
+Capability-based Autonomous Merge) with the exact missing capability
+(e.g. "no fine-grained PAT with Commit statuses: Write available in this
+session") and the concrete next command for a capable session/human to run.
+
 ## Commands
 
 ```bash

--- a/docs/governance/no_human_review_policy.md
+++ b/docs/governance/no_human_review_policy.md
@@ -22,10 +22,19 @@ and PR #1024.
 
 **Merge gate = required checks + live branch protection settings on `main`.**
 
+SSOT for the required check contract: [`docs/runbooks/merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md).
+The only merge-relevant required context on `main` is `cdb-local-ci` (a Commit
+Status, exact PR head SHA). `ci (Unit/Integration + Lint gesammelt)` and
+`policy-gate` are Hosted GitHub Actions workflow content that remain useful
+as advisory/safety signals but are **not** branch-protection-required
+(migration #4169).
+
 A PR may merge when:
-1. All required status checks pass (currently: `ci (Unit/Integration + Lint gesammelt)` and `policy-gate`)
-2. All conversation threads are resolved (`required_conversation_resolution: true`)
-3. Live branch protection remains satisfied (`required_approving_review_count=0`, `require_code_owner_reviews=false`, `dismiss_stale_reviews=true`, `required_linear_history=true`)
+1. The required status check passes (`cdb-local-ci`, live via `gh api`)
+2. Hosted Actions advisory checks are green, skipped with explanation, or
+   documented as non-blocking infra (billing/lock ≠ code failure)
+3. Live branch protection remains satisfied — reverify with `gh api`, do not
+   assume this document's field values are current (see table below)
 4. A self-review comment is present (see template below)
 
 AI/Jules review comments are advisory only. They do not grant approval or merge
@@ -74,7 +83,7 @@ PR authors post this as a comment before merge:
 
 | Risk | Mitigation |
 |------|-----------|
-| Bad code merges without review | Required checks on `main`: `ci (Unit/Integration + Lint gesammelt)` and `policy-gate` |
+| Bad code merges without review | Required merge context on `main`: `cdb-local-ci` (Commit Status); Hosted Actions (`ci`, `policy-gate`) remain advisory/safety-relevant |
 | Schema/infra breakage | Runbooks required for infra PRs; enforcement scripts are opt-in operator steps |
 | Silent behavioral regression | Decision contract tests (`tests/contract/`), deterministic gate in conftest.py |
 | Accidental secret exposure | Auxiliary scans (for example `gitleaks`) plus PR hygiene; not a required merge context on `main` |
@@ -98,20 +107,30 @@ are documented here. They do not block merge.
 When a quarantined test is fixed, remove it from this table and add it
 to the required CI check suite.
 
-## Branch Protection Settings (current state)
+## Branch Protection Settings (verify live, do not trust this table alone)
 
-| Setting | Value | Purpose |
+Live lookup (authoritative; reverify before relying on any value below):
+
+```bash
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection
+```
+
+| Setting | Last-known live value | Purpose |
 |---------|-------|---------|
-| `required_status_checks` | `ci (Unit/Integration + Lint gesammelt)`, `policy-gate` | Merge-relevant required contexts on `main` |
+| `required_status_checks.contexts` | `["cdb-local-ci"]` | Sole merge-relevant required context on `main` (Commit Status) |
 | `required_status_checks.strict` | `true` | Branch must be up-to-date |
+| `enforce_admins` | `true` | Admins also bound by checks |
+| `required_conversation_resolution` | `false` | Verify live — do not assume `true` |
+| `allow_force_pushes` | `true` | Verify live — do not assume `false` |
 | `required_approving_review_count` | `0` | No fixed approving-review count |
 | `require_code_owner_reviews` | `false` | Disabled to avoid `.github/CODEOWNERS` self-deadlock in solo-maintainer mode |
 | `dismiss_stale_reviews` | `true` | Prior review state is invalidated after new pushes |
 | `required_linear_history` | `true` | Merge commits are disallowed on `main` |
-| `enforce_admins` | `true` | Admins also bound by checks |
-| `required_conversation_resolution` | `true` | All threads must be resolved |
-| `allow_force_pushes` | `false` | No force-push to main |
 | `allow_deletions` | `false` | Cannot delete main |
+
+All other fields not confirmed by the most recent live `gh api` check must be
+re-verified rather than assumed from this table; treat this table as a
+historical snapshot, not a live source of truth.
 
 ## References
 

--- a/docs/onboarding/cdb_glossary.md
+++ b/docs/onboarding/cdb_glossary.md
@@ -393,22 +393,22 @@ LR remains NO-GO. Board stage `trade-capable` is not Live-Go. No Echtgeld-Go.
 - **Primary Source:** [`knowledge/governance/CDB_AGENT_POLICY.md`](../../knowledge/governance/CDB_AGENT_POLICY.md)
 
 ### Required Checks
-- **Definition:** GitHub Actions checks that must pass before a PR can merge.
-- **CDB Context:** Includes `ci` (unit/integration tests + lint) and `policy-gate` (governance compliance). `capture-intent` and `submit-pypi` are non-blocking.
-- **Authority Boundary:** Required checks are enforced by branch protection. No merge bypass possible.
-- **Primary Source:** [`.github/CONTROL_PLANE.md`](../../.github/CONTROL_PLANE.md)
+- **Definition:** The branch-protection-enforced status check that must pass before a PR can merge.
+- **CDB Context:** The only merge-relevant required context on `main` is `cdb-local-ci` (a Commit Status published by the local Fast-CI publisher, exact PR head SHA). Hosted GitHub Actions checks (`ci`, `policy-gate`) remain advisory/safety-relevant but are not branch-protection-required since migration #4169. Verify live with `gh api`, not this glossary entry.
+- **Authority Boundary:** Required checks are enforced by branch protection. No merge bypass possible; `--admin` is never a substitute for a missing/red `cdb-local-ci`.
+- **Primary Source:** [`docs/runbooks/merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md)
 
 ### policy-gate
-- **Definition:** A required check that validates PR compliance with CDB governance policies.
-- **CDB Context:** Runs on every PR. Must pass before merge. Fails if scope violations, forbidden paths, or policy breaches are detected.
-- **Authority Boundary:** policy-gate is a hard gate. A failing policy-gate blocks merge regardless of other checks.
-- **Primary Source:** [`.github/CONTROL_PLANE.md`](../../.github/CONTROL_PLANE.md)
+- **Definition:** A Hosted GitHub Actions workflow that validates PR compliance with CDB governance policies.
+- **CDB Context:** Runs on every PR as advisory/safety signal. Fails if scope violations, forbidden paths, or policy breaches are detected. Since migration #4169 it is not itself the branch-protection-required merge context (`cdb-local-ci` is).
+- **Authority Boundary:** `policy-gate` findings should be treated as a hard local gate before merge, but the live branch-protection required context is `cdb-local-ci`, not `policy-gate` directly.
+- **Primary Source:** [`docs/runbooks/merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md)
 
 ### CI
 - **Definition:** Continuous Integration. Automated test and validation pipeline running on every PR.
-- **CDB Context:** Runs unit tests, integration tests, lint (ruff), and type checks (mypy). Must be green before merge.
-- **Authority Boundary:** CI is a pre-merge gate. It validates code quality, not operational readiness.
-- **Primary Source:** [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+- **CDB Context:** Local Fast-CI (`ci/`) runs unit tests, integration tests, lint (ruff), and publishes the `cdb-local-ci` Commit Status that is the actual merge gate. Hosted Actions `ci.yml` runs the same class of checks on `ubuntu-latest` as an advisory/safety signal.
+- **Authority Boundary:** `cdb-local-ci` is the pre-merge gate. It validates code quality, not operational readiness.
+- **Primary Source:** [`docs/runbooks/merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md)
 
 ## Safety boundaries
 

--- a/docs/onboarding/examples/first_issue_to_pr_flow.md
+++ b/docs/onboarding/examples/first_issue_to_pr_flow.md
@@ -113,23 +113,33 @@ Safety/LR statement, and issue links. Use
 [`../templates/pr_body_template.md`](../templates/pr_body_template.md) as the
 starting point.
 
-## 6. Wait For Checks And Merge Only If Safe
+## 6. Wait For Required Status And Merge Only If Capable
 
-Before merge:
+Before merge (SSOT: [`docs/runbooks/merge_policy_ci_gate.md`](../../runbooks/merge_policy_ci_gate.md)):
 
-1. Required checks are green.
-2. Diff remains in scope.
+1. Live `cdb-local-ci` SUCCESS on the exact PR head SHA (Commit Status).
+2. Diff remains in scope; local Fast-CI evidence bound to that head.
 3. No new stop condition appeared in comments or checks.
 4. No live, runtime, Docker, trading, DB write, memory write, or LR change was
    introduced.
+5. Session can perform regular squash merge (capability gate). Hosted Actions
+   red due to billing/lock is not automatically a merge blocker.
 
-Use squash merge only when the repo rules and required checks allow it.
+Use squash merge when the capability gate is proven:
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+If the session lacks publisher/merge rights: leave the PR open and report
+`DONE_PR_OPEN_MERGE_HANDOFF`. Never use `--admin` as a bypass. Do not
+re-push a remote branch deleted after squash merge.
 
 ## 7. Comment And Close
 
-After merge, comment on the target issue with the PR link, commit, validation,
-and scope boundary. Close the issue only when the merged PR satisfies the issue
-acceptance.
+After a **live-verified** merge (`DONE_MERGED_CLOSED`), comment on the target
+issue with the PR link, commit, validation, and scope boundary. Close the
+issue only when the merged PR satisfies the issue acceptance.
 
 If the issue is part of a parent chain, add a short parent status comment with
 the next recommended slice.

--- a/docs/onboarding/first_issue_sandbox.md
+++ b/docs/onboarding/first_issue_sandbox.md
@@ -216,48 +216,55 @@ gh pr comment <pr-number> --body "LOCK: agent=<agent-id> issue=#<issue> ts=<ISO8
 All GitHub writes (PR create, comment, merge, issue comment, labels) go through
 `gh` CLI only. No MCP/GitHub API/connector writes.
 
-## Check required checks
+## Check required status (merge gate)
 
-As defined in `docs/onboarding/cdb_glossary.md` and `.github/CONTROL_PLANE.md`:
+SSOT: [`docs/runbooks/merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md).
+Verify live with `gh api` — do not hardcode elsewhere.
 
-| Check | Required? | What it validates |
-|-------|-----------|-------------------|
-| `ci` | **Yes** | Unit + integration tests, lint (ruff), type checks (mypy) |
-| `policy-gate` | **Yes** | Governance compliance, scope violations, forbidden paths |
+| Context | Required? | What it validates |
+|---------|-----------|-------------------|
+| `cdb-local-ci` | **Yes** (Commit Status, exact PR head) | Local Fast-CI evidence published for this head |
+| Hosted Actions (`ci`, `policy-gate`, …) | Advisory | Safety/diagnostics; billing-red ≠ code failure |
 
-Non-required checks that should be green or skipped:
-- `capture-intent` (non-blocking)
-- `submit-pypi` (non-blocking)
+Publish path (when the session has `statuses:write`):
 
-Wait for both required checks to go green. If either is red: fix the issue
-inside the PR scope, push, and wait again. If the failure is outside your
-scope, comment on the PR and stop.
+```powershell
+pwsh -File ci/scripts/run_all.ps1 -Profile fast
+pwsh -File ci/scripts/publish_status.ps1 -Command publish `
+  -EvidenceDir ci/artifacts/<run_id> -StatusContext cdb-local-ci -PrNumber <n>
+```
 
-## Merge criteria
+If `cdb-local-ci` is missing/red and the session cannot publish: fix inside
+scope if possible, otherwise stop with `DONE_PR_OPEN_MERGE_HANDOFF`.
 
-Before merging, verify:
+## Merge criteria (capability-based)
 
-1. Required checks `ci` and `policy-gate` are green.
-2. No non-required check has a red status caused by this PR's content.
+Autonomous squash merge is allowed when **all** capability gates are proven
+(see merge-policy runbook). Not agent-type-based. Checklist:
+
+1. Live `cdb-local-ci` SUCCESS on the exact PR head SHA.
+2. Full local Fast-CI PASS bound to that head; validated `main` unchanged.
 3. Diff stays inside the approved scope (docs/onboarding + narrow discovery).
-4. No new `LOCK:` from another writer appeared.
-5. No `CHANGES_REQUESTED` review from a blocking reviewer.
-6. PR is not in draft / HOLD / BLOCKED state.
-7. No secrets in the diff.
-8. No LR, Live, or Echtgeld boundary touched.
-9. `CURRENT_STATUS.md` is not treated as live truth in the change.
+4. No new `LOCK:` from another writer; no blocking reviews / `CHANGES_REQUESTED`.
+5. PR is not draft / HOLD / BLOCKED; mergeable.
+6. No secrets in the diff; no LR/Live/Echtgeld boundary touched.
+7. Session can perform regular squash merge (no `--admin` bypass).
 
-Use **squash merge** to keep a clean main history:
+If gates are met and the task allows autonomous merge:
 
 ```bash
 gh pr merge <pr-number> --squash --delete-branch
 ```
 
-After merge, verify the merge SHA:
+If the session lacks publisher/merge capability: leave the PR open and report
+`DONE_PR_OPEN_MERGE_HANDOFF` (do not loop, do not `--admin`).
+
+After a successful merge, verify and **do not re-push** the deleted remote branch:
 
 ```bash
 git fetch origin --prune
 git rev-parse origin/main
+gh pr view <pr-number> --json state,mergedAt,mergeCommit
 ```
 
 ## Close issue / parent comment pattern
@@ -334,8 +341,8 @@ at [`examples/first_issue_to_pr_flow.md`](examples/first_issue_to_pr_flow.md).
 | `main` diverged from `origin/main` | `git fetch origin --prune && git reset --hard origin/main` |
 | Issue already closed | Pick a different open issue. |
 | Matching open PR with active `LOCK:` by another writer | HARD STOP. Wait or ask. |
-| Required check `ci` is red | Fix the issue inside PR scope. Do not expand scope. |
-| Required check `policy-gate` is red | Read the failure output. Fix governance issue or stop. |
+| Required status `cdb-local-ci` missing/red | Run local Fast-CI + publish, or hand off with `DONE_PR_OPEN_MERGE_HANDOFF` if lacking `statuses:write`. |
+| Hosted Actions `ci`/`policy-gate` red | Treat as advisory; fix real code/governance issues; billing-red ≠ code failure. |
 | Diff grows into runtime/Docker/trading/LR/DB scope | Revert the out-of-scope change. Commit only docs. |
 | Secret value appears in diff | Revert immediately. Do not push. |
 | `CURRENT_STATUS.md` treated as live truth in the change | Correct to ledger/ledger wording. |

--- a/docs/onboarding/templates/agent_prompt_template.md
+++ b/docs/onboarding/templates/agent_prompt_template.md
@@ -129,9 +129,20 @@ rg -n "Live-Go|Echtgeld-Go|LR bleibt NO-GO|Docs/UI sind Orientierung" <target-pa
 - Post the exact `LOCK:` as the first PR comment on the associated PR before
   further push, PR update, or follow-up GitHub mutation; an issue-only status
   comment does not satisfy the PR lock requirement.
-- Do not merge while required checks are red or scope is unclear.
+- Do not merge while live `cdb-local-ci` is missing/red on the exact PR head,
+  or while scope is unclear. Hosted Actions red due to billing/lock is not
+  automatically a merge blocker.
+- Autonomous squash merge is capability-based (see
+  `docs/runbooks/merge_policy_ci_gate.md`): when the task allows
+  `autonomous_regular_merge_allowed` and all gates are proven, merge with
+  `gh pr merge <PR> --squash --delete-branch` without asking for a separate
+  Merge-GO. Never use `--admin` as a bypass for missing `cdb-local-ci`.
+- If the session lacks `statuses:write` / merge capability: leave the PR open
+  and finish with `DONE_PR_OPEN_MERGE_HANDOFF` (no retry loops).
 - Comment the target issue with the PR link after PR creation.
-- After merge, comment and close only if the merged diff satisfies acceptance.
+- After a live-verified merge (`DONE_MERGED_CLOSED`), comment and close only
+  if the merged diff satisfies acceptance. Do not re-push a remote branch
+  deleted by `--delete-branch`.
 
 ## Safety
 

--- a/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
+++ b/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
@@ -21,13 +21,24 @@ historischen Evidence- und Session-Unterlagen erwähnt.
 
 ## Merge-relevante Checks
 
-| Workflow | Check |
-|---|---|
-| `ci.yml` | `ci (Unit/Integration + Lint gesammelt)` |
-| `policy-gate.yml` | `policy-gate` |
+SSOT: [`merge_policy_ci_gate.md`](merge_policy_ci_gate.md). Der einzige
+merge-relevante Required Context auf `main` ist `cdb-local-ci` (Commit
+Status, lokaler Publisher), live verifizierbar via `gh api`, nicht aus
+dieser Tabelle.
 
-Nur diese beiden Check-Kontexte sind der kanonische PR-Merge-Vertrag. Andere
-Workflows liefern ergänzende Prüfungen, Reports oder Automatisierung.
+| Quelle | Check-Kontext | Typ |
+|---|---|---|
+| Local CI Status Publisher | `cdb-local-ci` | Commit Status |
+
+| Workflow | Rolle |
+|---|---|
+| `ci.yml` | Hosted Actions, advisory (nicht branch-protection-required) |
+| `policy-gate.yml` | Hosted Actions, advisory (nicht branch-protection-required) |
+
+`ci.yml` und `policy-gate.yml` sind seit Migration #4169 keine
+Branch-Protection-Required-Checks mehr. Andere Workflows liefern
+ergänzende Prüfungen, Reports oder Automatisierung, ersetzen aber ebenfalls
+nicht `cdb-local-ci`.
 
 ## Vollständiges Inventar
 

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -42,6 +42,64 @@ prüfen, erzeugt selbst aber keinen merge-relevanten Ersatzcheck.
 4. Publisher-Evidence und Policy-Mirror-Fail prüfen.
 5. Erst nach grünem aktuellem `cdb-local-ci` mergen.
 
+## Capability-based Autonomous Merge
+
+Autonomous squash merge is **capability-based, not agent-type-based**. Any
+session (local or cloud) may autonomously run
+`gh pr merge <PR> --squash --delete-branch` once all of the following are
+proven true for the exact PR head SHA:
+
+1. `autonomous_regular_merge_allowed` for this task scope.
+2. PR fully in approved scope, not draft, mergeable.
+3. No blocking reviews / unresolved scope or governance blockers.
+4. Full local Fast-CI PASS for the exact PR head.
+5. Evidence bound to the exact PR head (no stale/other-SHA evidence).
+6. Validated `main` unchanged since validation (no drift since evidence).
+7. `cdb-local-ci` SUCCESS on the exact PR head SHA (live via `gh api`).
+8. The session can perform the regular squash merge itself (has merge
+   permission / `statuses:write`), and can publish `cdb-local-ci` itself if
+   it is still missing and the session holds bound evidence to do so.
+
+`--admin` is **never** a bypass for a missing/red/stale `cdb-local-ci`.
+Fake-green claims and merging an untested head are forbidden.
+
+### Honest handoff when capability is missing
+
+If a session lacks any gate above (no `statuses:write`, no verifiable
+identity, evidence not bound to the exact head, publisher auth blocked):
+leave the PR open, do not use `--admin`, do not loop the same blocked
+attempt, and report `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing
+capability and the next command for a capable session/human. See
+`.cursor/rules/CDB-Checks-and-Merge-Rule.mdc` for the full status taxonomy
+(`DONE_MERGED_CLOSED`, `DONE_PR_OPEN_MERGE_HANDOFF`, `BLOCKED_REQUIRED_STATUS`,
+`BLOCKED_AUTH_PUBLISHER`, `HOLD_SCOPE_OR_REVIEW`, `HOLD_MAIN_OR_HEAD_DRIFT`).
+
+### Auth token override for the publisher
+
+The publisher (`ci.publisher`, see
+[`local-status-publisher.md`](../ci/local-status-publisher.md)) reads its
+token only from the environment, in this order: `GITHUB_TOKEN`, then
+`GH_TOKEN`, else falling back to `gh auth token`. A fine-grained PAT with
+**Commit statuses: Write** is sufficient; no admin, branch-protection, or
+contents-write scope is required or should be granted for publishing.
+Never pass a token as a CLI argument or commit it to the repo.
+
+### Merge waves
+
+When merging multiple PRs in sequence: after each squash merge, rebase the
+next PR onto the updated `main` and fully revalidate — rerun local Fast-CI
+and confirm `cdb-local-ci` SUCCESS on the new head — before merging the next
+PR in the wave. Do not batch-merge later PRs on evidence collected before
+the wave started; treat `main` movement mid-wave as `HOLD_MAIN_OR_HEAD_DRIFT`
+until revalidated.
+
+### Anti-repush
+
+After `gh pr merge --squash --delete-branch`, do not automatically re-push,
+recreate, or resurrect the deleted remote branch. If follow-up work is
+needed on the same topic, open a new branch explicitly instead of reviving
+the merged/deleted one.
+
 ## Dokumentationspflicht
 
 Änderungen an Check-Namen, Triggern oder Branch Protection müssen gemeinsam in

--- a/docs/runbooks/resolve_review_threads_via_graphql.md
+++ b/docs/runbooks/resolve_review_threads_via_graphql.md
@@ -107,7 +107,9 @@ PR #2639 was blocked on `required_conversation_resolution` despite green CI. Pat
 2. Confirm thread had no open human action items.
 3. `resolveReviewThread` with the returned `threadId` (Step 2).
 4. Verify unresolved count `0` (Step 3).
-5. `gh pr merge 2639 --squash --delete-branch` after required checks passed.
+5. `gh pr merge 2639 --squash --delete-branch` after live `cdb-local-ci`
+   SUCCESS on the exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`).
+   Never use `--admin` as a bypass.
 
 No secrets or tokens belong in thread bodies; sanitize before posting examples.
 

--- a/docs/skills/SKILL_SURFACE_REGISTRY.md
+++ b/docs/skills/SKILL_SURFACE_REGISTRY.md
@@ -159,8 +159,8 @@ python tools/validate_skill_surface_mirror.py --skill <name>
 - **Pflicht:** Nach jeder Aenderung an `docs/skills/<name>/SKILL.md` den
   Drift-Guard laufen lassen und Adapter nachziehen, bevor die Session als
   vollstaendig abgeschlossen gilt. Bei `DRIFT_FOUND` re-mirror im Scope oder
-  dedupliziertes Re-Mirror-Follow-up-Issue anlegen (kein Auto-Merge ohne gruene
-  Required Checks).
+  dedupliziertes Re-Mirror-Follow-up-Issue anlegen (kein Auto-Merge ohne live
+  `cdb-local-ci` SUCCESS; siehe `docs/runbooks/merge_policy_ci_gate.md`).
 - Dokumentierte Ausnahmen (kein Drift): `cdb-onboarding` (codex-only Alias),
   `gh-fix-ci` Canon-Extras (`META.yaml`/`evals.json`/`scripts/`),
   `.claude/skills/*.skill`, `.gemini/skills/`.

--- a/docs/skills/cdb-ci-cd-guard/SKILL.md
+++ b/docs/skills/cdb-ci-cd-guard/SKILL.md
@@ -1,10 +1,3 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-ci-cd-guard/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-ci-cd-guard
 description: CDB CI/CD governance audit and hardening for the Claire de Binare repository. Use when GitHub Actions, rulesets, required checks, secret guards, or fake-green behavior need to be verified or fixed. Derive protected refs, required checks, and enforcement behavior from current repo evidence and GitHub state instead of assuming old branch patterns or legacy repository-canon paths.
@@ -37,6 +30,14 @@ disable-model-invocation: true
 - No silent stub or mock path on protected refs.
 - Missing critical secrets on protected refs must fail closed.
 - Without explicit approval, default to audit plus fix plan rather than mutation.
+- The sole live merge-relevant required context is `cdb-local-ci` (a Commit
+  Status, not a Check Run). Verify live with `gh api`; do not hardcode a
+  required-checks list from memory. Hosted Actions check-runs are
+  advisory/safety-relevant only (migration #4169).
+- Autonomous squash merge is capability-based (see
+  `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+  merge), not agent-type-based. `--admin` is never a valid bypass for a
+  missing/red `cdb-local-ci`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/docs/skills/cdb-drift-reconcile/SKILL.md
+++ b/docs/skills/cdb-drift-reconcile/SKILL.md
@@ -1,10 +1,3 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-drift-reconcile/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-drift-reconcile
 description: >
@@ -98,7 +91,9 @@ report `skill surface drift unknown`.
 
 **Follow-up rule:** On `DRIFT_FOUND`, either re-mirror the affected adapters from
 canon within the current scope, or create a deduplicated re-mirror follow-up issue
-and hand off. Never auto-merge without green required checks.
+and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
+exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
+merge remains capability-based when those gates are proven.
 
 ## Classification Rules
 

--- a/docs/skills/cdb-github-api-ops/SKILL.md
+++ b/docs/skills/cdb-github-api-ops/SKILL.md
@@ -1,10 +1,3 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-github-api-ops/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-github-api-ops
 description: >
@@ -159,7 +152,8 @@ collection_errors:
 | Comment on issue/PR | Only if Plan-GO explicitly allows it |
 | Create issue/PR | Only if Plan-GO explicitly allows it |
 | Label/milestone changes | Only if Plan-GO explicitly allows it |
-| Merge/rebase/push | Separate scope, never automatic |
+| Rebase/push | Only if Plan-GO explicitly allows it |
+| Squash merge (`gh pr merge --squash --delete-branch`) | Autonomous only when every capability gate in `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous merge is proven for the exact PR head (task allows autonomous merge, PR in scope/mergeable, no blocking reviews, local Fast-CI PASS bound to head, main unchanged since validation, `cdb-local-ci` SUCCESS on exact head, session can perform the merge). Capability-based, not agent-type-based. `--admin` is never a substitute for missing/red `cdb-local-ci`. If any gate is unproven: report `DONE_PR_OPEN_MERGE_HANDOFF` naming the exact missing capability — do not loop, do not force. |
 | Repo settings/admin | Separate scope, never automatic |
 | Branch protection changes | Separate scope, never automatic |
 
@@ -169,6 +163,10 @@ When a write seems necessary but no approved scope exists:
 2. Report what needs writing and why.
 3. Propose the write as a follow-up with explicit Human-GO.
 4. Do NOT execute the write.
+
+For the merge row specifically: an unproven capability gate is a
+`DONE_PR_OPEN_MERGE_HANDOFF` report, not a STOP-and-ask — the PR stays open
+and the missing capability is named for the next session/human to close.
 
 ## Hard rules
 

--- a/docs/skills/cdb-issue-to-session-plan/SKILL.md
+++ b/docs/skills/cdb-issue-to-session-plan/SKILL.md
@@ -1,10 +1,3 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-issue-to-session-plan/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-issue-to-session-plan
 description: >
@@ -49,6 +42,14 @@ Use this after `cdb-control-intake` when the next concrete unit of work is one s
    - Rank the issue inside the current stage and weekly context.
    - Name guardrails, blockers, and explicit non-goals.
    - Break the work into a short, ordered session plan with concrete next steps.
+   - If the plan ends in a PR, name the expected close state honestly:
+     autonomous squash merge only when the full capability gate in
+     `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+     merge is provable for the exact head; otherwise plan for
+     `DONE_PR_OPEN_MERGE_HANDOFF`, not a silent assumption of merge.
+   - If the plan spans multiple sequential PRs on the same base (a merge
+     wave), state that each merge requires a rebase + full revalidation
+     against the just-merged main before the next merge is attempted.
    - Mark all unresolved assumptions as unconfirmed.
 
 ## Interpretation Rules

--- a/docs/skills/cdb-operator/SKILL.md
+++ b/docs/skills/cdb-operator/SKILL.md
@@ -1,13 +1,6 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-operator/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-operator
-description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates, no merge without human approval.
+description: Enforces Claire de Binare operator workflow: bootloader first, live GitHub truth, dry-run planning, strict GO gates. Autonomous squash-merge is allowed only when the full capability gate (docs/runbooks/merge_policy_ci_gate.md) is proven for the exact PR head; otherwise honest DONE_PR_OPEN_MERGE_HANDOFF, never --admin.
 compatibility: opencode
 metadata:
   project: claire-de-binare
@@ -30,9 +23,23 @@ Use this skill when working on Claire_de_Binare with OpenCode.
 5. Pull GitHub issue and PR state live.
 6. Treat `CURRENT_STATUS.md` as ledger, not live truth.
 7. Produce only Lage, Befund, Plan, Dry-Run, Validierung, Restunsicherheiten.
-8. Do not write, commit, push, comment, label, close, or merge without explicit human GO.
+8. Do not write, commit, push, comment, label, or close without explicit human GO.
+9. Merge is capability-based, not agent-type-based: after Plan-GO, a squash
+   merge (`gh pr merge <PR> --squash --delete-branch`) is autonomous and
+   allowed only when every capability gate in
+   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
+   merge is proven for the exact PR head (task allows autonomous merge, PR
+   in scope/mergeable/no blocking reviews, local Fast-CI PASS bound to head,
+   main unchanged since validation, `cdb-local-ci` SUCCESS on exact head,
+   session can perform the merge). `--admin` is never a substitute for a
+   missing `cdb-local-ci`. If any gate is unproven: report
+   `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
+   loop or force.
 
 ## Stop conditions
 
-Stop immediately on missing bootloader, unclear scope, unexpected diff, red checks, pending checks before merge, scope growth, or any live-readiness/echtgeld implication.
+Stop immediately on missing bootloader, unclear scope, unexpected diff, red
+`cdb-local-ci` (the sole required merge context; Hosted Actions red is
+advisory), a capability gate unproven for merge, scope growth, or any
+live-readiness/echtgeld implication.
 

--- a/docs/skills/cdb-session-close/SKILL.md
+++ b/docs/skills/cdb-session-close/SKILL.md
@@ -1,10 +1,3 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-session-close/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-session-close
 description: >
@@ -78,7 +71,12 @@ Close a working session so the repo, git state, and issue thread reflect reality
    - If push is not done, say so explicitly in the rest status.
    - If the issue state should change, describe the correct next state rather than claiming it changed when it did not.
    - If the work is still local-only, make that explicit in the issue-facing close-out instead of implying landed or review-ready state.
-   - If a PR was merged during this session, proceed to step 6. If no PR exists or the PR is still open, skip steps 6–7 and record `pending main-verification` or `n.a.` in the rest status.
+   - If a PR was merged during this session, proceed to step 6. If no PR
+     exists: skip steps 6–7. If the PR is still open because this session
+     could not prove the autonomous-merge capability gate (missing
+     `statuses:write`, unbound evidence, auth/publisher block): record
+     `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
+     skip steps 6–7. Do not use `--admin` and do not loop retries.
 6. Verify delivery on `main` — only when a PR was merged in this session:
 
    ```bash
@@ -103,6 +101,10 @@ Close a working session so the repo, git state, and issue thread reflect reality
 
    - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
    - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
+   - After squash merge with `--delete-branch`: do **not** re-push or
+     recreate the deleted remote branch (anti-repush). Local `[gone]`
+     tracking refs may remain historical; clean them with `git fetch
+     --prune` / `git branch -d` only when unambiguous.
    - Otherwise: record as `n.a.` or `pending` — no blind deletes.
    - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:

--- a/docs/skills/cdb-session-start/SKILL.md
+++ b/docs/skills/cdb-session-start/SKILL.md
@@ -1,10 +1,3 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-session-start/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-session-start
 description: >
@@ -68,7 +61,7 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it |
+   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
    | Old local worktree from a prior session | Do not read as implicit active progress |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
@@ -188,6 +181,10 @@ Establish a verified, fail-closed starting state before any repo work begins.
    - Scope stated: what is IN, what is OUT.
    - Closure semantics confirmed: `Closes #N` (full delivery) vs. `Refs #N`
      (partial or scoped delivery).
+   - If the session may end in an autonomous merge, note that capability
+     (not agent type) gates it; see `docs/runbooks/merge_policy_ci_gate.md`
+     § Capability-based autonomous merge. Missing capability at close time
+     is `DONE_PR_OPEN_MERGE_HANDOFF`, not a blocker to starting session work.
 
 ## Fail-Closed Rules
 

--- a/docs/skills/gh-fix-ci/META.yaml
+++ b/docs/skills/gh-fix-ci/META.yaml
@@ -1,8 +1,8 @@
 ---
 skill_name: gh-fix-ci
-version: 1.0.0
+version: 1.1.0
 created: 2026-02-08
-last_updated: 2026-02-08
+last_updated: 2026-07-30
 status: active
 
 description: |
@@ -66,7 +66,16 @@ safety_rules:
   - "Never auto-switch GitHub accounts"
   - "Suggest-only fixes (no auto-apply)"
 
+# SSOT: docs/runbooks/merge_policy_ci_gate.md. `cdb-local-ci` is the sole
+# live merge-relevant required context (Commit Status, exact PR head SHA).
+# Verify live with `gh api`; do not hardcode elsewhere. Hosted GitHub
+# Actions check-runs (ci, validate-branch-name, gitleaks, trivy, Check Core
+# Duplicates, Check Delivery Gate, guard, E2E Happy Path) are
+# advisory/safety-relevant only since migration #4169.
 required_checks:
+  - "cdb-local-ci"
+
+advisory_hosted_actions_checks:
   - "ci (Unit/Integration + Lint gesammelt)"
   - "validate-branch-name"
   - "gitleaks (Secrets-Alarm)"
@@ -158,6 +167,13 @@ notes: |
   - Suggest-only fixes (no auto-apply for safety)
 
 changelog:
+  - version: 1.1.0
+    date: 2026-07-30
+    changes:
+      - "BREAKING: required_checks reduced to sole live context cdb-local-ci (Commit Status), per merge_policy_ci_gate.md and migration #4169"
+      - Added advisory_hosted_actions_checks for the former 8-check list (still useful signal, no longer merge-relevant)
+      - inspect_pr_checks.py now normalizes Commit Status (context/state) alongside Check Run (name/status/conclusion)
+      - Added failure classification: MERGE_READY / REQUIRED_STATUS_MISSING / CODE_FAILURE / HOSTED_ACTIONS_INFRA_BLOCK / AUTH_PUBLISHER_BLOCK
   - version: 1.0.0
     date: 2026-02-08
     changes:

--- a/docs/skills/gh-fix-ci/SKILL.md
+++ b/docs/skills/gh-fix-ci/SKILL.md
@@ -1,13 +1,6 @@
-<!--
-Canonical Skill Source: docs/skills/gh-fix-ci/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-01
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 # gh-fix-ci - GitHub CI Failure Inspector
 
-**Version:** 1.0.0
+**Version:** 1.1.0
 **Status:** Active
 **Canonical Location:** `docs/skills/gh-fix-ci/`
 
@@ -79,24 +72,63 @@ Based on [DISCOVERY_REPORT.md](../../../docs/skills/gh-fix-ci/DISCOVERY_REPORT.m
 
 ## Required Checks for CDB
 
-Based on branch protection rules for `main`:
+**SSOT:** `docs/runbooks/merge_policy_ci_gate.md`.
+Live branch protection on `main` requires **exactly one** merge-relevant
+context:
 
-1. **ci (Unit/Integration + Lint gesammelt)** - Python tests, Ruff, Black, mypy
-2. **validate-branch-name** - Branch naming policy
-3. **gitleaks (Secrets-Alarm)** - Secret detection
-4. **trivy (kritische CVEs/Supply-Chain)** - Container CVE scan
-5. **Check Core Duplicates** - Prevents duplicate `core/` directories
-6. **Check Delivery Gate** - Enforces `DELIVERY_APPROVED.yaml` gate
-7. **guard** - repository canon consistency check
-8. **E2E Happy Path** - Full integration test (Redis, Postgres, Docker Compose)
+- **`cdb-local-ci`** — a GitHub **Commit Status** (not a Check Run) published
+  by the local Fast-CI status publisher for the exact PR head SHA. Verify
+  live with `gh api`, not from any hardcoded list (including this one).
+
+Since migration #4169, hosted GitHub Actions check-runs — `ci (Unit/Integration + Lint gesammelt)`,
+`validate-branch-name`, `gitleaks (Secrets-Alarm)`, `trivy (kritische CVEs/Supply-Chain)`,
+`Check Core Duplicates`, `Check Delivery Gate`, `guard`, `E2E Happy Path`, and
+similar — are **advisory/safety-relevant only**. They remain useful signal
+(lint, tests, security, governance, E2E) and should be inspected and fixed
+when red, but their status alone does **not** gate merge and does not need
+to be "8/8 present" for merge eligibility.
+
+### Failure classification (used by this skill)
+
+- `MERGE_READY` — `cdb-local-ci` SUCCESS on the exact PR head SHA. PR is
+  merge-eligible regardless of Hosted Actions state (surface Hosted Actions
+  findings as advisory only).
+- `REQUIRED_STATUS_MISSING` — `cdb-local-ci` absent or stale for the exact
+  head SHA. Not merge-eligible; needs a local Fast-CI run + publish, or a
+  capable session to do so.
+- `CODE_FAILURE` — a check (local Fast-CI stage or Hosted Actions job) fails
+  due to an actual code/test/lint/type issue. Fixable in-repo.
+  `--check` name filtering (e.g. `--check "ci (Unit"`) still works for
+  Hosted Actions advisory triage.
+- `HOSTED_ACTIONS_INFRA_BLOCK` — Hosted Actions run is red/blocked due to
+  billing, runner lock, `action_required` approval gate, or similar
+  infrastructure condition unrelated to code correctness. Report distinctly
+  from `CODE_FAILURE`; does not block merge if `cdb-local-ci` is SUCCESS.
+- `AUTH_PUBLISHER_BLOCK` — the session cannot read/verify `cdb-local-ci` or
+  (if attempting to publish) cannot authenticate with sufficient scope. See
+  Auth Preflight below.
 
 ### Conditional Checks
 
-Some required checks may not be present on every PR due to workflow path filters:
+Some Hosted Actions checks may not be present on every PR due to workflow
+path filters:
 
 - **E2E Happy Path**: Ergänzender E2E-Workflow; kein branch-protected Required Check.
-- The script reports these as "not triggered" rather than failures
-- Output format: `[OK] All required checks passed (7/7 present, 1 not triggered)`
+- The script reports these as "not triggered" rather than failures.
+- Output format: `[OK] Hosted Actions advisory checks: 7/7 present, 1 not triggered (cdb-local-ci: SUCCESS)`
+
+### Auth Preflight
+
+Before relying on any check result, verify the identity/token can actually
+read live status:
+
+1. `gh auth status` — confirm an authenticated identity.
+2. `gh api repos/<owner>/<repo>/commits/<head_sha>/status` — confirm
+   `cdb-local-ci` is readable for the exact PR head SHA (billing/lock
+   conditions on Hosted Actions do not affect this read).
+3. If step 2 fails with an auth/permission error, classify as
+   `AUTH_PUBLISHER_BLOCK`, not `REQUIRED_STATUS_MISSING` — these have
+   different remediations (fix auth vs. run+publish local CI).
 
 ---
 
@@ -158,39 +190,42 @@ Failing Checks (2/15):
 
 ### Human-Readable Summary (Default)
 ```
-PR #807: docs(lr): add LR-007 Shadow Mode status tracking
-Branch: docs/lr-007-status-tracking
-Status: 13 passed, 2 in_progress, 0 failed
+PR #807: jannekbuengener/Claire_de_Binare
+Status: 13 passed, 0 failed, 2 in_progress
 
-✅ All required checks passed (8/8)
+[OK] Required merge context is SUCCESS: MERGE_READY (1/1)
 
-Passing Checks:
-- ci (Unit/Integration + Lint gesammelt) ✅
-- validate-branch-name ✅
-- gitleaks (Secrets-Alarm) ✅
-...
+[ADVISORY] 1 Hosted Actions check(s) red (does not block merge if cdb-local-ci is SUCCESS):
+  - trivy (kritische CVEs/Supply-Chain)
+```
 
-In Progress:
-- trivy (kritische CVEs/Supply-Chain) ⏳ (elapsed: 45s)
+Missing/red required context is reported instead as:
+```
+[FAIL] Required merge context missing on this head SHA: REQUIRED_STATUS_MISSING
+   Missing: cdb-local-ci
+```
+or
+```
+[FAIL] Required merge context failed/red (1/1): BLOCKED_REQUIRED_STATUS
+  - cdb-local-ci
 ```
 
 ### JSON Output (with `--json`)
 ```json
 {
   "pr_number": 807,
-  "pr_title": "docs(lr): add LR-007 Shadow Mode status tracking",
-  "branch": "docs/lr-007-status-tracking",
-  "total_checks": 15,
-  "passed": 13,
-  "failed": 0,
-  "in_progress": 2,
-  "skipped": 0,
-  "failing_checks": [],
-  "required_checks_status": {
-    "ci (Unit/Integration + Lint gesammelt)": "SUCCESS",
-    "validate-branch-name": "SUCCESS",
-    ...
-  }
+  "repo": "jannekbuengener/Claire_de_Binare",
+  "summary": {
+    "total": 15,
+    "passed": 13,
+    "failed": 0,
+    "in_progress": 2,
+    "skipped": 0,
+    "required_checks_status": {
+      "cdb-local-ci": "SUCCESS"
+    }
+  },
+  "failing_checks": []
 }
 ```
 
@@ -377,5 +412,5 @@ Exit code: 2
 ---
 
 **Created:** 2026-02-08
-**Last Updated:** 2026-02-08
+**Last Updated:** 2026-07-30
 **Maintainer:** Claude Code (Session Lead)

--- a/docs/skills/gh-fix-ci/evals.json
+++ b/docs/skills/gh-fix-ci/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "gh-fix-ci",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "evals": [
     {
       "name": "no_failing_checks",
@@ -8,10 +8,9 @@
       "command": "python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --repo jannekbuengener/Claire_de_Binare",
       "expected_exit_code": 0,
       "expected_output_contains": [
-        "All required checks passed",
-        "✅"
+        "MERGE_READY"
       ],
-      "note": "PR #807 has all checks passing (as of 2026-02-08)"
+      "note": "PR #807 had all checks passing (as of 2026-02-08); required context is now cdb-local-ci (Commit Status) per migration #4169, re-verify against a current PR"
     },
     {
       "name": "failing_check_mypy",
@@ -68,26 +67,25 @@
     },
     {
       "name": "required_checks_validation",
-      "description": "Should validate all 8 required checks for main branch",
+      "description": "Should validate the single live required merge context (cdb-local-ci)",
       "command": "python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --repo jannekbuengener/Claire_de_Binare",
       "expected_exit_code": 0,
       "expected_output_contains": [
-        "All required checks passed",
-        "present"
+        "MERGE_READY"
       ],
-      "note": "Validates all required checks from DISCOVERY_REPORT.md Section 2.1. PR #807 is docs-only so E2E Happy Path is not triggered (paths-ignore filter)."
+      "note": "SSOT: docs/runbooks/merge_policy_ci_gate.md. Since migration #4169 only cdb-local-ci (Commit Status) is merge-relevant; the former 8-check list is advisory only."
     },
     {
-      "name": "required_checks_with_not_found",
-      "description": "Should report NOT_FOUND checks separately when path filters skip them",
+      "name": "required_status_missing",
+      "description": "Should report REQUIRED_STATUS_MISSING when cdb-local-ci is absent for the exact head SHA",
       "command": "python docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py --pr 807 --repo jannekbuengener/Claire_de_Binare",
       "expected_exit_code": 0,
       "expected_output_contains": [
-        "7/7 present",
-        "1 not triggered",
-        "E2E Happy Path"
+        "REQUIRED_STATUS_MISSING",
+        "cdb-local-ci"
       ],
-      "note": "PR #807 has docs-only changes; E2E Happy Path is an optional non-required workflow and may be absent"
+      "note": "Applies to any PR head SHA where the local publisher has not yet published cdb-local-ci",
+      "skip_reason": "Requires a live PR without a published cdb-local-ci status at test time"
     },
     {
       "name": "polling_wait_mode",

--- a/docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py
+++ b/docs/skills/gh-fix-ci/scripts/inspect_pr_checks.py
@@ -32,17 +32,19 @@ DEFAULT_LOG_LINES = 100
 MAX_LOG_LINES = 500
 RETRY_COUNT = 2
 
-# Required checks for main branch
-REQUIRED_CHECKS = [
-    "ci (Unit/Integration + Lint gesammelt)",
-    "validate-branch-name",
-    "gitleaks (Secrets-Alarm)",
-    "trivy (kritische CVEs/Supply-Chain)",
-    "Check Core Duplicates",
-    "Check Delivery Gate",
-    "guard",
-    "E2E Happy Path",
-]
+# The sole live merge-relevant required context on `main` (Commit Status,
+# not a Check Run). SSOT: docs/runbooks/merge_policy_ci_gate.md.
+# Hosted GitHub Actions check-runs remain advisory/safety-relevant only
+# (migration #4169) and are reported separately below.
+REQUIRED_CHECKS = ["cdb-local-ci"]
+
+# Commit Status `state` values (cdb-local-ci) normalized to Check Run-style
+# conclusions so the rest of this script can treat both uniformly.
+_STATUS_STATE_TO_CONCLUSION = {
+    "SUCCESS": "SUCCESS",
+    "FAILURE": "FAILURE",
+    "ERROR": "FAILURE",
+}
 
 # Status handling
 POLL_STATUSES = ["IN_PROGRESS", "QUEUED", "PENDING"]
@@ -53,6 +55,7 @@ SUCCESS_STATUSES = ["SUCCESS", "NEUTRAL"]
 
 class FailureCategory(Enum):
     """Failure categories from DISCOVERY_REPORT.md"""
+
     LINT = "LINT"
     TYPE_CHECK = "TYPE_CHECK"
     TEST = "TEST"
@@ -65,6 +68,7 @@ class FailureCategory(Enum):
 @dataclass
 class FailurePattern:
     """Pattern for categorizing failures"""
+
     category: FailureCategory
     check_names: List[str]
     keywords: List[str]
@@ -77,37 +81,42 @@ FAILURE_PATTERNS = [
         category=FailureCategory.LINT,
         check_names=["ci (Ruff)", "Linting (Ruff)", "Format Check (Black)"],
         keywords=["Ruff found", "Black would reformat", "style violation"],
-        fix_hint="Run: black . && ruff check --fix ."
+        fix_hint="Run: black . && ruff check --fix .",
     ),
     FailurePattern(
         category=FailureCategory.TYPE_CHECK,
         check_names=["Type Checking (mypy)", "ci (mypy)"],
-        keywords=["mypy error", "incompatible type", "missing return", "Duplicate module"],
-        fix_hint="Add type hints or configure mypy excludes"
+        keywords=[
+            "mypy error",
+            "incompatible type",
+            "missing return",
+            "Duplicate module",
+        ],
+        fix_hint="Add type hints or configure mypy excludes",
     ),
     FailurePattern(
         category=FailureCategory.TEST,
         check_names=["Tests (Python", "ci (pytest)"],
         keywords=["FAILED tests/", "AssertionError", "test_"],
-        fix_hint="Run: pytest tests/ -v --tb=short --maxfail=1"
+        fix_hint="Run: pytest tests/ -v --tb=short --maxfail=1",
     ),
     FailurePattern(
         category=FailureCategory.SECURITY,
         check_names=["gitleaks", "trivy", "pip-audit"],
         keywords=["Credential detected", "CVE-", "vulnerability"],
-        fix_hint="Remove credentials, update dependencies, or add CVE to allowlist"
+        fix_hint="Remove credentials, update dependencies, or add CVE to allowlist",
     ),
     FailurePattern(
         category=FailureCategory.GOVERNANCE,
         check_names=["Check Delivery Gate", "Check Core Duplicates"],
         keywords=["DELIVERY_APPROVED", "duplicate core/"],
-        fix_hint="Review governance requirements in knowledge/governance/"
+        fix_hint="Review governance requirements in knowledge/governance/",
     ),
     FailurePattern(
         category=FailureCategory.E2E,
         check_names=["E2E", "e2e-"],
         keywords=["Redis connection", "Postgres", "Docker Compose"],
-        fix_hint="Check if STUB mode expected (PR fork?), verify credentials"
+        fix_hint="Check if STUB mode expected (PR fork?), verify credentials",
     ),
 ]
 
@@ -115,6 +124,7 @@ FAILURE_PATTERNS = [
 @dataclass
 class CheckResult:
     """Result of a single check"""
+
     name: str
     status: str
     conclusion: Optional[str]
@@ -126,6 +136,7 @@ class CheckResult:
 @dataclass
 class FailingCheck:
     """Detailed information about a failing check"""
+
     name: str
     conclusion: str
     url: str
@@ -162,10 +173,10 @@ class PRCheckInspector:
                     cmd,
                     capture_output=True,
                     text=True,
-                    encoding='utf-8',
-                    errors='replace',
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=timeout,
-                    check=True
+                    check=True,
                 )
                 stdout = result.stdout if result.stdout else ""
                 return json.loads(stdout) if stdout.strip() else {}
@@ -173,7 +184,10 @@ class PRCheckInspector:
             except subprocess.TimeoutExpired:
                 if attempt < RETRY_COUNT:
                     if self.verbose:
-                        print(f"[WARN] Timeout, retrying ({attempt+1}/{RETRY_COUNT})...", file=sys.stderr)
+                        print(
+                            f"[WARN] Timeout, retrying ({attempt+1}/{RETRY_COUNT})...",
+                            file=sys.stderr,
+                        )
                     time.sleep(2)
                     continue
                 else:
@@ -181,12 +195,19 @@ class PRCheckInspector:
 
             except subprocess.CalledProcessError as e:
                 # Check for auth failures
-                if "403" in e.stderr or "401" in e.stderr or "authentication" in e.stderr.lower():
+                if (
+                    "403" in e.stderr
+                    or "401" in e.stderr
+                    or "authentication" in e.stderr.lower()
+                ):
                     self._handle_auth_failure(e.stderr)
 
                 if attempt < RETRY_COUNT:
                     if self.verbose:
-                        print(f"[WARN] Command failed, retrying ({attempt+1}/{RETRY_COUNT})...", file=sys.stderr)
+                        print(
+                            f"[WARN] Command failed, retrying ({attempt+1}/{RETRY_COUNT})...",
+                            file=sys.stderr,
+                        )
                     time.sleep(2)
                     continue
                 else:
@@ -209,14 +230,16 @@ class PRCheckInspector:
                 ["gh", "auth", "status"],
                 capture_output=True,
                 text=True,
-                encoding='utf-8',
-                errors='replace',
-                timeout=5
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
             )
             print("Current auth status:", file=sys.stderr)
             print(result.stderr, file=sys.stderr)
         except Exception:
-            logging.getLogger(__name__).debug("Could not get auth status (ignored)", exc_info=True)
+            logging.getLogger(__name__).debug(
+                "Could not get auth status (ignored)", exc_info=True
+            )
 
         print(file=sys.stderr)
         print("Remediation:", file=sys.stderr)
@@ -232,27 +255,55 @@ class PRCheckInspector:
         sys.exit(exit_code)
 
     def get_pr_checks(self) -> List[CheckResult]:
-        """Get all checks for the PR"""
-        data = self.run_gh_command([
-            "pr", "view", str(self.pr_number),
-            "--repo", self.repo,
-            "--json", "statusCheckRollup"
-        ])
+        """Get all checks for the PR.
+
+        `statusCheckRollup` mixes two GitHub object shapes:
+        - Check Run (Hosted Actions): `name` / `status` / `conclusion`.
+        - Commit Status (`cdb-local-ci`): `context` / `state` (no separate
+          status/conclusion pair). Both are normalized into `CheckResult`
+          here so downstream logic (required-check lookup, categorization)
+          does not need to special-case the required context.
+        """
+        data = self.run_gh_command(
+            [
+                "pr",
+                "view",
+                str(self.pr_number),
+                "--repo",
+                self.repo,
+                "--json",
+                "statusCheckRollup",
+            ]
+        )
 
         checks = []
         for check_data in data.get("statusCheckRollup", []):
-            checks.append(CheckResult(
-                name=check_data.get("name", "Unknown"),
-                status=check_data.get("status", ""),
-                conclusion=check_data.get("conclusion"),
-                details_url=check_data.get("detailsUrl", ""),
-                started_at=check_data.get("startedAt"),
-                completed_at=check_data.get("completedAt")
-            ))
+            name = check_data.get("name") or check_data.get("context") or "Unknown"
+            status = check_data.get("status")
+            conclusion = check_data.get("conclusion")
+            state = check_data.get("state")
+            if state is not None and status is None and conclusion is None:
+                normalized_state = str(state).upper()
+                conclusion = _STATUS_STATE_TO_CONCLUSION.get(normalized_state)
+                status = "COMPLETED" if conclusion else normalized_state
+
+            checks.append(
+                CheckResult(
+                    name=name,
+                    status=status or "",
+                    conclusion=conclusion,
+                    details_url=check_data.get("detailsUrl")
+                    or check_data.get("targetUrl", ""),
+                    started_at=check_data.get("startedAt"),
+                    completed_at=check_data.get("completedAt"),
+                )
+            )
 
         return checks
 
-    def categorize_failure(self, check_name: str, log_snippet: Optional[str]) -> tuple[FailureCategory, str]:
+    def categorize_failure(
+        self, check_name: str, log_snippet: Optional[str]
+    ) -> tuple[FailureCategory, str]:
         """
         Categorize a failing check based on name and log content
 
@@ -267,12 +318,17 @@ class PRCheckInspector:
         # Match by log keywords if snippet available
         if log_snippet:
             for pattern in FAILURE_PATTERNS:
-                if any(keyword.lower() in log_snippet.lower() for keyword in pattern.keywords):
+                if any(
+                    keyword.lower() in log_snippet.lower()
+                    for keyword in pattern.keywords
+                ):
                     return pattern.category, pattern.fix_hint
 
         return FailureCategory.UNKNOWN, "Inspect check logs for details"
 
-    def get_check_logs(self, check: CheckResult, lines: int = DEFAULT_LOG_LINES) -> Optional[str]:
+    def get_check_logs(
+        self, check: CheckResult, lines: int = DEFAULT_LOG_LINES
+    ) -> Optional[str]:
         """
         Retrieve logs for a failing check
 
@@ -301,9 +357,9 @@ class PRCheckInspector:
                 cmd,
                 capture_output=True,
                 text=True,
-                encoding='utf-8',
-                errors='replace',
-                timeout=30
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
             )
 
             if result.returncode != 0 or not result.stdout:
@@ -313,9 +369,17 @@ class PRCheckInspector:
             log_lines = result.stdout.splitlines()
 
             # Filter for error keywords
-            error_keywords = ["error", "fail", "fatal", "exception", "traceback", "##[error]"]
+            error_keywords = [
+                "error",
+                "fail",
+                "fatal",
+                "exception",
+                "traceback",
+                "##[error]",
+            ]
             filtered_lines = [
-                line for line in log_lines
+                line
+                for line in log_lines
                 if any(keyword in line.lower() for keyword in error_keywords)
             ]
 
@@ -329,7 +393,10 @@ class PRCheckInspector:
 
         except Exception as e:
             if self.verbose:
-                print(f"[WARN] Could not retrieve logs for {check.name}: {e}", file=sys.stderr)
+                print(
+                    f"[WARN] Could not retrieve logs for {check.name}: {e}",
+                    file=sys.stderr,
+                )
             return None
 
     def poll_for_completion(self, max_wait: int = MAX_WAIT_TIME) -> List[CheckResult]:
@@ -347,10 +414,7 @@ class PRCheckInspector:
             checks = self.get_pr_checks()
 
             # Count in-progress checks
-            in_progress = [
-                c for c in checks
-                if c.status in POLL_STATUSES
-            ]
+            in_progress = [c for c in checks if c.status in POLL_STATUSES]
 
             if not in_progress:
                 print("\n✅ All checks complete", file=sys.stderr)
@@ -358,7 +422,11 @@ class PRCheckInspector:
 
             # Show progress
             elapsed = int(time.time() - start_time)
-            print(f"\r⏳ [{elapsed}s] Waiting for {len(in_progress)} check(s) to complete...", end="", file=sys.stderr)
+            print(
+                f"\r⏳ [{elapsed}s] Waiting for {len(in_progress)} check(s) to complete...",
+                end="",
+                file=sys.stderr,
+            )
 
             if iteration % 6 == 0:  # Every minute, show check names
                 print(file=sys.stderr)
@@ -367,10 +435,15 @@ class PRCheckInspector:
 
             time.sleep(POLL_INTERVAL)
 
-        print(f"\n⚠️  Timeout after {max_wait}s with {len(in_progress)} check(s) still in progress", file=sys.stderr)
+        print(
+            f"\n⚠️  Timeout after {max_wait}s with {len(in_progress)} check(s) still in progress",
+            file=sys.stderr,
+        )
         return checks
 
-    def analyze_checks(self, checks: List[CheckResult], log_lines: int = DEFAULT_LOG_LINES) -> tuple[List[FailingCheck], Dict[str, Any]]:
+    def analyze_checks(
+        self, checks: List[CheckResult], log_lines: int = DEFAULT_LOG_LINES
+    ) -> tuple[List[FailingCheck], Dict[str, Any]]:
         """
         Analyze checks and generate failure report
 
@@ -383,14 +456,20 @@ class PRCheckInspector:
         passed = sum(1 for c in checks if c.conclusion in SUCCESS_STATUSES)
         failed = sum(1 for c in checks if c.conclusion in FAILURE_STATUSES)
         in_progress = sum(1 for c in checks if c.status in POLL_STATUSES)
-        skipped = sum(1 for c in checks if c.status in SKIP_STATUSES or c.conclusion in SKIP_STATUSES)
+        skipped = sum(
+            1
+            for c in checks
+            if c.status in SKIP_STATUSES or c.conclusion in SKIP_STATUSES
+        )
 
         # Check required checks
         required_status = {}
         for req_check in REQUIRED_CHECKS:
             matching = [c for c in checks if c.name == req_check]
             if matching:
-                required_status[req_check] = matching[0].conclusion or matching[0].status
+                required_status[req_check] = (
+                    matching[0].conclusion or matching[0].status
+                )
             else:
                 required_status[req_check] = "NOT_FOUND"
 
@@ -405,14 +484,16 @@ class PRCheckInspector:
             # Categorize
             category, fix_hint = self.categorize_failure(check.name, log_snippet)
 
-            failing_checks.append(FailingCheck(
-                name=check.name,
-                conclusion=check.conclusion,
-                url=check.details_url,
-                category=category,
-                log_snippet=log_snippet,
-                fix_hint=fix_hint
-            ))
+            failing_checks.append(
+                FailingCheck(
+                    name=check.name,
+                    conclusion=check.conclusion,
+                    url=check.details_url,
+                    category=category,
+                    log_snippet=log_snippet,
+                    fix_hint=fix_hint,
+                )
+            )
 
         summary = {
             "total": len(checks),
@@ -420,44 +501,75 @@ class PRCheckInspector:
             "failed": failed,
             "in_progress": in_progress,
             "skipped": skipped,
-            "required_checks_status": required_status
+            "required_checks_status": required_status,
         }
 
         return failing_checks, summary
 
 
-def format_human_output(pr_number: int, repo: str, failing_checks: List[FailingCheck], summary: Dict[str, Any]):
+def format_human_output(
+    pr_number: int,
+    repo: str,
+    failing_checks: List[FailingCheck],
+    summary: Dict[str, Any],
+):
     """Format human-readable output"""
     # Use ASCII-safe characters for Windows console compatibility
     check_pass = "[OK]"
     check_fail = "[FAIL]"
 
     print(f"PR #{pr_number}: {repo}")
-    print(f"Status: {summary['passed']} passed, {summary['failed']} failed, {summary['in_progress']} in_progress")
+    print(
+        f"Status: {summary['passed']} passed, {summary['failed']} failed, {summary['in_progress']} in_progress"
+    )
     print()
 
     # Check required checks
     required_failed = [
-        name for name, status in summary["required_checks_status"].items()
+        name
+        for name, status in summary["required_checks_status"].items()
         if status in FAILURE_STATUSES
     ]
 
     if required_failed:
-        print(f"{check_fail} Required checks failed ({len(required_failed)}/{len(REQUIRED_CHECKS)}):")
+        print(
+            f"{check_fail} Required merge context failed/red ({len(required_failed)}/{len(REQUIRED_CHECKS)}): BLOCKED_REQUIRED_STATUS"
+        )
         for name in required_failed:
             print(f"  - {name}")
         print()
-    elif summary["failed"] == 0:
-        # Count checks that are present (not NOT_FOUND) and passed
-        passed_count = len([s for s in summary['required_checks_status'].values() if s in SUCCESS_STATUSES])
-        present_count = len([s for s in summary['required_checks_status'].values() if s != "NOT_FOUND"])
-        not_found = [name for name, s in summary['required_checks_status'].items() if s == "NOT_FOUND"]
+    else:
+        not_found = [
+            name
+            for name, s in summary["required_checks_status"].items()
+            if s == "NOT_FOUND"
+        ]
+        passed_count = len(
+            [
+                s
+                for s in summary["required_checks_status"].values()
+                if s in SUCCESS_STATUSES
+            ]
+        )
 
         if not_found:
-            print(f"{check_pass} All required checks passed ({passed_count}/{present_count} present, {len(not_found)} not triggered)")
-            print(f"   Not triggered: {', '.join(not_found)}")
+            print(
+                f"{check_fail} Required merge context missing on this head SHA: REQUIRED_STATUS_MISSING"
+            )
+            print(f"   Missing: {', '.join(not_found)}")
         else:
-            print(f"{check_pass} All required checks passed ({passed_count}/{len(REQUIRED_CHECKS)})")
+            print(
+                f"{check_pass} Required merge context is SUCCESS: MERGE_READY ({passed_count}/{len(REQUIRED_CHECKS)})"
+            )
+        print()
+
+    hosted_actions_failed = [c for c in failing_checks if c.name not in REQUIRED_CHECKS]
+    if hosted_actions_failed:
+        print(
+            f"[ADVISORY] {len(hosted_actions_failed)} Hosted Actions check(s) red (does not block merge if cdb-local-ci is SUCCESS):"
+        )
+        for check in hosted_actions_failed:
+            print(f"  - {check.name}")
         print()
 
     # Show failing checks
@@ -471,16 +583,25 @@ def format_human_output(pr_number: int, repo: str, failing_checks: List[FailingC
 
             if check.log_snippet:
                 print(f"\n   Error Snippet (last {DEFAULT_LOG_LINES} lines, filtered):")
-                for line in check.log_snippet.splitlines()[:20]:  # Show first 20 lines of snippet
+                for line in check.log_snippet.splitlines()[
+                    :20
+                ]:  # Show first 20 lines of snippet
                     print(f"     {line}")
                 if len(check.log_snippet.splitlines()) > 20:
-                    print(f"     ... ({len(check.log_snippet.splitlines()) - 20} more lines)")
+                    print(
+                        f"     ... ({len(check.log_snippet.splitlines()) - 20} more lines)"
+                    )
 
             print(f"\n   Fix: {check.fix_hint}")
             print()
 
 
-def format_json_output(pr_number: int, repo: str, failing_checks: List[FailingCheck], summary: Dict[str, Any]):
+def format_json_output(
+    pr_number: int,
+    repo: str,
+    failing_checks: List[FailingCheck],
+    summary: Dict[str, Any],
+):
     """Format JSON output"""
     output = {
         "pr_number": pr_number,
@@ -493,10 +614,10 @@ def format_json_output(pr_number: int, repo: str, failing_checks: List[FailingCh
                 "url": check.url,
                 "category": check.category.value,
                 "log_snippet": check.log_snippet,
-                "fix_hint": check.fix_hint
+                "fix_hint": check.fix_hint,
             }
             for check in failing_checks
-        ]
+        ],
     }
     print(json.dumps(output, indent=2))
 
@@ -512,14 +633,23 @@ Examples:
   %(prog)s --pr 807 --wait
   %(prog)s --pr 807 --json
   %(prog)s --pr 807 --check "ci (Unit" --lines 200
-"""
+""",
     )
 
     parser.add_argument("--pr", type=int, required=True, help="Pull Request number")
-    parser.add_argument("--repo", default=DEFAULT_REPO, help=f"Repository (default: {DEFAULT_REPO})")
-    parser.add_argument("--wait", action="store_true", help="Poll for in-progress checks (max 10 min)")
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help=f"Repository (default: {DEFAULT_REPO})"
+    )
+    parser.add_argument(
+        "--wait", action="store_true", help="Poll for in-progress checks (max 10 min)"
+    )
     parser.add_argument("--check", help="Filter by check name (substring match)")
-    parser.add_argument("--lines", type=int, default=DEFAULT_LOG_LINES, help=f"Log lines to show (default: {DEFAULT_LOG_LINES}, max: {MAX_LOG_LINES})")
+    parser.add_argument(
+        "--lines",
+        type=int,
+        default=DEFAULT_LOG_LINES,
+        help=f"Log lines to show (default: {DEFAULT_LOG_LINES}, max: {MAX_LOG_LINES})",
+    )
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
 

--- a/docs/surrealdb/context-evidence-claim-memory-runbook.md
+++ b/docs/surrealdb/context-evidence-claim-memory-runbook.md
@@ -342,7 +342,7 @@ The following actions **always require explicit human GO** regardless of trust l
 | Merge of code changes | GO MERGE |
 | Push to main | GO PUSH |
 | Issue close / comment | GO GITHUB LIVE |
-| Admin merge (bypass policy) | GO ADMIN MERGE |
+| Admin merge (`--admin`) | GO ADMIN MERGE — **never** a bypass for missing/red `cdb-local-ci`; with `enforce_admins=true` the Required Status remains mandatory |
 | Review thread resolve | GO REVIEW THREAD RESOLVE |
 | Commit | GO COMMIT |
 

--- a/tests/unit/github/test_dependabot_autopilot_classifier.py
+++ b/tests/unit/github/test_dependabot_autopilot_classifier.py
@@ -42,19 +42,16 @@ def _load_policy() -> classifier.AllowlistPolicy:
 
 def _checks(
     *,
-    policy_status: str = "COMPLETED",
-    policy_conclusion: str = "SUCCESS",
-    ci_status: str = "COMPLETED",
-    ci_conclusion: str = "SUCCESS",
+    status: str = "COMPLETED",
+    conclusion: str = "SUCCESS",
 ) -> tuple[RequiredCheckFact, ...]:
-    return (
-        RequiredCheckFact("policy-gate", policy_status, policy_conclusion),
-        RequiredCheckFact(
-            "ci (Unit/Integration + Lint gesammelt)",
-            ci_status,
-            ci_conclusion,
-        ),
-    )
+    """Build the sole live required merge context (`cdb-local-ci`).
+
+    `cdb-local-ci` is a Commit Status (not a hosted Actions check-run) per
+    docs/runbooks/merge_policy_ci_gate.md; it is the only merge-relevant
+    required context.
+    """
+    return (RequiredCheckFact("cdb-local-ci", status, conclusion),)
 
 
 def _facts(**overrides: object) -> Facts:
@@ -352,7 +349,9 @@ def test_incomplete_metadata_holds() -> None:
 def test_missing_required_check_holds() -> None:
     result = classifier.classify_dependabot_pr(
         _facts(
-            required_checks=(RequiredCheckFact("policy-gate", "COMPLETED", "SUCCESS"),)
+            required_checks=(
+                RequiredCheckFact("unrelated-check", "COMPLETED", "SUCCESS"),
+            )
         ),
         _load_policy(),
     )
@@ -365,8 +364,8 @@ def test_completed_with_failure_conclusion_holds() -> None:
     result = classifier.classify_dependabot_pr(
         _facts(
             required_checks=_checks(
-                ci_status="COMPLETED",
-                ci_conclusion="FAILURE",
+                status="COMPLETED",
+                conclusion="FAILURE",
             )
         ),
         _load_policy(),
@@ -380,8 +379,8 @@ def test_in_progress_with_success_conclusion_holds() -> None:
     result = classifier.classify_dependabot_pr(
         _facts(
             required_checks=_checks(
-                ci_status="IN_PROGRESS",
-                ci_conclusion="SUCCESS",
+                status="IN_PROGRESS",
+                conclusion="SUCCESS",
             )
         ),
         _load_policy(),
@@ -395,13 +394,8 @@ def test_duplicate_required_check_with_conflicting_results_holds() -> None:
     result = classifier.classify_dependabot_pr(
         _facts(
             required_checks=(
-                RequiredCheckFact("policy-gate", "COMPLETED", "SUCCESS"),
-                RequiredCheckFact("policy-gate", "COMPLETED", "FAILURE"),
-                RequiredCheckFact(
-                    "ci (Unit/Integration + Lint gesammelt)",
-                    "COMPLETED",
-                    "SUCCESS",
-                ),
+                RequiredCheckFact("cdb-local-ci", "COMPLETED", "SUCCESS"),
+                RequiredCheckFact("cdb-local-ci", "COMPLETED", "FAILURE"),
             )
         ),
         _load_policy(),
@@ -666,11 +660,6 @@ MALFORMED_FACT_CASES = [
         {
             "required_checks": (
                 RequiredCheckFact(None, "COMPLETED", "SUCCESS"),  # type: ignore[arg-type]
-                RequiredCheckFact(
-                    "ci (Unit/Integration + Lint gesammelt)",
-                    "COMPLETED",
-                    "SUCCESS",
-                ),
             )
         },
         id="required_check_name_none",
@@ -678,12 +667,7 @@ MALFORMED_FACT_CASES = [
     pytest.param(
         {
             "required_checks": (
-                RequiredCheckFact("policy-gate", 123, "SUCCESS"),  # type: ignore[arg-type]
-                RequiredCheckFact(
-                    "ci (Unit/Integration + Lint gesammelt)",
-                    "COMPLETED",
-                    "SUCCESS",
-                ),
+                RequiredCheckFact("cdb-local-ci", 123, "SUCCESS"),  # type: ignore[arg-type]
             )
         },
         id="required_check_status_int",
@@ -691,12 +675,7 @@ MALFORMED_FACT_CASES = [
     pytest.param(
         {
             "required_checks": (
-                RequiredCheckFact("policy-gate", "COMPLETED", []),  # type: ignore[arg-type]
-                RequiredCheckFact(
-                    "ci (Unit/Integration + Lint gesammelt)",
-                    "COMPLETED",
-                    "SUCCESS",
-                ),
+                RequiredCheckFact("cdb-local-ci", "COMPLETED", []),  # type: ignore[arg-type]
             )
         },
         id="required_check_conclusion_list",

--- a/tests/unit/github/test_dependabot_autopilot_report.py
+++ b/tests/unit/github/test_dependabot_autopilot_report.py
@@ -58,34 +58,18 @@ def _load_policy() -> classifier.AllowlistPolicy:
 
 def _checks(
     *,
-    policy_status: str = "COMPLETED",
-    policy_conclusion: str = "SUCCESS",
-    ci_status: str = "COMPLETED",
-    ci_conclusion: str = "SUCCESS",
-    duplicate_policy: tuple[str, str] | None = None,
+    state: str = "success",
+    duplicate: str | None = None,
 ) -> list[dict[str, str]]:
-    runs = [
-        {
-            "name": "policy-gate",
-            "status": policy_status.lower(),
-            "conclusion": policy_conclusion.lower(),
-        },
-        {
-            "name": "ci (Unit/Integration + Lint gesammelt)",
-            "status": ci_status.lower(),
-            "conclusion": ci_conclusion.lower(),
-        },
-    ]
-    if duplicate_policy is not None:
-        status, conclusion = duplicate_policy
-        runs.append(
-            {
-                "name": "policy-gate",
-                "status": status.lower(),
-                "conclusion": conclusion.lower(),
-            }
-        )
-    return runs
+    """Build live Commit Status entries for the `cdb-local-ci` context.
+
+    `cdb-local-ci` is published as a Commit Status (`context`/`state`), not a
+    hosted Actions check-run (`name`/`status`/`conclusion`).
+    """
+    statuses = [{"context": "cdb-local-ci", "state": state.lower()}]
+    if duplicate is not None:
+        statuses.append({"context": "cdb-local-ci", "state": duplicate.lower()})
+    return statuses
 
 
 def _dependabot_commit_message() -> str:
@@ -204,11 +188,11 @@ def _build_transport(
         f"repos/{REPO}/compare/{BASE_SHA}...{HEAD_SHA}": compare,
     }
     if check_runs_error is not None:
-        routes[f"repos/{REPO}/commits/{HEAD_SHA}/check-runs"] = (
-            lambda *_args, **_kwargs: (_ for _ in ()).throw(check_runs_error)
-        )
+        routes[f"repos/{REPO}/commits/{HEAD_SHA}/status"] = lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(check_runs_error)
     else:
-        routes[f"repos/{REPO}/commits/{HEAD_SHA}/check-runs"] = check_runs
+        routes[f"repos/{REPO}/commits/{HEAD_SHA}/status"] = check_runs
     return report.InMemoryGhTransport(routes)
 
 
@@ -280,9 +264,8 @@ def test_missing_required_check_holds() -> None:
         _build_transport(
             check_runs=[
                 {
-                    "name": "policy-gate",
-                    "status": "completed",
-                    "conclusion": "success",
+                    "context": "unrelated-check",
+                    "state": "success",
                 }
             ]
         )
@@ -294,11 +277,7 @@ def test_missing_required_check_holds() -> None:
 
 
 def test_in_progress_required_check_holds() -> None:
-    outcome = _run(
-        _build_transport(
-            check_runs=_checks(ci_status="IN_PROGRESS", ci_conclusion="SUCCESS")
-        )
-    )
+    outcome = _run(_build_transport(check_runs=_checks(state="pending")))
 
     row = outcome.rows[0]
     assert row.classification == "HOLD"
@@ -306,9 +285,7 @@ def test_in_progress_required_check_holds() -> None:
 
 
 def test_duplicate_required_check_holds() -> None:
-    outcome = _run(
-        _build_transport(check_runs=_checks(duplicate_policy=("COMPLETED", "FAILURE")))
-    )
+    outcome = _run(_build_transport(check_runs=_checks(duplicate="failure")))
 
     row = outcome.rows[0]
     assert row.classification == "HOLD"
@@ -451,7 +428,7 @@ def test_multiple_open_dependabot_pulls_sorted_by_number() -> None:
             f"repos/{REPO}/pulls/4049/commits": _commits_stub(),
             f"repos/{REPO}/pulls/4049/files": _files_stub(),
             f"repos/{REPO}/compare/{BASE_SHA}...{HEAD_SHA}": _compare_stub(),
-            f"repos/{REPO}/commits/{HEAD_SHA}/check-runs": _checks(),
+            f"repos/{REPO}/commits/{HEAD_SHA}/status": _checks(),
         }
     )
     outcome = report.run_report(transport, REPO, ALLOWLIST_PATH)
@@ -464,16 +441,16 @@ def test_merge_paginated_payload_merges_two_pull_array_pages() -> None:
     assert merged == [{"number": 4048}, {"number": 4049}]
 
 
-def test_merge_paginated_payload_merges_two_check_runs_object_pages() -> None:
+def test_merge_paginated_payload_merges_two_statuses_object_pages() -> None:
     merged = report._merge_paginated_payload(
         [
-            {"check_runs": [{"name": "policy-gate"}]},
-            {"check_runs": [{"name": "ci (Unit/Integration + Lint gesammelt)"}]},
+            {"statuses": [{"context": "cdb-local-ci"}]},
+            {"statuses": [{"context": "unrelated-check"}]},
         ]
     )
     assert merged == [
-        {"name": "policy-gate"},
-        {"name": "ci (Unit/Integration + Lint gesammelt)"},
+        {"context": "cdb-local-ci"},
+        {"context": "unrelated-check"},
     ]
 
 
@@ -750,7 +727,7 @@ def test_workflow_has_read_only_permissions_and_no_merge_commands() -> None:
     assert permissions == {
         "contents": "read",
         "pull-requests": "read",
-        "checks": "read",
+        "statuses": "read",
     }
     lowered = content.lower()
     assert ": write" not in lowered


### PR DESCRIPTION
## Closes #4195

## Problem
Active docs, Cursor rules, skills, onboarding, and Dependabot automation still described the pre-#4169 merge contract (ci + policy-gate / eight Actions checks) or implied agent-type merge bans. That drove impossible merge loops when sessions lacked statuses:write.

## Management Decision
Autonomous regular squash-merge remains **allowed and desired**. Authority is **capability-based**, not agent-type-based. Sessions that cannot publish cdb-local-ci or merge end with DONE_PR_OPEN_MERGE_HANDOFF — never --admin, never fake-green.

## Capability-Based Autonomous Merge
Any session may run `gh pr merge <PR> --squash --delete-branch` when all gates are proven (task allows autonomous merge; scope clean; Fast-CI PASS on exact head; cdb-local-ci SUCCESS; validated main unchanged; session can merge). No extra Merge-GO when those gates hold.

## Required Status Truth
Live required context: **only** `cdb-local-ci` (Commit Status, exact head). Hosted Actions are advisory; billing-red ≠ code failure. `--admin` is not a bypass under `enforce_admins=true`.

## Delivered
- Cursor always-applied rules: capability gate + status taxonomy
- Canon merge policy / publisher / CI index / CONTROL_PLANE / CONTRIBUTING / CLAUDE / glossary / Active governance policy
- `gh-fix-ci` skill + `inspect_pr_checks.py` + META/evals
- Session/operator skills + mirrors (cursor/claude/opencode/codex)
- Dependabot classifier/report → `cdb-local-ci`
- Onboarding sandbox/templates/examples + anti-repush

## Affected Surfaces
Rules, docs/runbooks, docs/ci, docs/skills (+ mirrors), onboarding, Dependabot scripts/tests, CONTROL_PLANE, CONTRIBUTING, CLAUDE.md

## Brain Evidence
`brain_source=repo-only`, `brain_status=not-used`, context tools available but LOW trust / no records; live GitHub/BP leads.

## Validation
- `pytest` Dependabot tests: 118 passed
- `ruff` + `black --check` on touched Python
- `python tools/validate_skill_surface_mirror.py` PASS for touched skills
- Fast-CI `--profile fast`: PASS — evidence `ci/artifacts/20260730T065248Z_82b50587` — SHA `c124462830a5e109df3fc6259f38d6b006ac44a5`

## Mirror Validation
PASS for gh-fix-ci, cdb-session-close, cdb-drift-reconcile, cdb-ci-cd-guard, cdb-operator, cdb-session-start, cdb-github-api-ops, cdb-issue-to-session-plan

## Hosted Actions / Billing Semantics
Documented as advisory; not the merge gate.

## Auth and Publisher Semantics
`GITHUB_TOKEN`/`GH_TOKEN` override `gh auth`; publisher needs Commit statuses: Write; identity preflight via `gh api user`.

## Post-Merge Anti-Repush
Documented in merge policy, Cursor rules, session-close, onboarding.

## Non-goals
- No branch-protection mutation
- No new GitHub App token
- No secrets / runtime / Live-Go
- No rewrite of historical session logs

## Safety Boundaries
LR=NO-GO. No productive DB/MCP writes. No admin merge.

## Restunsicherheiten
- Live `allow_force_pushes=true` / conversation_resolution=false documented via live lookup, not mutated
- Dependabot runtime against live Actions not re-probed beyond unit tests