### PR TITLE
fix(ci): make black execution portable and timeout-bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,8 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           pip install -r requirements-mcp.txt
-          pip install ruff black
+          # Toolchain SSOT (#4206): black/ruff pins from requirements-dev.txt only.
+          # Do not reinstall unversioned ruff/black after the requirements install.
 
       - name: Install SurrealDB CLI (pinned v3.1.5)
         run: |

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY requirements.txt requirements-dev.txt requirements-mcp.txt pyproject.toml ./
 RUN python -m pip install --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt -r requirements-mcp.txt \
-    && pip install --no-cache-dir ruff black
+    && pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt -r requirements-mcp.txt
+# Toolchain SSOT (#4206): black/ruff pins come only from requirements-dev.txt.
+# Do not reinstall unversioned ruff/black after the requirements install.
 
 # Application tree is bind-mounted at runtime for commit-bound evidence.
 CMD ["python", "ci/scripts/run.py", "--profile", "fast"]

--- a/ci/README.md
+++ b/ci/README.md
@@ -67,7 +67,7 @@ pwsh -File ci/scripts/publish_status.ps1 -Command publish -EvidenceDir ci/artifa
 
 | Stage | Wrapped commands |
 |-------|------------------|
-| lint | `ruff check .`; `black --config pyproject.toml --check` on changed `*.py` vs `origin/main` |
+| lint | `ruff check .`; `python -m black --config pyproject.toml --check --workers 1` on sorted changed `*.py` vs `origin/main` (timeout-bound) |
 | unit | `pytest -q -k "not test_mcp_time_server_runtime"` (SSOT; thin `ci.yml` delegates here) |
 | docs | `python -m tools.validate_onboarding_docs`; `python -m tools.validate_readme_links`; `python -m tools.ci.docs_conflict_guard`; `python -m tools.ci.repository_canon_guard` |
 | governance | MCP fixture validate; surreal validate; `scripts/governance/run_ci_drift_checks.py` (BP live when readable; offline baseline fallback + disclosure when gh API 403) |
@@ -76,20 +76,19 @@ pwsh -File ci/scripts/publish_status.ps1 -Command publish -EvidenceDir ci/artifa
 | containers | `docker build -f ci/Dockerfile` only; no push |
 | report | `reports/check-matrix.json` + fail-closed `manifest.json` |
 
-Auf Windows bleibt `sys.executable -m black` der Default (gepinntes
-`black==26.5.1` aus `requirements-dev.txt`). Black erhält einen Timeout aus
-`ci/config/resources.yaml` (`black_timeout_seconds`, Default 120). Ein Hang
-endet als Stage-**FAIL** mit `reason_code=BLACK_TIMEOUT` und Exit-Code 124 —
-niemals als SKIP oder PASS. Dockerfile-/ci.yml-unpinned Black ist bewusst
-außerhalb dieses Slices.
+### Black toolchain SSOT (#4206)
 
-Falls genau dieser Interpreter einen belegten Black-Runtime-Defekt hat, darf
-der lokale Operator `CDB_BLACK_EXECUTABLE` auf eine existierende Black-CLI
-setzen. Das ist ein **strikt validierter Escape Hatch** (Pfad muss eine Datei
-sein; Shell-Metazeichen wie `;`, `|`, `&`, `$()` werden abgelehnt). Der Runner
-protokolliert das konkrete Executable in der Stage-Evidence; die Formatprüfung
-wird nicht übersprungen. Invalid override → FAIL mit
-`reason_code=BLACK_EXECUTABLE_INVALID`.
+- **Versionsquelle:** `requirements-dev.txt` (`black==26.5.1`, `ruff==0.16.0`). Keine unversionierte Zweitinstallation in `ci/Dockerfile` oder `.github/workflows/ci.yml`.
+- **Kanonischer Ausführungsweg:** `sys.executable -m black` (CI-Frontdoor-Interpreter), Config aus `pyproject.toml`, nur Changed-Files, `--workers 1`.
+- **Timeout:** Default `300` Sekunden aus `ci/config/resources.yaml` (`black_timeout_seconds`); Override `CDB_BLACK_TIMEOUT_SECONDS` (Cap `900`). Hang → Stage-**FAIL** mit `reason_code=BLACK_TIMEOUT` und Exit 124 — niemals SKIP/PASS. Timeout und Version stehen in der Lint-Evidence.
+- **Reason Codes:** `BLACK_TIMEOUT`, `BLACK_EXECUTABLE_MISSING`, `BLACK_EXECUTABLE_INVALID`, `BLACK_VERSION_MISMATCH`, `BLACK_EXECUTION_FAILED`.
+- **Changed-File-Contract:** deterministisch sortiert; gelöschte Dateien ausgeschlossen; `.codex/**` / `.opencode/**` ausgeschlossen; Git-Fehler fail-closed; leerer Satz explizit geloggt.
+- **Keine globale Python-3.14-Abhängigkeit.**
+
+`CDB_BLACK_EXECUTABLE` bleibt ein strikt validierter Escape Hatch (kein Default):
+existierende reguläre Datei, keine Shell-Argumente, `black --version` muss exakt
+dem Pin aus `requirements-dev.txt` entsprechen. Override-Nutzung wird mit
+`$HOME`-Redaktion in der Evidence ausgewiesen. Abweichungen enden fail-closed.
 
 ## Evidence contract
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -76,11 +76,20 @@ pwsh -File ci/scripts/publish_status.ps1 -Command publish -EvidenceDir ci/artifa
 | containers | `docker build -f ci/Dockerfile` only; no push |
 | report | `reports/check-matrix.json` + fail-closed `manifest.json` |
 
-Auf Windows bleibt `sys.executable -m black` der Default. Falls genau dieser
-Interpreter einen belegten Black-Runtime-Defekt hat, darf der lokale Operator
-`CDB_BLACK_EXECUTABLE` auf eine existierende Black-CLI setzen. Der Runner
-validiert den Pfad fail-closed und protokolliert das konkrete Executable in der
-Stage-Evidence; die Formatprüfung wird nicht übersprungen.
+Auf Windows bleibt `sys.executable -m black` der Default (gepinntes
+`black==26.5.1` aus `requirements-dev.txt`). Black erhält einen Timeout aus
+`ci/config/resources.yaml` (`black_timeout_seconds`, Default 120). Ein Hang
+endet als Stage-**FAIL** mit `reason_code=BLACK_TIMEOUT` und Exit-Code 124 —
+niemals als SKIP oder PASS. Dockerfile-/ci.yml-unpinned Black ist bewusst
+außerhalb dieses Slices.
+
+Falls genau dieser Interpreter einen belegten Black-Runtime-Defekt hat, darf
+der lokale Operator `CDB_BLACK_EXECUTABLE` auf eine existierende Black-CLI
+setzen. Das ist ein **strikt validierter Escape Hatch** (Pfad muss eine Datei
+sein; Shell-Metazeichen wie `;`, `|`, `&`, `$()` werden abgelehnt). Der Runner
+protokolliert das konkrete Executable in der Stage-Evidence; die Formatprüfung
+wird nicht übersprungen. Invalid override → FAIL mit
+`reason_code=BLACK_EXECUTABLE_INVALID`.
 
 ## Evidence contract
 

--- a/ci/config/resources.yaml
+++ b/ci/config/resources.yaml
@@ -32,4 +32,5 @@ temp_preflight: true
 
 # Bound Black --check so a hung formatter cannot stall local CI indefinitely.
 # Timeout → FAIL with reason_code=BLACK_TIMEOUT (never SKIP/PASS).
-black_timeout_seconds: 120
+# Override via CDB_BLACK_TIMEOUT_SECONDS (positive int, hard cap 900).
+black_timeout_seconds: 300

--- a/ci/config/resources.yaml
+++ b/ci/config/resources.yaml
@@ -29,3 +29,7 @@ cache:
   cleanup_must_not_delete_unrelated_images_or_volumes: true
 
 temp_preflight: true
+
+# Bound Black --check so a hung formatter cannot stall local CI indefinitely.
+# Timeout → FAIL with reason_code=BLACK_TIMEOUT (never SKIP/PASS).
+black_timeout_seconds: 120

--- a/ci/lib/evidence.py
+++ b/ci/lib/evidence.py
@@ -32,6 +32,7 @@ class StageResult:
     artifacts: list[str] = field(default_factory=list)
     skip_reason: str | None = None
     required: bool = True
+    reason_code: str | None = None
 
 
 class EvidenceError(ValueError):

--- a/ci/lib/process.py
+++ b/ci/lib/process.py
@@ -13,6 +13,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
 
+# Conventional exit code when a subprocess hits its wall-clock timeout.
+# Matches GNU timeout(1); stages map this to a typed reason_code (never SKIP).
+EXIT_CODE_TIMEOUT = 124
+
 
 @dataclass(frozen=True)
 class CommandResult:
@@ -21,6 +25,7 @@ class CommandResult:
     duration_seconds: float
     stdout: str
     stderr: str
+    timed_out: bool = False
 
 
 def run_command(
@@ -43,16 +48,30 @@ def run_command(
     with log_path.open("w", encoding="utf-8") as handle:
         handle.write(f"$ {' '.join(command)}\n")
         handle.flush()
-        proc = subprocess.run(
-            list(command),
-            cwd=str(cwd),
-            stdout=handle,
-            stderr=subprocess.STDOUT,
-            text=True,
-            env=merged,
-            timeout=timeout,
-            check=False,
-        )
+        try:
+            proc = subprocess.run(
+                list(command),
+                cwd=str(cwd),
+                stdout=handle,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=merged,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            # Never re-raise: callers treat exit_code=124 as FAIL, not SKIP/PASS.
+            handle.write("\nreason_code=COMMAND_TIMEOUT\n")
+            handle.write(f"exit_code={EXIT_CODE_TIMEOUT}\n")
+            duration = time.perf_counter() - started
+            return CommandResult(
+                command=list(command),
+                exit_code=EXIT_CODE_TIMEOUT,
+                duration_seconds=round(duration, 3),
+                stdout="",
+                stderr="",
+                timed_out=True,
+            )
         handle.write(f"\nexit_code={proc.returncode}\n")
     duration = time.perf_counter() - started
     return CommandResult(
@@ -61,4 +80,5 @@ def run_command(
         duration_seconds=round(duration, 3),
         stdout="",
         stderr="",
+        timed_out=False,
     )

--- a/ci/lib/process.py
+++ b/ci/lib/process.py
@@ -26,6 +26,7 @@ class CommandResult:
     stdout: str
     stderr: str
     timed_out: bool = False
+    reason_code: str | None = None
 
 
 def run_command(
@@ -35,6 +36,7 @@ def run_command(
     log_path: Path,
     env: Mapping[str, str] | None = None,
     timeout: int | None = None,
+    timeout_reason_code: str | None = None,
 ) -> CommandResult:
     # Fail-closed UTF-8 on Windows consoles (emoji in existing scripts).
     base_env = {
@@ -61,7 +63,9 @@ def run_command(
             )
         except subprocess.TimeoutExpired:
             # Never re-raise: callers treat exit_code=124 as FAIL, not SKIP/PASS.
-            handle.write("\nreason_code=COMMAND_TIMEOUT\n")
+            reason = timeout_reason_code or "COMMAND_TIMEOUT"
+            handle.write(f"\nTIMEOUT after {timeout}s\n")
+            handle.write(f"reason_code={reason}\n")
             handle.write(f"exit_code={EXIT_CODE_TIMEOUT}\n")
             duration = time.perf_counter() - started
             return CommandResult(
@@ -71,6 +75,7 @@ def run_command(
                 stdout="",
                 stderr="",
                 timed_out=True,
+                reason_code=reason,
             )
         handle.write(f"\nexit_code={proc.returncode}\n")
     duration = time.perf_counter() - started
@@ -81,4 +86,5 @@ def run_command(
         stdout="",
         stderr="",
         timed_out=False,
+        reason_code=None,
     )

--- a/ci/stages/_common.py
+++ b/ci/stages/_common.py
@@ -52,7 +52,13 @@ def run_commands_as_stage(
     commands: list[list[str]],
     required: bool = True,
     env: Mapping[str, str] | None = None,
+    timeout: int | None = None,
 ) -> StageResult:
+    """Run commands sequentially; first non-zero exit stops the stage as FAIL.
+
+    ``timeout`` applies to each command. On ``subprocess.TimeoutExpired``,
+    ``run_command`` returns exit_code 124 (never SKIP/PASS).
+    """
     started = utc_now()
     log_path = ctx.logs_dir / f"{name}.log"
     summaries: list[str] = []
@@ -61,8 +67,16 @@ def run_commands_as_stage(
     wall_start = time.perf_counter()
     for command in commands:
         part_log = ctx.logs_dir / f"{name}.{len(summaries)}.log"
-        result = run_command(command, cwd=ctx.repo_root, log_path=part_log, env=env)
+        result = run_command(
+            command,
+            cwd=ctx.repo_root,
+            log_path=part_log,
+            env=env,
+            timeout=timeout,
+        )
         summaries.append(" ".join(command))
+        if result.timed_out:
+            summaries.append("reason_code=COMMAND_TIMEOUT")
         combined_parts.append(part_log.read_text(encoding="utf-8"))
         if result.exit_code != 0:
             exit_code = result.exit_code

--- a/ci/stages/lint.py
+++ b/ci/stages/lint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -13,26 +14,62 @@ from ci.stages._common import StageContext, python_executable
 
 # Typed fail reasons for Black (never SKIP/PASS on timeout or invalid override).
 BLACK_TIMEOUT = "BLACK_TIMEOUT"
+BLACK_EXECUTABLE_MISSING = "BLACK_EXECUTABLE_MISSING"
 BLACK_EXECUTABLE_INVALID = "BLACK_EXECUTABLE_INVALID"
-BLACK_NONZERO_EXIT = "BLACK_NONZERO_EXIT"
+BLACK_VERSION_MISMATCH = "BLACK_VERSION_MISMATCH"
+BLACK_EXECUTION_FAILED = "BLACK_EXECUTION_FAILED"
+# Backward-compatible alias used by earlier #4206 slice tests.
+BLACK_NONZERO_EXIT = BLACK_EXECUTION_FAILED
+CHANGED_FILES_ENUMERATION_FAILED = "CHANGED_FILES_ENUMERATION_FAILED"
 
 # Characters / patterns that make an override unsafe as an argv element.
 _BLACK_OVERRIDE_UNSAFE = (";", "|", "&", "$(", "`", "\n", "\r")
+_SHELL_META = re.compile(r"[;&|<>`$]|\\")
+_BLACK_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 
-_DEFAULT_BLACK_TIMEOUT_SECONDS = 120
+_DEFAULT_BLACK_TIMEOUT_SECONDS = 300
+_BLACK_TIMEOUT_CAP_SECONDS = 900
+_BLACK_TIMEOUT_ENV = "CDB_BLACK_TIMEOUT_SECONDS"
+_REQUIREMENTS_DEV = "requirements-dev.txt"
+
+
+class BlackResolutionError(RuntimeError):
+    """Fail-closed Black executable / version / changed-file resolution error."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+def pinned_black_version(repo_root: Path) -> str:
+    path = repo_root / _REQUIREMENTS_DEV
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("black=="):
+            return stripped.split("==", 1)[1].strip()
+    raise BlackResolutionError(
+        BLACK_EXECUTABLE_INVALID,
+        f"No black== pin found in {_REQUIREMENTS_DEV}",
+    )
+
+
+def redact_path_for_evidence(path: str) -> str:
+    home = str(Path.home())
+    if home and path.startswith(home):
+        return "$HOME" + path[len(home) :]
+    return path
 
 
 def _changed_python_files(repo_root: Path) -> list[str]:
-    base = "origin/main"
-    head = "HEAD"
+    """Return sorted changed *.py paths vs origin/main (fail-closed on git error)."""
     result = subprocess.run(
         [
             "git",
             "diff",
             "--name-only",
             "--diff-filter=d",
-            base,
-            head,
+            "origin/main",
+            "HEAD",
             "--",
             "*.py",
             ":!.codex/**",
@@ -44,22 +81,39 @@ def _changed_python_files(repo_root: Path) -> list[str]:
         check=False,
     )
     if result.returncode != 0:
-        return []
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        detail = (result.stderr or result.stdout or "").strip()
+        raise BlackResolutionError(
+            CHANGED_FILES_ENUMERATION_FAILED,
+            f"git diff for changed python files failed: {detail}",
+        )
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return sorted(files)
 
 
 def _validate_black_override(override: str) -> Path:
     """Fail-closed validation for CDB_BLACK_EXECUTABLE (escape hatch only)."""
-    if any(token in override for token in _BLACK_OVERRIDE_UNSAFE):
-        raise RuntimeError(
+    if (
+        any(token in override for token in _BLACK_OVERRIDE_UNSAFE)
+        or _SHELL_META.search(override)
+        or len(override.split()) > 1
+    ):
+        raise BlackResolutionError(
+            BLACK_EXECUTABLE_INVALID,
             f"{BLACK_EXECUTABLE_INVALID}: CDB_BLACK_EXECUTABLE contains "
-            "unsafe shell metacharacters"
+            "unsafe shell metacharacters or embedded arguments",
         )
     executable = Path(override)
+    if not executable.exists():
+        raise BlackResolutionError(
+            BLACK_EXECUTABLE_MISSING,
+            f"{BLACK_EXECUTABLE_MISSING}: CDB_BLACK_EXECUTABLE must name an "
+            "existing executable file",
+        )
     if not executable.is_file():
-        raise RuntimeError(
-            f"{BLACK_EXECUTABLE_INVALID}: CDB_BLACK_EXECUTABLE must name an "
-            "existing executable file"
+        raise BlackResolutionError(
+            BLACK_EXECUTABLE_INVALID,
+            f"{BLACK_EXECUTABLE_INVALID}: CDB_BLACK_EXECUTABLE must name a "
+            "regular file, not a directory",
         )
     return executable
 
@@ -76,12 +130,72 @@ def _black_command(python: str) -> list[str]:
 
 
 def _black_timeout_seconds(resources: dict) -> int:
+    """Positive bounded timeout; env overrides resources; hard cap 900s."""
+    env_raw = (os.environ.get(_BLACK_TIMEOUT_ENV) or "").strip()
+    if env_raw:
+        try:
+            value = int(env_raw)
+        except ValueError as exc:
+            raise BlackResolutionError(
+                BLACK_EXECUTABLE_INVALID,
+                f"{_BLACK_TIMEOUT_ENV} must be a positive integer",
+            ) from exc
+        if value <= 0:
+            raise BlackResolutionError(
+                BLACK_EXECUTABLE_INVALID,
+                f"{_BLACK_TIMEOUT_ENV} must be a positive integer",
+            )
+        return min(value, _BLACK_TIMEOUT_CAP_SECONDS)
+
     raw = resources.get("black_timeout_seconds", _DEFAULT_BLACK_TIMEOUT_SECONDS)
     try:
         value = int(raw)
     except (TypeError, ValueError):
         return _DEFAULT_BLACK_TIMEOUT_SECONDS
-    return value if value > 0 else _DEFAULT_BLACK_TIMEOUT_SECONDS
+    if value <= 0:
+        return _DEFAULT_BLACK_TIMEOUT_SECONDS
+    return min(value, _BLACK_TIMEOUT_CAP_SECONDS)
+
+
+def _probe_black_version(argv: list[str], *, cwd: Path) -> str:
+    try:
+        proc = subprocess.run(
+            [*argv, "--version"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BlackResolutionError(
+            BLACK_EXECUTABLE_INVALID,
+            f"Unable to execute black --version: {exc}",
+        ) from exc
+    combined = f"{proc.stdout or ''}{proc.stderr or ''}"
+    if proc.returncode != 0:
+        raise BlackResolutionError(
+            BLACK_EXECUTABLE_INVALID,
+            f"black --version failed (exit {proc.returncode}): {combined.strip()}",
+        )
+    match = _BLACK_VERSION_RE.search(combined)
+    if not match:
+        raise BlackResolutionError(
+            BLACK_EXECUTABLE_INVALID,
+            f"Could not parse black version from: {combined.strip()!r}",
+        )
+    return match.group(1)
+
+
+def ensure_black_version(argv: list[str], *, repo_root: Path) -> str:
+    expected = pinned_black_version(repo_root)
+    version = _probe_black_version(argv, cwd=repo_root)
+    if version != expected:
+        raise BlackResolutionError(
+            BLACK_VERSION_MISMATCH,
+            f"Active black {version} does not match pin {expected}",
+        )
+    return version
 
 
 def _fail_stage(
@@ -109,6 +223,7 @@ def _fail_stage(
         artifacts=[],
         skip_reason=None,
         required=True,
+        reason_code=reason_code,
     )
 
 
@@ -119,7 +234,19 @@ def run(ctx: StageContext) -> StageResult:
     wall_start = time.perf_counter()
     summaries: list[str] = []
     combined_parts: list[str] = []
-    black_timeout = _black_timeout_seconds(ctx.resources)
+
+    try:
+        black_timeout = _black_timeout_seconds(ctx.resources)
+    except BlackResolutionError as exc:
+        return _fail_stage(
+            ctx=ctx,
+            started=started,
+            summaries=summaries,
+            combined_parts=[str(exc)],
+            exit_code=1,
+            reason_code=exc.reason_code,
+            wall_start=wall_start,
+        )
 
     ruff_cmd = [py, "-m", "ruff", "check", "."]
     ruff_log = ctx.logs_dir / "lint.0.log"
@@ -141,21 +268,37 @@ def run(ctx: StageContext) -> StageResult:
             artifacts=[],
             skip_reason=None,
             required=True,
+            reason_code=None,
         )
 
-    files = _changed_python_files(ctx.repo_root)
+    try:
+        files = _changed_python_files(ctx.repo_root)
+    except BlackResolutionError as exc:
+        return _fail_stage(
+            ctx=ctx,
+            started=started,
+            summaries=summaries,
+            combined_parts=[*combined_parts, str(exc)],
+            exit_code=1,
+            reason_code=exc.reason_code,
+            wall_start=wall_start,
+        )
+
     if not files:
-        skip_cmd = [
-            py,
-            "-c",
-            "print('No python changes vs origin/main; black check skipped')",
-        ]
+        skip_msg = (
+            "No python changes vs origin/main; black check skipped "
+            "(empty changed-file set)"
+        )
+        skip_cmd = [py, "-c", f"print({skip_msg!r})"]
         skip_log = ctx.logs_dir / "lint.1.log"
         skip_result = run_command(skip_cmd, cwd=ctx.repo_root, log_path=skip_log)
         summaries.append(" ".join(skip_cmd))
         combined_parts.append(skip_log.read_text(encoding="utf-8"))
         log_path = ctx.logs_dir / "lint.log"
-        log_path.write_text("\n".join(combined_parts), encoding="utf-8")
+        log_path.write_text(
+            f"black_timeout_seconds={black_timeout}\n" + "\n".join(combined_parts),
+            encoding="utf-8",
+        )
         return StageResult(
             name="lint",
             status="PASS" if skip_result.exit_code == 0 else "FAIL",
@@ -168,11 +311,25 @@ def run(ctx: StageContext) -> StageResult:
             artifacts=[],
             skip_reason=None,
             required=True,
+            reason_code=None,
         )
 
     try:
         black_prefix = _black_command(py)
+        version = ensure_black_version(black_prefix, repo_root=ctx.repo_root)
+    except BlackResolutionError as exc:
+        combined_parts.append(str(exc))
+        return _fail_stage(
+            ctx=ctx,
+            started=started,
+            summaries=summaries,
+            combined_parts=combined_parts,
+            exit_code=1,
+            reason_code=exc.reason_code,
+            wall_start=wall_start,
+        )
     except RuntimeError as exc:
+        # Legacy raise path from older validators.
         combined_parts.append(str(exc))
         return _fail_stage(
             ctx=ctx,
@@ -183,6 +340,15 @@ def run(ctx: StageContext) -> StageResult:
             reason_code=BLACK_EXECUTABLE_INVALID,
             wall_start=wall_start,
         )
+
+    override = (os.environ.get("CDB_BLACK_EXECUTABLE") or "").strip()
+    if override:
+        combined_parts.append(
+            f"black_override=CDB_BLACK_EXECUTABLE="
+            f"{redact_path_for_evidence(override)} version={version}"
+        )
+    combined_parts.append(f"black_timeout_seconds={black_timeout}")
+    combined_parts.append(f"black_version={version}")
 
     black_cmd = [
         *black_prefix,
@@ -199,13 +365,12 @@ def run(ctx: StageContext) -> StageResult:
         cwd=ctx.repo_root,
         log_path=black_log,
         timeout=black_timeout,
+        timeout_reason_code=BLACK_TIMEOUT,
     )
     summaries.append(" ".join(black_cmd))
     combined_parts.append(black_log.read_text(encoding="utf-8"))
 
     if black_result.timed_out or black_result.exit_code == EXIT_CODE_TIMEOUT:
-        # Annotate log with the Black-specific reason (process layer writes
-        # COMMAND_TIMEOUT generically).
         with black_log.open("a", encoding="utf-8") as handle:
             handle.write(f"reason_code={BLACK_TIMEOUT}\n")
         combined_parts[-1] = black_log.read_text(encoding="utf-8")
@@ -226,7 +391,7 @@ def run(ctx: StageContext) -> StageResult:
             summaries=summaries,
             combined_parts=combined_parts,
             exit_code=black_result.exit_code,
-            reason_code=BLACK_NONZERO_EXIT,
+            reason_code=BLACK_EXECUTION_FAILED,
             wall_start=wall_start,
         )
 
@@ -244,4 +409,5 @@ def run(ctx: StageContext) -> StageResult:
         artifacts=[],
         skip_reason=None,
         required=True,
+        reason_code=None,
     )

--- a/ci/stages/lint.py
+++ b/ci/stages/lint.py
@@ -4,10 +4,22 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
 from pathlib import Path
 
-from ci.lib.evidence import StageResult
-from ci.stages._common import StageContext, python_executable, run_commands_as_stage
+from ci.lib.evidence import StageResult, utc_now
+from ci.lib.process import EXIT_CODE_TIMEOUT, run_command
+from ci.stages._common import StageContext, python_executable
+
+# Typed fail reasons for Black (never SKIP/PASS on timeout or invalid override).
+BLACK_TIMEOUT = "BLACK_TIMEOUT"
+BLACK_EXECUTABLE_INVALID = "BLACK_EXECUTABLE_INVALID"
+BLACK_NONZERO_EXIT = "BLACK_NONZERO_EXIT"
+
+# Characters / patterns that make an override unsafe as an argv element.
+_BLACK_OVERRIDE_UNSAFE = (";", "|", "&", "$(", "`", "\n", "\r")
+
+_DEFAULT_BLACK_TIMEOUT_SECONDS = 120
 
 
 def _changed_python_files(repo_root: Path) -> list[str]:
@@ -36,38 +48,200 @@ def _changed_python_files(repo_root: Path) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def _validate_black_override(override: str) -> Path:
+    """Fail-closed validation for CDB_BLACK_EXECUTABLE (escape hatch only)."""
+    if any(token in override for token in _BLACK_OVERRIDE_UNSAFE):
+        raise RuntimeError(
+            f"{BLACK_EXECUTABLE_INVALID}: CDB_BLACK_EXECUTABLE contains "
+            "unsafe shell metacharacters"
+        )
+    executable = Path(override)
+    if not executable.is_file():
+        raise RuntimeError(
+            f"{BLACK_EXECUTABLE_INVALID}: CDB_BLACK_EXECUTABLE must name an "
+            "existing executable file"
+        )
+    return executable
+
+
 def _black_command(python: str) -> list[str]:
+    """Default: ``python -m black`` (pinned black==26.5.1 in requirements-dev).
+
+    ``CDB_BLACK_EXECUTABLE`` is a strictly validated escape hatch only.
+    """
     override = (os.environ.get("CDB_BLACK_EXECUTABLE") or "").strip()
     if not override:
         return [python, "-m", "black"]
-    executable = Path(override)
-    if not executable.is_file():
-        raise RuntimeError("CDB_BLACK_EXECUTABLE must name an existing executable file")
-    return [str(executable)]
+    return [str(_validate_black_override(override))]
+
+
+def _black_timeout_seconds(resources: dict) -> int:
+    raw = resources.get("black_timeout_seconds", _DEFAULT_BLACK_TIMEOUT_SECONDS)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_BLACK_TIMEOUT_SECONDS
+    return value if value > 0 else _DEFAULT_BLACK_TIMEOUT_SECONDS
+
+
+def _fail_stage(
+    *,
+    ctx: StageContext,
+    started: str,
+    summaries: list[str],
+    combined_parts: list[str],
+    exit_code: int,
+    reason_code: str,
+    wall_start: float,
+) -> StageResult:
+    summaries = [*summaries, f"reason_code={reason_code}"]
+    log_path = ctx.logs_dir / "lint.log"
+    log_path.write_text("\n".join(combined_parts), encoding="utf-8")
+    return StageResult(
+        name="lint",
+        status="FAIL",
+        exit_code=exit_code,
+        started_at_utc=started,
+        ended_at_utc=utc_now(),
+        duration_seconds=round(time.perf_counter() - wall_start, 3),
+        command_summary=summaries,
+        log_path=str(log_path.relative_to(ctx.run_dir).as_posix()),
+        artifacts=[],
+        skip_reason=None,
+        required=True,
+    )
 
 
 def run(ctx: StageContext) -> StageResult:
+    """Run ruff (unbounded) then Black with a resource-bounded timeout."""
     py = python_executable()
-    commands: list[list[str]] = [[py, "-m", "ruff", "check", "."]]
+    started = utc_now()
+    wall_start = time.perf_counter()
+    summaries: list[str] = []
+    combined_parts: list[str] = []
+    black_timeout = _black_timeout_seconds(ctx.resources)
+
+    ruff_cmd = [py, "-m", "ruff", "check", "."]
+    ruff_log = ctx.logs_dir / "lint.0.log"
+    ruff_result = run_command(ruff_cmd, cwd=ctx.repo_root, log_path=ruff_log)
+    summaries.append(" ".join(ruff_cmd))
+    combined_parts.append(ruff_log.read_text(encoding="utf-8"))
+    if ruff_result.exit_code != 0:
+        log_path = ctx.logs_dir / "lint.log"
+        log_path.write_text("\n".join(combined_parts), encoding="utf-8")
+        return StageResult(
+            name="lint",
+            status="FAIL",
+            exit_code=ruff_result.exit_code,
+            started_at_utc=started,
+            ended_at_utc=utc_now(),
+            duration_seconds=round(time.perf_counter() - wall_start, 3),
+            command_summary=summaries,
+            log_path=str(log_path.relative_to(ctx.run_dir).as_posix()),
+            artifacts=[],
+            skip_reason=None,
+            required=True,
+        )
+
     files = _changed_python_files(ctx.repo_root)
-    if files:
-        commands.append(
-            [
-                *_black_command(py),
-                "--config",
-                "pyproject.toml",
-                "--check",
-                "--workers",
-                "1",
-                *files,
-            ]
+    if not files:
+        skip_cmd = [
+            py,
+            "-c",
+            "print('No python changes vs origin/main; black check skipped')",
+        ]
+        skip_log = ctx.logs_dir / "lint.1.log"
+        skip_result = run_command(skip_cmd, cwd=ctx.repo_root, log_path=skip_log)
+        summaries.append(" ".join(skip_cmd))
+        combined_parts.append(skip_log.read_text(encoding="utf-8"))
+        log_path = ctx.logs_dir / "lint.log"
+        log_path.write_text("\n".join(combined_parts), encoding="utf-8")
+        return StageResult(
+            name="lint",
+            status="PASS" if skip_result.exit_code == 0 else "FAIL",
+            exit_code=skip_result.exit_code,
+            started_at_utc=started,
+            ended_at_utc=utc_now(),
+            duration_seconds=round(time.perf_counter() - wall_start, 3),
+            command_summary=summaries,
+            log_path=str(log_path.relative_to(ctx.run_dir).as_posix()),
+            artifacts=[],
+            skip_reason=None,
+            required=True,
         )
-    else:
-        commands.append(
-            [
-                py,
-                "-c",
-                "print('No python changes vs origin/main; black check skipped')",
-            ]
+
+    try:
+        black_prefix = _black_command(py)
+    except RuntimeError as exc:
+        combined_parts.append(str(exc))
+        return _fail_stage(
+            ctx=ctx,
+            started=started,
+            summaries=summaries,
+            combined_parts=combined_parts,
+            exit_code=1,
+            reason_code=BLACK_EXECUTABLE_INVALID,
+            wall_start=wall_start,
         )
-    return run_commands_as_stage(ctx, name="lint", commands=commands, required=True)
+
+    black_cmd = [
+        *black_prefix,
+        "--config",
+        "pyproject.toml",
+        "--check",
+        "--workers",
+        "1",
+        *files,
+    ]
+    black_log = ctx.logs_dir / "lint.1.log"
+    black_result = run_command(
+        black_cmd,
+        cwd=ctx.repo_root,
+        log_path=black_log,
+        timeout=black_timeout,
+    )
+    summaries.append(" ".join(black_cmd))
+    combined_parts.append(black_log.read_text(encoding="utf-8"))
+
+    if black_result.timed_out or black_result.exit_code == EXIT_CODE_TIMEOUT:
+        # Annotate log with the Black-specific reason (process layer writes
+        # COMMAND_TIMEOUT generically).
+        with black_log.open("a", encoding="utf-8") as handle:
+            handle.write(f"reason_code={BLACK_TIMEOUT}\n")
+        combined_parts[-1] = black_log.read_text(encoding="utf-8")
+        return _fail_stage(
+            ctx=ctx,
+            started=started,
+            summaries=summaries,
+            combined_parts=combined_parts,
+            exit_code=EXIT_CODE_TIMEOUT,
+            reason_code=BLACK_TIMEOUT,
+            wall_start=wall_start,
+        )
+
+    if black_result.exit_code != 0:
+        return _fail_stage(
+            ctx=ctx,
+            started=started,
+            summaries=summaries,
+            combined_parts=combined_parts,
+            exit_code=black_result.exit_code,
+            reason_code=BLACK_NONZERO_EXIT,
+            wall_start=wall_start,
+        )
+
+    log_path = ctx.logs_dir / "lint.log"
+    log_path.write_text("\n".join(combined_parts), encoding="utf-8")
+    return StageResult(
+        name="lint",
+        status="PASS",
+        exit_code=0,
+        started_at_utc=started,
+        ended_at_utc=utc_now(),
+        duration_seconds=round(time.perf_counter() - wall_start, 3),
+        command_summary=summaries,
+        log_path=str(log_path.relative_to(ctx.run_dir).as_posix()),
+        artifacts=[],
+        skip_reason=None,
+        required=True,
+    )

--- a/ci/stages/lint.py
+++ b/ci/stages/lint.py
@@ -23,8 +23,9 @@ BLACK_NONZERO_EXIT = BLACK_EXECUTION_FAILED
 CHANGED_FILES_ENUMERATION_FAILED = "CHANGED_FILES_ENUMERATION_FAILED"
 
 # Characters / patterns that make an override unsafe as an argv element.
+# Note: backslash is NOT treated as meta — Windows paths use ``\``.
 _BLACK_OVERRIDE_UNSAFE = (";", "|", "&", "$(", "`", "\n", "\r")
-_SHELL_META = re.compile(r"[;&|<>`$]|\\")
+_SHELL_META = re.compile(r"[;&|<>`$]")
 _BLACK_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
 
 _DEFAULT_BLACK_TIMEOUT_SECONDS = 300

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -26,6 +26,12 @@ Die früheren Required Checks `ci (Unit/Integration + Lint gesammelt)` und
 `ci.yml` und `policy-gate.yml` bleiben als Workflow-Inhalt / Safety-Gates
 nützlich, ersetzen aber den Required Context nicht.
 
+Lint/Format (orchestrator stage `lint`, Issue #4206): Black und Ruff kommen
+ausschließlich aus dem Pin in `requirements-dev.txt`. Black läuft als
+`python -m black --check` auf dem Changed-File-Satz mit hartem Timeout
+(Default 300s); Timeout und Toolauflösungsfehler sind Stage-`FAIL` mit Reason
+Code, niemals Fake-Green. Details: `ci/README.md` § Black toolchain SSOT.
+
 ## Merge-Gates
 
 Vor einem Merge muss `cdb-local-ci` für den aktuellen PR-Head-SHA erfolgreich

--- a/knowledge/logs/sessions/2026-07-30-4206-portable-black-timeout.md
+++ b/knowledge/logs/sessions/2026-07-30-4206-portable-black-timeout.md
@@ -1,0 +1,31 @@
+# Session 2026-07-30 — #4206 portable Black + timeout (batch PR #4213 continuation)
+
+## Scope
+
+Continue existing batch PR #4213: close remaining plan gaps (toolchain parity,
+version pin, fail-closed changed-files, docs).
+
+## Brain Evidence
+
+- brain_source: repo-only
+- brain_status: not-used
+- context_tool_status: absent
+- repo_fallback_reason: unavailable
+
+## Delivered (this slice)
+
+- Removed unversioned `pip install ruff black` from Dockerfile + ci.yml
+- Black version must match `requirements-dev.txt` pin
+- Changed-file git errors fail-closed; sorted file set
+- Timeout default 300s; StageResult.reason_code; `$HOME` redaction
+- Docs: ci/README.md + merge_policy_ci_gate.md
+
+## Validation
+
+Cloud unit/contract tests; Native Windows / Container / GHA remote open.
+
+## Status
+
+DONE_PR_OPEN_PENDING_PLATFORM_VALIDATION
+
+LR remains NO-GO.

--- a/tests/unit/ci/test_black_timeout_contract.py
+++ b/tests/unit/ci/test_black_timeout_contract.py
@@ -1,0 +1,238 @@
+"""Timeout and FAIL-reason contracts for portable Black in the lint stage."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from ci.lib.process import EXIT_CODE_TIMEOUT, CommandResult, run_command
+from ci.stages._common import StageContext
+from ci.stages.lint import (
+    BLACK_EXECUTABLE_INVALID,
+    BLACK_NONZERO_EXIT,
+    BLACK_TIMEOUT,
+    run as lint_run,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def _ctx(tmp_path: Path, *, resources: dict | None = None) -> StageContext:
+    run_dir = tmp_path / "run"
+    (run_dir / "logs").mkdir(parents=True)
+    (run_dir / "reports").mkdir(parents=True)
+    return StageContext(
+        repo_root=tmp_path,
+        run_dir=run_dir,
+        run_id="run_black_timeout_test",
+        git=MagicMock(),
+        profile="fast",
+        resources=resources or {"black_timeout_seconds": 120},
+    )
+
+
+def _ok_result(command: list[str]) -> CommandResult:
+    return CommandResult(
+        command=command,
+        exit_code=0,
+        duration_seconds=0.01,
+        stdout="",
+        stderr="",
+        timed_out=False,
+    )
+
+
+def test_run_command_timeout_returns_exit_124_not_raise(
+    tmp_path: Path,
+) -> None:
+    """Hung process → TimeoutExpired caught → exit 124 + COMMAND_TIMEOUT."""
+    log_path = tmp_path / "hang.log"
+    # Cross-platform sleep via the active interpreter (no shell).
+    result = run_command(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        cwd=tmp_path,
+        log_path=log_path,
+        timeout=1,
+    )
+    assert result.timed_out is True
+    assert result.exit_code == EXIT_CODE_TIMEOUT
+    text = log_path.read_text(encoding="utf-8")
+    assert "reason_code=COMMAND_TIMEOUT" in text
+    assert f"exit_code={EXIT_CODE_TIMEOUT}" in text
+    # No credential-shaped leakage from the timeout path.
+    assert "token" not in text.lower()
+    assert "password" not in text.lower()
+    assert "secret" not in text.lower()
+
+
+def test_lint_black_timeout_fails_with_black_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ctx = _ctx(tmp_path, resources={"black_timeout_seconds": 1})
+    monkeypatch.delenv("CDB_BLACK_EXECUTABLE", raising=False)
+    monkeypatch.setattr(
+        "ci.stages.lint._changed_python_files",
+        lambda _root: ["services/example.py"],
+    )
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_run_command(
+        command: list[str],
+        *,
+        cwd: Path,
+        log_path: Path,
+        env: Any = None,
+        timeout: int | None = None,
+    ) -> CommandResult:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(f"$ {' '.join(command)}\n", encoding="utf-8")
+        calls.append({"command": list(command), "timeout": timeout})
+        if "-m" in command and "ruff" in command:
+            return _ok_result(list(command))
+        # Simulate Black hang → timeout contract from process layer.
+        log_path.write_text(
+            f"$ {' '.join(command)}\n\nreason_code=COMMAND_TIMEOUT\n"
+            f"exit_code={EXIT_CODE_TIMEOUT}\n",
+            encoding="utf-8",
+        )
+        return CommandResult(
+            command=list(command),
+            exit_code=EXIT_CODE_TIMEOUT,
+            duration_seconds=1.0,
+            stdout="",
+            stderr="",
+            timed_out=True,
+        )
+
+    monkeypatch.setattr("ci.stages.lint.run_command", fake_run_command)
+    result = lint_run(ctx)
+
+    assert result.status == "FAIL"
+    assert result.exit_code == EXIT_CODE_TIMEOUT
+    assert result.skip_reason is None
+    assert f"reason_code={BLACK_TIMEOUT}" in result.command_summary
+    # Timeout applied only to Black, not ruff.
+    assert calls[0]["timeout"] is None
+    assert calls[1]["timeout"] == 1
+    assert "black" in " ".join(calls[1]["command"]).lower() or any(
+        part.endswith("black") or part.endswith("black.exe")
+        for part in calls[1]["command"]
+    )
+
+
+def test_lint_black_nonzero_exit_fails_with_reason(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.delenv("CDB_BLACK_EXECUTABLE", raising=False)
+    monkeypatch.setattr(
+        "ci.stages.lint._changed_python_files",
+        lambda _root: ["services/example.py"],
+    )
+
+    def fake_run_command(
+        command: list[str],
+        *,
+        cwd: Path,
+        log_path: Path,
+        env: Any = None,
+        timeout: int | None = None,
+    ) -> CommandResult:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(f"$ {' '.join(command)}\nexit_code=1\n", encoding="utf-8")
+        if "-m" in command and "ruff" in command:
+            return _ok_result(list(command))
+        return CommandResult(
+            command=list(command),
+            exit_code=1,
+            duration_seconds=0.1,
+            stdout="",
+            stderr="",
+            timed_out=False,
+        )
+
+    monkeypatch.setattr("ci.stages.lint.run_command", fake_run_command)
+    result = lint_run(ctx)
+    assert result.status == "FAIL"
+    assert result.exit_code == 1
+    assert result.skip_reason is None
+    assert f"reason_code={BLACK_NONZERO_EXIT}" in result.command_summary
+
+
+def test_lint_invalid_executable_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setenv("CDB_BLACK_EXECUTABLE", str(tmp_path / "missing-black.exe"))
+    monkeypatch.setattr(
+        "ci.stages.lint._changed_python_files",
+        lambda _root: ["services/example.py"],
+    )
+
+    def fake_run_command(
+        command: list[str],
+        *,
+        cwd: Path,
+        log_path: Path,
+        env: Any = None,
+        timeout: int | None = None,
+    ) -> CommandResult:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(f"$ {' '.join(command)}\n", encoding="utf-8")
+        return _ok_result(list(command))
+
+    monkeypatch.setattr("ci.stages.lint.run_command", fake_run_command)
+    result = lint_run(ctx)
+    assert result.status == "FAIL"
+    assert result.skip_reason is None
+    assert f"reason_code={BLACK_EXECUTABLE_INVALID}" in result.command_summary
+    # Error text must not leak env secrets / tokens.
+    joined = " ".join(result.command_summary) + "\n".join(
+        p.read_text(encoding="utf-8") for p in (ctx.logs_dir).glob("*.log")
+    )
+    assert "GITHUB_TOKEN" not in joined
+    assert "password=" not in joined.lower()
+
+
+def test_lint_identical_changed_set_uses_same_command_shape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same changed-file set → same argv shape (portable default: python -m black)."""
+    ctx = _ctx(tmp_path)
+    files = ["core/a.py", "services/b.py"]
+    monkeypatch.delenv("CDB_BLACK_EXECUTABLE", raising=False)
+    monkeypatch.setattr(
+        "ci.stages.lint._changed_python_files",
+        lambda _root: list(files),
+    )
+    captured: list[list[str]] = []
+
+    def fake_run_command(
+        command: list[str],
+        *,
+        cwd: Path,
+        log_path: Path,
+        env: Any = None,
+        timeout: int | None = None,
+    ) -> CommandResult:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(f"$ {' '.join(command)}\n", encoding="utf-8")
+        captured.append(list(command))
+        return _ok_result(list(command))
+
+    monkeypatch.setattr("ci.stages.lint.run_command", fake_run_command)
+    result = lint_run(ctx)
+    assert result.status == "PASS"
+    black_cmd = captured[1]
+    assert black_cmd[1:3] == ["-m", "black"]
+    assert "--config" in black_cmd
+    assert "pyproject.toml" in black_cmd
+    assert "--check" in black_cmd
+    assert "--workers" in black_cmd
+    assert "1" in black_cmd
+    assert black_cmd[-2:] == files

--- a/tests/unit/ci/test_black_timeout_contract.py
+++ b/tests/unit/ci/test_black_timeout_contract.py
@@ -13,6 +13,7 @@ from ci.lib.process import EXIT_CODE_TIMEOUT, CommandResult, run_command
 from ci.stages._common import StageContext
 from ci.stages.lint import (
     BLACK_EXECUTABLE_INVALID,
+    BLACK_EXECUTABLE_MISSING,
     BLACK_NONZERO_EXIT,
     BLACK_TIMEOUT,
     run as lint_run,
@@ -60,7 +61,9 @@ def test_run_command_timeout_returns_exit_124_not_raise(
     )
     assert result.timed_out is True
     assert result.exit_code == EXIT_CODE_TIMEOUT
+    assert result.reason_code == "COMMAND_TIMEOUT"
     text = log_path.read_text(encoding="utf-8")
+    assert "TIMEOUT after 1s" in text
     assert "reason_code=COMMAND_TIMEOUT" in text
     assert f"exit_code={EXIT_CODE_TIMEOUT}" in text
     # No credential-shaped leakage from the timeout path.
@@ -78,6 +81,10 @@ def test_lint_black_timeout_fails_with_black_timeout(
         "ci.stages.lint._changed_python_files",
         lambda _root: ["services/example.py"],
     )
+    monkeypatch.setattr(
+        "ci.stages.lint.ensure_black_version",
+        lambda argv, repo_root: "26.5.1",
+    )
 
     calls: list[dict[str, Any]] = []
 
@@ -88,6 +95,7 @@ def test_lint_black_timeout_fails_with_black_timeout(
         log_path: Path,
         env: Any = None,
         timeout: int | None = None,
+        timeout_reason_code: str | None = None,
     ) -> CommandResult:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text(f"$ {' '.join(command)}\n", encoding="utf-8")
@@ -96,7 +104,8 @@ def test_lint_black_timeout_fails_with_black_timeout(
             return _ok_result(list(command))
         # Simulate Black hang → timeout contract from process layer.
         log_path.write_text(
-            f"$ {' '.join(command)}\n\nreason_code=COMMAND_TIMEOUT\n"
+            f"$ {' '.join(command)}\n\nTIMEOUT after {timeout}s\n"
+            f"reason_code={timeout_reason_code or 'COMMAND_TIMEOUT'}\n"
             f"exit_code={EXIT_CODE_TIMEOUT}\n",
             encoding="utf-8",
         )
@@ -107,6 +116,7 @@ def test_lint_black_timeout_fails_with_black_timeout(
             stdout="",
             stderr="",
             timed_out=True,
+            reason_code=timeout_reason_code or "COMMAND_TIMEOUT",
         )
 
     monkeypatch.setattr("ci.stages.lint.run_command", fake_run_command)
@@ -115,6 +125,7 @@ def test_lint_black_timeout_fails_with_black_timeout(
     assert result.status == "FAIL"
     assert result.exit_code == EXIT_CODE_TIMEOUT
     assert result.skip_reason is None
+    assert result.reason_code == BLACK_TIMEOUT
     assert f"reason_code={BLACK_TIMEOUT}" in result.command_summary
     # Timeout applied only to Black, not ruff.
     assert calls[0]["timeout"] is None
@@ -134,6 +145,10 @@ def test_lint_black_nonzero_exit_fails_with_reason(
         "ci.stages.lint._changed_python_files",
         lambda _root: ["services/example.py"],
     )
+    monkeypatch.setattr(
+        "ci.stages.lint.ensure_black_version",
+        lambda argv, repo_root: "26.5.1",
+    )
 
     def fake_run_command(
         command: list[str],
@@ -142,6 +157,7 @@ def test_lint_black_nonzero_exit_fails_with_reason(
         log_path: Path,
         env: Any = None,
         timeout: int | None = None,
+        timeout_reason_code: str | None = None,
     ) -> CommandResult:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text(f"$ {' '.join(command)}\nexit_code=1\n", encoding="utf-8")
@@ -161,6 +177,7 @@ def test_lint_black_nonzero_exit_fails_with_reason(
     assert result.status == "FAIL"
     assert result.exit_code == 1
     assert result.skip_reason is None
+    assert result.reason_code == BLACK_NONZERO_EXIT
     assert f"reason_code={BLACK_NONZERO_EXIT}" in result.command_summary
 
 
@@ -181,6 +198,7 @@ def test_lint_invalid_executable_fails_closed(
         log_path: Path,
         env: Any = None,
         timeout: int | None = None,
+        timeout_reason_code: str | None = None,
     ) -> CommandResult:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text(f"$ {' '.join(command)}\n", encoding="utf-8")
@@ -190,7 +208,8 @@ def test_lint_invalid_executable_fails_closed(
     result = lint_run(ctx)
     assert result.status == "FAIL"
     assert result.skip_reason is None
-    assert f"reason_code={BLACK_EXECUTABLE_INVALID}" in result.command_summary
+    assert result.reason_code == BLACK_EXECUTABLE_MISSING
+    assert f"reason_code={BLACK_EXECUTABLE_MISSING}" in result.command_summary
     # Error text must not leak env secrets / tokens.
     joined = " ".join(result.command_summary) + "\n".join(
         p.read_text(encoding="utf-8") for p in (ctx.logs_dir).glob("*.log")
@@ -210,6 +229,10 @@ def test_lint_identical_changed_set_uses_same_command_shape(
         "ci.stages.lint._changed_python_files",
         lambda _root: list(files),
     )
+    monkeypatch.setattr(
+        "ci.stages.lint.ensure_black_version",
+        lambda argv, repo_root: "26.5.1",
+    )
     captured: list[list[str]] = []
 
     def fake_run_command(
@@ -219,6 +242,7 @@ def test_lint_identical_changed_set_uses_same_command_shape(
         log_path: Path,
         env: Any = None,
         timeout: int | None = None,
+        timeout_reason_code: str | None = None,
     ) -> CommandResult:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_path.write_text(f"$ {' '.join(command)}\n", encoding="utf-8")
@@ -236,3 +260,39 @@ def test_lint_identical_changed_set_uses_same_command_shape(
     assert "--workers" in black_cmd
     assert "1" in black_cmd
     assert black_cmd[-2:] == files
+
+
+def test_lint_paths_with_spaces_remain_separate_argv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    ctx = _ctx(tmp_path)
+    spaced = "dir with spaces/mod.py"
+    monkeypatch.delenv("CDB_BLACK_EXECUTABLE", raising=False)
+    monkeypatch.setattr(
+        "ci.stages.lint._changed_python_files",
+        lambda _root: [spaced],
+    )
+    monkeypatch.setattr(
+        "ci.stages.lint.ensure_black_version",
+        lambda argv, repo_root: "26.5.1",
+    )
+    captured: list[list[str]] = []
+
+    def fake_run_command(
+        command: list[str],
+        *,
+        cwd: Path,
+        log_path: Path,
+        env: Any = None,
+        timeout: int | None = None,
+        timeout_reason_code: str | None = None,
+    ) -> CommandResult:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("ok\n", encoding="utf-8")
+        captured.append(list(command))
+        return _ok_result(list(command))
+
+    monkeypatch.setattr("ci.stages.lint.run_command", fake_run_command)
+    lint_run(ctx)
+    assert spaced in captured[1]
+    assert captured[1][-1] == spaced

--- a/tests/unit/ci/test_black_toolchain_parity.py
+++ b/tests/unit/ci/test_black_toolchain_parity.py
@@ -1,0 +1,47 @@
+"""Toolchain parity: requirements-dev pin vs Dockerfile / ci.yml (#4206).
+
+test_id: tc_ci_black_toolchain_parity_001
+test_type: contract
+cdb_area: ci
+issue_ref: #4206
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from ci.stages.lint import pinned_black_version
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+UNVERSIONED_RUFF_BLACK = re.compile(
+    r"pip\s+install(?:\s+[^\n]*)?\s+(?:--no-cache-dir\s+)?ruff\s+black\b"
+)
+
+
+def test_requirements_dev_pins_expected_black() -> None:
+    assert pinned_black_version(REPO_ROOT) == "26.5.1"
+    text = (REPO_ROOT / "requirements-dev.txt").read_text(encoding="utf-8")
+    assert "ruff==0.16.0" in text
+
+
+def test_dockerfile_has_no_unversioned_ruff_black_reinstall() -> None:
+    text = (REPO_ROOT / "ci" / "Dockerfile").read_text(encoding="utf-8")
+    assert "requirements-dev.txt" in text
+    assert UNVERSIONED_RUFF_BLACK.search(text) is None
+
+
+def test_ci_workflow_has_no_unversioned_ruff_black_reinstall() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "requirements-dev.txt" in text
+    assert UNVERSIONED_RUFF_BLACK.search(text) is None
+    assert "pip install ruff black" not in text
+
+
+def test_resources_yaml_timeout_default_is_300() -> None:
+    text = (REPO_ROOT / "ci" / "config" / "resources.yaml").read_text(encoding="utf-8")
+    assert "black_timeout_seconds: 300" in text

--- a/tests/unit/ci/test_lint_stage_black_executable.py
+++ b/tests/unit/ci/test_lint_stage_black_executable.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import pytest
 
-from ci.stages.lint import _black_command
+from ci.stages.lint import (
+    BLACK_EXECUTABLE_INVALID,
+    _black_command,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.contract]
 
@@ -32,5 +35,31 @@ def test_black_command_rejects_missing_override(
 ) -> None:
     missing = tmp_path / "missing-black.exe"
     monkeypatch.setenv("CDB_BLACK_EXECUTABLE", str(missing))
-    with pytest.raises(RuntimeError, match="existing executable"):
+    with pytest.raises(RuntimeError, match=BLACK_EXECUTABLE_INVALID):
+        _black_command("python.exe")
+
+
+def test_black_command_rejects_directory_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CDB_BLACK_EXECUTABLE", str(tmp_path))
+    with pytest.raises(RuntimeError, match=BLACK_EXECUTABLE_INVALID):
+        _black_command("python.exe")
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        "C:\\tools\\black.exe;calc.exe",
+        "C:\\tools\\black.exe|whoami",
+        "C:\\tools\\black.exe&whoami",
+        "C:\\tools\\$(whoami)\\black.exe",
+        "C:\\tools\\`whoami`\\black.exe",
+    ],
+)
+def test_black_command_rejects_shell_metacharacters(
+    monkeypatch: pytest.MonkeyPatch, unsafe: str
+) -> None:
+    monkeypatch.setenv("CDB_BLACK_EXECUTABLE", unsafe)
+    with pytest.raises(RuntimeError, match=BLACK_EXECUTABLE_INVALID):
         _black_command("python.exe")

--- a/tests/unit/ci/test_lint_stage_black_executable.py
+++ b/tests/unit/ci/test_lint_stage_black_executable.py
@@ -28,8 +28,9 @@ def test_black_command_accepts_existing_explicit_executable(
 ) -> None:
     executable = tmp_path / "black.exe"
     executable.write_bytes(b"test")
-    monkeypatch.setenv("CDB_BLACK_EXECUTABLE", str(executable))
-    assert _black_command("python.exe") == [str(executable)]
+    # Windows-style absolute path with backslashes must remain valid.
+    monkeypatch.setenv("CDB_BLACK_EXECUTABLE", str(executable.resolve()))
+    assert _black_command("python.exe") == [str(executable.resolve())]
 
 
 def test_black_command_rejects_missing_override(

--- a/tests/unit/ci/test_lint_stage_black_executable.py
+++ b/tests/unit/ci/test_lint_stage_black_executable.py
@@ -8,7 +8,9 @@ import pytest
 
 from ci.stages.lint import (
     BLACK_EXECUTABLE_INVALID,
+    BLACK_EXECUTABLE_MISSING,
     _black_command,
+    redact_path_for_evidence,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.contract]
@@ -35,7 +37,7 @@ def test_black_command_rejects_missing_override(
 ) -> None:
     missing = tmp_path / "missing-black.exe"
     monkeypatch.setenv("CDB_BLACK_EXECUTABLE", str(missing))
-    with pytest.raises(RuntimeError, match=BLACK_EXECUTABLE_INVALID):
+    with pytest.raises(RuntimeError, match=BLACK_EXECUTABLE_MISSING):
         _black_command("python.exe")
 
 
@@ -63,3 +65,9 @@ def test_black_command_rejects_shell_metacharacters(
     monkeypatch.setenv("CDB_BLACK_EXECUTABLE", unsafe)
     with pytest.raises(RuntimeError, match=BLACK_EXECUTABLE_INVALID):
         _black_command("python.exe")
+
+
+def test_redact_path_masks_home() -> None:
+    home = str(Path.home())
+    assert redact_path_for_evidence(f"{home}/tools/black") == "$HOME/tools/black"
+    assert redact_path_for_evidence("/opt/other/black") == "/opt/other/black"


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: ci-tooling
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: frozen
objective_key: ci-black-portable
planned_issues: #4206
contract_keys: ci-local-runner-v1
risk_flags: none
-->

## Summary

Portable, timeout-bounded Black for local CI (#4206).

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4206 | SLICE_DELIVERED | 398c2dd948d2c6606a4a01096ca6640d5cbef1d0 | Full Fast-CI PASS + windows path fix | none | none |

Closes #4206