### PR TITLE
security: disable force pushes on main

### DIFF
--- a/docs/evidence/reports/BRANCH_PROTECTION_APPLY_PAYLOAD_main.json
+++ b/docs/evidence/reports/BRANCH_PROTECTION_APPLY_PAYLOAD_main.json
@@ -16,12 +16,7 @@
   "required_status_checks": {
     "checks": [
       {
-        "app_id": 15368,
-        "context": "ci (Unit/Integration + Lint gesammelt)"
-      },
-      {
-        "app_id": 15368,
-        "context": "policy-gate"
+        "context": "cdb-local-ci"
       }
     ],
     "strict": true

--- a/docs/evidence/reports/BRANCH_PROTECTION_BASELINE_main.json
+++ b/docs/evidence/reports/BRANCH_PROTECTION_BASELINE_main.json
@@ -3,7 +3,7 @@
     "enabled": false
   },
   "allow_force_pushes": {
-    "enabled": true
+    "enabled": false
   },
   "allow_fork_syncing": {
     "enabled": false

--- a/docs/evidence/reports/BRANCH_PROTECTION_DRIFT_REPORT_main.md
+++ b/docs/evidence/reports/BRANCH_PROTECTION_DRIFT_REPORT_main.md
@@ -1,7 +1,7 @@
 # Branch Protection Drift Report (main)
 
-Timestamp (Europe/Berlin): `2026-03-15T22:16:32+01:00`  
-Timestamp (UTC): `2026-03-15T21:16:32Z`  
+Timestamp (Europe/Berlin): `2026-07-30T11:50:51+02:00`
+Timestamp (UTC): `2026-07-30T09:50:51Z`
 Repo: `jannekbuengener/Claire_de_Binare`  
 Branch: `main`  
 State: **NO DRIFT**
@@ -14,8 +14,8 @@ State: **NO DRIFT**
 
 ## Hashes (SHA256)
 
-- Baseline snapshot hash: `e987fc8d7369348df2bdfaa1fbc964029af693254b7a243a6c9a429eb4f32b28`
-- Current snapshot hash: `e987fc8d7369348df2bdfaa1fbc964029af693254b7a243a6c9a429eb4f32b28`
+- Baseline snapshot hash: `ca793caaf1dc8a3d666749c4eb7d17f97437792d66ce8041f64153ffee103ff2`
+- Current snapshot hash: `ca793caaf1dc8a3d666749c4eb7d17f97437792d66ce8041f64153ffee103ff2`
 
 ## Drift Summary
 
@@ -30,7 +30,7 @@ State: **NO DRIFT**
 ## Manual Apply Commands (maintainer only, never auto-executed)
 
 ```bash
-gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection > docs/evidence/reports/BRANCH_PROTECTION_CURRENT_main.json
+gh api repos/jannekbuengener/Claire_de_Binare/branches/main/protection > artifacts/reports/governance/BRANCH_PROTECTION_CURRENT_main.json
 gh api --method PUT repos/jannekbuengener/Claire_de_Binare/branches/main/protection --input docs/evidence/reports/BRANCH_PROTECTION_APPLY_PAYLOAD_main.json
 gh api --method DELETE repos/jannekbuengener/Claire_de_Binare/branches/main/protection/required_signatures
 ```

--- a/docs/governance/BRANCH_PROTECTION_LOG.md
+++ b/docs/governance/BRANCH_PROTECTION_LOG.md
@@ -4,6 +4,50 @@ This document records governance interventions on branch protection rules for au
 
 ---
 
+## 2026-07-30T09:50Z - Disable Force Pushes on `main` (Issue #4196, PR #4201)
+
+**Context:** PR #4193 exposed that live Branch Protection allowed force pushes
+on `main`. Its evidence-only baseline refresh recorded the live value but did
+not authorize that operating mode. Issue #4196 records the explicit decision to
+restore the fail-closed setting.
+
+**Action Taken:**
+- Read the complete live protection state through `gh api`.
+- Derived a complete update payload from that response.
+- Changed only `allow_force_pushes` from `true` to `false`.
+- Applied the payload manually through `gh api`; no workflow auto-apply path was
+  introduced.
+
+**Verification:**
+- A complete post-apply read matched the pre-apply projection for required
+  checks, pull-request reviews, signatures, admin enforcement, linear history,
+  deletions, branch creation, conversation resolution, branch lock, fork sync,
+  and restrictions.
+- The only changed path was
+  `allow_force_pushes.enabled: true -> false`.
+- The live drift check reported `NO DRIFT`.
+- Baseline and live normalized SHA256:
+  `ca793caaf1dc8a3d666749c4eb7d17f97437792d66ce8041f64153ffee103ff2`.
+
+**Final State:**
+
+| Setting | Before | After |
+|---------|--------|-------|
+| `allow_force_pushes` | `true` | `false` |
+| `required_status_checks` | `cdb-local-ci`, strict | unchanged |
+| `enforce_admins` | `true` | unchanged |
+| `required_linear_history` | `true` | unchanged |
+| `allow_deletions` | `false` | unchanged |
+
+**Decision:** Force pushes are not an intentional operating mode for `main`.
+
+**Scope:** Branch Protection governance only. No workflow, runtime, Docker,
+WSL, trading, LR, #4184, or PR #4187 change.
+
+**Approver:** jannekbuengener (repo owner; explicit #4196 instruction)
+
+---
+
 ## 2026-04-12T11:35:24Z - Disable Repo Auto-Merge (Issue #1661, Option A)
 
 **Context:** Issue #1661 mandated Option A: disable GitHub Auto-Merge repo-wide to remove

--- a/docs/governance/GOVERNANCE_AUDIT_RUNBOOK.md
+++ b/docs/governance/GOVERNANCE_AUDIT_RUNBOOK.md
@@ -50,6 +50,14 @@ Branch protection mode note:
 - Branch protection drift:
   - Use generated apply payload/commands as manual maintainer action only.
   - Never apply via CI workflow automation.
+  - `main` must keep `allow_force_pushes=false`; Issue #4196 records the
+    decision that force pushes are not an intentional operating mode.
+  - Before applying this setting, derive a complete update payload from the
+    current live protection response. Change only `allow_force_pushes` to
+    `false`; preserve every other field.
+  - Read the complete live protection again after apply and compare it with the
+    pre-apply response. Any additional changed field is a failed apply and
+    requires immediate investigation before delivery continues.
 - Always capture evidence:
   - Actions run URL.
   - Artifact filename(s) and hash (for audit traceability).


### PR DESCRIPTION
## Kurzbefund
- Live Branch Protection auf `main` wurde eng begrenzt von `allow_force_pushes.enabled=true` auf `false` gehärtet.
- Ein vollständiger Vorher-/Nachher-Vergleich bestätigte, dass alle übrigen Branch-Protection-Felder unverändert blieben.
- Baseline, vollständiger Apply-Payload, Drift-Report, Change-Log und Governance-Runbook sind auf den verifizierten Live-Zustand synchronisiert.

## Warum jetzt
- Issue #4196 wurde aus der in PR #4193 belegten Abweichung zwischen Live Branch Protection und der gewünschten Sicherheitsposition eröffnet.
- Force-Pushes auf `main` sind kein bestätigter Betriebsmodus.

## Scope
- In: ausschließlich `allow_force_pushes.enabled=false` live sowie die zugehörige Governance-Baseline, Evidence und Runbook-Präzisierung.
- Out: alle anderen Branch-Protection-Felder, Required Context `cdb-local-ci`, Workflows, Runtime, Docker/WSL sowie #4184 und PR #4187.

## Betroffene Dateien / Artefakte
- `docs/evidence/reports/BRANCH_PROTECTION_BASELINE_main.json`
- `docs/evidence/reports/BRANCH_PROTECTION_APPLY_PAYLOAD_main.json`
- `docs/evidence/reports/BRANCH_PROTECTION_DRIFT_REPORT_main.md`
- `docs/governance/BRANCH_PROTECTION_LOG.md`
- `docs/governance/GOVERNANCE_AUDIT_RUNBOOK.md`

## Validierung / Checks
- Live Preserve-and-Verify: ausschließlich `allow_force_pushes.enabled:true->false`; alle übrigen Felder identisch.
- Gezielte Governance-Tests: `12 passed`.
- Live Branch-Protection-Drift-Check: PASS / no drift.
- JSON-Validierung für Baseline und Apply-Payload: PASS.
- `git diff --check`: PASS.
- Fast-CI Run `20260730T102212Z_da0e9201`: PASS auf SHA `2848eeb28aa74ae47c3cafb807771c747cc6034d`.
- Required Commit Status `cdb-local-ci`: success auf exakt demselben SHA.
- Lokaler Policy-Gate-Mirror: PASS (`docs-only`).

## Risiken / Guardrails
- LR bleibt `NO-GO`; die Änderung autorisiert weder Live-Trading noch Echtgeld.
- `cdb-local-ci` bleibt der einzige Required Status Context und wurde nicht verändert.
- Kein Admin-Merge zum Übergehen fehlender Safety-Evidence.
- #4184 und PR #4187 bleiben unverändert auf `PAUSED_RESOURCE_CAPACITY`.

## Restunsicherheiten
- GitHub-hosted Actions starteten wegen eines von GitHub annotierten Billing-Locks nicht und meldeten deshalb `failure`; sie sind für `main` nicht required.
- Die erforderliche lokale Evidence und der Required Commit Status sind vollständig grün.

## Issue-Bezug
- Closes #4196
