### PR TITLE
ci(windows): add temp-root preflight for local CI (#4205)

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -100,6 +100,16 @@ Bindings:
 - Any required SKIPPED ⇒ overall `FAIL`
 - Optional SKIPPED requires `skip_reason`
 
+## Temp-root preflight (#4205)
+
+Before unit/pytest stages, the orchestrator probes a run-scoped temp root at
+`ci/artifacts/<run_id>/tmp` (create/read/rename/delete). Failure stops the run
+with a stable reason code (`TEMP_ROOT_*`) and writes
+`reports/temp_preflight.json` (redacted paths only — no user-home absolutes).
+On success, `TEMP`/`TMP`/`TMPDIR` and pytest `--basetemp` / `cache_dir` point
+at that controlled root. No global ACL changes, no foreign-temp cleanup, no
+`.wslconfig` edits.
+
 ## Resources (16 GB host defaults)
 
 See `ci/config/resources.yaml`: light parallelism ≤2, heavy serial, memory caps

--- a/ci/config/resources.yaml
+++ b/ci/config/resources.yaml
@@ -27,3 +27,5 @@ cache:
   pip_cache_cap: "2g"
   docker_build_cache_cleanup_supported: true
   cleanup_must_not_delete_unrelated_images_or_volumes: true
+
+temp_preflight: true

--- a/ci/lib/temp_preflight.py
+++ b/ci/lib/temp_preflight.py
@@ -1,0 +1,143 @@
+"""Run-scoped temp-root preflight for local CI (Issue #4205).
+
+Probes create/read/rename/delete under ``run_dir/tmp`` before pytest collection.
+Never touches foreign temp trees, global ACLs, or ``.wslconfig``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+TEMP_ROOT_CREATE_FAILED = "TEMP_ROOT_CREATE_FAILED"
+TEMP_ROOT_READ_FAILED = "TEMP_ROOT_READ_FAILED"
+TEMP_ROOT_RENAME_FAILED = "TEMP_ROOT_RENAME_FAILED"
+TEMP_ROOT_DELETE_FAILED = "TEMP_ROOT_DELETE_FAILED"
+TEMP_ROOT_NOT_WRITABLE = "TEMP_ROOT_NOT_WRITABLE"
+TEMP_ROOT_OK = "TEMP_ROOT_OK"
+
+_PROBE_MARKER = "cdb-temp-preflight\n"
+_BASETEMP_NAME = "pytest-basetemp"
+_CACHE_NAME = "pytest-cache"
+_PROBE_DIR_NAME = "_probe"
+
+
+@dataclass(frozen=True)
+class TempRootResult:
+    ok: bool
+    reason_code: str
+    temp_root: Path
+    basetemp: Path
+    cache_dir: Path
+    redacted_root: str
+
+
+def redacted_temp_root(run_id: str) -> str:
+    """Stable evidence path without user-home absolute segments."""
+    return f"ci/artifacts/{run_id}/tmp"
+
+
+def temp_env_for(temp_root: Path) -> dict[str, str]:
+    root = str(temp_root)
+    return {"TEMP": root, "TMP": root, "TMPDIR": root}
+
+
+def write_temp_preflight_report(path: Path, result: TempRootResult) -> None:
+    """Write redacted preflight evidence (no absolute home paths)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "ok": result.ok,
+        "reason_code": result.reason_code,
+        "redacted_root": result.redacted_root,
+        "basetemp_rel": f"{result.redacted_root}/{_BASETEMP_NAME}",
+        "cache_dir_rel": f"{result.redacted_root}/{_CACHE_NAME}",
+    }
+    path.write_text(
+        json.dumps(payload, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def prepare_ci_temp_root(run_dir: Path, run_id: str) -> TempRootResult:
+    """Create and probe ``run_dir/tmp``; fail fast with a stable reason code."""
+    temp_root = (run_dir / "tmp").resolve()
+    basetemp = temp_root / _BASETEMP_NAME
+    cache_dir = temp_root / _CACHE_NAME
+    redacted = redacted_temp_root(run_id)
+
+    def _result(*, ok: bool, reason_code: str) -> TempRootResult:
+        return TempRootResult(
+            ok=ok,
+            reason_code=reason_code,
+            temp_root=temp_root,
+            basetemp=basetemp,
+            cache_dir=cache_dir,
+            redacted_root=redacted,
+        )
+
+    probe_dir = temp_root / _PROBE_DIR_NAME
+    if probe_dir.exists():
+        try:
+            shutil.rmtree(probe_dir)
+        except OSError:
+            # Stale leftovers under our probe dir only; continue into create probe.
+            pass
+
+    try:
+        temp_root.mkdir(parents=True, exist_ok=True)
+        probe_dir.mkdir(parents=True, exist_ok=True)
+        probe_file = probe_dir / "probe.txt"
+        probe_file.write_text(_PROBE_MARKER, encoding="utf-8")
+    except OSError:
+        return _result(ok=False, reason_code=TEMP_ROOT_CREATE_FAILED)
+
+    try:
+        data = probe_file.read_text(encoding="utf-8")
+        if data != _PROBE_MARKER:
+            return _result(ok=False, reason_code=TEMP_ROOT_READ_FAILED)
+    except OSError:
+        return _result(ok=False, reason_code=TEMP_ROOT_READ_FAILED)
+
+    renamed = probe_dir / "probe_renamed.txt"
+    try:
+        probe_file.rename(renamed)
+    except OSError:
+        return _result(ok=False, reason_code=TEMP_ROOT_RENAME_FAILED)
+
+    try:
+        renamed.unlink()
+    except OSError:
+        return _result(ok=False, reason_code=TEMP_ROOT_DELETE_FAILED)
+
+    try:
+        basetemp.mkdir(parents=True, exist_ok=True)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        marker = cache_dir / ".writable"
+        marker.write_text("ok\n", encoding="utf-8")
+        marker.unlink()
+    except OSError:
+        return _result(ok=False, reason_code=TEMP_ROOT_NOT_WRITABLE)
+
+    try:
+        if probe_dir.exists():
+            # Remove only our empty probe subdirectory (no foreign temps).
+            remaining = list(probe_dir.iterdir())
+            if not remaining:
+                probe_dir.rmdir()
+            else:
+                shutil.rmtree(probe_dir)
+    except OSError:
+        pass
+
+    return _result(ok=True, reason_code=TEMP_ROOT_OK)
+
+
+def temp_preflight_as_dict(result: TempRootResult) -> dict[str, object]:
+    """Serialize result with pathlib paths as posix strings (tests/helpers)."""
+    data = asdict(result)
+    data["temp_root"] = result.temp_root.as_posix()
+    data["basetemp"] = result.basetemp.as_posix()
+    data["cache_dir"] = result.cache_dir.as_posix()
+    return data

--- a/ci/lib/temp_preflight.py
+++ b/ci/lib/temp_preflight.py
@@ -1,13 +1,18 @@
 """Run-scoped temp-root preflight for local CI (Issue #4205).
 
-Probes create/read/rename/delete under ``run_dir/tmp`` before pytest collection.
-Never touches foreign temp trees, global ACLs, or ``.wslconfig``.
+Probes create/read/rename/delete under an *outside-repo* CI temp root before
+pytest collection. Never touches foreign temp trees, global ACLs, or
+``.wslconfig``. Roots live under ``C:\\tmp\\cdb-ci\\<run_id>`` (Windows) or
+``$TEMP/cdb-ci/<run_id>`` so pytest basetemp files are not mistaken for
+repo-relative paths by scanners.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -36,7 +41,7 @@ class TempRootResult:
 
 def redacted_temp_root(run_id: str) -> str:
     """Stable evidence path without user-home absolute segments."""
-    return f"ci/artifacts/{run_id}/tmp"
+    return f"<ci-temp>/cdb-ci/{run_id}"
 
 
 def temp_env_for(temp_root: Path) -> dict[str, str]:
@@ -60,29 +65,49 @@ def write_temp_preflight_report(path: Path, result: TempRootResult) -> None:
     )
 
 
-def prepare_ci_temp_root(run_dir: Path, run_id: str) -> TempRootResult:
-    """Create and probe ``run_dir/tmp``; fail fast with a stable reason code."""
-    temp_root = (run_dir / "tmp").resolve()
-    basetemp = temp_root / _BASETEMP_NAME
-    cache_dir = temp_root / _CACHE_NAME
-    redacted = redacted_temp_root(run_id)
+def _is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except ValueError:
+        return False
 
-    def _result(*, ok: bool, reason_code: str) -> TempRootResult:
-        return TempRootResult(
-            ok=ok,
-            reason_code=reason_code,
-            temp_root=temp_root,
-            basetemp=basetemp,
-            cache_dir=cache_dir,
-            redacted_root=redacted,
-        )
 
+def candidate_temp_roots(
+    *,
+    run_id: str,
+    repo_root: Path,
+    preferred_root: Path | None = None,
+) -> list[Path]:
+    """Ordered outside-repo candidates for a run-scoped CI temp root."""
+    ordered: list[Path] = []
+    if preferred_root is not None:
+        ordered.append(Path(preferred_root))
+    if os.name == "nt":
+        ordered.append(Path(r"C:\tmp\cdb-ci") / run_id)
+    ordered.append(Path(tempfile.gettempdir()) / "cdb-ci" / run_id)
+
+    seen: set[Path] = set()
+    out: list[Path] = []
+    repo = repo_root.resolve()
+    for raw in ordered:
+        candidate = raw.resolve()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if _is_under(candidate, repo):
+            continue
+        out.append(candidate)
+    return out
+
+
+def _probe_root(temp_root: Path) -> str:
+    """Return TEMP_ROOT_OK or a failure reason code after probing temp_root."""
     probe_dir = temp_root / _PROBE_DIR_NAME
     if probe_dir.exists():
         try:
             shutil.rmtree(probe_dir)
         except OSError:
-            # Stale leftovers under our probe dir only; continue into create probe.
             pass
 
     try:
@@ -91,26 +116,28 @@ def prepare_ci_temp_root(run_dir: Path, run_id: str) -> TempRootResult:
         probe_file = probe_dir / "probe.txt"
         probe_file.write_text(_PROBE_MARKER, encoding="utf-8")
     except OSError:
-        return _result(ok=False, reason_code=TEMP_ROOT_CREATE_FAILED)
+        return TEMP_ROOT_CREATE_FAILED
 
     try:
         data = probe_file.read_text(encoding="utf-8")
         if data != _PROBE_MARKER:
-            return _result(ok=False, reason_code=TEMP_ROOT_READ_FAILED)
+            return TEMP_ROOT_READ_FAILED
     except OSError:
-        return _result(ok=False, reason_code=TEMP_ROOT_READ_FAILED)
+        return TEMP_ROOT_READ_FAILED
 
     renamed = probe_dir / "probe_renamed.txt"
     try:
         probe_file.rename(renamed)
     except OSError:
-        return _result(ok=False, reason_code=TEMP_ROOT_RENAME_FAILED)
+        return TEMP_ROOT_RENAME_FAILED
 
     try:
         renamed.unlink()
     except OSError:
-        return _result(ok=False, reason_code=TEMP_ROOT_DELETE_FAILED)
+        return TEMP_ROOT_DELETE_FAILED
 
+    basetemp = temp_root / _BASETEMP_NAME
+    cache_dir = temp_root / _CACHE_NAME
     try:
         basetemp.mkdir(parents=True, exist_ok=True)
         cache_dir.mkdir(parents=True, exist_ok=True)
@@ -118,11 +145,10 @@ def prepare_ci_temp_root(run_dir: Path, run_id: str) -> TempRootResult:
         marker.write_text("ok\n", encoding="utf-8")
         marker.unlink()
     except OSError:
-        return _result(ok=False, reason_code=TEMP_ROOT_NOT_WRITABLE)
+        return TEMP_ROOT_NOT_WRITABLE
 
     try:
         if probe_dir.exists():
-            # Remove only our empty probe subdirectory (no foreign temps).
             remaining = list(probe_dir.iterdir())
             if not remaining:
                 probe_dir.rmdir()
@@ -131,7 +157,68 @@ def prepare_ci_temp_root(run_dir: Path, run_id: str) -> TempRootResult:
     except OSError:
         pass
 
-    return _result(ok=True, reason_code=TEMP_ROOT_OK)
+    return TEMP_ROOT_OK
+
+
+def prepare_ci_temp_root(
+    run_dir: Path,
+    run_id: str,
+    *,
+    repo_root: Path | None = None,
+    preferred_root: Path | None = None,
+) -> TempRootResult:
+    """Probe an outside-repo CI temp root; fail fast with a stable reason code.
+
+    ``run_dir`` remains the evidence directory (reports stay under artifacts).
+    ``preferred_root`` is for tests; production tries ``C:\\tmp\\cdb-ci`` then
+    ``$TEMP/cdb-ci``.
+    """
+    if repo_root is not None:
+        repo = repo_root.resolve()
+    elif run_dir.parent.name == "artifacts" and run_dir.parent.parent.name == "ci":
+        repo = run_dir.parents[2].resolve()
+    else:
+        repo = Path.cwd().resolve()
+
+    redacted = redacted_temp_root(run_id)
+    candidates = candidate_temp_roots(
+        run_id=run_id, repo_root=repo, preferred_root=preferred_root
+    )
+    if not candidates:
+        empty = (run_dir / "tmp-unavailable").resolve()
+        return TempRootResult(
+            ok=False,
+            reason_code=TEMP_ROOT_CREATE_FAILED,
+            temp_root=empty,
+            basetemp=empty / _BASETEMP_NAME,
+            cache_dir=empty / _CACHE_NAME,
+            redacted_root=redacted,
+        )
+
+    last_reason = TEMP_ROOT_CREATE_FAILED
+    last_root = candidates[0]
+    for temp_root in candidates:
+        last_root = temp_root
+        reason = _probe_root(temp_root)
+        if reason == TEMP_ROOT_OK:
+            return TempRootResult(
+                ok=True,
+                reason_code=TEMP_ROOT_OK,
+                temp_root=temp_root,
+                basetemp=temp_root / _BASETEMP_NAME,
+                cache_dir=temp_root / _CACHE_NAME,
+                redacted_root=redacted,
+            )
+        last_reason = reason
+
+    return TempRootResult(
+        ok=False,
+        reason_code=last_reason,
+        temp_root=last_root,
+        basetemp=last_root / _BASETEMP_NAME,
+        cache_dir=last_root / _CACHE_NAME,
+        redacted_root=redacted,
+    )
 
 
 def temp_preflight_as_dict(result: TempRootResult) -> dict[str, object]:

--- a/ci/scripts/run.py
+++ b/ci/scripts/run.py
@@ -23,6 +23,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from ci.lib.config import load_yaml, profiles_from_config  # noqa: E402
 from ci.lib.evidence import (  # noqa: E402
+    StageResult,
     assert_run_id_available,
     assert_safe_cleanup_project,
     build_manifest,
@@ -33,6 +34,11 @@ from ci.lib.evidence import (  # noqa: E402
     write_manifest,
 )
 from ci.lib.gitinfo import collect_git_info  # noqa: E402
+from ci.lib.temp_preflight import (  # noqa: E402
+    prepare_ci_temp_root,
+    temp_env_for,
+    write_temp_preflight_report,
+)
 from ci.stages import containers as stage_containers  # noqa: E402
 from ci.stages import docs as stage_docs  # noqa: E402
 from ci.stages import governance as stage_governance  # noqa: E402
@@ -162,13 +168,79 @@ def run_ci(
     selected = [stage] if stage else list(profiles[profile])
     # Always append report aggregation for full/profile runs; for single-stage,
     # still produce a report unless stage==report.
-    stage_results = []
+    stage_results: list[StageResult] = []
     skipped_checks = [
         {
             "check": "policy-gate",
             "skip_reason": "GitHub-native PR API evaluation; local mirror only in Phase 1",
         }
     ]
+
+    # Temp-root preflight before any pytest/unit collection (#4205).
+    print("==> stage temp_preflight")
+    preflight_started = utc_now()
+    preflight = prepare_ci_temp_root(run_dir, rid)
+    preflight_report = run_dir / "reports" / "temp_preflight.json"
+    write_temp_preflight_report(preflight_report, preflight)
+    preflight_ended = utc_now()
+    preflight_stage = StageResult(
+        name="temp_preflight",
+        status="PASS" if preflight.ok else "FAIL",
+        exit_code=0 if preflight.ok else 1,
+        started_at_utc=preflight_started,
+        ended_at_utc=preflight_ended,
+        duration_seconds=0.0,
+        command_summary=[f"prepare_ci_temp_root:{preflight.reason_code}"],
+        log_path="",
+        artifacts=["reports/temp_preflight.json"],
+        skip_reason=None if preflight.ok else preflight.reason_code,
+        required=True,
+    )
+    stage_results.append(preflight_stage)
+    skipped_checks.append(
+        {
+            "check": "temp_root",
+            "skip_reason": f"{preflight.reason_code}:{preflight.redacted_root}",
+        }
+    )
+
+    if not preflight.ok:
+        print(f"temp_preflight FAIL reason_code={preflight.reason_code}")
+        report_result = stage_report.run(ctx, stage_results)
+        stage_results.append(report_result)
+        artifact_paths = sorted(run_dir.rglob("*"))
+        artifact_paths = [p for p in artifact_paths if p.is_file()]
+        artifact_hashes = hash_artifacts(artifact_paths, relative_to=run_dir)
+        ended = utc_now()
+        docker_v, compose_v = _docker_versions()
+        manifest = build_manifest(
+            run_id=rid,
+            commit_sha=git.commit_sha,
+            branch=git.branch,
+            dirty_worktree=git.dirty_worktree,
+            started_at_utc=started,
+            ended_at_utc=ended,
+            host_platform=platform.platform(),
+            tool_versions={
+                "python": platform.python_version(),
+                "ruff": _tool_version(["ruff", "--version"]),
+                "pytest": _tool_version([sys.executable, "-m", "pytest", "--version"]),
+            },
+            docker_version=docker_v,
+            compose_version=compose_v,
+            profile=profile if not stage else f"stage:{stage}",
+            stages=stage_results,
+            skipped_checks=skipped_checks,
+            artifact_hashes=artifact_hashes,
+            repo_name=git.repo_name,
+        )
+        write_manifest(run_dir, manifest)
+        print(f"overall_status={manifest['overall_status']}")
+        print(f"evidence={run_dir}")
+        return 1
+
+    ctx.temp_root = preflight.temp_root
+    ctx.temp_env = temp_env_for(preflight.temp_root)
 
     for name in selected:
         if name == "report":

--- a/ci/scripts/run.py
+++ b/ci/scripts/run.py
@@ -179,7 +179,7 @@ def run_ci(
     # Temp-root preflight before any pytest/unit collection (#4205).
     print("==> stage temp_preflight")
     preflight_started = utc_now()
-    preflight = prepare_ci_temp_root(run_dir, rid)
+    preflight = prepare_ci_temp_root(run_dir, rid, repo_root=repo_root)
     preflight_report = run_dir / "reports" / "temp_preflight.json"
     write_temp_preflight_report(preflight_report, preflight)
     preflight_ended = utc_now()

--- a/ci/stages/_common.py
+++ b/ci/stages/_common.py
@@ -6,7 +6,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from ci.lib.evidence import StageResult, utc_now
 from ci.lib.process import run_command
@@ -25,6 +25,8 @@ class StageContext:
     git: Any
     profile: str
     resources: dict
+    temp_root: Path | None = None
+    temp_env: dict[str, str] | None = None
 
     @property
     def logs_dir(self) -> Path:
@@ -49,6 +51,7 @@ def run_commands_as_stage(
     name: str,
     commands: list[list[str]],
     required: bool = True,
+    env: Mapping[str, str] | None = None,
 ) -> StageResult:
     started = utc_now()
     log_path = ctx.logs_dir / f"{name}.log"
@@ -58,7 +61,7 @@ def run_commands_as_stage(
     wall_start = time.perf_counter()
     for command in commands:
         part_log = ctx.logs_dir / f"{name}.{len(summaries)}.log"
-        result = run_command(command, cwd=ctx.repo_root, log_path=part_log)
+        result = run_command(command, cwd=ctx.repo_root, log_path=part_log, env=env)
         summaries.append(" ".join(command))
         combined_parts.append(part_log.read_text(encoding="utf-8"))
         if result.exit_code != 0:

--- a/ci/stages/unit.py
+++ b/ci/stages/unit.py
@@ -9,18 +9,32 @@ from ci.stages._common import StageContext, python_executable, run_commands_as_s
 def run(ctx: StageContext) -> StageResult:
     # SSOT filter for the fast profile / GitHub ci.yml thin wrapper (#4163).
     # Invoke via the orchestrator interpreter (-m pytest) for local venv parity.
+    command = [
+        python_executable(),
+        "-m",
+        "pytest",
+        "-q",
+        "-k",
+        "not test_mcp_time_server_runtime",
+    ]
+    env = None
+    if ctx.temp_root is not None:
+        basetemp = ctx.temp_root / "pytest-basetemp"
+        cache_dir = ctx.temp_root / "pytest-cache"
+        # Prefer controlled cache under run-scoped temp root (pytest ini via -o).
+        command.extend(
+            [
+                "--basetemp",
+                str(basetemp),
+                "-o",
+                f"cache_dir={cache_dir.as_posix()}",
+            ]
+        )
+        env = ctx.temp_env
     return run_commands_as_stage(
         ctx,
         name="unit",
-        commands=[
-            [
-                python_executable(),
-                "-m",
-                "pytest",
-                "-q",
-                "-k",
-                "not test_mcp_time_server_runtime",
-            ]
-        ],
+        commands=[command],
         required=True,
+        env=env,
     )

--- a/tests/unit/ci/test_temp_root_preflight.py
+++ b/tests/unit/ci/test_temp_root_preflight.py
@@ -1,0 +1,194 @@
+"""Unit tests for local CI temp-root preflight (#4205)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from ci.lib.temp_preflight import (
+    TEMP_ROOT_CREATE_FAILED,
+    TEMP_ROOT_DELETE_FAILED,
+    TEMP_ROOT_NOT_WRITABLE,
+    TEMP_ROOT_OK,
+    TEMP_ROOT_READ_FAILED,
+    TEMP_ROOT_RENAME_FAILED,
+    prepare_ci_temp_root,
+    redacted_temp_root,
+    write_temp_preflight_report,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_prepare_ok_creates_controlled_layout(tmp_path: Path) -> None:
+    run_id = "run_ok_00001"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is True
+    assert result.reason_code == TEMP_ROOT_OK
+    assert result.temp_root == (run_dir / "tmp").resolve()
+    assert result.basetemp == result.temp_root / "pytest-basetemp"
+    assert result.cache_dir == result.temp_root / "pytest-cache"
+    assert result.basetemp.is_dir()
+    assert result.cache_dir.is_dir()
+    assert result.redacted_root == f"ci/artifacts/{run_id}/tmp"
+    assert not (result.temp_root / "_probe").exists()
+
+
+def test_create_failed_reason_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id = "run_create_fail"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+
+    def boom_mkdir(self: Path, *args: object, **kwargs: object) -> None:
+        raise OSError("simulated create denial")
+
+    monkeypatch.setattr(Path, "mkdir", boom_mkdir)
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is False
+    assert result.reason_code == TEMP_ROOT_CREATE_FAILED
+
+
+def test_read_failed_reason_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id = "run_read_fail"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    real_read = Path.read_text
+
+    def boom_read(self: Path, *args: object, **kwargs: object) -> str:
+        if self.name == "probe.txt":
+            raise OSError("simulated read denial")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", boom_read)
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is False
+    assert result.reason_code == TEMP_ROOT_READ_FAILED
+
+
+def test_rename_failed_reason_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id = "run_rename_fail"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    real_rename = Path.rename
+
+    def boom_rename(self: Path, target: Path) -> Path:
+        if self.name == "probe.txt":
+            raise OSError("simulated rename denial")
+        return real_rename(self, target)
+
+    monkeypatch.setattr(Path, "rename", boom_rename)
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is False
+    assert result.reason_code == TEMP_ROOT_RENAME_FAILED
+
+
+def test_delete_failed_reason_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id = "run_delete_fail"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    real_unlink = Path.unlink
+
+    def boom_unlink(self: Path, *args: object, **kwargs: object) -> None:
+        if self.name == "probe_renamed.txt":
+            raise OSError("simulated delete denial")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", boom_unlink)
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is False
+    assert result.reason_code == TEMP_ROOT_DELETE_FAILED
+
+
+def test_stale_probe_rest_cleaned(tmp_path: Path) -> None:
+    run_id = "run_stale_001"
+    run_dir = tmp_path / run_id
+    probe = run_dir / "tmp" / "_probe"
+    probe.mkdir(parents=True)
+    leftover = probe / "stale.bin"
+    leftover.write_bytes(b"leftover")
+    foreign = run_dir / "tmp" / "keep_me.txt"
+    foreign.write_text("foreign-not-probe\n", encoding="utf-8")
+
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is True
+    assert result.reason_code == TEMP_ROOT_OK
+    assert not leftover.exists()
+    assert not probe.exists()
+    assert foreign.exists()
+
+
+def test_parallel_run_ids_use_distinct_roots(tmp_path: Path) -> None:
+    run_a = tmp_path / "run_par_a"
+    run_b = tmp_path / "run_par_b"
+    run_a.mkdir()
+    run_b.mkdir()
+    a = prepare_ci_temp_root(run_a, "run_par_a")
+    b = prepare_ci_temp_root(run_b, "run_par_b")
+    assert a.ok and b.ok
+    assert a.temp_root != b.temp_root
+    assert a.redacted_root != b.redacted_root
+    assert a.temp_root.parent.name == "run_par_a"
+    assert b.temp_root.parent.name == "run_par_b"
+
+
+def test_non_writable_cache_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    run_id = "run_nowrite_01"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    real_write = Path.write_text
+
+    def selective_write(self: Path, *args: object, **kwargs: object) -> int:
+        if self.name == ".writable":
+            raise OSError("simulated cache not writable")
+        return real_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", selective_write)
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is False
+    assert result.reason_code == TEMP_ROOT_NOT_WRITABLE
+
+
+def test_redacted_manifest_has_no_home_path(tmp_path: Path) -> None:
+    run_id = "run_redact_01"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    result = prepare_ci_temp_root(run_dir, run_id)
+    report = tmp_path / "temp_preflight.json"
+    write_temp_preflight_report(report, result)
+    text = report.read_text(encoding="utf-8")
+    payload = json.loads(text)
+    home = str(Path.home())
+    assert home not in text
+    assert "Users" not in payload["redacted_root"]
+    assert "AppData" not in text
+    assert payload["redacted_root"] == redacted_temp_root(run_id)
+    assert payload["redacted_root"].startswith("ci/artifacts/")
+    assert payload["reason_code"] == TEMP_ROOT_OK
+
+
+def test_windows_path_normalization_uses_pathlib(tmp_path: Path) -> None:
+    run_id = "run_winpath_1"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    result = prepare_ci_temp_root(run_dir, run_id)
+    assert result.ok is True
+    assert isinstance(result.temp_root, Path)
+    assert result.temp_root.is_absolute()
+    # pathlib normalize: same as resolve under run_dir/tmp
+    assert result.temp_root == Path(os.path.normpath(result.temp_root))
+    assert result.temp_root.name == "tmp"

--- a/tests/unit/ci/test_temp_root_preflight.py
+++ b/tests/unit/ci/test_temp_root_preflight.py
@@ -23,34 +23,54 @@ from ci.lib.temp_preflight import (
 pytestmark = pytest.mark.unit
 
 
+def _prepare(tmp_path: Path, run_id: str, **kwargs: object):
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    run_dir = tmp_path / "artifacts" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    preferred = tmp_path / "cdb-ci" / run_id
+    return prepare_ci_temp_root(
+        run_dir,
+        run_id,
+        repo_root=repo,
+        preferred_root=preferred,
+        **kwargs,
+    )
+
+
 def test_prepare_ok_creates_controlled_layout(tmp_path: Path) -> None:
     run_id = "run_ok_00001"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     assert result.ok is True
     assert result.reason_code == TEMP_ROOT_OK
-    assert result.temp_root == (run_dir / "tmp").resolve()
+    assert result.temp_root == (tmp_path / "cdb-ci" / run_id).resolve()
     assert result.basetemp == result.temp_root / "pytest-basetemp"
     assert result.cache_dir == result.temp_root / "pytest-cache"
     assert result.basetemp.is_dir()
     assert result.cache_dir.is_dir()
-    assert result.redacted_root == f"ci/artifacts/{run_id}/tmp"
+    assert result.redacted_root == f"<ci-temp>/cdb-ci/{run_id}"
     assert not (result.temp_root / "_probe").exists()
+    # Must stay outside the fake repo tree.
+    assert "repo" not in result.temp_root.parts
 
 
 def test_create_failed_reason_code(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run_id = "run_create_fail"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_dir = tmp_path / "artifacts" / run_id
+    run_dir.mkdir(parents=True)
+    preferred = tmp_path / "cdb-ci" / run_id
 
     def boom_mkdir(self: Path, *args: object, **kwargs: object) -> None:
         raise OSError("simulated create denial")
 
     monkeypatch.setattr(Path, "mkdir", boom_mkdir)
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = prepare_ci_temp_root(
+        run_dir, run_id, repo_root=repo, preferred_root=preferred
+    )
     assert result.ok is False
     assert result.reason_code == TEMP_ROOT_CREATE_FAILED
 
@@ -59,8 +79,6 @@ def test_read_failed_reason_code(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run_id = "run_read_fail"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
     real_read = Path.read_text
 
     def boom_read(self: Path, *args: object, **kwargs: object) -> str:
@@ -69,7 +87,7 @@ def test_read_failed_reason_code(
         return real_read(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "read_text", boom_read)
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     assert result.ok is False
     assert result.reason_code == TEMP_ROOT_READ_FAILED
 
@@ -78,8 +96,6 @@ def test_rename_failed_reason_code(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run_id = "run_rename_fail"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
     real_rename = Path.rename
 
     def boom_rename(self: Path, target: Path) -> Path:
@@ -88,7 +104,7 @@ def test_rename_failed_reason_code(
         return real_rename(self, target)
 
     monkeypatch.setattr(Path, "rename", boom_rename)
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     assert result.ok is False
     assert result.reason_code == TEMP_ROOT_RENAME_FAILED
 
@@ -97,8 +113,6 @@ def test_delete_failed_reason_code(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run_id = "run_delete_fail"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
     real_unlink = Path.unlink
 
     def boom_unlink(self: Path, *args: object, **kwargs: object) -> None:
@@ -107,22 +121,22 @@ def test_delete_failed_reason_code(
         return real_unlink(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "unlink", boom_unlink)
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     assert result.ok is False
     assert result.reason_code == TEMP_ROOT_DELETE_FAILED
 
 
 def test_stale_probe_rest_cleaned(tmp_path: Path) -> None:
     run_id = "run_stale_001"
-    run_dir = tmp_path / run_id
-    probe = run_dir / "tmp" / "_probe"
+    preferred = tmp_path / "cdb-ci" / run_id
+    probe = preferred / "_probe"
     probe.mkdir(parents=True)
     leftover = probe / "stale.bin"
     leftover.write_bytes(b"leftover")
-    foreign = run_dir / "tmp" / "keep_me.txt"
+    foreign = preferred / "keep_me.txt"
     foreign.write_text("foreign-not-probe\n", encoding="utf-8")
 
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     assert result.ok is True
     assert result.reason_code == TEMP_ROOT_OK
     assert not leftover.exists()
@@ -131,25 +145,19 @@ def test_stale_probe_rest_cleaned(tmp_path: Path) -> None:
 
 
 def test_parallel_run_ids_use_distinct_roots(tmp_path: Path) -> None:
-    run_a = tmp_path / "run_par_a"
-    run_b = tmp_path / "run_par_b"
-    run_a.mkdir()
-    run_b.mkdir()
-    a = prepare_ci_temp_root(run_a, "run_par_a")
-    b = prepare_ci_temp_root(run_b, "run_par_b")
+    a = _prepare(tmp_path, "run_par_a")
+    b = _prepare(tmp_path, "run_par_b")
     assert a.ok and b.ok
     assert a.temp_root != b.temp_root
     assert a.redacted_root != b.redacted_root
-    assert a.temp_root.parent.name == "run_par_a"
-    assert b.temp_root.parent.name == "run_par_b"
+    assert a.temp_root.name == "run_par_a"
+    assert b.temp_root.name == "run_par_b"
 
 
 def test_non_writable_cache_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     run_id = "run_nowrite_01"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
     real_write = Path.write_text
 
     def selective_write(self: Path, *args: object, **kwargs: object) -> int:
@@ -158,16 +166,14 @@ def test_non_writable_cache_path(
         return real_write(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "write_text", selective_write)
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     assert result.ok is False
     assert result.reason_code == TEMP_ROOT_NOT_WRITABLE
 
 
 def test_redacted_manifest_has_no_home_path(tmp_path: Path) -> None:
     run_id = "run_redact_01"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     report = tmp_path / "temp_preflight.json"
     write_temp_preflight_report(report, result)
     text = report.read_text(encoding="utf-8")
@@ -177,18 +183,35 @@ def test_redacted_manifest_has_no_home_path(tmp_path: Path) -> None:
     assert "Users" not in payload["redacted_root"]
     assert "AppData" not in text
     assert payload["redacted_root"] == redacted_temp_root(run_id)
-    assert payload["redacted_root"].startswith("ci/artifacts/")
+    assert payload["redacted_root"].startswith("<ci-temp>/cdb-ci/")
     assert payload["reason_code"] == TEMP_ROOT_OK
 
 
 def test_windows_path_normalization_uses_pathlib(tmp_path: Path) -> None:
     run_id = "run_winpath_1"
-    run_dir = tmp_path / run_id
-    run_dir.mkdir()
-    result = prepare_ci_temp_root(run_dir, run_id)
+    result = _prepare(tmp_path, run_id)
     assert result.ok is True
     assert isinstance(result.temp_root, Path)
     assert result.temp_root.is_absolute()
-    # pathlib normalize: same as resolve under run_dir/tmp
     assert result.temp_root == Path(os.path.normpath(result.temp_root))
-    assert result.temp_root.name == "tmp"
+    assert result.temp_root.name == run_id
+
+
+def test_rejects_in_repo_preferred_root(tmp_path: Path) -> None:
+    """Candidates under the repo are skipped; fallback outside still works."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_dir = tmp_path / "artifacts" / "run_inrepo"
+    run_dir.mkdir(parents=True)
+    inside = repo / "ci" / "artifacts" / "run_inrepo" / "tmp"
+    # Only candidate is inside repo → create fails (no outside candidate forced).
+    # Provide an outside preferred via second call pattern: empty preferred list
+    # by putting preferred inside repo and ensuring system temp is used.
+    result = prepare_ci_temp_root(
+        run_dir,
+        "run_inrepo",
+        repo_root=repo,
+        preferred_root=inside,
+    )
+    assert result.ok is True
+    assert not str(result.temp_root.resolve()).startswith(str(repo.resolve()))


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: ci-tooling
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: frozen
objective_key: ci-temp-root-preflight
planned_issues: #4205
contract_keys: ci-local-runner-v1
risk_flags: none
-->

## Summary

Temp-Root-Preflight for local CI before pytest collection (#4205).
CI temp root is outside the repository (`C:\tmp\cdb-ci/<run_id>` or `$TEMP/cdb-ci`).

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4205 | SLICE_DELIVERED | 67736bbb22f83468744e6f86ddbcddc6a7560281 | unit temp_preflight + evidence + ruff/black | none | final Fast-CI |

Closes #4205