### PR TITLE
docs(skills): canonicalize safe post-merge cleanup

### DIFF
--- a/.claude/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.claude/skills/cdb-ci-cd-guard/SKILL.md
@@ -45,6 +45,11 @@ disable-model-invocation: true
   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
   merge), not agent-type-based. `--admin` is never a valid bypass for a
   missing/red `cdb-local-ci`.
+- CI PASS / green Hosted Actions does **not** authorize blind local post-merge
+  cleanup. After `--delete-branch`, remote absence is expected; local
+  worktree/branch removal remains evidence-based
+  (`cdb-session-close` § Safe Post-Merge Cleanup). Do not equate required-status
+  SUCCESS with safe `worktree remove` / `branch -D`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.claude/skills/cdb-debug-handoff/SKILL.md
+++ b/.claude/skills/cdb-debug-handoff/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-debug-handoff/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-02
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -118,6 +118,10 @@ complete.
 - Handing off a record with empty core fields as if it were complete.
 - Bundling several unrelated debug cases into one handoff.
 - Reading a board stage as an LR verdict, or a red CI check as a runtime outage.
+- Treating unclear branch lineage or unproven squash patch/tree equivalence as
+  safe cleanup — route those cases to `cdb-session-close` § Safe Post-Merge
+  Cleanup with `handoff_state: blocked` / `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  rather than deleting worktrees or using `branch -D`.
 
 ## Standalone value and family fit
 

--- a/.claude/skills/cdb-drift-reconcile/SKILL.md
+++ b/.claude/skills/cdb-drift-reconcile/SKILL.md
@@ -102,6 +102,20 @@ and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
 exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
 merge remains capability-based when those gates are proven.
 
+## Post-merge branch / worktree drift
+
+When classifying local/remote branch lineage after a squash merge:
+
+- Treat `[gone]` after `--delete-branch` as normal, not as a push trigger.
+- Detect republished merged heads (same topic branch reappearing remotely
+  after MERGED) as drift; do not recommend `git push -u origin HEAD` to
+  "restore" them.
+- Squash non-ancestor / `git cherry +` is **not** alone proof of unmerged
+  work — require tree/patch equivalence (see `cdb-session-close`
+  § Safe Post-Merge Cleanup).
+- Worktree/branch cleanup routing: hand off to `cdb-session-close`; do not
+  remove foreign worktrees from this skill.
+
 ## Classification Rules
 
 - `belegt` means the repo surface directly contradicts or lags the current canon.

--- a/.claude/skills/cdb-operator/SKILL.md
+++ b/.claude/skills/cdb-operator/SKILL.md
@@ -42,11 +42,17 @@ Use this skill when working on Claire_de_Binare with OpenCode.
    missing `cdb-local-ci`. If any gate is unproven: report
    `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
    loop or force.
+10. After a live-verified merge, local post-merge cleanup is
+    evidence-based only (`cdb-session-close` § Safe Post-Merge Cleanup):
+    never discard unsaved changes, never `branch -D` without tree/patch
+    equivalence, never republish a deleted remote head (anti-repush),
+    update local `main` with `ff-only` only.
 
 ## Stop conditions
 
 Stop immediately on missing bootloader, unclear scope, unexpected diff, red
 `cdb-local-ci` (the sole required merge context; Hosted Actions red is
-advisory), a capability gate unproven for merge, scope growth, or any
-live-readiness/echtgeld implication.
+advisory), a capability gate unproven for merge, scope growth, any
+live-readiness/echtgeld implication, or a cleanup request that would
+discard unsaved/unmerged local work.
 

--- a/.claude/skills/cdb-session-close/SKILL.md
+++ b/.claude/skills/cdb-session-close/SKILL.md
@@ -84,36 +84,34 @@ Close a working session so the repo, git state, and issue thread reflect reality
      `statuses:write`, unbound evidence, auth/publisher block): record
      `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
      skip steps 6–7. Do not use `--admin` and do not loop retries.
-6. Verify delivery on `main` — only when a PR was merged in this session:
+6. Verify remote merge delivery — only when a PR was merged in this session
+   (or when closing after a known merge of this session's PR):
 
    ```bash
-   gh pr view <PR> --json state,mergedAt,mergeCommit
-   git fetch origin main
-   git log origin/main --oneline -5
-   git checkout main
-   git merge --ff-only origin/main
+   git fetch origin --prune
+   gh pr view <PR> --json state,mergedAt,mergeCommit,headRefName,headRefOid
+   gh issue view <N> --json state,closedAt   # if an issue was targeted
+   git rev-parse origin/main
+   git merge-base --is-ancestor <MERGE_SHA> origin/main
    ```
 
    Determine:
-   - PR merged + merge commit visible on `origin/main` + `--ff-only` succeeded → proceed to step 7.
-   - PR merged but merge commit absent from `origin/main` → STOP, session = incomplete.
-   - `--ff-only` fails → report as pending, do not force.
-   - No PR in this session → mark as `n.a.`, skip this step.
-7. Classify temporary git surfaces — only when applicable:
+   - PR `MERGED` + merge commit on `origin/main` → proceed to step 7
+     (local post-merge cleanup). Issue may be `CLOSED` or still open; document
+     which. Remote head-branch absent (API 404 after `--delete-branch`) is
+     expected; do not recreate it.
+   - PR merged but merge commit absent from `origin/main` → STOP,
+     session incomplete / `HOLD_REMOTE_STATE_DRIFT`.
+   - Unexpected remote branch still present after squash+delete →
+     `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` (do not auto-delete/repush).
+   - No PR in this session → mark as `n.a.`, skip steps 6–7.
 
-   ```bash
-   git worktree list                       # any session worktrees?
-   git branch -v --merged origin/main      # any merged feature branch?
-   ```
+7. Local post-merge cleanup (evidence-based; never blind delete) — only when
+   step 6 proved `MERGED` for this session's PR. Full contract:
+   **§ Safe Post-Merge Cleanup** below. Success status for this hop:
+   `DONE_LOCAL_POST_MERGE_CLEANUP`. Note: `DONE_MERGED_CLOSED` alone does
+   **not** mean local cleanup already finished.
 
-   - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
-   - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
-   - After squash merge with `--delete-branch`: do **not** re-push or
-     recreate the deleted remote branch (anti-repush). Local `[gone]`
-     tracking refs may remain historical; clean them with `git fetch
-     --prune` / `git branch -d` only when unambiguous.
-   - Otherwise: record as `n.a.` or `pending` — no blind deletes.
-   - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
 
    Always after a merged PR or issue-driven session close, sweep for new
@@ -288,6 +286,123 @@ Close a working session so the repo, git state, and issue thread reflect reality
   follow-up issue that was not created or linked.
 - Do not silently expand scope to resolve residual findings during close.
 
+## Safe Post-Merge Cleanup (canonical)
+
+Trigger: a PR from this session (or an explicitly identified PR) is live
+`MERGED` and the merge commit is on `origin/main`. Cleanup is **not** blind
+deletion. Remove worktree/branch only when evidence proves no unsaved or
+unmerged content would be lost.
+
+### Status taxonomy (cleanup hop)
+
+| Status | Meaning |
+|---|---|
+| `DONE_LOCAL_POST_MERGE_CLEANUP` | Remote merge verified + local worktree/branch cleaned + main ff-only + no repush |
+| `HOLD_REMOTE_STATE_DRIFT` | PR/issue/merge-SHA state unexpected |
+| `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` | Remote head still present after expected `--delete-branch` |
+| `HOLD_UNSAVED_LOCAL_CHANGES` | Target worktree dirty (staged/unstaged/untracked) |
+| `HOLD_REAL_UNMERGED_CHANGES` | Extra commits/patches not in `origin/main` |
+| `HOLD_MAIN_NOT_FAST_FORWARDABLE` | Local main cannot ff-only to `origin/main` |
+| `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR` | Squash tree/patch equivalence not proven |
+| `BLOCKED_WORKTREE_REMOVAL` | Worktree cannot be removed safely |
+| `BLOCKED_LOCAL_BRANCH_REMOVAL` | Local branch cannot be removed safely |
+
+`DONE_MERGED_CLOSED` ≠ local cleanup done. Report cleanup separately.
+
+### Phase A — Inventory
+
+```bash
+git worktree list --porcelain
+git branch -vv
+```
+
+Identify: primary/main worktree, PR worktree path, local `[gone]` branch,
+whether the branch is checked out anywhere. Touch **only** this PR's worktree
+and branch.
+
+### Phase B — Data safety (inside target worktree)
+
+```bash
+git status --porcelain=v1 --untracked-files=all   # must be empty
+git rev-parse HEAD HEAD^{tree} origin/main origin/main^{tree}
+git log --oneline origin/main..HEAD               # expect PR commits or empty after squash tip
+git diff --quiet HEAD origin/main                 # exit 0 ⇒ identical trees preferred
+git diff --stat origin/main..HEAD                 # two-dot should be empty when trees match
+git cherry origin/main HEAD                       # advisory only after squash
+```
+
+**Squash rule:** Squash merges create new SHAs. `git cherry` / missing ancestry
+are **not** alone proof of unmerged work. Prefer identical
+`HEAD^{tree}` vs `origin/main^{tree}`, empty two-dot diff, and/or all PR
+paths blob-identical on `origin/main`. Optional: stable patch-id when lineage
+is unclear. No commits after the verified PR head. No open PR on that head.
+
+Dirty → `HOLD_UNSAVED_LOCAL_CHANGES`. Real delta → `HOLD_REAL_UNMERGED_CHANGES`.
+Unclear equivalence → `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
+### Phase C — Worktree removal
+
+Preconditions: Phase B clean + equivalence proven; remote branch absent;
+worktree is not the main worktree; remove from **another** worktree.
+
+```bash
+git worktree remove <TARGET_WORKTREE_PATH>
+git worktree prune
+git worktree list --porcelain
+```
+
+No `--force` while cause is unclear. Never delete foreign worktrees.
+
+### Phase D — Local branch removal
+
+Preconditions: worktree removed; branch not checked out; remote absent;
+equivalence proven.
+
+```bash
+git branch -d <PR_HEAD_BRANCH>
+```
+
+If `-d` fails **only** because squash non-ancestor and Phase B fully proved
+tree/patch equivalence, then:
+
+```bash
+git branch -D <PR_HEAD_BRANCH>
+```
+
+`-D` is a controlled squash fallback, not the default.
+
+### Phase E — Main ff-only
+
+Use the existing main worktree (do not force a second `main`). Require clean
+main worktree, then:
+
+```bash
+git fetch origin --prune
+git pull --ff-only origin main
+git rev-parse HEAD origin/main   # must match; merge SHA on HEAD
+```
+
+No local merge commit. No `reset --hard` / `git clean -fd` as default. If
+divergent → `HOLD_MAIN_NOT_FAST_FORWARDABLE`.
+
+### Phase F — Anti-repush (hard)
+
+Before any `git push -u origin HEAD`:
+
+1. Is the associated PR already `MERGED`?
+2. Is the remote branch deleted?
+3. Is the local branch only historical (`[gone]`)?
+
+If yes: **do not** republish that branch. New unmerged work → **new** branch
+name / follow-up PR — never revive the deleted merged head.
+
+### Fail-closed additions for cleanup
+
+- If `git merge --ff-only origin/main` fails: `HOLD_MAIN_NOT_FAST_FORWARDABLE`;
+  do not force.
+- If worktree remove fails for unclear dirty state: `BLOCKED_WORKTREE_REMOVAL`.
+- If equivalence is incomplete: do not `-D`; `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
 ## Fail-Closed Rules
 
 - If any write step would exceed the agreed scope (unexpected files/hunks, scope growth): STOP and ask for clarification + explicit GO.
@@ -301,7 +416,13 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If push or issue-status updates were not performed, keep them as pending actions in the close-out.
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
-- If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If `git merge --ff-only origin/main` / main ff-only fails: report
+  `HOLD_MAIN_NOT_FAST_FORWARDABLE`; do not force a merge or ignore divergence.
+- If local post-merge cleanup would discard unsaved changes: `HOLD_UNSAVED_LOCAL_CHANGES`.
+- If squash tree/patch equivalence is unclear: `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  (do not `branch -D`).
+- If tempted to `git push -u origin HEAD` for a MERGED/`[gone]` branch: STOP
+  (anti-repush).
 - If new follow-up issues are found but their link to this session is unclear: do not auto-start.
 - If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
 - If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
@@ -341,6 +462,8 @@ Main-Verifikation (nur wenn PR gemergt, sonst n.a.)
 Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Worktrees: entfernt: <liste> / n.a. / pending
 - Feature-Branch: gelöscht: <name> / n.a. / pending
+- Local post-merge cleanup: DONE_LOCAL_POST_MERGE_CLEANUP / HOLD_* / BLOCKED_* / n.a.
+- Anti-repush: confirmed (no republish of deleted remote) / n.a.
 - Leftover-Files: <klassifikation> / keine / n.a.
 
 Post-Close Follow-up Intake

--- a/.claude/skills/cdb-session-start/SKILL.md
+++ b/.claude/skills/cdb-session-start/SKILL.md
@@ -68,8 +68,8 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
-   | Old local worktree from a prior session | Do not read as implicit active progress |
+| Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush). Do **not** auto-delete the local branch/worktree here — route cleanup to `cdb-session-close` § Safe Post-Merge Cleanup (or `cdb-drift-reconcile` for lineage classification) with evidence |
+| Old local worktree from a prior session | Do not read as implicit active progress; do not auto-remove; route to `cdb-session-close` cleanup if a merged PR is identified |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
 

--- a/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
+++ b/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
@@ -45,6 +45,11 @@ disable-model-invocation: true
   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
   merge), not agent-type-based. `--admin` is never a valid bypass for a
   missing/red `cdb-local-ci`.
+- CI PASS / green Hosted Actions does **not** authorize blind local post-merge
+  cleanup. After `--delete-branch`, remote absence is expected; local
+  worktree/branch removal remains evidence-based
+  (`cdb-session-close` § Safe Post-Merge Cleanup). Do not equate required-status
+  SUCCESS with safe `worktree remove` / `branch -D`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.codex/cdb_skills/cdb-debug-handoff/SKILL.md
+++ b/.codex/cdb_skills/cdb-debug-handoff/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-debug-handoff/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-02
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -118,6 +118,10 @@ complete.
 - Handing off a record with empty core fields as if it were complete.
 - Bundling several unrelated debug cases into one handoff.
 - Reading a board stage as an LR verdict, or a red CI check as a runtime outage.
+- Treating unclear branch lineage or unproven squash patch/tree equivalence as
+  safe cleanup — route those cases to `cdb-session-close` § Safe Post-Merge
+  Cleanup with `handoff_state: blocked` / `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  rather than deleting worktrees or using `branch -D`.
 
 ## Standalone value and family fit
 

--- a/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
+++ b/.codex/cdb_skills/cdb-drift-reconcile/SKILL.md
@@ -102,6 +102,20 @@ and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
 exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
 merge remains capability-based when those gates are proven.
 
+## Post-merge branch / worktree drift
+
+When classifying local/remote branch lineage after a squash merge:
+
+- Treat `[gone]` after `--delete-branch` as normal, not as a push trigger.
+- Detect republished merged heads (same topic branch reappearing remotely
+  after MERGED) as drift; do not recommend `git push -u origin HEAD` to
+  "restore" them.
+- Squash non-ancestor / `git cherry +` is **not** alone proof of unmerged
+  work — require tree/patch equivalence (see `cdb-session-close`
+  § Safe Post-Merge Cleanup).
+- Worktree/branch cleanup routing: hand off to `cdb-session-close`; do not
+  remove foreign worktrees from this skill.
+
 ## Classification Rules
 
 - `belegt` means the repo surface directly contradicts or lags the current canon.

--- a/.codex/cdb_skills/cdb-operator/SKILL.md
+++ b/.codex/cdb_skills/cdb-operator/SKILL.md
@@ -42,11 +42,17 @@ Use this skill when working on Claire_de_Binare with OpenCode.
    missing `cdb-local-ci`. If any gate is unproven: report
    `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
    loop or force.
+10. After a live-verified merge, local post-merge cleanup is
+    evidence-based only (`cdb-session-close` § Safe Post-Merge Cleanup):
+    never discard unsaved changes, never `branch -D` without tree/patch
+    equivalence, never republish a deleted remote head (anti-repush),
+    update local `main` with `ff-only` only.
 
 ## Stop conditions
 
 Stop immediately on missing bootloader, unclear scope, unexpected diff, red
 `cdb-local-ci` (the sole required merge context; Hosted Actions red is
-advisory), a capability gate unproven for merge, scope growth, or any
-live-readiness/echtgeld implication.
+advisory), a capability gate unproven for merge, scope growth, any
+live-readiness/echtgeld implication, or a cleanup request that would
+discard unsaved/unmerged local work.
 

--- a/.codex/cdb_skills/cdb-session-close/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-close/SKILL.md
@@ -84,36 +84,34 @@ Close a working session so the repo, git state, and issue thread reflect reality
      `statuses:write`, unbound evidence, auth/publisher block): record
      `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
      skip steps 6–7. Do not use `--admin` and do not loop retries.
-6. Verify delivery on `main` — only when a PR was merged in this session:
+6. Verify remote merge delivery — only when a PR was merged in this session
+   (or when closing after a known merge of this session's PR):
 
    ```bash
-   gh pr view <PR> --json state,mergedAt,mergeCommit
-   git fetch origin main
-   git log origin/main --oneline -5
-   git checkout main
-   git merge --ff-only origin/main
+   git fetch origin --prune
+   gh pr view <PR> --json state,mergedAt,mergeCommit,headRefName,headRefOid
+   gh issue view <N> --json state,closedAt   # if an issue was targeted
+   git rev-parse origin/main
+   git merge-base --is-ancestor <MERGE_SHA> origin/main
    ```
 
    Determine:
-   - PR merged + merge commit visible on `origin/main` + `--ff-only` succeeded → proceed to step 7.
-   - PR merged but merge commit absent from `origin/main` → STOP, session = incomplete.
-   - `--ff-only` fails → report as pending, do not force.
-   - No PR in this session → mark as `n.a.`, skip this step.
-7. Classify temporary git surfaces — only when applicable:
+   - PR `MERGED` + merge commit on `origin/main` → proceed to step 7
+     (local post-merge cleanup). Issue may be `CLOSED` or still open; document
+     which. Remote head-branch absent (API 404 after `--delete-branch`) is
+     expected; do not recreate it.
+   - PR merged but merge commit absent from `origin/main` → STOP,
+     session incomplete / `HOLD_REMOTE_STATE_DRIFT`.
+   - Unexpected remote branch still present after squash+delete →
+     `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` (do not auto-delete/repush).
+   - No PR in this session → mark as `n.a.`, skip steps 6–7.
 
-   ```bash
-   git worktree list                       # any session worktrees?
-   git branch -v --merged origin/main      # any merged feature branch?
-   ```
+7. Local post-merge cleanup (evidence-based; never blind delete) — only when
+   step 6 proved `MERGED` for this session's PR. Full contract:
+   **§ Safe Post-Merge Cleanup** below. Success status for this hop:
+   `DONE_LOCAL_POST_MERGE_CLEANUP`. Note: `DONE_MERGED_CLOSED` alone does
+   **not** mean local cleanup already finished.
 
-   - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
-   - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
-   - After squash merge with `--delete-branch`: do **not** re-push or
-     recreate the deleted remote branch (anti-repush). Local `[gone]`
-     tracking refs may remain historical; clean them with `git fetch
-     --prune` / `git branch -d` only when unambiguous.
-   - Otherwise: record as `n.a.` or `pending` — no blind deletes.
-   - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
 
    Always after a merged PR or issue-driven session close, sweep for new
@@ -288,6 +286,123 @@ Close a working session so the repo, git state, and issue thread reflect reality
   follow-up issue that was not created or linked.
 - Do not silently expand scope to resolve residual findings during close.
 
+## Safe Post-Merge Cleanup (canonical)
+
+Trigger: a PR from this session (or an explicitly identified PR) is live
+`MERGED` and the merge commit is on `origin/main`. Cleanup is **not** blind
+deletion. Remove worktree/branch only when evidence proves no unsaved or
+unmerged content would be lost.
+
+### Status taxonomy (cleanup hop)
+
+| Status | Meaning |
+|---|---|
+| `DONE_LOCAL_POST_MERGE_CLEANUP` | Remote merge verified + local worktree/branch cleaned + main ff-only + no repush |
+| `HOLD_REMOTE_STATE_DRIFT` | PR/issue/merge-SHA state unexpected |
+| `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` | Remote head still present after expected `--delete-branch` |
+| `HOLD_UNSAVED_LOCAL_CHANGES` | Target worktree dirty (staged/unstaged/untracked) |
+| `HOLD_REAL_UNMERGED_CHANGES` | Extra commits/patches not in `origin/main` |
+| `HOLD_MAIN_NOT_FAST_FORWARDABLE` | Local main cannot ff-only to `origin/main` |
+| `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR` | Squash tree/patch equivalence not proven |
+| `BLOCKED_WORKTREE_REMOVAL` | Worktree cannot be removed safely |
+| `BLOCKED_LOCAL_BRANCH_REMOVAL` | Local branch cannot be removed safely |
+
+`DONE_MERGED_CLOSED` ≠ local cleanup done. Report cleanup separately.
+
+### Phase A — Inventory
+
+```bash
+git worktree list --porcelain
+git branch -vv
+```
+
+Identify: primary/main worktree, PR worktree path, local `[gone]` branch,
+whether the branch is checked out anywhere. Touch **only** this PR's worktree
+and branch.
+
+### Phase B — Data safety (inside target worktree)
+
+```bash
+git status --porcelain=v1 --untracked-files=all   # must be empty
+git rev-parse HEAD HEAD^{tree} origin/main origin/main^{tree}
+git log --oneline origin/main..HEAD               # expect PR commits or empty after squash tip
+git diff --quiet HEAD origin/main                 # exit 0 ⇒ identical trees preferred
+git diff --stat origin/main..HEAD                 # two-dot should be empty when trees match
+git cherry origin/main HEAD                       # advisory only after squash
+```
+
+**Squash rule:** Squash merges create new SHAs. `git cherry` / missing ancestry
+are **not** alone proof of unmerged work. Prefer identical
+`HEAD^{tree}` vs `origin/main^{tree}`, empty two-dot diff, and/or all PR
+paths blob-identical on `origin/main`. Optional: stable patch-id when lineage
+is unclear. No commits after the verified PR head. No open PR on that head.
+
+Dirty → `HOLD_UNSAVED_LOCAL_CHANGES`. Real delta → `HOLD_REAL_UNMERGED_CHANGES`.
+Unclear equivalence → `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
+### Phase C — Worktree removal
+
+Preconditions: Phase B clean + equivalence proven; remote branch absent;
+worktree is not the main worktree; remove from **another** worktree.
+
+```bash
+git worktree remove <TARGET_WORKTREE_PATH>
+git worktree prune
+git worktree list --porcelain
+```
+
+No `--force` while cause is unclear. Never delete foreign worktrees.
+
+### Phase D — Local branch removal
+
+Preconditions: worktree removed; branch not checked out; remote absent;
+equivalence proven.
+
+```bash
+git branch -d <PR_HEAD_BRANCH>
+```
+
+If `-d` fails **only** because squash non-ancestor and Phase B fully proved
+tree/patch equivalence, then:
+
+```bash
+git branch -D <PR_HEAD_BRANCH>
+```
+
+`-D` is a controlled squash fallback, not the default.
+
+### Phase E — Main ff-only
+
+Use the existing main worktree (do not force a second `main`). Require clean
+main worktree, then:
+
+```bash
+git fetch origin --prune
+git pull --ff-only origin main
+git rev-parse HEAD origin/main   # must match; merge SHA on HEAD
+```
+
+No local merge commit. No `reset --hard` / `git clean -fd` as default. If
+divergent → `HOLD_MAIN_NOT_FAST_FORWARDABLE`.
+
+### Phase F — Anti-repush (hard)
+
+Before any `git push -u origin HEAD`:
+
+1. Is the associated PR already `MERGED`?
+2. Is the remote branch deleted?
+3. Is the local branch only historical (`[gone]`)?
+
+If yes: **do not** republish that branch. New unmerged work → **new** branch
+name / follow-up PR — never revive the deleted merged head.
+
+### Fail-closed additions for cleanup
+
+- If `git merge --ff-only origin/main` fails: `HOLD_MAIN_NOT_FAST_FORWARDABLE`;
+  do not force.
+- If worktree remove fails for unclear dirty state: `BLOCKED_WORKTREE_REMOVAL`.
+- If equivalence is incomplete: do not `-D`; `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
 ## Fail-Closed Rules
 
 - If any write step would exceed the agreed scope (unexpected files/hunks, scope growth): STOP and ask for clarification + explicit GO.
@@ -301,7 +416,13 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If push or issue-status updates were not performed, keep them as pending actions in the close-out.
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
-- If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If `git merge --ff-only origin/main` / main ff-only fails: report
+  `HOLD_MAIN_NOT_FAST_FORWARDABLE`; do not force a merge or ignore divergence.
+- If local post-merge cleanup would discard unsaved changes: `HOLD_UNSAVED_LOCAL_CHANGES`.
+- If squash tree/patch equivalence is unclear: `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  (do not `branch -D`).
+- If tempted to `git push -u origin HEAD` for a MERGED/`[gone]` branch: STOP
+  (anti-repush).
 - If new follow-up issues are found but their link to this session is unclear: do not auto-start.
 - If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
 - If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
@@ -341,6 +462,8 @@ Main-Verifikation (nur wenn PR gemergt, sonst n.a.)
 Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Worktrees: entfernt: <liste> / n.a. / pending
 - Feature-Branch: gelöscht: <name> / n.a. / pending
+- Local post-merge cleanup: DONE_LOCAL_POST_MERGE_CLEANUP / HOLD_* / BLOCKED_* / n.a.
+- Anti-repush: confirmed (no republish of deleted remote) / n.a.
 - Leftover-Files: <klassifikation> / keine / n.a.
 
 Post-Close Follow-up Intake

--- a/.codex/cdb_skills/cdb-session-start/SKILL.md
+++ b/.codex/cdb_skills/cdb-session-start/SKILL.md
@@ -68,8 +68,8 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
-   | Old local worktree from a prior session | Do not read as implicit active progress |
+| Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush). Do **not** auto-delete the local branch/worktree here — route cleanup to `cdb-session-close` § Safe Post-Merge Cleanup (or `cdb-drift-reconcile` for lineage classification) with evidence |
+| Old local worktree from a prior session | Do not read as implicit active progress; do not auto-remove; route to `cdb-session-close` cleanup if a merged PR is identified |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
 

--- a/.cursor/rules/CDB-Checks-and-Merge-Rule.mdc
+++ b/.cursor/rules/CDB-Checks-and-Merge-Rule.mdc
@@ -87,6 +87,10 @@ on stale evidence from before the wave started.
 After a squash merge with `--delete-branch`: do not automatically re-push,
 recreate, or resurrect the deleted remote branch (no anti-repush violation).
 If further work is needed on that topic, open a new branch explicitly.
+Local post-merge cleanup of `[gone]` worktrees/branches follows
+`cdb-session-close` § Safe Post-Merge Cleanup (evidence-based; never blind
+`branch -D` / worktree remove). Success of that hop:
+`DONE_LOCAL_POST_MERGE_CLEANUP`.
 
 ## Status taxonomy
 
@@ -95,6 +99,9 @@ report contract):
 
 - `DONE_MERGED_CLOSED` — merge verified live on `main` (commit present,
   PR closed as merged); only after live verification, never assumed.
+  Does **not** imply local worktree/branch cleanup finished.
+- `DONE_LOCAL_POST_MERGE_CLEANUP` — evidence-based local cleanup complete
+  per `cdb-session-close` § Safe Post-Merge Cleanup.
 - `DONE_PR_OPEN_MERGE_HANDOFF` — PR ready/near-ready, capability gate not
   fully met by this session; honest handoff with concrete next step.
 - `DONE_PR_OPEN` — PR open, not yet merge-eligible (e.g. still under

--- a/.cursor/rules/CDB-Final-Report-Rule.mdc
+++ b/.cursor/rules/CDB-Final-Report-Rule.mdc
@@ -7,15 +7,25 @@ For CDB work, finish with a compact evidence-based report.
 Use this structure:
 
 Status:
-- One of: `DONE_MERGED_CLOSED` | `DONE_PR_OPEN_MERGE_HANDOFF` | `DONE_PR_OPEN` |
-  `DONE_NO_PR` | `BLOCKED_LOCAL_VALIDATION` | `BLOCKED_REQUIRED_STATUS` |
+- One of: `DONE_MERGED_CLOSED` | `DONE_LOCAL_POST_MERGE_CLEANUP` |
+  `DONE_PR_OPEN_MERGE_HANDOFF` | `DONE_PR_OPEN` | `DONE_NO_PR` |
+  `BLOCKED_LOCAL_VALIDATION` | `BLOCKED_REQUIRED_STATUS` |
   `BLOCKED_AUTH_PUBLISHER` | `HOLD_SCOPE_OR_REVIEW` | `HOLD_MAIN_OR_HEAD_DRIFT` |
+  `HOLD_REMOTE_STATE_DRIFT` | `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` |
+  `HOLD_UNSAVED_LOCAL_CHANGES` | `HOLD_REAL_UNMERGED_CHANGES` |
+  `HOLD_MAIN_NOT_FAST_FORWARDABLE` | `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR` |
+  `BLOCKED_WORKTREE_REMOVAL` | `BLOCKED_LOCAL_BRANCH_REMOVAL` |
   `HOLD` | `BLOCKED` | `PARTIAL`
 
 Status rules:
 - `DONE_MERGED_CLOSED` requires live verification that the PR is merged on
   `main` (commit present via `gh api`/`git log`, PR state closed as merged).
   Never report a merged/`DONE_MERGED` status from a queued or assumed merge.
+  It does **not** imply local worktree/branch cleanup finished.
+- `DONE_LOCAL_POST_MERGE_CLEANUP` requires the evidence-based local cleanup
+  contract in `cdb-session-close` § Safe Post-Merge Cleanup (remote verify,
+  clean tree, squash equivalence, worktree/branch removal, main ff-only,
+  anti-repush). Report only after final git verification.
 - `DONE_PR_OPEN_MERGE_HANDOFF` is the honest result when the PR is
   ready/near-ready but this session could not prove the full autonomous-merge
   capability gate (see `CDB-Checks-and-Merge-Rule.mdc`). State the exact
@@ -27,6 +37,9 @@ Status rules:
   the required status itself.
 - `HOLD_MAIN_OR_HEAD_DRIFT` means validated `main` or the PR head changed
   since evidence was produced; revalidate before merging.
+- Cleanup HOLDs/BLOCKs (`HOLD_UNSAVED_LOCAL_CHANGES`,
+  `HOLD_REAL_UNMERGED_CHANGES`, `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`, …)
+  follow `cdb-session-close` § Safe Post-Merge Cleanup.
 
 Scope:
 - <what was approved>

--- a/.cursor/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.cursor/skills/cdb-ci-cd-guard/SKILL.md
@@ -45,6 +45,11 @@ disable-model-invocation: true
   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
   merge), not agent-type-based. `--admin` is never a valid bypass for a
   missing/red `cdb-local-ci`.
+- CI PASS / green Hosted Actions does **not** authorize blind local post-merge
+  cleanup. After `--delete-branch`, remote absence is expected; local
+  worktree/branch removal remains evidence-based
+  (`cdb-session-close` § Safe Post-Merge Cleanup). Do not equate required-status
+  SUCCESS with safe `worktree remove` / `branch -D`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.cursor/skills/cdb-debug-handoff/SKILL.md
+++ b/.cursor/skills/cdb-debug-handoff/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-debug-handoff/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-02
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -118,6 +118,10 @@ complete.
 - Handing off a record with empty core fields as if it were complete.
 - Bundling several unrelated debug cases into one handoff.
 - Reading a board stage as an LR verdict, or a red CI check as a runtime outage.
+- Treating unclear branch lineage or unproven squash patch/tree equivalence as
+  safe cleanup — route those cases to `cdb-session-close` § Safe Post-Merge
+  Cleanup with `handoff_state: blocked` / `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  rather than deleting worktrees or using `branch -D`.
 
 ## Standalone value and family fit
 

--- a/.cursor/skills/cdb-drift-reconcile/SKILL.md
+++ b/.cursor/skills/cdb-drift-reconcile/SKILL.md
@@ -102,6 +102,20 @@ and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
 exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
 merge remains capability-based when those gates are proven.
 
+## Post-merge branch / worktree drift
+
+When classifying local/remote branch lineage after a squash merge:
+
+- Treat `[gone]` after `--delete-branch` as normal, not as a push trigger.
+- Detect republished merged heads (same topic branch reappearing remotely
+  after MERGED) as drift; do not recommend `git push -u origin HEAD` to
+  "restore" them.
+- Squash non-ancestor / `git cherry +` is **not** alone proof of unmerged
+  work — require tree/patch equivalence (see `cdb-session-close`
+  § Safe Post-Merge Cleanup).
+- Worktree/branch cleanup routing: hand off to `cdb-session-close`; do not
+  remove foreign worktrees from this skill.
+
 ## Classification Rules
 
 - `belegt` means the repo surface directly contradicts or lags the current canon.

--- a/.cursor/skills/cdb-operator/SKILL.md
+++ b/.cursor/skills/cdb-operator/SKILL.md
@@ -42,11 +42,17 @@ Use this skill when working on Claire_de_Binare with OpenCode.
    missing `cdb-local-ci`. If any gate is unproven: report
    `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
    loop or force.
+10. After a live-verified merge, local post-merge cleanup is
+    evidence-based only (`cdb-session-close` § Safe Post-Merge Cleanup):
+    never discard unsaved changes, never `branch -D` without tree/patch
+    equivalence, never republish a deleted remote head (anti-repush),
+    update local `main` with `ff-only` only.
 
 ## Stop conditions
 
 Stop immediately on missing bootloader, unclear scope, unexpected diff, red
 `cdb-local-ci` (the sole required merge context; Hosted Actions red is
-advisory), a capability gate unproven for merge, scope growth, or any
-live-readiness/echtgeld implication.
+advisory), a capability gate unproven for merge, scope growth, any
+live-readiness/echtgeld implication, or a cleanup request that would
+discard unsaved/unmerged local work.
 

--- a/.cursor/skills/cdb-session-close/SKILL.md
+++ b/.cursor/skills/cdb-session-close/SKILL.md
@@ -84,36 +84,34 @@ Close a working session so the repo, git state, and issue thread reflect reality
      `statuses:write`, unbound evidence, auth/publisher block): record
      `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
      skip steps 6–7. Do not use `--admin` and do not loop retries.
-6. Verify delivery on `main` — only when a PR was merged in this session:
+6. Verify remote merge delivery — only when a PR was merged in this session
+   (or when closing after a known merge of this session's PR):
 
    ```bash
-   gh pr view <PR> --json state,mergedAt,mergeCommit
-   git fetch origin main
-   git log origin/main --oneline -5
-   git checkout main
-   git merge --ff-only origin/main
+   git fetch origin --prune
+   gh pr view <PR> --json state,mergedAt,mergeCommit,headRefName,headRefOid
+   gh issue view <N> --json state,closedAt   # if an issue was targeted
+   git rev-parse origin/main
+   git merge-base --is-ancestor <MERGE_SHA> origin/main
    ```
 
    Determine:
-   - PR merged + merge commit visible on `origin/main` + `--ff-only` succeeded → proceed to step 7.
-   - PR merged but merge commit absent from `origin/main` → STOP, session = incomplete.
-   - `--ff-only` fails → report as pending, do not force.
-   - No PR in this session → mark as `n.a.`, skip this step.
-7. Classify temporary git surfaces — only when applicable:
+   - PR `MERGED` + merge commit on `origin/main` → proceed to step 7
+     (local post-merge cleanup). Issue may be `CLOSED` or still open; document
+     which. Remote head-branch absent (API 404 after `--delete-branch`) is
+     expected; do not recreate it.
+   - PR merged but merge commit absent from `origin/main` → STOP,
+     session incomplete / `HOLD_REMOTE_STATE_DRIFT`.
+   - Unexpected remote branch still present after squash+delete →
+     `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` (do not auto-delete/repush).
+   - No PR in this session → mark as `n.a.`, skip steps 6–7.
 
-   ```bash
-   git worktree list                       # any session worktrees?
-   git branch -v --merged origin/main      # any merged feature branch?
-   ```
+7. Local post-merge cleanup (evidence-based; never blind delete) — only when
+   step 6 proved `MERGED` for this session's PR. Full contract:
+   **§ Safe Post-Merge Cleanup** below. Success status for this hop:
+   `DONE_LOCAL_POST_MERGE_CLEANUP`. Note: `DONE_MERGED_CLOSED` alone does
+   **not** mean local cleanup already finished.
 
-   - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
-   - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
-   - After squash merge with `--delete-branch`: do **not** re-push or
-     recreate the deleted remote branch (anti-repush). Local `[gone]`
-     tracking refs may remain historical; clean them with `git fetch
-     --prune` / `git branch -d` only when unambiguous.
-   - Otherwise: record as `n.a.` or `pending` — no blind deletes.
-   - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
 
    Always after a merged PR or issue-driven session close, sweep for new
@@ -288,6 +286,123 @@ Close a working session so the repo, git state, and issue thread reflect reality
   follow-up issue that was not created or linked.
 - Do not silently expand scope to resolve residual findings during close.
 
+## Safe Post-Merge Cleanup (canonical)
+
+Trigger: a PR from this session (or an explicitly identified PR) is live
+`MERGED` and the merge commit is on `origin/main`. Cleanup is **not** blind
+deletion. Remove worktree/branch only when evidence proves no unsaved or
+unmerged content would be lost.
+
+### Status taxonomy (cleanup hop)
+
+| Status | Meaning |
+|---|---|
+| `DONE_LOCAL_POST_MERGE_CLEANUP` | Remote merge verified + local worktree/branch cleaned + main ff-only + no repush |
+| `HOLD_REMOTE_STATE_DRIFT` | PR/issue/merge-SHA state unexpected |
+| `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` | Remote head still present after expected `--delete-branch` |
+| `HOLD_UNSAVED_LOCAL_CHANGES` | Target worktree dirty (staged/unstaged/untracked) |
+| `HOLD_REAL_UNMERGED_CHANGES` | Extra commits/patches not in `origin/main` |
+| `HOLD_MAIN_NOT_FAST_FORWARDABLE` | Local main cannot ff-only to `origin/main` |
+| `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR` | Squash tree/patch equivalence not proven |
+| `BLOCKED_WORKTREE_REMOVAL` | Worktree cannot be removed safely |
+| `BLOCKED_LOCAL_BRANCH_REMOVAL` | Local branch cannot be removed safely |
+
+`DONE_MERGED_CLOSED` ≠ local cleanup done. Report cleanup separately.
+
+### Phase A — Inventory
+
+```bash
+git worktree list --porcelain
+git branch -vv
+```
+
+Identify: primary/main worktree, PR worktree path, local `[gone]` branch,
+whether the branch is checked out anywhere. Touch **only** this PR's worktree
+and branch.
+
+### Phase B — Data safety (inside target worktree)
+
+```bash
+git status --porcelain=v1 --untracked-files=all   # must be empty
+git rev-parse HEAD HEAD^{tree} origin/main origin/main^{tree}
+git log --oneline origin/main..HEAD               # expect PR commits or empty after squash tip
+git diff --quiet HEAD origin/main                 # exit 0 ⇒ identical trees preferred
+git diff --stat origin/main..HEAD                 # two-dot should be empty when trees match
+git cherry origin/main HEAD                       # advisory only after squash
+```
+
+**Squash rule:** Squash merges create new SHAs. `git cherry` / missing ancestry
+are **not** alone proof of unmerged work. Prefer identical
+`HEAD^{tree}` vs `origin/main^{tree}`, empty two-dot diff, and/or all PR
+paths blob-identical on `origin/main`. Optional: stable patch-id when lineage
+is unclear. No commits after the verified PR head. No open PR on that head.
+
+Dirty → `HOLD_UNSAVED_LOCAL_CHANGES`. Real delta → `HOLD_REAL_UNMERGED_CHANGES`.
+Unclear equivalence → `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
+### Phase C — Worktree removal
+
+Preconditions: Phase B clean + equivalence proven; remote branch absent;
+worktree is not the main worktree; remove from **another** worktree.
+
+```bash
+git worktree remove <TARGET_WORKTREE_PATH>
+git worktree prune
+git worktree list --porcelain
+```
+
+No `--force` while cause is unclear. Never delete foreign worktrees.
+
+### Phase D — Local branch removal
+
+Preconditions: worktree removed; branch not checked out; remote absent;
+equivalence proven.
+
+```bash
+git branch -d <PR_HEAD_BRANCH>
+```
+
+If `-d` fails **only** because squash non-ancestor and Phase B fully proved
+tree/patch equivalence, then:
+
+```bash
+git branch -D <PR_HEAD_BRANCH>
+```
+
+`-D` is a controlled squash fallback, not the default.
+
+### Phase E — Main ff-only
+
+Use the existing main worktree (do not force a second `main`). Require clean
+main worktree, then:
+
+```bash
+git fetch origin --prune
+git pull --ff-only origin main
+git rev-parse HEAD origin/main   # must match; merge SHA on HEAD
+```
+
+No local merge commit. No `reset --hard` / `git clean -fd` as default. If
+divergent → `HOLD_MAIN_NOT_FAST_FORWARDABLE`.
+
+### Phase F — Anti-repush (hard)
+
+Before any `git push -u origin HEAD`:
+
+1. Is the associated PR already `MERGED`?
+2. Is the remote branch deleted?
+3. Is the local branch only historical (`[gone]`)?
+
+If yes: **do not** republish that branch. New unmerged work → **new** branch
+name / follow-up PR — never revive the deleted merged head.
+
+### Fail-closed additions for cleanup
+
+- If `git merge --ff-only origin/main` fails: `HOLD_MAIN_NOT_FAST_FORWARDABLE`;
+  do not force.
+- If worktree remove fails for unclear dirty state: `BLOCKED_WORKTREE_REMOVAL`.
+- If equivalence is incomplete: do not `-D`; `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
 ## Fail-Closed Rules
 
 - If any write step would exceed the agreed scope (unexpected files/hunks, scope growth): STOP and ask for clarification + explicit GO.
@@ -301,7 +416,13 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If push or issue-status updates were not performed, keep them as pending actions in the close-out.
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
-- If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If `git merge --ff-only origin/main` / main ff-only fails: report
+  `HOLD_MAIN_NOT_FAST_FORWARDABLE`; do not force a merge or ignore divergence.
+- If local post-merge cleanup would discard unsaved changes: `HOLD_UNSAVED_LOCAL_CHANGES`.
+- If squash tree/patch equivalence is unclear: `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  (do not `branch -D`).
+- If tempted to `git push -u origin HEAD` for a MERGED/`[gone]` branch: STOP
+  (anti-repush).
 - If new follow-up issues are found but their link to this session is unclear: do not auto-start.
 - If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
 - If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
@@ -341,6 +462,8 @@ Main-Verifikation (nur wenn PR gemergt, sonst n.a.)
 Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Worktrees: entfernt: <liste> / n.a. / pending
 - Feature-Branch: gelöscht: <name> / n.a. / pending
+- Local post-merge cleanup: DONE_LOCAL_POST_MERGE_CLEANUP / HOLD_* / BLOCKED_* / n.a.
+- Anti-repush: confirmed (no republish of deleted remote) / n.a.
 - Leftover-Files: <klassifikation> / keine / n.a.
 
 Post-Close Follow-up Intake

--- a/.cursor/skills/cdb-session-start/SKILL.md
+++ b/.cursor/skills/cdb-session-start/SKILL.md
@@ -68,8 +68,8 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
-   | Old local worktree from a prior session | Do not read as implicit active progress |
+| Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush). Do **not** auto-delete the local branch/worktree here — route cleanup to `cdb-session-close` § Safe Post-Merge Cleanup (or `cdb-drift-reconcile` for lineage classification) with evidence |
+| Old local worktree from a prior session | Do not read as implicit active progress; do not auto-remove; route to `cdb-session-close` cleanup if a merged PR is identified |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
 

--- a/.opencode/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.opencode/skills/cdb-ci-cd-guard/SKILL.md
@@ -45,6 +45,11 @@ disable-model-invocation: true
   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
   merge), not agent-type-based. `--admin` is never a valid bypass for a
   missing/red `cdb-local-ci`.
+- CI PASS / green Hosted Actions does **not** authorize blind local post-merge
+  cleanup. After `--delete-branch`, remote absence is expected; local
+  worktree/branch removal remains evidence-based
+  (`cdb-session-close` § Safe Post-Merge Cleanup). Do not equate required-status
+  SUCCESS with safe `worktree remove` / `branch -D`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/.opencode/skills/cdb-debug-handoff/SKILL.md
+++ b/.opencode/skills/cdb-debug-handoff/SKILL.md
@@ -2,7 +2,7 @@
 Canonical Skill Source: docs/skills/cdb-debug-handoff/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-02
+Last Verified: 2026-07-30
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
@@ -118,6 +118,10 @@ complete.
 - Handing off a record with empty core fields as if it were complete.
 - Bundling several unrelated debug cases into one handoff.
 - Reading a board stage as an LR verdict, or a red CI check as a runtime outage.
+- Treating unclear branch lineage or unproven squash patch/tree equivalence as
+  safe cleanup — route those cases to `cdb-session-close` § Safe Post-Merge
+  Cleanup with `handoff_state: blocked` / `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  rather than deleting worktrees or using `branch -D`.
 
 ## Standalone value and family fit
 

--- a/.opencode/skills/cdb-drift-reconcile/SKILL.md
+++ b/.opencode/skills/cdb-drift-reconcile/SKILL.md
@@ -102,6 +102,20 @@ and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
 exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
 merge remains capability-based when those gates are proven.
 
+## Post-merge branch / worktree drift
+
+When classifying local/remote branch lineage after a squash merge:
+
+- Treat `[gone]` after `--delete-branch` as normal, not as a push trigger.
+- Detect republished merged heads (same topic branch reappearing remotely
+  after MERGED) as drift; do not recommend `git push -u origin HEAD` to
+  "restore" them.
+- Squash non-ancestor / `git cherry +` is **not** alone proof of unmerged
+  work — require tree/patch equivalence (see `cdb-session-close`
+  § Safe Post-Merge Cleanup).
+- Worktree/branch cleanup routing: hand off to `cdb-session-close`; do not
+  remove foreign worktrees from this skill.
+
 ## Classification Rules
 
 - `belegt` means the repo surface directly contradicts or lags the current canon.

--- a/.opencode/skills/cdb-operator/SKILL.md
+++ b/.opencode/skills/cdb-operator/SKILL.md
@@ -42,11 +42,17 @@ Use this skill when working on Claire_de_Binare with OpenCode.
    missing `cdb-local-ci`. If any gate is unproven: report
    `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
    loop or force.
+10. After a live-verified merge, local post-merge cleanup is
+    evidence-based only (`cdb-session-close` § Safe Post-Merge Cleanup):
+    never discard unsaved changes, never `branch -D` without tree/patch
+    equivalence, never republish a deleted remote head (anti-repush),
+    update local `main` with `ff-only` only.
 
 ## Stop conditions
 
 Stop immediately on missing bootloader, unclear scope, unexpected diff, red
 `cdb-local-ci` (the sole required merge context; Hosted Actions red is
-advisory), a capability gate unproven for merge, scope growth, or any
-live-readiness/echtgeld implication.
+advisory), a capability gate unproven for merge, scope growth, any
+live-readiness/echtgeld implication, or a cleanup request that would
+discard unsaved/unmerged local work.
 

--- a/.opencode/skills/cdb-session-close/SKILL.md
+++ b/.opencode/skills/cdb-session-close/SKILL.md
@@ -84,36 +84,34 @@ Close a working session so the repo, git state, and issue thread reflect reality
      `statuses:write`, unbound evidence, auth/publisher block): record
      `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
      skip steps 6–7. Do not use `--admin` and do not loop retries.
-6. Verify delivery on `main` — only when a PR was merged in this session:
+6. Verify remote merge delivery — only when a PR was merged in this session
+   (or when closing after a known merge of this session's PR):
 
    ```bash
-   gh pr view <PR> --json state,mergedAt,mergeCommit
-   git fetch origin main
-   git log origin/main --oneline -5
-   git checkout main
-   git merge --ff-only origin/main
+   git fetch origin --prune
+   gh pr view <PR> --json state,mergedAt,mergeCommit,headRefName,headRefOid
+   gh issue view <N> --json state,closedAt   # if an issue was targeted
+   git rev-parse origin/main
+   git merge-base --is-ancestor <MERGE_SHA> origin/main
    ```
 
    Determine:
-   - PR merged + merge commit visible on `origin/main` + `--ff-only` succeeded → proceed to step 7.
-   - PR merged but merge commit absent from `origin/main` → STOP, session = incomplete.
-   - `--ff-only` fails → report as pending, do not force.
-   - No PR in this session → mark as `n.a.`, skip this step.
-7. Classify temporary git surfaces — only when applicable:
+   - PR `MERGED` + merge commit on `origin/main` → proceed to step 7
+     (local post-merge cleanup). Issue may be `CLOSED` or still open; document
+     which. Remote head-branch absent (API 404 after `--delete-branch`) is
+     expected; do not recreate it.
+   - PR merged but merge commit absent from `origin/main` → STOP,
+     session incomplete / `HOLD_REMOTE_STATE_DRIFT`.
+   - Unexpected remote branch still present after squash+delete →
+     `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` (do not auto-delete/repush).
+   - No PR in this session → mark as `n.a.`, skip steps 6–7.
 
-   ```bash
-   git worktree list                       # any session worktrees?
-   git branch -v --merged origin/main      # any merged feature branch?
-   ```
+7. Local post-merge cleanup (evidence-based; never blind delete) — only when
+   step 6 proved `MERGED` for this session's PR. Full contract:
+   **§ Safe Post-Merge Cleanup** below. Success status for this hop:
+   `DONE_LOCAL_POST_MERGE_CLEANUP`. Note: `DONE_MERGED_CLOSED` alone does
+   **not** mean local cleanup already finished.
 
-   - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
-   - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
-   - After squash merge with `--delete-branch`: do **not** re-push or
-     recreate the deleted remote branch (anti-repush). Local `[gone]`
-     tracking refs may remain historical; clean them with `git fetch
-     --prune` / `git branch -d` only when unambiguous.
-   - Otherwise: record as `n.a.` or `pending` — no blind deletes.
-   - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
 
    Always after a merged PR or issue-driven session close, sweep for new
@@ -288,6 +286,123 @@ Close a working session so the repo, git state, and issue thread reflect reality
   follow-up issue that was not created or linked.
 - Do not silently expand scope to resolve residual findings during close.
 
+## Safe Post-Merge Cleanup (canonical)
+
+Trigger: a PR from this session (or an explicitly identified PR) is live
+`MERGED` and the merge commit is on `origin/main`. Cleanup is **not** blind
+deletion. Remove worktree/branch only when evidence proves no unsaved or
+unmerged content would be lost.
+
+### Status taxonomy (cleanup hop)
+
+| Status | Meaning |
+|---|---|
+| `DONE_LOCAL_POST_MERGE_CLEANUP` | Remote merge verified + local worktree/branch cleaned + main ff-only + no repush |
+| `HOLD_REMOTE_STATE_DRIFT` | PR/issue/merge-SHA state unexpected |
+| `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` | Remote head still present after expected `--delete-branch` |
+| `HOLD_UNSAVED_LOCAL_CHANGES` | Target worktree dirty (staged/unstaged/untracked) |
+| `HOLD_REAL_UNMERGED_CHANGES` | Extra commits/patches not in `origin/main` |
+| `HOLD_MAIN_NOT_FAST_FORWARDABLE` | Local main cannot ff-only to `origin/main` |
+| `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR` | Squash tree/patch equivalence not proven |
+| `BLOCKED_WORKTREE_REMOVAL` | Worktree cannot be removed safely |
+| `BLOCKED_LOCAL_BRANCH_REMOVAL` | Local branch cannot be removed safely |
+
+`DONE_MERGED_CLOSED` ≠ local cleanup done. Report cleanup separately.
+
+### Phase A — Inventory
+
+```bash
+git worktree list --porcelain
+git branch -vv
+```
+
+Identify: primary/main worktree, PR worktree path, local `[gone]` branch,
+whether the branch is checked out anywhere. Touch **only** this PR's worktree
+and branch.
+
+### Phase B — Data safety (inside target worktree)
+
+```bash
+git status --porcelain=v1 --untracked-files=all   # must be empty
+git rev-parse HEAD HEAD^{tree} origin/main origin/main^{tree}
+git log --oneline origin/main..HEAD               # expect PR commits or empty after squash tip
+git diff --quiet HEAD origin/main                 # exit 0 ⇒ identical trees preferred
+git diff --stat origin/main..HEAD                 # two-dot should be empty when trees match
+git cherry origin/main HEAD                       # advisory only after squash
+```
+
+**Squash rule:** Squash merges create new SHAs. `git cherry` / missing ancestry
+are **not** alone proof of unmerged work. Prefer identical
+`HEAD^{tree}` vs `origin/main^{tree}`, empty two-dot diff, and/or all PR
+paths blob-identical on `origin/main`. Optional: stable patch-id when lineage
+is unclear. No commits after the verified PR head. No open PR on that head.
+
+Dirty → `HOLD_UNSAVED_LOCAL_CHANGES`. Real delta → `HOLD_REAL_UNMERGED_CHANGES`.
+Unclear equivalence → `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
+### Phase C — Worktree removal
+
+Preconditions: Phase B clean + equivalence proven; remote branch absent;
+worktree is not the main worktree; remove from **another** worktree.
+
+```bash
+git worktree remove <TARGET_WORKTREE_PATH>
+git worktree prune
+git worktree list --porcelain
+```
+
+No `--force` while cause is unclear. Never delete foreign worktrees.
+
+### Phase D — Local branch removal
+
+Preconditions: worktree removed; branch not checked out; remote absent;
+equivalence proven.
+
+```bash
+git branch -d <PR_HEAD_BRANCH>
+```
+
+If `-d` fails **only** because squash non-ancestor and Phase B fully proved
+tree/patch equivalence, then:
+
+```bash
+git branch -D <PR_HEAD_BRANCH>
+```
+
+`-D` is a controlled squash fallback, not the default.
+
+### Phase E — Main ff-only
+
+Use the existing main worktree (do not force a second `main`). Require clean
+main worktree, then:
+
+```bash
+git fetch origin --prune
+git pull --ff-only origin main
+git rev-parse HEAD origin/main   # must match; merge SHA on HEAD
+```
+
+No local merge commit. No `reset --hard` / `git clean -fd` as default. If
+divergent → `HOLD_MAIN_NOT_FAST_FORWARDABLE`.
+
+### Phase F — Anti-repush (hard)
+
+Before any `git push -u origin HEAD`:
+
+1. Is the associated PR already `MERGED`?
+2. Is the remote branch deleted?
+3. Is the local branch only historical (`[gone]`)?
+
+If yes: **do not** republish that branch. New unmerged work → **new** branch
+name / follow-up PR — never revive the deleted merged head.
+
+### Fail-closed additions for cleanup
+
+- If `git merge --ff-only origin/main` fails: `HOLD_MAIN_NOT_FAST_FORWARDABLE`;
+  do not force.
+- If worktree remove fails for unclear dirty state: `BLOCKED_WORKTREE_REMOVAL`.
+- If equivalence is incomplete: do not `-D`; `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
 ## Fail-Closed Rules
 
 - If any write step would exceed the agreed scope (unexpected files/hunks, scope growth): STOP and ask for clarification + explicit GO.
@@ -301,7 +416,13 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If push or issue-status updates were not performed, keep them as pending actions in the close-out.
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
-- If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If `git merge --ff-only origin/main` / main ff-only fails: report
+  `HOLD_MAIN_NOT_FAST_FORWARDABLE`; do not force a merge or ignore divergence.
+- If local post-merge cleanup would discard unsaved changes: `HOLD_UNSAVED_LOCAL_CHANGES`.
+- If squash tree/patch equivalence is unclear: `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  (do not `branch -D`).
+- If tempted to `git push -u origin HEAD` for a MERGED/`[gone]` branch: STOP
+  (anti-repush).
 - If new follow-up issues are found but their link to this session is unclear: do not auto-start.
 - If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
 - If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
@@ -341,6 +462,8 @@ Main-Verifikation (nur wenn PR gemergt, sonst n.a.)
 Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Worktrees: entfernt: <liste> / n.a. / pending
 - Feature-Branch: gelöscht: <name> / n.a. / pending
+- Local post-merge cleanup: DONE_LOCAL_POST_MERGE_CLEANUP / HOLD_* / BLOCKED_* / n.a.
+- Anti-repush: confirmed (no republish of deleted remote) / n.a.
 - Leftover-Files: <klassifikation> / keine / n.a.
 
 Post-Close Follow-up Intake

--- a/.opencode/skills/cdb-session-start/SKILL.md
+++ b/.opencode/skills/cdb-session-start/SKILL.md
@@ -68,8 +68,8 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
-   | Old local worktree from a prior session | Do not read as implicit active progress |
+| Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush). Do **not** auto-delete the local branch/worktree here — route cleanup to `cdb-session-close` § Safe Post-Merge Cleanup (or `cdb-drift-reconcile` for lineage classification) with evidence |
+| Old local worktree from a prior session | Do not read as implicit active progress; do not auto-remove; route to `cdb-session-close` cleanup if a merged PR is identified |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
 

--- a/docs/skills/cdb-ci-cd-guard/SKILL.md
+++ b/docs/skills/cdb-ci-cd-guard/SKILL.md
@@ -38,6 +38,11 @@ disable-model-invocation: true
   `docs/runbooks/merge_policy_ci_gate.md` § Capability-based autonomous
   merge), not agent-type-based. `--admin` is never a valid bypass for a
   missing/red `cdb-local-ci`.
+- CI PASS / green Hosted Actions does **not** authorize blind local post-merge
+  cleanup. After `--delete-branch`, remote absence is expected; local
+  worktree/branch removal remains evidence-based
+  (`cdb-session-close` § Safe Post-Merge Cleanup). Do not equate required-status
+  SUCCESS with safe `worktree remove` / `branch -D`.
 
 ## Workflow
 1. Inventory active workflows and identify gate-bearing jobs.

--- a/docs/skills/cdb-debug-handoff/SKILL.md
+++ b/docs/skills/cdb-debug-handoff/SKILL.md
@@ -1,10 +1,3 @@
-<!--
-Canonical Skill Source: docs/skills/cdb-debug-handoff/SKILL.md
-Surface: docs (canonical)
-Sync Status: canonical
-Last Verified: 2026-07-02
-Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
--->
 ---
 name: cdb-debug-handoff
 description: >
@@ -118,6 +111,10 @@ complete.
 - Handing off a record with empty core fields as if it were complete.
 - Bundling several unrelated debug cases into one handoff.
 - Reading a board stage as an LR verdict, or a red CI check as a runtime outage.
+- Treating unclear branch lineage or unproven squash patch/tree equivalence as
+  safe cleanup — route those cases to `cdb-session-close` § Safe Post-Merge
+  Cleanup with `handoff_state: blocked` / `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  rather than deleting worktrees or using `branch -D`.
 
 ## Standalone value and family fit
 

--- a/docs/skills/cdb-drift-reconcile/SKILL.md
+++ b/docs/skills/cdb-drift-reconcile/SKILL.md
@@ -95,6 +95,20 @@ and hand off. Never auto-merge without live `cdb-local-ci` SUCCESS on the
 exact PR head (SSOT: `docs/runbooks/merge_policy_ci_gate.md`). Autonomous
 merge remains capability-based when those gates are proven.
 
+## Post-merge branch / worktree drift
+
+When classifying local/remote branch lineage after a squash merge:
+
+- Treat `[gone]` after `--delete-branch` as normal, not as a push trigger.
+- Detect republished merged heads (same topic branch reappearing remotely
+  after MERGED) as drift; do not recommend `git push -u origin HEAD` to
+  "restore" them.
+- Squash non-ancestor / `git cherry +` is **not** alone proof of unmerged
+  work — require tree/patch equivalence (see `cdb-session-close`
+  § Safe Post-Merge Cleanup).
+- Worktree/branch cleanup routing: hand off to `cdb-session-close`; do not
+  remove foreign worktrees from this skill.
+
 ## Classification Rules
 
 - `belegt` means the repo surface directly contradicts or lags the current canon.

--- a/docs/skills/cdb-operator/SKILL.md
+++ b/docs/skills/cdb-operator/SKILL.md
@@ -35,11 +35,17 @@ Use this skill when working on Claire_de_Binare with OpenCode.
    missing `cdb-local-ci`. If any gate is unproven: report
    `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability; do not
    loop or force.
+10. After a live-verified merge, local post-merge cleanup is
+    evidence-based only (`cdb-session-close` § Safe Post-Merge Cleanup):
+    never discard unsaved changes, never `branch -D` without tree/patch
+    equivalence, never republish a deleted remote head (anti-repush),
+    update local `main` with `ff-only` only.
 
 ## Stop conditions
 
 Stop immediately on missing bootloader, unclear scope, unexpected diff, red
 `cdb-local-ci` (the sole required merge context; Hosted Actions red is
-advisory), a capability gate unproven for merge, scope growth, or any
-live-readiness/echtgeld implication.
+advisory), a capability gate unproven for merge, scope growth, any
+live-readiness/echtgeld implication, or a cleanup request that would
+discard unsaved/unmerged local work.
 

--- a/docs/skills/cdb-session-close/SKILL.md
+++ b/docs/skills/cdb-session-close/SKILL.md
@@ -77,36 +77,34 @@ Close a working session so the repo, git state, and issue thread reflect reality
      `statuses:write`, unbound evidence, auth/publisher block): record
      `DONE_PR_OPEN_MERGE_HANDOFF` with the exact missing capability and
      skip steps 6–7. Do not use `--admin` and do not loop retries.
-6. Verify delivery on `main` — only when a PR was merged in this session:
+6. Verify remote merge delivery — only when a PR was merged in this session
+   (or when closing after a known merge of this session's PR):
 
    ```bash
-   gh pr view <PR> --json state,mergedAt,mergeCommit
-   git fetch origin main
-   git log origin/main --oneline -5
-   git checkout main
-   git merge --ff-only origin/main
+   git fetch origin --prune
+   gh pr view <PR> --json state,mergedAt,mergeCommit,headRefName,headRefOid
+   gh issue view <N> --json state,closedAt   # if an issue was targeted
+   git rev-parse origin/main
+   git merge-base --is-ancestor <MERGE_SHA> origin/main
    ```
 
    Determine:
-   - PR merged + merge commit visible on `origin/main` + `--ff-only` succeeded → proceed to step 7.
-   - PR merged but merge commit absent from `origin/main` → STOP, session = incomplete.
-   - `--ff-only` fails → report as pending, do not force.
-   - No PR in this session → mark as `n.a.`, skip this step.
-7. Classify temporary git surfaces — only when applicable:
+   - PR `MERGED` + merge commit on `origin/main` → proceed to step 7
+     (local post-merge cleanup). Issue may be `CLOSED` or still open; document
+     which. Remote head-branch absent (API 404 after `--delete-branch`) is
+     expected; do not recreate it.
+   - PR merged but merge commit absent from `origin/main` → STOP,
+     session incomplete / `HOLD_REMOTE_STATE_DRIFT`.
+   - Unexpected remote branch still present after squash+delete →
+     `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` (do not auto-delete/repush).
+   - No PR in this session → mark as `n.a.`, skip steps 6–7.
 
-   ```bash
-   git worktree list                       # any session worktrees?
-   git branch -v --merged origin/main      # any merged feature branch?
-   ```
+7. Local post-merge cleanup (evidence-based; never blind delete) — only when
+   step 6 proved `MERGED` for this session's PR. Full contract:
+   **§ Safe Post-Merge Cleanup** below. Success status for this hop:
+   `DONE_LOCAL_POST_MERGE_CLEANUP`. Note: `DONE_MERGED_CLOSED` alone does
+   **not** mean local cleanup already finished.
 
-   - If a session worktree is present and unambiguously from this session: `git worktree remove <path>`.
-   - If a feature branch is merged and clearly tied to this session: `git branch -d <branch>`.
-   - After squash merge with `--delete-branch`: do **not** re-push or
-     recreate the deleted remote branch (anti-repush). Local `[gone]`
-     tracking refs may remain historical; clean them with `git fetch
-     --prune` / `git branch -d` only when unambiguous.
-   - Otherwise: record as `n.a.` or `pending` — no blind deletes.
-   - Leftover untracked files (session logs, patches): name each one explicitly and state whether it is committed, discarded, or pending. Do not ignore.
 8. Post-close Control-Plane Follow-up Intake — mandatory after steps 6–7 when applicable, or after any issue-driven session close:
 
    Always after a merged PR or issue-driven session close, sweep for new
@@ -281,6 +279,123 @@ Close a working session so the repo, git state, and issue thread reflect reality
   follow-up issue that was not created or linked.
 - Do not silently expand scope to resolve residual findings during close.
 
+## Safe Post-Merge Cleanup (canonical)
+
+Trigger: a PR from this session (or an explicitly identified PR) is live
+`MERGED` and the merge commit is on `origin/main`. Cleanup is **not** blind
+deletion. Remove worktree/branch only when evidence proves no unsaved or
+unmerged content would be lost.
+
+### Status taxonomy (cleanup hop)
+
+| Status | Meaning |
+|---|---|
+| `DONE_LOCAL_POST_MERGE_CLEANUP` | Remote merge verified + local worktree/branch cleaned + main ff-only + no repush |
+| `HOLD_REMOTE_STATE_DRIFT` | PR/issue/merge-SHA state unexpected |
+| `HOLD_REMOTE_BRANCH_UNEXPECTEDLY_EXISTS` | Remote head still present after expected `--delete-branch` |
+| `HOLD_UNSAVED_LOCAL_CHANGES` | Target worktree dirty (staged/unstaged/untracked) |
+| `HOLD_REAL_UNMERGED_CHANGES` | Extra commits/patches not in `origin/main` |
+| `HOLD_MAIN_NOT_FAST_FORWARDABLE` | Local main cannot ff-only to `origin/main` |
+| `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR` | Squash tree/patch equivalence not proven |
+| `BLOCKED_WORKTREE_REMOVAL` | Worktree cannot be removed safely |
+| `BLOCKED_LOCAL_BRANCH_REMOVAL` | Local branch cannot be removed safely |
+
+`DONE_MERGED_CLOSED` ≠ local cleanup done. Report cleanup separately.
+
+### Phase A — Inventory
+
+```bash
+git worktree list --porcelain
+git branch -vv
+```
+
+Identify: primary/main worktree, PR worktree path, local `[gone]` branch,
+whether the branch is checked out anywhere. Touch **only** this PR's worktree
+and branch.
+
+### Phase B — Data safety (inside target worktree)
+
+```bash
+git status --porcelain=v1 --untracked-files=all   # must be empty
+git rev-parse HEAD HEAD^{tree} origin/main origin/main^{tree}
+git log --oneline origin/main..HEAD               # expect PR commits or empty after squash tip
+git diff --quiet HEAD origin/main                 # exit 0 ⇒ identical trees preferred
+git diff --stat origin/main..HEAD                 # two-dot should be empty when trees match
+git cherry origin/main HEAD                       # advisory only after squash
+```
+
+**Squash rule:** Squash merges create new SHAs. `git cherry` / missing ancestry
+are **not** alone proof of unmerged work. Prefer identical
+`HEAD^{tree}` vs `origin/main^{tree}`, empty two-dot diff, and/or all PR
+paths blob-identical on `origin/main`. Optional: stable patch-id when lineage
+is unclear. No commits after the verified PR head. No open PR on that head.
+
+Dirty → `HOLD_UNSAVED_LOCAL_CHANGES`. Real delta → `HOLD_REAL_UNMERGED_CHANGES`.
+Unclear equivalence → `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
+### Phase C — Worktree removal
+
+Preconditions: Phase B clean + equivalence proven; remote branch absent;
+worktree is not the main worktree; remove from **another** worktree.
+
+```bash
+git worktree remove <TARGET_WORKTREE_PATH>
+git worktree prune
+git worktree list --porcelain
+```
+
+No `--force` while cause is unclear. Never delete foreign worktrees.
+
+### Phase D — Local branch removal
+
+Preconditions: worktree removed; branch not checked out; remote absent;
+equivalence proven.
+
+```bash
+git branch -d <PR_HEAD_BRANCH>
+```
+
+If `-d` fails **only** because squash non-ancestor and Phase B fully proved
+tree/patch equivalence, then:
+
+```bash
+git branch -D <PR_HEAD_BRANCH>
+```
+
+`-D` is a controlled squash fallback, not the default.
+
+### Phase E — Main ff-only
+
+Use the existing main worktree (do not force a second `main`). Require clean
+main worktree, then:
+
+```bash
+git fetch origin --prune
+git pull --ff-only origin main
+git rev-parse HEAD origin/main   # must match; merge SHA on HEAD
+```
+
+No local merge commit. No `reset --hard` / `git clean -fd` as default. If
+divergent → `HOLD_MAIN_NOT_FAST_FORWARDABLE`.
+
+### Phase F — Anti-repush (hard)
+
+Before any `git push -u origin HEAD`:
+
+1. Is the associated PR already `MERGED`?
+2. Is the remote branch deleted?
+3. Is the local branch only historical (`[gone]`)?
+
+If yes: **do not** republish that branch. New unmerged work → **new** branch
+name / follow-up PR — never revive the deleted merged head.
+
+### Fail-closed additions for cleanup
+
+- If `git merge --ff-only origin/main` fails: `HOLD_MAIN_NOT_FAST_FORWARDABLE`;
+  do not force.
+- If worktree remove fails for unclear dirty state: `BLOCKED_WORKTREE_REMOVAL`.
+- If equivalence is incomplete: do not `-D`; `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`.
+
 ## Fail-Closed Rules
 
 - If any write step would exceed the agreed scope (unexpected files/hunks, scope growth): STOP and ask for clarification + explicit GO.
@@ -294,7 +409,13 @@ Close a working session so the repo, git state, and issue thread reflect reality
 - If push or issue-status updates were not performed, keep them as pending actions in the close-out.
 - If the issue comment would overstate what landed, what was pushed, or what is actually done, downgrade the final status and state the pending step explicitly.
 - If a PR was merged but the merge commit cannot be verified on `origin/main`: the session is incomplete; do not set status to `erledigt`.
-- If `git merge --ff-only origin/main` fails: report as pending; do not force a merge or ignore the divergence.
+- If `git merge --ff-only origin/main` / main ff-only fails: report
+  `HOLD_MAIN_NOT_FAST_FORWARDABLE`; do not force a merge or ignore divergence.
+- If local post-merge cleanup would discard unsaved changes: `HOLD_UNSAVED_LOCAL_CHANGES`.
+- If squash tree/patch equivalence is unclear: `BLOCKED_CLEANUP_EQUIVALENCE_UNCLEAR`
+  (do not `branch -D`).
+- If tempted to `git push -u origin HEAD` for a MERGED/`[gone]` branch: STOP
+  (anti-repush).
 - If new follow-up issues are found but their link to this session is unclear: do not auto-start.
 - If more than one equally ranked candidate exists: do not pick blindly; emit a prioritized list.
 - If the candidate issue has Runtime-, Docker-rebuild-, Secrets-, Security-, LR-, Live-,
@@ -334,6 +455,8 @@ Main-Verifikation (nur wenn PR gemergt, sonst n.a.)
 Surface-Cleanup (nur wenn applicable, sonst n.a.)
 - Worktrees: entfernt: <liste> / n.a. / pending
 - Feature-Branch: gelöscht: <name> / n.a. / pending
+- Local post-merge cleanup: DONE_LOCAL_POST_MERGE_CLEANUP / HOLD_* / BLOCKED_* / n.a.
+- Anti-repush: confirmed (no republish of deleted remote) / n.a.
 - Leftover-Files: <klassifikation> / keine / n.a.
 
 Post-Close Follow-up Intake

--- a/docs/skills/cdb-session-start/SKILL.md
+++ b/docs/skills/cdb-session-start/SKILL.md
@@ -61,8 +61,8 @@ Establish a verified, fail-closed starting state before any repo work begins.
    |---|---|
    | Dirty worktree with unknown changes | STOP — identify origin, stash or resolve |
    | Local main behind origin/main | Do not start from stale local main; refresh or use origin/main explicitly |
-   | Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush); prune the local ref instead |
-   | Old local worktree from a prior session | Do not read as implicit active progress |
+| Gone upstream branch (remote deleted, local present) | Mark stale; do not build on it. If the remote was deleted by a prior squash-merge (`--delete-branch`), do not re-push or recreate it (anti-repush). Do **not** auto-delete the local branch/worktree here — route cleanup to `cdb-session-close` § Safe Post-Merge Cleanup (or `cdb-drift-reconcile` for lineage classification) with evidence |
+| Old local worktree from a prior session | Do not read as implicit active progress; do not auto-remove; route to `cdb-session-close` cleanup if a merged PR is identified |
    | Branch-local commits presented as merged truth | Verify via `gh pr list --state merged` |
    | Auto-merge enabled on repo during closure-sensitive work | State `Closes #N` vs `Refs #N` explicitly |
 


### PR DESCRIPTION
## Summary
Closes #4199

Canonicalize the evidence-based post-merge cleanup contract in CDB skills so agents no longer treat `DONE_MERGED_CLOSED` as local cleanup done, and never blindly remove worktrees/branches or repush deleted remote heads after squash merge.

## Delivered
- Full cleanup contract in `docs/skills/cdb-session-close/SKILL.md` (§ Safe Post-Merge Cleanup): remote verify, inventory, data safety, worktree remove, branch remove (`-D` only after squash equivalence), main ff-only, anti-repush, status taxonomy
- Routing/triggers only in `cdb-session-start`, `cdb-drift-reconcile`, `cdb-operator`, `cdb-ci-cd-guard`, `cdb-debug-handoff`
- Cursor rules: `CDB-Final-Report-Rule` + `CDB-Checks-and-Merge-Rule` status/anti-repush alignment
- Skill mirrors regenerated for cursor/codex/claude/opencode

## Canonical Skill
`cdb-session-close` — sole full-procedure SSOT

## Routing Skills
session-start, drift-reconcile, operator, ci-cd-guard, debug-handoff

## Mirror Regeneration
Adapters rewritten from canon with `mirrored-from-canon` headers; `validate_skill_surface_mirror.py --skill <name>` PASS for all six

## Validation
- `git diff --check` clean
- Mirror validators PASS (6 skills × 4 adapters)
- Fast-CI: `overall_status=PASS` evidence `ci/artifacts/20260730T072029Z_e0a254b5` @ `2f8ac00dc4ee9047ebb3bbc1a8dc9142e219a5a9`

## Anti-Repush
Hard rule: after MERGED + deleted remote, do not `git push -u origin HEAD` on the historical `[gone]` branch

## Squash Equivalence
`git cherry` alone insufficient; require tree/patch equivalence before `branch -D`

## Safety Boundaries
LR NO-GO · no runtime · no BP changes · no admin merge · no remote repush · no blind delete

## Restunsicherheiten
Behavior cases documented in skill prose; no new automated pytest suite for git cleanup choreography in this PR