### PR TITLE
feat(ci): add app-bound cdb-local-ci check runs

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -7,8 +7,12 @@ Lokale, Docker-fähige CI-Ausführungsschicht für Claire_de_Binare.
 - **Phase 1:** Scaffold + Evidence-Contract unter `ci/`.
 - **Phase 3a + BP #4169:** Nach strikter Evidence-Validation setzt der
   Status-Publisher (`ci/publisher/`) den Required Commit Status `cdb-local-ci`
-  (interim PAT / Commit Status, noch kein GitHub-App Check Run).
+  (interim PAT / Commit Status, `app_id=null`).
   Siehe [docs/ci/local-status-publisher.md](../docs/ci/local-status-publisher.md).
+- **#4170 Phase A:** Explizites Check-Run-Backend
+  (`--publisher-backend check-run`) ist code-ready; Branch Protection und der
+  Default-Pfad bleiben Commit Status bis zum externen Cutover.
+  Siehe [docs/runbooks/cdb_local_ci_app_check_run_cutover.md](../docs/runbooks/cdb_local_ci_app_check_run_cutover.md).
 - Lokale Evidence allein autorisiert keinen Merge; der published Status
   `cdb-local-ci` ist der live Required Context.
 - `policy-gate.yml` bleibt als Workflow-Safety-Gate; der lokale Mirror

--- a/ci/publisher/__init__.py
+++ b/ci/publisher/__init__.py
@@ -1,7 +1,7 @@
-"""Trusted local CI status publisher (Phase 3a — Commit Status).
+"""Trusted local CI status publisher (Phase 3a Commit Status + #4170 Check Run backend).
 
-Publishes GitHub commit statuses only after fail-closed validation of local
-Docker CI evidence. Check Runs require a GitHub App and are not used here.
+Default publish path remains Commit Status. Check Runs are available only via
+explicit ``--publisher-backend check-run`` with App installation credentials.
 """
 
 from __future__ import annotations

--- a/ci/publisher/backends.py
+++ b/ci/publisher/backends.py
@@ -1,0 +1,528 @@
+"""Publisher backends: Commit Status (interim) and App-bound Check Runs."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.parse import quote
+
+from ci.publisher import EXPECTED_REPOSITORY
+from ci.publisher.exceptions import AuthenticationError, GitHubApiError, PublisherError
+from ci.publisher.github_client import (
+    DEFAULT_TIMEOUT_SECONDS,
+    GITHUB_API,
+    GitHubResponse,
+    GitHubStatusClient,
+    Transport,
+    _default_transport,
+)
+from ci.publisher.models import (
+    CHECK_RUN_NAME,
+    CheckRunPayload,
+    PublishResult,
+    StatusPayload,
+)
+from ci.publisher.redaction import redact_mapping, redact_text
+
+APP_INSTALLATION_TOKEN_ENV = "CDB_GH_APP_INSTALLATION_TOKEN"
+EXPECTED_APP_ID_ENV = "CDB_GH_APP_ID"
+EXPECTED_INSTALLATION_ID_ENV = "CDB_GH_APP_INSTALLATION_ID"
+ALLOWED_BACKENDS = frozenset({"commit-status", "check-run"})
+_DEFAULT_OWNER, _DEFAULT_REPO = EXPECTED_REPOSITORY.split("/", 1)
+
+
+def parse_positive_int(value: object, *, field_name: str) -> int:
+    """Parse a required positive integer (App / Installation ID)."""
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise PublisherError(
+            f"{field_name} must be a positive integer, got {value!r}"
+        ) from exc
+    if parsed <= 0:
+        raise PublisherError(f"{field_name} must be a positive integer, got {parsed}")
+    return parsed
+
+
+def resolve_app_installation_token(*, explicit: str | None = None) -> str:
+    """Resolve GitHub App installation token — never gh auth / GITHUB_TOKEN / GH_TOKEN.
+
+    Only ``CDB_GH_APP_INSTALLATION_TOKEN`` (or an explicit test inject) is accepted.
+    """
+    if explicit is not None:
+        token = explicit.strip()
+        if not token:
+            raise AuthenticationError("Empty GitHub App installation token")
+        return token
+    token = (os.environ.get(APP_INSTALLATION_TOKEN_ENV) or "").strip()
+    if not token:
+        raise AuthenticationError(
+            f"Missing {APP_INSTALLATION_TOKEN_ENV}; Check Run mode refuses "
+            "GITHUB_TOKEN / GH_TOKEN / gh auth token as App identity proof"
+        )
+    return token
+
+
+def resolve_expected_app_id(
+    *, cli_value: int | None = None, require: bool = True
+) -> int | None:
+    if cli_value is not None:
+        return parse_positive_int(cli_value, field_name="expected-app-id")
+    env_raw = (os.environ.get(EXPECTED_APP_ID_ENV) or "").strip()
+    if env_raw:
+        return parse_positive_int(env_raw, field_name=EXPECTED_APP_ID_ENV)
+    if require:
+        raise PublisherError(
+            f"Check Run mode requires --expected-app-id or {EXPECTED_APP_ID_ENV}"
+        )
+    return None
+
+
+def resolve_expected_installation_id(
+    *, cli_value: int | None = None, require: bool = True
+) -> int | None:
+    if cli_value is not None:
+        return parse_positive_int(cli_value, field_name="expected-installation-id")
+    env_raw = (os.environ.get(EXPECTED_INSTALLATION_ID_ENV) or "").strip()
+    if env_raw:
+        return parse_positive_int(env_raw, field_name=EXPECTED_INSTALLATION_ID_ENV)
+    if require:
+        raise PublisherError(
+            "Check Run mode requires --expected-installation-id or "
+            f"{EXPECTED_INSTALLATION_ID_ENV}"
+        )
+    return None
+
+
+class PublisherBackend(Protocol):
+    """Internal protocol for deterministic publish + remote verification."""
+
+    name: str
+
+    def publish(
+        self,
+        *,
+        status_payload: StatusPayload | None = None,
+        check_run_payload: CheckRunPayload | None = None,
+        dry_run: bool = False,
+    ) -> PublishResult: ...
+
+
+@dataclass(frozen=True)
+class CommitStatusBackend:
+    """Wraps existing Commit Status publish behaviour during the transition."""
+
+    client: GitHubStatusClient
+    name: str = "commit-status"
+
+    def publish(
+        self,
+        *,
+        status_payload: StatusPayload | None = None,
+        check_run_payload: CheckRunPayload | None = None,
+        dry_run: bool = False,
+    ) -> PublishResult:
+        if check_run_payload is not None:
+            raise PublisherError(
+                "CommitStatusBackend rejects Check Run payloads "
+                "(no silent backend mix)"
+            )
+        if status_payload is None:
+            raise PublisherError("CommitStatusBackend requires StatusPayload")
+        body = status_payload.to_api_body()
+        if dry_run:
+            raw = {"dry_run": True, "sha": status_payload.sha, "body": body}
+            return PublishResult(
+                ok=True,
+                publisher_backend="commit-status",
+                github_object_type="commit_status",
+                remote_id=None,
+                head_sha=status_payload.sha,
+                dry_run=True,
+                idempotent_noop=False,
+                remote_verification_status="dry_run",
+                payload_body=body,
+                raw=raw,
+            )
+        raw = self.client.create_commit_status(status_payload, dry_run=False)
+        status_id = raw.get("id")
+        return PublishResult(
+            ok=True,
+            publisher_backend="commit-status",
+            github_object_type="commit_status",
+            remote_id=int(status_id) if status_id is not None else None,
+            head_sha=status_payload.sha,
+            dry_run=False,
+            idempotent_noop=False,
+            remote_verification_status="written",
+            payload_body=body,
+            raw=redact_mapping(raw) if isinstance(raw, dict) else {"result": raw},
+        )
+
+
+class CheckRunBackend:
+    """Create and verify GitHub Check Runs with an App installation token only."""
+
+    name = "check-run"
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        expected_app_id: int,
+        expected_installation_id: int,
+        owner: str = _DEFAULT_OWNER,
+        repo: str = _DEFAULT_REPO,
+        transport: Transport | None = None,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        if not token:
+            raise AuthenticationError("Empty GitHub App installation token")
+        self._token = token
+        self.expected_app_id = parse_positive_int(
+            expected_app_id, field_name="expected_app_id"
+        )
+        self.expected_installation_id = parse_positive_int(
+            expected_installation_id, field_name="expected_installation_id"
+        )
+        self.owner = owner
+        self.repo = repo
+        if f"{owner}/{repo}" != EXPECTED_REPOSITORY:
+            raise PublisherError(
+                "CheckRunBackend refuses non-canonical repository target"
+            )
+        self._transport = transport or _default_transport
+        self._timeout = timeout_seconds
+        self.write_calls: list[dict[str, Any]] = []
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self._token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "cdb-local-ci-check-run-publisher",
+            "Content-Type": "application/json",
+        }
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+    ) -> GitHubResponse:
+        url = f"{GITHUB_API}{path}"
+        encoded = (
+            json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            if body is not None
+            else None
+        )
+        try:
+            response = self._transport(
+                method, url, self._headers(), encoded, self._timeout
+            )
+        except TimeoutError as exc:
+            raise GitHubApiError("GitHub Check Run API request timed out") from exc
+        remaining = response.headers.get("x-ratelimit-remaining")
+        if remaining == "0" and response.status_code in {403, 429}:
+            raise GitHubApiError("GitHub API rate limit prevents reliable verification")
+        return response
+
+    def _raise_for_status(self, response: GitHubResponse, *, action: str) -> None:
+        if response.status_code in {401, 403}:
+            raise AuthenticationError(
+                f"Insufficient App permission to {action} Check Run"
+            )
+        if response.status_code == 429:
+            raise GitHubApiError("GitHub API rate limit prevents Check Run publish")
+        if response.status_code in {404, 422}:
+            raise GitHubApiError(
+                f"Check Run {action} failed HTTP {response.status_code}: "
+                f"{redact_mapping(response.body)}"
+            )
+        if response.status_code >= 400:
+            raise GitHubApiError(
+                f"Ambiguous Check Run {action} HTTP {response.status_code}: "
+                f"{redact_mapping(response.body)}"
+            )
+
+    def get_check_run(self, check_run_id: int) -> dict[str, Any]:
+        path = f"/repos/{self.owner}/{self.repo}/check-runs/{int(check_run_id)}"
+        response = self._request("GET", path)
+        self._raise_for_status(response, action="read")
+        if not isinstance(response.body, dict):
+            raise GitHubApiError("Ambiguous Check Run read payload")
+        return response.body
+
+    def list_check_runs_for_sha(
+        self, sha: str, *, check_name: str | None = None
+    ) -> list[dict[str, Any]]:
+        path = f"/repos/{self.owner}/{self.repo}/commits/{quote(sha)}/check-runs"
+        if check_name:
+            path = f"{path}?check_name={quote(check_name)}&filter=latest"
+        response = self._request("GET", path)
+        self._raise_for_status(response, action="list")
+        body = response.body
+        if not isinstance(body, dict):
+            raise GitHubApiError("Ambiguous Check Run list payload")
+        runs = body.get("check_runs")
+        if not isinstance(runs, list):
+            raise GitHubApiError("Ambiguous Check Run list check_runs field")
+        return [item for item in runs if isinstance(item, dict)]
+
+    def find_by_external_id(
+        self, *, sha: str, external_id: str, check_name: str
+    ) -> dict[str, Any] | None:
+        matches = [
+            run
+            for run in self.list_check_runs_for_sha(sha, check_name=check_name)
+            if str(run.get("external_id") or "") == external_id
+        ]
+        if not matches:
+            # Broader scan without name filter in case name drifted.
+            matches = [
+                run
+                for run in self.list_check_runs_for_sha(sha)
+                if str(run.get("external_id") or "") == external_id
+            ]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise GitHubApiError(
+                f"Ambiguous Check Run external_id {external_id!r}: "
+                f"{len(matches)} matches"
+            )
+        return matches[0]
+
+    def verify_remote_check_run(
+        self,
+        remote: dict[str, Any],
+        *,
+        payload: CheckRunPayload,
+    ) -> dict[str, Any]:
+        app = remote.get("app")
+        if not isinstance(app, dict) or app.get("id") is None:
+            raise GitHubApiError("Remote Check Run missing app identity")
+        remote_app_id = parse_positive_int(app.get("id"), field_name="remote app.id")
+        if remote_app_id != self.expected_app_id:
+            raise GitHubApiError(
+                f"Remote app.id {remote_app_id} does not match expected "
+                f"{self.expected_app_id}"
+            )
+        remote_name = str(remote.get("name") or "")
+        if remote_name != payload.name:
+            raise GitHubApiError(
+                f"Remote Check Run name {remote_name!r} != {payload.name!r}"
+            )
+        remote_sha = str(remote.get("head_sha") or "").lower()
+        if remote_sha != payload.head_sha.lower():
+            raise GitHubApiError(
+                f"Remote head_sha {remote_sha} != {payload.head_sha.lower()}"
+            )
+        if str(remote.get("status") or "") != "completed":
+            raise GitHubApiError(
+                f"Remote Check Run status is not completed: {remote.get('status')!r}"
+            )
+        if str(remote.get("conclusion") or "") != payload.conclusion:
+            raise GitHubApiError(
+                f"Remote conclusion {remote.get('conclusion')!r} != "
+                f"{payload.conclusion!r}"
+            )
+        if str(remote.get("external_id") or "") != payload.external_id:
+            raise GitHubApiError(
+                f"Remote external_id {remote.get('external_id')!r} != "
+                f"{payload.external_id!r}"
+            )
+        return {
+            "remote_verification_status": "verified",
+            "github_app_id": remote_app_id,
+            "github_check_run_id": int(remote["id"]) if remote.get("id") else None,
+            "check_run_name": remote_name,
+            "head_sha": remote_sha,
+            "external_id": payload.external_id,
+        }
+
+    def _assert_no_external_id_conflict(
+        self, existing: dict[str, Any], payload: CheckRunPayload
+    ) -> None:
+        existing_sha = str(existing.get("head_sha") or "").lower()
+        if existing_sha and existing_sha != payload.head_sha.lower():
+            raise PublisherError(
+                f"external_id {payload.external_id!r} already bound to SHA "
+                f"{existing_sha}, refusing {payload.head_sha.lower()}"
+            )
+        existing_conclusion = str(existing.get("conclusion") or "")
+        if existing_conclusion and existing_conclusion != payload.conclusion:
+            raise PublisherError(
+                f"external_id {payload.external_id!r} already concluded "
+                f"{existing_conclusion!r}, refusing {payload.conclusion!r}"
+            )
+
+    def publish(
+        self,
+        *,
+        status_payload: StatusPayload | None = None,
+        check_run_payload: CheckRunPayload | None = None,
+        dry_run: bool = False,
+    ) -> PublishResult:
+        if status_payload is not None:
+            raise PublisherError(
+                "CheckRunBackend rejects Commit Status payloads "
+                "(no silent fallback to Commit Status)"
+            )
+        if check_run_payload is None:
+            raise PublisherError("CheckRunBackend requires CheckRunPayload")
+        payload = check_run_payload
+        if payload.conclusion == "success" and not payload.head_sha:
+            raise GitHubApiError("Refusing success Check Run without commit SHA")
+        body = payload.to_api_body()
+        record = {
+            "head_sha": payload.head_sha,
+            "body": body,
+            "dry_run": dry_run,
+            "expected_app_id": self.expected_app_id,
+            "expected_installation_id": self.expected_installation_id,
+        }
+        self.write_calls.append(record)
+        if dry_run:
+            return PublishResult(
+                ok=True,
+                publisher_backend="check-run",
+                github_object_type="check_run",
+                remote_id=None,
+                head_sha=payload.head_sha,
+                dry_run=True,
+                idempotent_noop=False,
+                remote_verification_status="dry_run",
+                payload_body=body,
+                raw={"dry_run": True, "body": body},
+                external_id=payload.external_id,
+                github_app_id=self.expected_app_id,
+                github_installation_id=self.expected_installation_id,
+                check_run_name=payload.name,
+            )
+
+        existing = self.find_by_external_id(
+            sha=payload.head_sha,
+            external_id=payload.external_id,
+            check_name=payload.name or CHECK_RUN_NAME,
+        )
+        if existing is not None:
+            self._assert_no_external_id_conflict(existing, payload)
+            verified = self.verify_remote_check_run(existing, payload=payload)
+            return PublishResult(
+                ok=True,
+                publisher_backend="check-run",
+                github_object_type="check_run",
+                remote_id=verified.get("github_check_run_id"),
+                head_sha=payload.head_sha,
+                dry_run=False,
+                idempotent_noop=True,
+                remote_verification_status="verified",
+                payload_body=body,
+                raw=redact_mapping(existing),
+                external_id=payload.external_id,
+                github_app_id=self.expected_app_id,
+                github_installation_id=self.expected_installation_id,
+                check_run_name=payload.name,
+            )
+
+        path = f"/repos/{self.owner}/{self.repo}/check-runs"
+        try:
+            response = self._request("POST", path, body=body)
+        except GitHubApiError as exc:
+            # Ambiguous write → attempt readback by external_id instead of blind retry.
+            if "timed out" in str(exc).lower():
+                recovered = self.find_by_external_id(
+                    sha=payload.head_sha,
+                    external_id=payload.external_id,
+                    check_name=payload.name,
+                )
+                if recovered is None:
+                    raise GitHubApiError(
+                        "Check Run write timed out and remote readback found nothing"
+                    ) from exc
+                self._assert_no_external_id_conflict(recovered, payload)
+                verified = self.verify_remote_check_run(recovered, payload=payload)
+                return PublishResult(
+                    ok=True,
+                    publisher_backend="check-run",
+                    github_object_type="check_run",
+                    remote_id=verified.get("github_check_run_id"),
+                    head_sha=payload.head_sha,
+                    dry_run=False,
+                    idempotent_noop=False,
+                    remote_verification_status="verified_after_timeout",
+                    payload_body=body,
+                    raw=redact_mapping(recovered),
+                    external_id=payload.external_id,
+                    github_app_id=self.expected_app_id,
+                    github_installation_id=self.expected_installation_id,
+                    check_run_name=payload.name,
+                )
+            raise
+
+        self._raise_for_status(response, action="create")
+        if not isinstance(response.body, dict):
+            raise GitHubApiError("Ambiguous Check Run create response")
+        created = response.body
+        check_run_id = created.get("id")
+        if check_run_id is None:
+            raise GitHubApiError("Check Run create response missing id")
+        # Mandatory readback — publish is confirmed only after verified remote.
+        remote = self.get_check_run(int(check_run_id))
+        verified = self.verify_remote_check_run(remote, payload=payload)
+        return PublishResult(
+            ok=True,
+            publisher_backend="check-run",
+            github_object_type="check_run",
+            remote_id=verified.get("github_check_run_id"),
+            head_sha=payload.head_sha,
+            dry_run=False,
+            idempotent_noop=False,
+            remote_verification_status="verified",
+            payload_body=body,
+            raw=redact_mapping(remote),
+            external_id=payload.external_id,
+            github_app_id=self.expected_app_id,
+            github_installation_id=self.expected_installation_id,
+            check_run_name=payload.name,
+        )
+
+
+def build_publisher_backend(
+    *,
+    backend: str,
+    status_client: GitHubStatusClient | None = None,
+    app_token: str | None = None,
+    expected_app_id: int | None = None,
+    expected_installation_id: int | None = None,
+    owner: str = _DEFAULT_OWNER,
+    repo: str = _DEFAULT_REPO,
+    transport: Transport | None = None,
+) -> PublisherBackend:
+    if backend not in ALLOWED_BACKENDS:
+        raise PublisherError(
+            f"Unknown publisher backend {backend!r}; "
+            f"allowed: {sorted(ALLOWED_BACKENDS)}"
+        )
+    if backend == "commit-status":
+        if status_client is None:
+            raise PublisherError("commit-status backend requires GitHubStatusClient")
+        return CommitStatusBackend(client=status_client)
+    token = resolve_app_installation_token(explicit=app_token)
+    app_id = resolve_expected_app_id(cli_value=expected_app_id, require=True)
+    installation_id = resolve_expected_installation_id(
+        cli_value=expected_installation_id, require=True
+    )
+    assert app_id is not None and installation_id is not None
+    return CheckRunBackend(
+        token=token,
+        expected_app_id=app_id,
+        expected_installation_id=installation_id,
+        owner=owner,
+        repo=repo,
+        transport=transport,
+    )

--- a/ci/publisher/cli.py
+++ b/ci/publisher/cli.py
@@ -11,7 +11,19 @@ from typing import Any, Sequence
 from ci.lib.evidence import DEFAULT_FRESHNESS_HOURS, utc_now
 from ci.lib.gitinfo import EXPECTED_REPOSITORY, collect_git_info
 from ci.publisher import DEFAULT_STATUS_CONTEXT, PREVIEW_STATUS_CONTEXT
-from ci.publisher.evidence import validate_evidence_for_publish
+from ci.publisher.backends import (
+    ALLOWED_BACKENDS,
+    CheckRunBackend,
+    build_publisher_backend,
+    parse_positive_int,
+    resolve_app_installation_token,
+    resolve_expected_app_id,
+    resolve_expected_installation_id,
+)
+from ci.publisher.evidence import (
+    build_check_run_payload,
+    validate_evidence_for_publish,
+)
 from ci.publisher.exceptions import (
     AuthenticationError,
     GitHubApiError,
@@ -27,6 +39,7 @@ from ci.publisher.ledger import (
     find_exact_publication,
     load_ledger,
 )
+from ci.publisher.models import CHECK_RUN_NAME, SHADOW_CHECK_RUN_NAME
 from ci.publisher.redaction import redact_mapping, redact_text
 from tools.ci.policy_gate_local import evaluate_policy_gate
 
@@ -110,7 +123,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--target-url",
         default="",
-        help="Optional target URL attached to the status",
+        help="Optional target URL attached to the status / details_url",
     )
     parser.add_argument(
         "--ledger",
@@ -121,6 +134,35 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         "--repo-root",
         default="",
         help="Repository root for git binding (default: detected)",
+    )
+    parser.add_argument(
+        "--publisher-backend",
+        default="commit-status",
+        choices=sorted(ALLOWED_BACKENDS),
+        help=(
+            "Publish surface: commit-status (default, interim required path) or "
+            "check-run (explicit App-bound; Branch Protection unchanged until cutover)"
+        ),
+    )
+    parser.add_argument(
+        "--expected-app-id",
+        type=int,
+        default=0,
+        help="Expected GitHub App ID (required for check-run; positive int)",
+    )
+    parser.add_argument(
+        "--expected-installation-id",
+        type=int,
+        default=0,
+        help="Expected GitHub App installation ID (required for check-run)",
+    )
+    parser.add_argument(
+        "--check-run-name",
+        default=CHECK_RUN_NAME,
+        help=(
+            f"Check Run name (default {CHECK_RUN_NAME}; shadow "
+            f"{SHADOW_CHECK_RUN_NAME} for non-required smoke only)"
+        ),
     )
 
 
@@ -149,6 +191,27 @@ def _require_pr_for_required_context(args: argparse.Namespace) -> None:
             f"--pr-number > 0 is required when --status-context is "
             f"{DEFAULT_STATUS_CONTEXT} (local policy-gate mirror at publish time)"
         )
+
+
+def _backend_name(args: argparse.Namespace) -> str:
+    backend = str(
+        getattr(args, "publisher_backend", "commit-status") or "commit-status"
+    )
+    if backend not in ALLOWED_BACKENDS:
+        raise PublisherError(
+            f"Unknown publisher backend {backend!r}; "
+            f"allowed: {sorted(ALLOWED_BACKENDS)}"
+        )
+    return backend
+
+
+def _cli_app_ids(args: argparse.Namespace) -> tuple[int | None, int | None]:
+    app_id = int(getattr(args, "expected_app_id", 0) or 0)
+    installation_id = int(getattr(args, "expected_installation_id", 0) or 0)
+    return (
+        app_id if app_id > 0 else None,
+        installation_id if installation_id > 0 else None,
+    )
 
 
 def _pr_labels(pr: dict[str, Any]) -> list[str]:
@@ -220,6 +283,25 @@ def _assert_clean_live_worktree(repo_root: Path) -> None:
         )
 
 
+def _build_check_run_from_validation(result: Any, args: argparse.Namespace) -> Any:
+    started = str(result.started_at_utc or "")
+    ended = str(result.ended_at_utc or "")
+    if not started or not ended:
+        raise PublisherError(
+            "Check Run mode requires started_at_utc and ended_at_utc in evidence"
+        )
+    return build_check_run_payload(
+        commit_sha=result.commit_sha,
+        run_id=result.run_id,
+        ok=True,
+        started_at_utc=started,
+        ended_at_utc=ended,
+        target_url=args.target_url or None,
+        optional_skipped=result.optional_skipped,
+        name=str(getattr(args, "check_run_name", None) or CHECK_RUN_NAME),
+    )
+
+
 def cmd_validate(args: argparse.Namespace) -> int:
     repo_root, evidence_dir, ledger_path = _resolve_paths(args)
     commit_sha = _resolve_commit_sha(args, repo_root)
@@ -250,8 +332,21 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 optional_skipped=result.optional_skipped,
                 reason=str(exc),
                 intended_payload=None,
+                started_at_utc=result.started_at_utc,
+                ended_at_utc=result.ended_at_utc,
             )
-    _print_json({"command": "validate", **result.to_dict()})
+    out: dict[str, Any] = {"command": "validate", **result.to_dict()}
+    if result.ok and _backend_name(args) == "check-run":
+        try:
+            check_payload = _build_check_run_from_validation(result, args)
+            out["intended_check_run_payload"] = check_payload.to_api_body()
+        except PublisherError as exc:
+            out["ok"] = False
+            out["reason"] = str(exc)
+            _print_json(out)
+            print(f"REJECT: {redact_text(str(exc))}", file=sys.stderr)
+            return FAILURE_EXIT
+    _print_json(out)
     if not result.ok:
         print(
             f"REJECT: {redact_text(result.reason or 'validation failed')}",
@@ -264,6 +359,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
 def cmd_dry_run(args: argparse.Namespace) -> int:
     try:
         _require_pr_for_required_context(args)
+        backend = _backend_name(args)
     except PublisherError as exc:
         print(f"REJECT: {redact_text(str(exc))}", file=sys.stderr)
         _print_json(
@@ -335,10 +431,65 @@ def cmd_dry_run(args: argparse.Namespace) -> int:
                     }
                 )
                 return FAILURE_EXIT
-        # Dry-run client never writes.
-        client = GitHubStatusClient(token="dry-run-token")
-        github_body = client.create_commit_status(result.intended_payload, dry_run=True)
-        write_attempted = any(not c.get("dry_run") for c in client.write_calls)
+        try:
+            owner, repo = result.repository.split("/", 1)
+            app_id, installation_id = _cli_app_ids(args)
+            if backend == "check-run":
+                # Dry-run must not require a live App token; inject a placeholder
+                # for payload shaping only — never used for network writes.
+                check_payload = _build_check_run_from_validation(result, args)
+                publisher = build_publisher_backend(
+                    backend=backend,
+                    app_token="dry-run-app-installation-token",
+                    expected_app_id=resolve_expected_app_id(
+                        cli_value=app_id, require=True
+                    ),
+                    expected_installation_id=resolve_expected_installation_id(
+                        cli_value=installation_id, require=True
+                    ),
+                    owner=owner,
+                    repo=repo,
+                )
+                publish_result = publisher.publish(
+                    check_run_payload=check_payload, dry_run=True
+                )
+                github_body = {
+                    "dry_run": True,
+                    "publisher_backend": backend,
+                    "body": publish_result.payload_body,
+                    "expected_app_id": publish_result.github_app_id,
+                    "expected_installation_id": publish_result.github_installation_id,
+                }
+                write_attempted = any(
+                    not c.get("dry_run") for c in getattr(publisher, "write_calls", [])
+                )
+            else:
+                client = GitHubStatusClient(token="dry-run-token")
+                publisher = build_publisher_backend(
+                    backend=backend, status_client=client, owner=owner, repo=repo
+                )
+                publish_result = publisher.publish(
+                    status_payload=result.intended_payload, dry_run=True
+                )
+                github_body = {
+                    "dry_run": True,
+                    "publisher_backend": backend,
+                    "sha": result.intended_payload.sha,
+                    "body": publish_result.payload_body,
+                }
+                write_attempted = any(not c.get("dry_run") for c in client.write_calls)
+        except (AuthenticationError, GitHubApiError, PublisherError) as exc:
+            print(f"REJECT: {redact_text(str(exc))}", file=sys.stderr)
+            _print_json(
+                {
+                    "command": "dry-run",
+                    "ok": False,
+                    "reason": redact_text(str(exc)),
+                    "write_attempted": False,
+                    "publisher_backend": backend,
+                }
+            )
+            return FAILURE_EXIT
     payload: dict[str, Any] = {
         "command": "dry-run",
         "ok": result.ok,
@@ -347,6 +498,7 @@ def cmd_dry_run(args: argparse.Namespace) -> int:
         "github_payload": github_body,
         "write_attempted": write_attempted,
         "network_write": False,
+        "publisher_backend": backend,
     }
     if policy_result is not None:
         payload["policy_gate"] = policy_result
@@ -363,6 +515,7 @@ def cmd_dry_run(args: argparse.Namespace) -> int:
 def cmd_publish(args: argparse.Namespace) -> int:
     try:
         _require_pr_for_required_context(args)
+        backend = _backend_name(args)
     except PublisherError as exc:
         print(f"REJECT: {redact_text(str(exc))}", file=sys.stderr)
         _print_json({"command": "publish", "ok": False, "reason": str(exc)})
@@ -388,84 +541,154 @@ def cmd_publish(args: argparse.Namespace) -> int:
         return FAILURE_EXIT
 
     try:
-        token = resolve_token()
         owner, repo = result.repository.split("/", 1)
-        client = GitHubStatusClient(token=token, owner=owner, repo=repo)
-        client.assert_commit_exists(commit_sha)
+        # Reads (commit exists, PR head, policy gate) stay on the interim token path.
+        read_token = resolve_token()
+        read_client = GitHubStatusClient(token=read_token, owner=owner, repo=repo)
+        read_client.assert_commit_exists(commit_sha)
         policy_result: dict[str, Any] | None = None
         if int(args.pr_number or 0) > 0:
             policy_result = enforce_policy_gate_for_pr(
-                client, pr_number=int(args.pr_number), commit_sha=commit_sha
+                read_client, pr_number=int(args.pr_number), commit_sha=commit_sha
             )
         ledger = load_ledger(ledger_path)
         assert_run_id_not_reused(
             ledger, run_id=result.run_id, commit_sha=result.commit_sha
         )
-        # Live dirty worktree re-check immediately before write.
         _assert_clean_live_worktree(repo_root)
-        # Final verification immediately before write.
-        client.assert_commit_exists(commit_sha)
+        read_client.assert_commit_exists(commit_sha)
         if int(args.pr_number or 0) > 0:
-            head = client.get_pull_request_head_sha(int(args.pr_number))
+            head = read_client.get_pull_request_head_sha(int(args.pr_number))
             if head.lower() != commit_sha.lower():
                 raise PublisherError(
                     f"PR #{args.pr_number} head SHA {head} does not match "
                     f"commit_sha {commit_sha}"
                 )
-        prior = find_exact_publication(
-            ledger,
-            run_id=result.run_id,
-            commit_sha=result.commit_sha,
-            repository=result.repository,
-            status_context=args.status_context,
-            manifest_sha256=result.manifest_sha256,
-            state=result.intended_payload.state,
-        )
-        idempotent_noop = False
-        if prior is not None:
-            live = client.get_commit_status(commit_sha)
-            latest = _latest_context_status(
-                live.get("statuses"), context=args.status_context
+
+        app_id, installation_id = _cli_app_ids(args)
+        if backend == "check-run":
+            check_payload = _build_check_run_from_validation(result, args)
+            publisher = build_publisher_backend(
+                backend=backend,
+                app_token=resolve_app_installation_token(),
+                expected_app_id=resolve_expected_app_id(cli_value=app_id, require=True),
+                expected_installation_id=resolve_expected_installation_id(
+                    cli_value=installation_id, require=True
+                ),
+                owner=owner,
+                repo=repo,
             )
-            expected_body = result.intended_payload.to_api_body()
-            expected_status_id = prior.get("github_status_id")
-            if latest is not None and all(
-                (
-                    latest.get("state") == expected_body["state"],
-                    latest.get("description") == expected_body["description"],
-                    latest.get("target_url") == expected_body.get("target_url"),
-                    expected_status_id is not None,
-                    str(latest.get("id")) == str(expected_status_id),
+            publish_result = publisher.publish(
+                check_run_payload=check_payload, dry_run=False
+            )
+            if not publish_result.idempotent_noop:
+                append_entry(
+                    ledger_path,
+                    LedgerEntry(
+                        run_id=result.run_id,
+                        commit_sha=result.commit_sha,
+                        repository=result.repository,
+                        status_context=args.status_context,
+                        manifest_sha256=result.manifest_sha256,
+                        published_at_utc=utc_now(),
+                        state=check_payload.conclusion,
+                        publisher_backend="check-run",
+                        github_object_type="check_run",
+                        github_check_run_id=publish_result.remote_id,
+                        github_app_id=publish_result.github_app_id,
+                        github_installation_id=publish_result.github_installation_id,
+                        check_run_name=publish_result.check_run_name,
+                        head_sha=publish_result.head_sha,
+                        external_id=publish_result.external_id,
+                        remote_verification_status=(
+                            publish_result.remote_verification_status
+                        ),
+                    ),
                 )
-            ):
+            api_result = {
+                "id": publish_result.remote_id,
+                "conclusion": check_payload.conclusion,
+                "name": check_payload.name,
+                "head_sha": commit_sha,
+                "external_id": check_payload.external_id,
+                "idempotent_noop": publish_result.idempotent_noop,
+                "remote_verification_status": (
+                    publish_result.remote_verification_status
+                ),
+                "app_id": publish_result.github_app_id,
+            }
+        else:
+            prior = find_exact_publication(
+                ledger,
+                run_id=result.run_id,
+                commit_sha=result.commit_sha,
+                repository=result.repository,
+                status_context=args.status_context,
+                manifest_sha256=result.manifest_sha256,
+                state=result.intended_payload.state,
+            )
+            idempotent_noop = False
+            api_result: dict[str, Any]
+            if prior is not None:
+                live = read_client.get_commit_status(commit_sha)
+                latest = _latest_context_status(
+                    live.get("statuses"), context=args.status_context
+                )
+                expected_body = result.intended_payload.to_api_body()
+                expected_status_id = prior.get("github_status_id")
+                if latest is not None and all(
+                    (
+                        latest.get("state") == expected_body["state"],
+                        latest.get("description") == expected_body["description"],
+                        latest.get("target_url") == expected_body.get("target_url"),
+                        expected_status_id is not None,
+                        str(latest.get("id")) == str(expected_status_id),
+                    )
+                ):
+                    api_result = {
+                        "id": prior.get("github_status_id"),
+                        "state": result.intended_payload.state,
+                        "context": args.status_context,
+                        "sha": commit_sha,
+                        "idempotent_noop": True,
+                    }
+                    idempotent_noop = True
+            if not idempotent_noop:
+                publisher = build_publisher_backend(
+                    backend=backend,
+                    status_client=read_client,
+                    owner=owner,
+                    repo=repo,
+                )
+                publish_result = publisher.publish(
+                    status_payload=result.intended_payload, dry_run=False
+                )
                 api_result = {
-                    "id": prior.get("github_status_id"),
+                    "id": publish_result.remote_id,
                     "state": result.intended_payload.state,
                     "context": args.status_context,
                     "sha": commit_sha,
-                    "idempotent_noop": True,
+                    "idempotent_noop": False,
                 }
-                idempotent_noop = True
-        if not idempotent_noop:
-            api_result = client.create_commit_status(
-                result.intended_payload, dry_run=False
-            )
-            status_id = api_result.get("id")
-            append_entry(
-                ledger_path,
-                LedgerEntry(
-                    run_id=result.run_id,
-                    commit_sha=result.commit_sha,
-                    repository=result.repository,
-                    status_context=args.status_context,
-                    manifest_sha256=result.manifest_sha256,
-                    published_at_utc=utc_now(),
-                    github_status_id=(
-                        int(status_id) if status_id is not None else None
+                append_entry(
+                    ledger_path,
+                    LedgerEntry(
+                        run_id=result.run_id,
+                        commit_sha=result.commit_sha,
+                        repository=result.repository,
+                        status_context=args.status_context,
+                        manifest_sha256=result.manifest_sha256,
+                        published_at_utc=utc_now(),
+                        github_status_id=publish_result.remote_id,
+                        state=result.intended_payload.state,
+                        publisher_backend="commit-status",
+                        github_object_type="commit_status",
+                        head_sha=commit_sha,
+                        remote_verification_status=(
+                            publish_result.remote_verification_status
+                        ),
                     ),
-                    state=result.intended_payload.state,
-                ),
-            )
+                )
     except (AuthenticationError, GitHubApiError, LedgerError, PublisherError) as exc:
         print(f"REJECT: {redact_text(str(exc))}", file=sys.stderr)
         _print_json(
@@ -473,6 +696,7 @@ def cmd_publish(args: argparse.Namespace) -> int:
                 "command": "publish",
                 "ok": False,
                 "reason": redact_text(str(exc)),
+                "publisher_backend": backend,
             }
         )
         return FAILURE_EXIT
@@ -484,6 +708,7 @@ def cmd_publish(args: argparse.Namespace) -> int:
         "context": args.status_context,
         "state": result.intended_payload.state,
         "run_id": result.run_id,
+        "publisher_backend": backend,
         "github": redact_mapping(api_result),
         "optional_skipped": result.optional_skipped,
     }
@@ -496,12 +721,70 @@ def cmd_publish(args: argparse.Namespace) -> int:
 def cmd_inspect(args: argparse.Namespace) -> int:
     repo_root, _evidence_dir, _ledger = _resolve_paths(args)
     commit_sha = _resolve_commit_sha(args, repo_root)
+    backend = _backend_name(args)
     try:
-        token = resolve_token()
         owner, repo = (args.repository or EXPECTED_REPOSITORY).split("/", 1)
+        if backend == "check-run":
+            app_id, installation_id = _cli_app_ids(args)
+            expected_app_id = resolve_expected_app_id(cli_value=app_id, require=True)
+            expected_installation_id = resolve_expected_installation_id(
+                cli_value=installation_id, require=True
+            )
+            assert expected_app_id is not None
+            assert expected_installation_id is not None
+            check_client = CheckRunBackend(
+                token=resolve_app_installation_token(),
+                expected_app_id=expected_app_id,
+                expected_installation_id=expected_installation_id,
+                owner=owner,
+                repo=repo,
+            )
+            name = str(getattr(args, "check_run_name", None) or CHECK_RUN_NAME)
+            runs = check_client.list_check_runs_for_sha(commit_sha, check_name=name)
+            filtered = []
+            for entry in runs:
+                app = entry.get("app") if isinstance(entry.get("app"), dict) else {}
+                remote_app_id = app.get("id")
+                if remote_app_id is not None:
+                    try:
+                        if (
+                            parse_positive_int(
+                                remote_app_id, field_name="remote app.id"
+                            )
+                            != expected_app_id
+                        ):
+                            continue
+                    except PublisherError:
+                        continue
+                filtered.append(
+                    {
+                        "id": entry.get("id"),
+                        "name": entry.get("name"),
+                        "head_sha": entry.get("head_sha"),
+                        "status": entry.get("status"),
+                        "conclusion": entry.get("conclusion"),
+                        "external_id": entry.get("external_id"),
+                        "app_id": remote_app_id,
+                        "html_url": entry.get("html_url"),
+                    }
+                )
+            _print_json(
+                {
+                    "command": "inspect",
+                    "publisher_backend": backend,
+                    "sha": commit_sha,
+                    "check_run_name": name,
+                    "expected_app_id": expected_app_id,
+                    "check_runs": filtered,
+                    "total_count": len(filtered),
+                }
+            )
+            return SUCCESS_EXIT
+
+        token = resolve_token()
         client = GitHubStatusClient(token=token, owner=owner, repo=repo)
         status = client.get_commit_status(commit_sha)
-    except (AuthenticationError, GitHubApiError) as exc:
+    except (AuthenticationError, GitHubApiError, PublisherError) as exc:
         print(f"REJECT: {redact_text(str(exc))}", file=sys.stderr)
         return FAILURE_EXIT
     contexts = []
@@ -515,7 +798,7 @@ def cmd_inspect(args: argparse.Namespace) -> int:
                 "target_url": entry.get("target_url"),
             }
         )
-    filtered = [
+    filtered_statuses = [
         c
         for c in contexts
         if not args.status_context or c.get("context") == args.status_context
@@ -523,9 +806,10 @@ def cmd_inspect(args: argparse.Namespace) -> int:
     _print_json(
         {
             "command": "inspect",
+            "publisher_backend": backend,
             "sha": commit_sha,
             "state": status.get("state"),
-            "statuses": filtered if args.status_context else contexts,
+            "statuses": filtered_statuses if args.status_context else contexts,
             "total_count": status.get("total_count"),
         }
     )
@@ -537,7 +821,9 @@ def build_parser() -> argparse.ArgumentParser:
         prog="python -m ci.publisher",
         description=(
             "Validate local Docker CI evidence and publish a commit-bound "
-            "GitHub Commit Status (not a Required Check / not a Check Run App)."
+            "GitHub Commit Status (default) or an explicit App-bound Check Run "
+            "(--publisher-backend check-run). Branch Protection is not changed "
+            "by this tool."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
@@ -550,11 +836,17 @@ def build_parser() -> argparse.ArgumentParser:
     _add_common_args(dry)
     dry.set_defaults(func=cmd_dry_run)
 
-    publish = sub.add_parser("publish", help="Validate and publish Commit Status")
+    publish = sub.add_parser(
+        "publish",
+        help="Validate and publish Commit Status or App Check Run",
+    )
     _add_common_args(publish)
     publish.set_defaults(func=cmd_publish)
 
-    inspect = sub.add_parser("inspect", help="Inspect GitHub statuses for a SHA")
+    inspect = sub.add_parser(
+        "inspect",
+        help="Inspect GitHub statuses or App Check Runs for a SHA",
+    )
     _add_common_args(inspect)
     # evidence-dir not strictly required for inspect — allow dummy.
     for action in inspect._actions:

--- a/ci/publisher/evidence.py
+++ b/ci/publisher/evidence.py
@@ -22,10 +22,18 @@ from ci.lib.gitinfo import (
     collect_git_info,
 )
 from ci.publisher.exceptions import PublisherError
-from ci.publisher.models import StatusPayload, ValidationResult
+from ci.publisher.models import (
+    CHECK_RUN_NAME,
+    CheckRunPayload,
+    StatusPayload,
+    ValidationResult,
+    build_check_run_external_id,
+)
 
 SUCCESS_SUMMARY = "Local Docker CI evidence verified for exact commit SHA."
 FAILURE_SUMMARY = "Local Docker CI evidence rejected or pipeline failed."
+CHECK_RUN_SUCCESS_TITLE = "cdb-local-ci success"
+CHECK_RUN_FAILURE_TITLE = "cdb-local-ci failure"
 
 
 def resolve_repository(
@@ -88,6 +96,44 @@ def build_status_payload(
     )
 
 
+def build_check_run_payload(
+    *,
+    commit_sha: str,
+    run_id: str,
+    ok: bool,
+    started_at_utc: str,
+    ended_at_utc: str,
+    target_url: str | None,
+    optional_skipped: list[dict[str, str]],
+    name: str = CHECK_RUN_NAME,
+) -> CheckRunPayload:
+    """Build a deterministic Check Run payload from validated evidence fields."""
+    if not commit_sha:
+        raise PublisherError("Refusing Check Run without exact head_sha")
+    if ok:
+        title = CHECK_RUN_SUCCESS_TITLE
+        summary = SUCCESS_SUMMARY
+        if optional_skipped:
+            names = ",".join(s["name"] for s in optional_skipped)
+            summary = f"{SUCCESS_SUMMARY} Optional skipped: {names}"
+        conclusion = "success"
+    else:
+        title = CHECK_RUN_FAILURE_TITLE
+        summary = FAILURE_SUMMARY
+        conclusion = "failure"
+    return CheckRunPayload(
+        name=name,
+        head_sha=commit_sha,
+        conclusion=conclusion,  # type: ignore[arg-type]
+        started_at=started_at_utc,
+        completed_at=ended_at_utc,
+        external_id=build_check_run_external_id(run_id=run_id, commit_sha=commit_sha),
+        output_title=title,
+        output_summary=summary,
+        details_url=target_url,
+    )
+
+
 def validate_evidence_for_publish(
     evidence_dir: Path,
     *,
@@ -134,6 +180,8 @@ def validate_evidence_for_publish(
             manifest_sha256=digest,
             optional_skipped=skipped,
             intended_payload=payload,
+            started_at_utc=str(manifest.get("started_at_utc") or ""),
+            ended_at_utc=str(manifest.get("ended_at_utc") or ""),
         )
     except (EvidenceError, PublisherError, ValueError) as exc:
         reason = str(exc)

--- a/ci/publisher/github_client.py
+++ b/ci/publisher/github_client.py
@@ -1,6 +1,8 @@
 """GitHub reads plus gh-cli-only Commit Status writes.
 
-Check Runs require a GitHub App and are intentionally separate.
+Check Runs are implemented in ``ci.publisher.backends.CheckRunBackend`` and
+require a GitHub App installation token — this client intentionally has no
+``create_check_run`` method.
 """
 
 from __future__ import annotations

--- a/ci/publisher/ledger.py
+++ b/ci/publisher/ledger.py
@@ -19,6 +19,18 @@ REQUIRED_ENTRY_FIELDS = (
     "manifest_sha256",
     "published_at_utc",
 )
+# Optional extension fields (#4170) — must not break existing ledger readers.
+OPTIONAL_ENTRY_FIELDS = (
+    "publisher_backend",
+    "github_object_type",
+    "github_check_run_id",
+    "github_app_id",
+    "github_installation_id",
+    "check_run_name",
+    "head_sha",
+    "external_id",
+    "remote_verification_status",
+)
 
 
 @dataclass(frozen=True)
@@ -31,9 +43,20 @@ class LedgerEntry:
     published_at_utc: str
     github_status_id: int | None = None
     state: str | None = None
+    publisher_backend: str | None = None
+    github_object_type: str | None = None
+    github_check_run_id: int | None = None
+    github_app_id: int | None = None
+    github_installation_id: int | None = None
+    check_run_name: str | None = None
+    head_sha: str | None = None
+    external_id: str | None = None
+    remote_verification_status: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        # Drop None optionals to keep legacy entries compact.
+        return {key: value for key, value in data.items() if value is not None}
 
 
 def default_ledger_path(artifacts_root: Path) -> Path:
@@ -118,6 +141,28 @@ def find_exact_publication(
         if all(str(entry.get(key)) == str(value) for key, value in expected.items()):
             return dict(entry)
     return None
+
+
+def find_check_run_publication(
+    ledger: dict[str, Any],
+    *,
+    external_id: str,
+) -> dict[str, Any] | None:
+    """Return a prior Check Run publication for the same external_id."""
+    matches = [
+        dict(entry)
+        for entry in ledger.get("entries") or []
+        if isinstance(entry, dict)
+        and str(entry.get("external_id") or "") == external_id
+    ]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        # Same external_id must be unique; multiple entries are a conflict.
+        raise LedgerError(
+            f"Ledger has {len(matches)} entries for external_id {external_id!r}"
+        )
+    return matches[0]
 
 
 def append_entry(path: Path, entry: LedgerEntry) -> None:

--- a/ci/publisher/models.py
+++ b/ci/publisher/models.py
@@ -6,6 +6,12 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
 StatusState = Literal["error", "failure", "pending", "success"]
+CheckRunConclusion = Literal["success", "failure"]
+PublisherBackendName = Literal["commit-status", "check-run"]
+
+CHECK_RUN_NAME = "cdb-local-ci"
+SHADOW_CHECK_RUN_NAME = "cdb-local-ci-app-preview"
+ALLOWED_CHECK_RUN_CONCLUSIONS = frozenset({"success", "failure"})
 
 
 @dataclass(frozen=True)
@@ -30,6 +36,79 @@ class StatusPayload:
 
 
 @dataclass(frozen=True)
+class CheckRunPayload:
+    """Deterministic Check Run payload bound to a GitHub App identity."""
+
+    name: str
+    head_sha: str
+    conclusion: CheckRunConclusion
+    started_at: str
+    completed_at: str
+    external_id: str
+    output_title: str
+    output_summary: str
+    details_url: str | None = None
+    status: Literal["completed"] = "completed"
+
+    def __post_init__(self) -> None:
+        if not self.head_sha:
+            raise ValueError("Check Run success/failure requires exact head_sha")
+        if self.conclusion not in ALLOWED_CHECK_RUN_CONCLUSIONS:
+            raise ValueError(f"Unknown Check Run conclusion: {self.conclusion!r}")
+        if self.status != "completed":
+            raise ValueError("Check Run status must be completed")
+        if not self.external_id:
+            raise ValueError("Check Run external_id is required")
+        if not self.name:
+            raise ValueError("Check Run name is required")
+
+    def to_api_body(self) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "name": self.name,
+            "head_sha": self.head_sha,
+            "status": self.status,
+            "conclusion": self.conclusion,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "external_id": self.external_id,
+            "output": {
+                "title": self.output_title[:1024],
+                "summary": self.output_summary[:65535],
+            },
+        }
+        if self.details_url:
+            body["details_url"] = self.details_url
+        return body
+
+
+def build_check_run_external_id(*, run_id: str, commit_sha: str) -> str:
+    """Deterministic external_id from evidence run_id and commit SHA."""
+    if not run_id or not commit_sha:
+        raise ValueError("external_id requires non-empty run_id and commit_sha")
+    return f"{run_id}:{commit_sha.lower()}"
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Outcome of a backend publish attempt after optional remote verification."""
+
+    ok: bool
+    publisher_backend: PublisherBackendName
+    github_object_type: str
+    remote_id: int | None
+    head_sha: str
+    dry_run: bool
+    idempotent_noop: bool
+    remote_verification_status: str
+    payload_body: dict[str, Any]
+    raw: dict[str, Any] = field(default_factory=dict)
+    external_id: str | None = None
+    github_app_id: int | None = None
+    github_installation_id: int | None = None
+    check_run_name: str | None = None
+
+
+@dataclass(frozen=True)
 class ValidationResult:
     """Outcome of evidence validation for publish / dry-run."""
 
@@ -42,6 +121,8 @@ class ValidationResult:
     optional_skipped: list[dict[str, str]] = field(default_factory=list)
     reason: str | None = None
     intended_payload: StatusPayload | None = None
+    started_at_utc: str | None = None
+    ended_at_utc: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/ci/publisher/redaction.py
+++ b/ci/publisher/redaction.py
@@ -16,6 +16,9 @@ _TOKEN_RE = re.compile(
     r"|Bearer\s+[A-Za-z0-9\-._~+/]+=*"
     r")\b"
 )
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----"
+)
 _AUTH_HEADER_RE = re.compile(
     r"(?i)(authorization\s*[:=]\s*)(['\"]?)([^'\"\s,;]+)(['\"]?)"
 )
@@ -28,6 +31,7 @@ def redact_text(value: str) -> str:
         return value
     redacted = _AUTH_HEADER_RE.sub(r"\1\2[REDACTED]\4", value)
     redacted = _QUERY_TOKEN_RE.sub(r"\1[REDACTED]", redacted)
+    redacted = _PRIVATE_KEY_RE.sub("[REDACTED_PRIVATE_KEY]", redacted)
     redacted = _TOKEN_RE.sub("[REDACTED]", redacted)
     return redacted
 
@@ -44,6 +48,8 @@ def redact_mapping(payload: Any) -> Any:
                 "access_token",
                 "password",
                 "secret",
+                "private_key",
+                "privatekey",
             }:
                 out[key] = "[REDACTED]"
             else:

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -9,13 +9,17 @@
 - Branch Protection and GitHub workflows remain unchanged in Phase 1.
 - See [merge_policy_ci_gate.md](../runbooks/merge_policy_ci_gate.md) § Local Docker CI Phase 1.
 
-## Local status publisher (Phase 3a)
+## Local status publisher (Phase 3a + #4170 Phase A)
 
 - Doc: [`local-status-publisher.md`](local-status-publisher.md)
+- Cutover runbook: [`cdb_local_ci_app_check_run_cutover.md`](../runbooks/cdb_local_ci_app_check_run_cutover.md)
 - Entry: `python -m ci.publisher` / `pwsh -File ci/scripts/publish_status.ps1`
 - Make: `ci-local-publish-dry-run` / `ci-local-publish` / `ci-local-publish-inspect`
-- Publishes a **non-required** Commit Status only after fail-closed evidence validation.
-- Preferred preview context: `cdb-local-ci-preview`. Branch Protection unchanged.
+- Default publishes required-path Commit Status `cdb-local-ci` after fail-closed
+  evidence validation (interim `app_id=null` trust model).
+- Explicit `--publisher-backend check-run` is code-ready; live Branch Protection
+  cutover remains an external Human-GO.
+- Preferred preview context: `cdb-local-ci-preview`.
 
 ## Kanonischer PR-Merge-Vertrag
 

--- a/docs/ci/local-status-publisher.md
+++ b/docs/ci/local-status-publisher.md
@@ -68,19 +68,41 @@ with an explicit `skip_reason`. Skips are disclosed in the status description.
 
 ## Check Run versus Commit Status
 
-**Phase 3a uses Commit Status** (`POST /repos/{owner}/{repo}/statuses/{sha}`).
-The trusted publisher performs this write exclusively through
-`gh api --method POST ... --input -`; it never places tokens or Authorization
-headers in command arguments, logs, or Evidence. Read-only verification may
-continue through the existing GitHub client.
+**Phase 3a default remains Commit Status**
+(`POST /repos/{owner}/{repo}/statuses/{sha}`) via
+`gh api --method POST ... --input -`.
 
-| Surface | Auth needed | Phase 3a |
-|---------|-------------|----------|
-| Commit Status | PAT / `gh` with statuses write (`repo` or fine-grained Commit statuses: Write) | **Used** |
-| Check Run | GitHub App installation token with `checks:write` | Documented future path |
+**#4170 adds an explicit Check Run backend** (`--publisher-backend check-run`)
+that uses `POST /repos/{owner}/{repo}/check-runs` with a GitHub App
+installation token only. Live Branch Protection is **unchanged** until a
+separate Human-GO cutover (see
+[`docs/runbooks/cdb_local_ci_app_check_run_cutover.md`](../runbooks/cdb_local_ci_app_check_run_cutover.md)).
 
-User/OAuth tokens from `gh auth` cannot safely create Check Runs without an App.
-The client intentionally has no `create_check_run` method.
+| Surface | Auth needed | Status |
+|---------|-------------|--------|
+| Commit Status | PAT / `gh` with statuses write | **Default / current required path** |
+| Check Run | GitHub App installation token (`CDB_GH_APP_INSTALLATION_TOKEN`) + expected App/Installation IDs | **Code-ready; BP cutover external** |
+
+`GitHubStatusClient` still has no `create_check_run` method. Check Runs live in
+`ci.publisher.backends.CheckRunBackend`. User/OAuth/`gh auth` tokens are **not**
+accepted as App identity proof for Check Run mode.
+
+### CLI backend switch
+
+```bash
+# Default — interim required Commit Status path
+python -m ci.publisher publish --evidence-dir ci/artifacts/<run_id> \
+  --commit-sha <sha> --pr-number <n>
+
+# Explicit App-bound Check Run (does not change Branch Protection by itself)
+python -m ci.publisher dry-run --publisher-backend check-run \
+  --expected-app-id <id> --expected-installation-id <id> \
+  --evidence-dir ci/artifacts/<run_id> --commit-sha <sha> --pr-number <n>
+```
+
+Why Commit Status `app_id=null` is not the long-term trust model: any actor with
+Commit statuses: Write can POST success for the same context. App-bound Check
+Runs bind the required check to a dedicated App identity after cutover.
 
 ## Authentication (least privilege)
 
@@ -199,11 +221,15 @@ BP-required.
 Use `cdb-local-ci-preview` for optional smoke publishes without the mandatory
 PR constraint of the required path.
 
-## Future hardening
+## Future hardening / cutover
 
-After publisher parity + security review, evaluate GitHub-App Check Runs and
-retiring or thinning GitHub-hosted heavy CI. Until then, `cdb-local-ci` remains
-the interim Commit Status required context.
+Phase A (#4170) delivers the Check Run publisher backend while keeping Commit
+Status as the live required path. App creation, installation-token minting,
+shadow smoke (`cdb-local-ci-app-preview`), and Branch Protection cutover are
+external Human-GO steps documented in
+[`docs/runbooks/cdb_local_ci_app_check_run_cutover.md`](../runbooks/cdb_local_ci_app_check_run_cutover.md).
+Until cutover evidence exists, `cdb-local-ci` remains the interim Commit Status
+required context (`app_id` null).
 
 ## Rollback / revocation
 
@@ -216,5 +242,6 @@ the interim Commit Status required context.
 
 - [`ci/README.md`](../../ci/README.md)
 - [`docs/runbooks/merge_policy_ci_gate.md`](../runbooks/merge_policy_ci_gate.md)
+- [`docs/runbooks/cdb_local_ci_app_check_run_cutover.md`](../runbooks/cdb_local_ci_app_check_run_cutover.md)
 - [`tools/ci/policy_gate_local.py`](../../tools/ci/policy_gate_local.py)
 - Phase 1 evidence contract + PR #4166

--- a/docs/runbooks/cdb_local_ci_app_check_run_cutover.md
+++ b/docs/runbooks/cdb_local_ci_app_check_run_cutover.md
@@ -1,0 +1,269 @@
+# cdb-local-ci App-bound Check Run Cutover
+
+Status: Phase A code-ready preparation (#4170)
+Authority: Operational runbook for migrating the required merge context from
+interim Commit Status (`app_id=null`) to a GitHub-App-bound Check Run.
+Live Branch Protection is **not** changed by the publisher code PR.
+
+LR remains **NO-GO**. This runbook does not authorize live trading.
+
+---
+
+## Why Commit Status `app_id=null` is not the target model
+
+After #4169 the sole Branch Protection required context on `main` is
+`cdb-local-ci` as a **Commit Status** with `app_id: null`. Any credential with
+Commit statuses: Write can POST `success` for that context. Evidence gates in
+`ci/publisher/` reduce accidental misuse, but they do not cryptographically bind
+the status to a single publisher identity.
+
+Target model: only a dedicated GitHub App may create the required Check Run
+named `cdb-local-ci`, bound to App identity, exact PR head SHA, and validated
+local CI evidence.
+
+---
+
+## Publisher backend architecture
+
+| Backend | CLI | Auth | GitHub object |
+|---|---|---|---|
+| `commit-status` (default) | `--publisher-backend commit-status` | `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth` via existing resolver | Commit Status |
+| `check-run` (explicit) | `--publisher-backend check-run` | **only** `CDB_GH_APP_INSTALLATION_TOKEN` | Check Run |
+
+Shared fail-closed gates (unchanged): evidence validation, exact SHA bind,
+`--pr-number` for required context, local policy-gate mirror, dirty-worktree
+reject, anti-replay ledger, no Fake-Green, no Admin bypass.
+
+Check Run path adds: expected App ID + Installation ID, remote `app.id`
+readback, deterministic `external_id={run_id}:{sha}`, no fallback to Commit
+Status on error.
+
+---
+
+## Exact minimal App permissions
+
+| Permission | Level | Required by |
+|---|---|---|
+| Metadata | Read | Installation / repository binding |
+| Checks | Read and Write | `POST /check-runs`, `GET /check-runs/{id}`, list by SHA |
+
+### Prohibited (forbidden) permissions
+
+- Administration: Write
+- Actions: Write
+- Contents: Write
+- Commit statuses: Write
+- Deployments: Write
+- Secrets: Read or Write
+
+Pull requests / Contents Read are only needed if the same installation token
+performs those reads; Phase A keeps PR/policy reads on the existing read token
+path so Checks R/W + Metadata Read is the minimum for the Check Run writer.
+
+---
+
+## Migration phases
+
+### A_CODE_READY (this PR)
+
+- Implement Check Run backend, tests, docs.
+- Keep Commit Status path active as default.
+- Do **not** change Branch Protection baselines or live BP.
+- Do **not** create a GitHub App from the agent session.
+
+### B_APP_INSTALLED (human / external only)
+
+1. Create a dedicated GitHub App (display name proposal: `CDB Local CI Publisher`).
+2. Set minimal permissions above.
+3. Install exclusively on the canonical Claire de Binare GitHub repository
+   (owner/name from publisher `EXPECTED_REPOSITORY`).
+4. Record App ID and Installation ID (non-secret).
+5. Store Private Key **outside** the repository (secrets SSOT directory only).
+6. Do **not** reuse the Control-Board / Projects App as the local-ci publisher
+   unless explicitly decided; least privilege prefers a dedicated App.
+
+### C_SHADOW_SMOKE (explicit credentials + Human-GO)
+
+Recommended shadow name: `cdb-local-ci-app-preview` (not required).
+
+```bash
+export CDB_GH_APP_INSTALLATION_TOKEN="<short-lived installation token>"
+export CDB_GH_APP_ID="<app_id>"
+export CDB_GH_APP_INSTALLATION_ID="<installation_id>"
+
+python -m ci.publisher dry-run \
+  --publisher-backend check-run \
+  --expected-app-id "$CDB_GH_APP_ID" \
+  --expected-installation-id "$CDB_GH_APP_INSTALLATION_ID" \
+  --check-run-name cdb-local-ci-app-preview \
+  --evidence-dir ci/artifacts/<run_id> \
+  --commit-sha <exact_pr_head_sha> \
+  --pr-number <n>
+
+# Only after dry-run OK and Human-GO:
+python -m ci.publisher publish \
+  --publisher-backend check-run \
+  --expected-app-id "$CDB_GH_APP_ID" \
+  --expected-installation-id "$CDB_GH_APP_INSTALLATION_ID" \
+  --check-run-name cdb-local-ci-app-preview \
+  --evidence-dir ci/artifacts/<run_id> \
+  --commit-sha <exact_pr_head_sha> \
+  --pr-number <n>
+
+python -m ci.publisher inspect \
+  --publisher-backend check-run \
+  --expected-app-id "$CDB_GH_APP_ID" \
+  --expected-installation-id "$CDB_GH_APP_INSTALLATION_ID" \
+  --check-run-name cdb-local-ci-app-preview \
+  --commit-sha <exact_pr_head_sha>
+```
+
+Verify remote: `name`, `head_sha`, `conclusion`, `external_id`, **`app.id`**.
+
+### D_CUTOVER (separate Human-GO; not this PR)
+
+1. Snapshot current Branch Protection (before-state).
+2. Prove shadow smoke success.
+3. Publish App-bound Check Run named `cdb-local-ci` for the exact test SHA.
+4. Verify remote `app.id`.
+5. Atomically switch Branch Protection required check to the App-bound Check Run.
+6. Confirm merge without App Check remains blocked.
+7. Remove interim Commit Status required context only after verification.
+8. Document rollback steps before applying.
+
+### E_RETIRE_INTERIM (after stable cutover evidence)
+
+- Retire Commit Status publisher default only after stable cutover evidence.
+- Refresh baselines and docs.
+- Re-evaluate #4165 (hosted heavy CI retirement) separately.
+
+---
+
+## Secrets, rotation, token lifetime
+
+| Name | Kind | Notes |
+|---|---|---|
+| `CDB_GH_APP_INSTALLATION_TOKEN` | ephemeral secret | Installation token (~1h); mint outside publisher core |
+| `CDB_GH_APP_ID` | non-secret config | Expected App ID for readback |
+| `CDB_GH_APP_INSTALLATION_ID` | non-secret config | Expected installation ID |
+| Private Key | secret, external SSOT only | Never in repo, logs, issues, or PR bodies |
+
+Rotation:
+
+1. Generate new Private Key in GitHub App settings (or rotate App).
+2. Store in external secrets SSOT; sync to GitHub repo secrets if needed.
+3. Revoke old key.
+4. Mint fresh installation tokens from the new key via a separate ops path.
+5. Re-run shadow smoke.
+
+Publisher core **consumes** an installation token; it does not mint from a
+Private Key in this slice.
+
+Collision note: Control-Board workflows already document `CDB_GH_APP_ID` /
+`PRIVATE_KEY` / `INSTALLATION_ID`. Prefer a **dedicated** local-ci App and
+document which values the publisher expects. Do not overwrite Control-Board
+secrets blindly.
+
+---
+
+## Preflight checklist (before shadow / cutover)
+
+- [ ] App ID known
+- [ ] Installation ID known
+- [ ] App installed only on the canonical Claire de Binare repository
+- [ ] Permission matrix matches this runbook (no prohibited grants)
+- [ ] Shadow check name `cdb-local-ci-app-preview` chosen
+- [ ] Test PR number and exact head SHA recorded
+- [ ] Installation token available in env (not argv, not logged)
+- [ ] Local evidence validated for that SHA
+
+---
+
+## Cutover checklist
+
+- [ ] Capture Branch Protection before-state
+- [ ] Shadow Check verified (`app.id`, SHA, name, conclusion)
+- [ ] App-bound `cdb-local-ci` Check Run on current test SHA
+- [ ] Remote `app.id` matches expected App ID
+- [ ] Branch Protection changed only after the above
+- [ ] Required check bound to App identity
+- [ ] Merge attempt without App Check remains blocked
+- [ ] Rollback sequence documented and ready
+
+---
+
+## Rollback
+
+If cutover fails or state is unknown → **HOLD** (do not Fake-Green, do not
+`--admin`).
+
+1. Restore Branch Protection required context to Commit Status `cdb-local-ci`
+   with `app_id: null` (before-state snapshot).
+2. Keep Commit Status publisher path available (`--publisher-backend commit-status`).
+3. Stop using Check Run publishes for the required name until re-verified.
+4. Rotate App credentials if compromise is suspected.
+5. File / update follow-up with evidence; do not close #4170 until cutover proven.
+
+---
+
+## Emergency rule
+
+Unknown API write result, ambiguous readback, missing `app.id`, SHA drift, or
+policy-mirror failure ⇒ **HOLD / FAIL**. Never assume success.
+
+---
+
+## APP_BOUND_CHECK_RUN_CUTOVER_HANDOFF
+
+```yaml
+artifact: APP_BOUND_CHECK_RUN_CUTOVER_HANDOFF
+issue: 4170
+phase_completed_by_code_pr: A_CODE_READY
+github_app_display_name_proposal: "CDB Local CI Publisher"
+expected_app_id: "<SET_AFTER_APP_CREATE>"
+expected_installation_id: "<SET_AFTER_INSTALL>"
+repository_installation_scope: "canonical Claire de Binare repository only (EXPECTED_REPOSITORY)"
+minimal_permissions:
+  - "Metadata: Read"
+  - "Checks: Read and Write"
+prohibited_permissions:
+  - "Administration: Write"
+  - "Actions: Write"
+  - "Contents: Write"
+  - "Commit statuses: Write"
+  - "Deployments: Write"
+  - "Secrets: Read or Write"
+secret_names:
+  installation_token: CDB_GH_APP_INSTALLATION_TOKEN
+  expected_app_id: CDB_GH_APP_ID
+  expected_installation_id: CDB_GH_APP_INSTALLATION_ID
+private_key_storage: "External secrets SSOT only (never repository)"
+token_minting_responsibility: "Human/ops outside publisher core"
+shadow_check_name: cdb-local-ci-app-preview
+shadow_smoke_command: >
+  python -m ci.publisher publish --publisher-backend check-run
+  --check-run-name cdb-local-ci-app-preview
+  --expected-app-id <ID> --expected-installation-id <ID>
+  --evidence-dir ci/artifacts/<run_id> --commit-sha <SHA> --pr-number <N>
+expected_remote_app_id_verification: "GET check-run → app.id == CDB_GH_APP_ID"
+branch_protection_before:
+  required_contexts: ["cdb-local-ci"]
+  type: "Commit Status"
+  app_id: null
+branch_protection_after_planned:
+  required_check: "cdb-local-ci"
+  type: "Check Run bound to dedicated App"
+  app_id: "<SET_AFTER_APP_CREATE>"
+rollback_sequence:
+  - "Restore BP required context to Commit Status cdb-local-ci app_id=null"
+  - "Use --publisher-backend commit-status"
+  - "HOLD until re-verified; rotate credentials if needed"
+human_go_points:
+  - "B_APP_INSTALLED"
+  - "C_SHADOW_SMOKE"
+  - "D_CUTOVER"
+unresolved_risks:
+  - "Live BP not writable/readable by cloud integration (403 observed)"
+  - "Control-Board CDB_GH_APP_* name collision if shared carelessly"
+  - "Installation token minting ops path not automated in this PR"
+```

--- a/docs/runbooks/cdb_secrets_ssot.md
+++ b/docs/runbooks/cdb_secrets_ssot.md
@@ -50,11 +50,21 @@ powershell -File scripts/secrets/sync_cdb_secrets.ps1
 - `ADD_TO_PROJECT_PAT`:
   - Legacy PAT fallback for Projects v2 operations.
 - `CDB_GH_APP_ID`:
-  - GitHub App auth path (optional).
+  - GitHub App auth path (optional). Used by Control-Board / Projects workflows.
+  - For #4170 local-ci Check Runs: expected App ID for publisher readback
+    (non-secret config). Prefer a **dedicated** local-ci App; do not blindly
+    overwrite Control-Board values.
 - `CDB_GH_APP_PRIVATE_KEY`:
-  - GitHub App private key (optional, required with app id).
+  - GitHub App private key (optional, required with app id for minting).
+  - Never commit; store only in external SSOT. Publisher core does not mint
+    tokens from this key (#4170).
 - `CDB_GH_APP_INSTALLATION_ID`:
-  - Optional explicit installation id for app path.
+  - Optional explicit installation id for app path / Check Run expected ID.
+- `CDB_GH_APP_INSTALLATION_TOKEN` (publisher Check Run mode, ephemeral):
+  - Short-lived installation token consumed by
+    `--publisher-backend check-run`. Not minted by the publisher itself.
+  - Never pass as CLI argument; never log. See
+    [`cdb_local_ci_app_check_run_cutover.md`](cdb_local_ci_app_check_run_cutover.md).
 
 ## Workflow Token Path (control board)
 - Workflows resolve auth in this order:

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -22,12 +22,20 @@ Für Pull Requests auf `main` gilt genau ein merge-relevanter Required Context
 
 | Quelle | Context | Typ |
 |---|---|---|
-| Local CI Status Publisher | `cdb-local-ci` | Commit Status (`app_id` null) |
+| Local CI Status Publisher | `cdb-local-ci` | Commit Status (`app_id` null) — interim |
 
 Die früheren Required Checks `ci (Unit/Integration + Lint gesammelt)` und
 `policy-gate` sind **nicht mehr** branch-protection-required (Migration #4169).
 `ci.yml` und `policy-gate.yml` bleiben als Workflow-Inhalt / Safety-Gates
 nützlich, ersetzen aber den Required Context nicht.
+
+**Trust gap / #4170:** Commit Status with `app_id=null` is not App-bound; any
+credential with Commit statuses: Write can POST the same context. Phase A of
+#4170 adds an explicit Check Run publisher backend
+(`--publisher-backend check-run`) but does **not** change live Branch
+Protection. Cutover to an App-bound required Check Run is a separate Human-GO
+(see [`cdb_local_ci_app_check_run_cutover.md`](cdb_local_ci_app_check_run_cutover.md)).
+Until that cutover, merge evidence remains the Commit Status path.
 
 Lint/Format (orchestrator stage `lint`, Issue #4206): Black und Ruff kommen
 ausschließlich aus dem Pin in `requirements-dev.txt`. Black läuft als

--- a/tests/unit/ci/test_status_publisher_check_run.py
+++ b/tests/unit/ci/test_status_publisher_check_run.py
@@ -1,0 +1,494 @@
+"""Unit tests for App-bound Check Run publisher backend (#4170)."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+
+from ci.publisher import EXPECTED_REPOSITORY
+from ci.publisher.backends import (
+    APP_INSTALLATION_TOKEN_ENV,
+    CheckRunBackend,
+    CommitStatusBackend,
+    build_publisher_backend,
+    resolve_app_installation_token,
+)
+from ci.publisher.exceptions import AuthenticationError, GitHubApiError, PublisherError
+from ci.publisher.github_client import GitHubResponse, GitHubStatusClient
+from ci.publisher.models import (
+    CHECK_RUN_NAME,
+    CheckRunPayload,
+    StatusPayload,
+    build_check_run_external_id,
+)
+from ci.publisher.redaction import redact_mapping, redact_text
+
+pytestmark = pytest.mark.unit
+
+SHA = "cccccccccccccccccccccccccccccccccccccccc"
+RUN_ID = "20260730T120000Z-abcdef"
+APP_ID = 123456
+INSTALLATION_ID = 654321
+EXTERNAL_ID = f"{RUN_ID}:{SHA}"
+
+
+def _payload(**overrides: Any) -> CheckRunPayload:
+    base = dict(
+        name=CHECK_RUN_NAME,
+        head_sha=SHA,
+        conclusion="success",
+        started_at="2026-07-30T12:00:00Z",
+        completed_at="2026-07-30T12:05:00Z",
+        external_id=EXTERNAL_ID,
+        output_title="cdb-local-ci success",
+        output_summary="Local Docker CI evidence verified for exact commit SHA.",
+        details_url="https://example.test/evidence",
+    )
+    base.update(overrides)
+    return CheckRunPayload(**base)
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses: list[GitHubResponse] = []
+
+    def __call__(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes | None,
+        timeout: float,
+    ) -> GitHubResponse:
+        parsed_body = json.loads(body.decode("utf-8")) if body else None
+        safe_headers = {
+            k: ("[REDACTED]" if k.lower() == "authorization" else v)
+            for k, v in headers.items()
+        }
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": safe_headers,
+                "body": parsed_body,
+                "timeout": timeout,
+            }
+        )
+        if not self.responses:
+            raise AssertionError("No fake response queued")
+        return self.responses.pop(0)
+
+
+def _remote_check_run(**overrides: Any) -> dict[str, Any]:
+    data = {
+        "id": 99,
+        "name": CHECK_RUN_NAME,
+        "head_sha": SHA,
+        "status": "completed",
+        "conclusion": "success",
+        "external_id": EXTERNAL_ID,
+        "app": {"id": APP_ID, "slug": "cdb-local-ci"},
+    }
+    data.update(overrides)
+    return data
+
+
+def test_check_run_payload_is_deterministic():
+    a = _payload()
+    b = _payload()
+    assert a.to_api_body() == b.to_api_body()
+    assert a.to_api_body()["name"] == CHECK_RUN_NAME
+    assert a.to_api_body()["head_sha"] == SHA
+    assert a.to_api_body()["external_id"] == EXTERNAL_ID
+
+
+def test_external_id_is_deterministic():
+    assert build_check_run_external_id(run_id=RUN_ID, commit_sha=SHA) == EXTERNAL_ID
+    assert (
+        build_check_run_external_id(run_id=RUN_ID, commit_sha=SHA.upper())
+        == EXTERNAL_ID
+    )
+
+
+def test_success_without_sha_rejected():
+    with pytest.raises(ValueError, match="head_sha"):
+        CheckRunPayload(
+            name=CHECK_RUN_NAME,
+            head_sha="",
+            conclusion="success",
+            started_at="2026-07-30T12:00:00Z",
+            completed_at="2026-07-30T12:05:00Z",
+            external_id=EXTERNAL_ID,
+            output_title="t",
+            output_summary="s",
+        )
+
+
+def test_unknown_conclusion_rejected():
+    with pytest.raises(ValueError, match="Unknown Check Run conclusion"):
+        CheckRunPayload(
+            name=CHECK_RUN_NAME,
+            head_sha=SHA,
+            conclusion="neutral",  # type: ignore[arg-type]
+            started_at="2026-07-30T12:00:00Z",
+            completed_at="2026-07-30T12:05:00Z",
+            external_id=EXTERNAL_ID,
+            output_title="t",
+            output_summary="s",
+        )
+
+
+def test_missing_installation_token_rejected(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(APP_INSTALLATION_TOKEN_ENV, raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_should_not_be_used_abcdefgh")
+    monkeypatch.setenv("GH_TOKEN", "ghs_also_not_used_abcdefghijkl")
+    with pytest.raises(AuthenticationError, match=APP_INSTALLATION_TOKEN_ENV):
+        resolve_app_installation_token()
+
+
+def test_empty_installation_token_rejected(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(APP_INSTALLATION_TOKEN_ENV, "   ")
+    with pytest.raises(AuthenticationError, match=APP_INSTALLATION_TOKEN_ENV):
+        resolve_app_installation_token()
+
+
+def test_gh_auth_token_not_auto_used(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(APP_INSTALLATION_TOKEN_ENV, raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    with pytest.raises(AuthenticationError, match="refuses"):
+        resolve_app_installation_token()
+
+
+def test_missing_expected_app_id_rejected():
+    with pytest.raises(PublisherError, match="expected-app-id"):
+        build_publisher_backend(
+            backend="check-run",
+            app_token="installation-token-test",
+            expected_app_id=None,
+            expected_installation_id=INSTALLATION_ID,
+        )
+
+
+def test_invalid_installation_id_rejected():
+    with pytest.raises(PublisherError, match="positive integer"):
+        CheckRunBackend(
+            token="tok",
+            expected_app_id=APP_ID,
+            expected_installation_id=0,
+        )
+
+
+def test_correct_check_run_post_route_and_headers():
+    transport = FakeTransport()
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    created = _remote_check_run()
+    transport.responses.append(GitHubResponse(201, created, {}))
+    transport.responses.append(GitHubResponse(200, created, {}))
+    backend = CheckRunBackend(
+        token="ghs_app_installation_token_value",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    result = backend.publish(check_run_payload=_payload(), dry_run=False)
+    assert result.ok is True
+    assert result.remote_verification_status == "verified"
+    post = next(c for c in transport.calls if c["method"] == "POST")
+    assert post["url"].endswith(f"/repos/{EXPECTED_REPOSITORY}/check-runs")
+    assert post["headers"]["Accept"] == "application/vnd.github+json"
+    assert post["headers"]["X-GitHub-Api-Version"] == "2022-11-28"
+    assert post["headers"]["Authorization"] == "[REDACTED]"
+    assert post["body"]["name"] == CHECK_RUN_NAME
+    assert post["body"]["head_sha"] == SHA
+    assert post["body"]["external_id"] == EXTERNAL_ID
+
+
+def test_auth_errors_map_to_authentication_error():
+    transport = FakeTransport()
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(401, {"message": "bad creds"}, {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    with pytest.raises(AuthenticationError):
+        backend.publish(check_run_payload=_payload(), dry_run=False)
+
+
+def test_404_and_422_map_to_github_api_error():
+    transport = FakeTransport()
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(422, {"message": "invalid"}, {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    with pytest.raises(GitHubApiError, match="422"):
+        backend.publish(check_run_payload=_payload(), dry_run=False)
+
+
+def test_rate_limit_fails_closed():
+    transport = FakeTransport()
+    transport.responses.append(
+        GitHubResponse(
+            403,
+            {"message": "API rate limit exceeded"},
+            {"x-ratelimit-remaining": "0"},
+        )
+    )
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    with pytest.raises(GitHubApiError, match="rate limit"):
+        backend.list_check_runs_for_sha(SHA)
+
+
+def test_timeout_fails_closed():
+    def boom(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes | None,
+        timeout: float,
+    ) -> GitHubResponse:
+        raise TimeoutError("timed out")
+
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=boom,
+    )
+    with pytest.raises(GitHubApiError, match="timed out"):
+        backend.list_check_runs_for_sha(SHA)
+
+
+def test_remote_app_id_match_passes():
+    transport = FakeTransport()
+    existing = _remote_check_run()
+    transport.responses.append(GitHubResponse(200, {"check_runs": [existing]}, {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    result = backend.publish(check_run_payload=_payload(), dry_run=False)
+    assert result.idempotent_noop is True
+    assert result.github_app_id == APP_ID
+
+
+def test_remote_app_id_missing_fails():
+    transport = FakeTransport()
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(201, _remote_check_run(app=None), {}))
+    transport.responses.append(GitHubResponse(200, _remote_check_run(app=None), {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    with pytest.raises(GitHubApiError, match="app identity"):
+        backend.publish(check_run_payload=_payload(), dry_run=False)
+
+
+def test_remote_app_id_mismatch_fails():
+    transport = FakeTransport()
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    transport.responses.append(GitHubResponse(200, {"check_runs": []}, {}))
+    bad = _remote_check_run(app={"id": 999})
+    transport.responses.append(GitHubResponse(201, bad, {}))
+    transport.responses.append(GitHubResponse(200, bad, {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    with pytest.raises(GitHubApiError, match="does not match"):
+        backend.publish(check_run_payload=_payload(), dry_run=False)
+
+
+def test_remote_head_sha_mismatch_fails():
+    remote = _remote_check_run(head_sha="dddddddddddddddddddddddddddddddddddddddd")
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=FakeTransport(),
+    )
+    with pytest.raises(GitHubApiError, match="head_sha"):
+        backend.verify_remote_check_run(remote, payload=_payload())
+
+
+def test_remote_name_mismatch_fails():
+    remote = _remote_check_run(name="other")
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=FakeTransport(),
+    )
+    with pytest.raises(GitHubApiError, match="name"):
+        backend.verify_remote_check_run(remote, payload=_payload())
+
+
+def test_remote_conclusion_mismatch_fails():
+    remote = _remote_check_run(conclusion="failure")
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=FakeTransport(),
+    )
+    with pytest.raises(GitHubApiError, match="conclusion"):
+        backend.verify_remote_check_run(remote, payload=_payload())
+
+
+def test_identical_external_id_noop():
+    transport = FakeTransport()
+    existing = _remote_check_run()
+    transport.responses.append(GitHubResponse(200, {"check_runs": [existing]}, {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    result = backend.publish(check_run_payload=_payload(), dry_run=False)
+    assert result.idempotent_noop is True
+    assert not any(c["method"] == "POST" for c in transport.calls)
+
+
+def test_identical_external_id_other_sha_rejected():
+    transport = FakeTransport()
+    existing = _remote_check_run(head_sha="dddddddddddddddddddddddddddddddddddddddd")
+    transport.responses.append(GitHubResponse(200, {"check_runs": [existing]}, {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    with pytest.raises(PublisherError, match="already bound to SHA"):
+        backend.publish(check_run_payload=_payload(), dry_run=False)
+
+
+def test_identical_external_id_conflicting_conclusion_rejected():
+    transport = FakeTransport()
+    existing = _remote_check_run(conclusion="failure")
+    transport.responses.append(GitHubResponse(200, {"check_runs": [existing]}, {}))
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    with pytest.raises(PublisherError, match="already concluded"):
+        backend.publish(check_run_payload=_payload(), dry_run=False)
+
+
+def test_no_fallback_to_commit_status():
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=FakeTransport(),
+    )
+    status = StatusPayload(
+        sha=SHA, state="success", context=CHECK_RUN_NAME, description="ok"
+    )
+    with pytest.raises(PublisherError, match="no silent fallback"):
+        backend.publish(status_payload=status, dry_run=False)
+
+
+def test_commit_status_backend_still_works():
+    calls: list[dict[str, Any]] = []
+
+    def writer(owner: str, repo: str, sha: str, body: dict[str, Any]) -> dict[str, Any]:
+        calls.append({"owner": owner, "repo": repo, "sha": sha, "body": body})
+        return {"id": 7, "state": body["state"], "sha": sha, "context": body["context"]}
+
+    client = GitHubStatusClient(token="tok", status_writer=writer)
+    backend = CommitStatusBackend(client=client)
+    payload = StatusPayload(
+        sha=SHA, state="success", context=CHECK_RUN_NAME, description="ok"
+    )
+    result = backend.publish(status_payload=payload, dry_run=False)
+    assert result.ok is True
+    assert result.publisher_backend == "commit-status"
+    assert calls[0]["body"]["context"] == CHECK_RUN_NAME
+
+
+def test_dry_run_never_writes_network():
+    transport = FakeTransport()
+    backend = CheckRunBackend(
+        token="tok",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    result = backend.publish(check_run_payload=_payload(), dry_run=True)
+    assert result.dry_run is True
+    assert transport.calls == []
+
+
+def test_authorization_header_redacted_in_errors():
+    text = redact_text("Authorization: Bearer ghs_secretvalue1234567890")
+    assert "ghs_secretvalue1234567890" not in text
+    assert "[REDACTED]" in text
+
+
+def test_token_in_api_error_body_redacted():
+    payload = redact_mapping(
+        {"message": "bad token ghs_secretvalue1234567890", "authorization": "Bearer x"}
+    )
+    assert "ghs_secretvalue1234567890" not in json.dumps(payload)
+    assert payload["authorization"] == "[REDACTED]"
+
+
+def test_private_key_like_material_redacted():
+    pem = (
+        "-----BEGIN RSA PRIVATE KEY-----\n"
+        "MIIEowIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF6PZGBw=\n"
+        "-----END RSA PRIVATE KEY-----"
+    )
+    assert "BEGIN RSA PRIVATE KEY" not in redact_text(pem)
+    assert "[REDACTED_PRIVATE_KEY]" in redact_text(pem)
+
+
+def test_non_canonical_repository_rejected():
+    with pytest.raises(PublisherError, match="non-canonical"):
+        CheckRunBackend(
+            token="tok",
+            expected_app_id=APP_ID,
+            expected_installation_id=INSTALLATION_ID,
+            owner="evil",
+            repo="repo",
+        )
+
+
+def test_github_status_client_still_has_no_create_check_run():
+    assert not hasattr(GitHubStatusClient, "create_check_run")
+
+
+def test_unknown_backend_rejected():
+    with pytest.raises(PublisherError, match="Unknown publisher backend"):
+        build_publisher_backend(backend="webhook")  # type: ignore[arg-type]

--- a/tests/unit/ci/test_status_publisher_check_run_contract.py
+++ b/tests/unit/ci/test_status_publisher_check_run_contract.py
@@ -1,0 +1,121 @@
+"""Contract / governance tests for App-bound Check Run migration (#4170)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASELINE_BP = REPO_ROOT / "docs/evidence/reports/BRANCH_PROTECTION_BASELINE_main.json"
+BASELINE_CTX = (
+    REPO_ROOT / "docs/evidence/reports/REQUIRED_CHECK_CONTEXTS_BASELINE_main.json"
+)
+CUTOVER_RUNBOOK = REPO_ROOT / "docs/runbooks/cdb_local_ci_app_check_run_cutover.md"
+PERMISSION_DOC_MARKERS = (
+    "Metadata: Read",
+    "Checks: Read and Write",
+    "Commit statuses: Write",
+    "Administration",
+)
+
+
+def test_branch_protection_baselines_unchanged_for_code_pr():
+    bp = json.loads(BASELINE_BP.read_text(encoding="utf-8"))
+    checks = bp["required_status_checks"]["checks"]
+    assert checks == [{"app_id": None, "context": "cdb-local-ci"}]
+    assert bp["required_status_checks"]["contexts"] == ["cdb-local-ci"]
+
+    ctx = json.loads(BASELINE_CTX.read_text(encoding="utf-8"))
+    assert ctx["contexts"] == ["cdb-local-ci"]
+    assert "cdb-local-ci" in ctx.get("commit_status_contexts", [])
+
+
+def test_no_private_key_or_token_examples_in_publisher_tree():
+    publisher_root = REPO_ROOT / "ci" / "publisher"
+    pem_markers = (
+        "-----BEGIN RSA PRIVATE KEY-----",
+        "-----BEGIN PRIVATE KEY-----",
+        "-----BEGIN OPENSSH PRIVATE KEY-----",
+    )
+    # Real token-shaped values (prefix + long secret), not detection literals.
+    import re
+
+    token_value_re = re.compile(
+        r"\b(?:ghp_|github_pat_|gho_|ghu_|ghs_|ghr_)[A-Za-z0-9_]{20,}\b"
+    )
+    for path in publisher_root.rglob("*"):
+        if not path.is_file() or path.suffix not in {".py", ".md", ".txt", ".pem"}:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for snippet in pem_markers:
+            assert snippet not in text, f"{path} contains PEM material"
+        match = token_value_re.search(text)
+        assert match is None, f"{path} contains token-like value {match.group(0)!r}"
+
+
+def test_cutover_runbook_documents_phases_and_holds():
+    assert CUTOVER_RUNBOOK.is_file()
+    text = CUTOVER_RUNBOOK.read_text(encoding="utf-8")
+    for marker in (
+        "A_CODE_READY",
+        "B_APP_INSTALLED",
+        "C_SHADOW_SMOKE",
+        "D_CUTOVER",
+        "E_RETIRE_INTERIM",
+        "cdb-local-ci-app-preview",
+        "APP_BOUND_CHECK_RUN_CUTOVER_HANDOFF",
+        "Rollback",
+        "HOLD",
+        "CDB_GH_APP_INSTALLATION_TOKEN",
+    ):
+        assert marker in text, f"missing {marker}"
+
+
+def test_app_permission_matrix_forbids_statuses_write_and_admin():
+    text = CUTOVER_RUNBOOK.read_text(encoding="utf-8")
+    assert "Metadata: Read" in text
+    assert "Checks: Read and Write" in text
+    # Documented as prohibited, not granted.
+    assert "Commit statuses: Write" in text
+    assert "prohibited" in text.lower() or "forbidden" in text.lower()
+    assert "Administration" in text
+
+
+def test_publisher_has_no_branch_protection_write_api():
+    publisher_root = REPO_ROOT / "ci" / "publisher"
+    blob = "\n".join(
+        path.read_text(encoding="utf-8") for path in publisher_root.rglob("*.py")
+    )
+    assert "branches/main/protection" not in blob
+    assert "/repos/{owner}/{repo}/branches/" not in blob
+    assert "PUT" not in blob or "check-runs" in blob  # no BP mutation helpers
+    assert "update_branch_protection" not in blob
+    assert "required_pull_request_reviews" not in blob
+
+
+def test_no_heavy_ci_restore_in_publisher_slice():
+    # This PR must not re-enable hosted heavy CI as required context.
+    bp = json.loads(BASELINE_BP.read_text(encoding="utf-8"))
+    contexts = bp["required_status_checks"]["contexts"]
+    assert "ci (Unit/Integration + Lint gesammelt)" not in contexts
+    assert contexts == ["cdb-local-ci"]
+
+
+def test_check_run_mode_requires_explicit_backend_flag():
+    from ci.publisher.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "dry-run",
+            "--evidence-dir",
+            ".",
+            "--pr-number",
+            "1",
+        ]
+    )
+    assert args.publisher_backend == "commit-status"

--- a/tests/unit/ci/test_status_publisher_check_run_e2e.py
+++ b/tests/unit/ci/test_status_publisher_check_run_e2e.py
@@ -1,0 +1,113 @@
+"""Mock E2E: evidence → Check Run payload → mock POST → readback → ledger (#4170)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ci.publisher import EXPECTED_REPOSITORY
+from ci.publisher.backends import CheckRunBackend
+from ci.publisher.evidence import build_check_run_payload
+from ci.publisher.github_client import GitHubResponse
+from ci.publisher.ledger import LedgerEntry, append_entry, load_ledger
+from ci.publisher.models import CHECK_RUN_NAME
+
+pytestmark = pytest.mark.unit
+
+SHA = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+RUN_ID = "20260730T150000Z-e2e001"
+APP_ID = 424242
+INSTALLATION_ID = 313131
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses: list[GitHubResponse] = []
+
+    def __call__(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes | None,
+        timeout: float,
+    ) -> GitHubResponse:
+        parsed = json.loads(body.decode("utf-8")) if body else None
+        self.calls.append({"method": method, "url": url, "body": parsed})
+        return self.responses.pop(0)
+
+
+def test_mock_e2e_check_run_publish_and_ledger(tmp_path: Path):
+    payload = build_check_run_payload(
+        commit_sha=SHA,
+        run_id=RUN_ID,
+        ok=True,
+        started_at_utc="2026-07-30T15:00:00Z",
+        ended_at_utc="2026-07-30T15:10:00Z",
+        target_url="https://example.test/run",
+        optional_skipped=[],
+        name=CHECK_RUN_NAME,
+    )
+    remote = {
+        "id": 555,
+        "name": CHECK_RUN_NAME,
+        "head_sha": SHA,
+        "status": "completed",
+        "conclusion": "success",
+        "external_id": payload.external_id,
+        "app": {"id": APP_ID},
+    }
+    transport = FakeTransport()
+    transport.responses.extend(
+        [
+            GitHubResponse(200, {"check_runs": []}, {}),
+            GitHubResponse(200, {"check_runs": []}, {}),
+            GitHubResponse(201, remote, {}),
+            GitHubResponse(200, remote, {}),
+        ]
+    )
+    backend = CheckRunBackend(
+        token="installation-token",
+        expected_app_id=APP_ID,
+        expected_installation_id=INSTALLATION_ID,
+        transport=transport,
+    )
+    result = backend.publish(check_run_payload=payload, dry_run=False)
+    assert result.ok is True
+    assert result.remote_id == 555
+    assert result.remote_verification_status == "verified"
+    assert result.github_app_id == APP_ID
+
+    ledger_path = tmp_path / "published-runs.json"
+    append_entry(
+        ledger_path,
+        LedgerEntry(
+            run_id=RUN_ID,
+            commit_sha=SHA,
+            repository=EXPECTED_REPOSITORY,
+            status_context=CHECK_RUN_NAME,
+            manifest_sha256="a" * 64,
+            published_at_utc="2026-07-30T15:10:01Z",
+            state="success",
+            publisher_backend="check-run",
+            github_object_type="check_run",
+            github_check_run_id=result.remote_id,
+            github_app_id=APP_ID,
+            github_installation_id=INSTALLATION_ID,
+            check_run_name=CHECK_RUN_NAME,
+            head_sha=SHA,
+            external_id=payload.external_id,
+            remote_verification_status=result.remote_verification_status,
+        ),
+    )
+    loaded = load_ledger(ledger_path)
+    entry = loaded["entries"][0]
+    assert entry["publisher_backend"] == "check-run"
+    assert entry["github_check_run_id"] == 555
+    assert entry["external_id"] == payload.external_id
+    assert entry["remote_verification_status"] == "verified"
+    assert "token" not in json.dumps(entry).lower()

--- a/tests/unit/ci/test_status_publisher_github.py
+++ b/tests/unit/ci/test_status_publisher_github.py
@@ -203,5 +203,8 @@ def test_check_run_and_commit_status_payloads_are_deterministic():
         target_url="https://example.test/evidence",
     )
     assert a.to_api_body() == b.to_api_body()
-    # Phase 3a documents Commit Status only; Check Run adapter is intentionally absent.
+    # Check Runs are implemented in CheckRunBackend, not on GitHubStatusClient.
     assert not hasattr(GitHubStatusClient, "create_check_run")
+    from ci.publisher.backends import CheckRunBackend
+
+    assert hasattr(CheckRunBackend, "publish")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase A for #4170: add an explicit GitHub-App Check Run publisher backend while keeping the interim Commit Status path as the live required merge context.

**Refs #4170** — Does **not** close #4170 (App install, live smoke, and Branch Protection cutover remain external).

## Conflict resolution (rebase onto current main)

- **Previous PR head:** `d5da6a3978f1e0e33d4aad73968df5a41adbb5a1`
- **New PR head:** `b04809ecf0489f60c28742c14d052f4e131cbf67`
- **origin/main:** `be9698892624a4a9abb28f44a78d29b9d08599f5` (includes #4212/#4213/#4211)
- **Conflict files:** `docs/runbooks/merge_policy_ci_gate.md` (content); `ci/README.md` auto-merged cleanly
- **Resolution:** kept #4170 Trust-gap + Check-Run Phase A docs **and** #4206 Black toolchain / Timeout / Pins **and** #4205 temp-root preflight
- **mergeable:** true (live API); `mergeable_state=blocked` expected without published `cdb-local-ci` / Hosted Actions billing lock

## Brain Evidence

```text
brain_source: repo-only
brain_status: not-used
context_brain_attempted: true
context_brain_used: false
context_available: false
repo_fallback_used: true
repo_fallback_reason: unavailable
context_tool_status: absent
context_trust_level: none
records_found: none
```

## Current trust gap

Required context `cdb-local-ci` is still a Commit Status with `app_id=null`. This PR prepares the App-bound Check Run publisher; it does **not** switch Branch Protection.

## Architecture

- `PublisherBackend` with `CommitStatusBackend` (default) and `CheckRunBackend` (explicit)
- Check Run auth: **only** `CDB_GH_APP_INSTALLATION_TOKEN`
- Required: `--expected-app-id`, `--expected-installation-id`
- Remote readback verifies `app.id`, name, head_sha, conclusion, external_id
- No fallback from Check Run to Commit Status on error

## Delivered

- `ci/publisher/backends.py` + models/ledger/CLI extensions
- Unit, contract, security, mock-E2E tests
- Cutover runbook + `APP_BOUND_CHECK_RUN_CUTOVER_HANDOFF`
- Docs updates including preserved #4206 Black SSOT after rebase

## Validation (post-rebase)

- Publisher + Black/Toolchain/Temp suite: **114 passed**
- `ruff check` / `black --check` on changed `.py`: pass
- `git diff --check`: pass
- README link guard + docs conflict guard: OK
- Regression: Commit-Status default; no `create_check_run` on status client; BP baselines unchanged; `black==26.5.1` pin; no unversioned Black/Ruff reinstall in Dockerfile
- **No** live GitHub Check Run publish
- **No** App smoke test
- **No** Branch Protection cutover
- **No** merge
- Hosted Actions remain billing/account-lock limited (advisory)

## Guardrails

- Branch Protection unchanged
- Commit Status path still active (default)
- No secrets in repo
- No Fake-Green
- Issue #4170 stays open
- LR remains **NO-GO**
- Scope excludes #4165 / #4167
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-238c7db5-55ee-4143-b87a-639adfc83c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-238c7db5-55ee-4143-b87a-639adfc83c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

