### PR TITLE
fix(ci): exclude nested worktrees from backlog curation

### DIFF
--- a/.github/scripts/backlog_curation.py
+++ b/.github/scripts/backlog_curation.py
@@ -34,6 +34,7 @@ SKIP_DIRS = {
     ".pytest_cache",
     ".ruff_cache",
     ".venv",
+    ".worktrees",
     "__pycache__",
     "artifacts",
     "node_modules",
@@ -471,17 +472,42 @@ def should_skip_dir(rel_dir: str) -> bool:
     return any(part in SKIP_DIRS or part.startswith(".codex") for part in parts)
 
 
+def is_nested_git_root(repo_root: Path, directory: Path) -> bool:
+    """Return True for nested git repos/worktrees under repo_root (not repo_root).
+
+    Named exclusions (e.g. `.worktrees`) are handled by ``should_skip_dir``.
+    This covers differently named nested roots that carry their own ``.git``
+    file or directory. Paths that resolve outside ``repo_root`` are treated as
+    non-canonical and skipped (symlink escape guard).
+    """
+    try:
+        resolved_root = repo_root.resolve()
+        resolved_dir = directory.resolve()
+    except OSError:
+        return True
+    if resolved_dir == resolved_root:
+        return False
+    try:
+        resolved_dir.relative_to(resolved_root)
+    except ValueError:
+        return True
+    return (directory / ".git").exists()
+
+
 def iter_repo_files(repo_root: Path) -> list[str]:
     files: list[str] = []
-    for root, dirs, filenames in os.walk(repo_root):
+    # followlinks=False (default): do not descend into symlink directories.
+    for root, dirs, filenames in os.walk(repo_root, followlinks=False):
         rel_root = Path(root).relative_to(repo_root).as_posix()
-        dirs[:] = [
-            directory
-            for directory in dirs
-            if not should_skip_dir(
-                f"{rel_root}/{directory}" if rel_root != "." else directory
-            )
-        ]
+        kept: list[str] = []
+        for directory in dirs:
+            rel_dir = f"{rel_root}/{directory}" if rel_root != "." else directory
+            if should_skip_dir(rel_dir):
+                continue
+            if is_nested_git_root(repo_root, Path(root) / directory):
+                continue
+            kept.append(directory)
+        dirs[:] = kept
         for filename in filenames:
             rel_path = (
                 f"{rel_root}/{filename}" if rel_root != "." else filename

--- a/knowledge/logs/sessions/2026-07-31-4224-backlog-curation-worktree-exclusion.md
+++ b/knowledge/logs/sessions/2026-07-31-4224-backlog-curation-worktree-exclusion.md
@@ -1,0 +1,40 @@
+# Session 2026-07-31 — #4224 backlog curation non-canon tree exclusion
+
+## Scope
+
+Issue #4224: Exclude nested `.worktrees` and nested git roots from
+`backlog_curation` source ranking so historical-only curation stays
+`fail_closed` independent of local worktree pollution.
+
+## Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+context_tool_status: available
+context_trust_level: none
+records_found: none
+```
+
+## Delivery
+
+- Branch: `batch/ci-tooling-issue-4224`
+- Commit: `d70f44b2027db98add0af35273439361a025ba1b`
+- PR: #4225 (draft batch)
+- Router: `CREATE_NEW_BATCH_PR` → later `ROUTE_TO_EXISTING_BATCH_PR` expected
+
+## Validation
+
+- 34 unit tests PASS (`tests/unit/scripts/test_backlog_curation.py`)
+- historical-only PASS on polluted primary and clean detached worktree
+- ruff/black/`git diff --check` PASS
+
+## Boundaries
+
+- No merge, no issue close, no Full Fast-CI, no `cdb-local-ci`
+- LR NO-GO unchanged

--- a/tests/unit/scripts/test_backlog_curation.py
+++ b/tests/unit/scripts/test_backlog_curation.py
@@ -19,6 +19,39 @@ sys.modules[_SPEC.name] = backlog_curation
 _SPEC.loader.exec_module(backlog_curation)
 
 
+def _write(path: Path, content: str = "# decoy\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _historical_only_payload() -> dict[str, object]:
+    return _payload(
+        event_label="task",
+        labels=["task"],
+        body=(
+            "See `docs/archive/knowledge/ARCHITECTURE_MAP.md` and "
+            "`knowledge/logs/sessions/historical-session.md`."
+        ),
+    )
+
+
+def _source_paths(artifact: dict[str, object]) -> set[str]:
+    sources = artifact.get("sources") or []
+    assert isinstance(sources, list)
+    return {str(item["path"]) for item in sources if isinstance(item, dict)}
+
+
+def _handoff_paths(artifact: dict[str, object]) -> set[str]:
+    handoff = artifact.get("handoff") or {}
+    assert isinstance(handoff, dict)
+    paths: set[str] = set()
+    for key in ("must_read", "supporting", "background"):
+        for item in handoff.get(key) or []:
+            if isinstance(item, dict) and "path" in item:
+                paths.add(str(item["path"]))
+    return paths
+
+
 def _payload(
     *,
     event_label: str,
@@ -385,3 +418,132 @@ def test_extract_explicit_repo_paths_adversarial_many_slashes() -> None:
     backlog_curation.extract_explicit_repo_paths(adversarial)
     elapsed = time.time() - start
     assert elapsed < 1.0, f"Path extraction took {elapsed}s (should complete in <1s)"
+
+
+def test_worktrees_decoy_does_not_change_historical_only_fail_closed(
+    tmp_path: Path,
+) -> None:
+    """Named `.worktrees/` trees must never enter ranking or flip fail_closed."""
+    decoy = (
+        tmp_path / ".worktrees" / "decoy-branch" / "knowledge" / "ARCHITECTURE_MAP.md"
+    )
+    _write(
+        decoy,
+        "# Architecture Map\narchitecture map knowledge sessions archive\n",
+    )
+    _write(tmp_path / "CURRENT_STATUS.md", "# status\n")
+
+    artifact = backlog_curation.curate_issue_payload(
+        _historical_only_payload(), repo_root=tmp_path
+    )
+
+    assert artifact is not None
+    assert artifact["curation_status"]["state"] == "fail_closed"
+    decoy_rel = decoy.relative_to(tmp_path).as_posix()
+    all_paths = _source_paths(artifact) | _handoff_paths(artifact)
+    assert decoy_rel not in all_paths
+    assert not any(".worktrees/" in path for path in all_paths)
+    assert decoy_rel not in backlog_curation.iter_repo_files(tmp_path)
+
+
+def test_nested_git_root_outside_named_worktrees_is_not_traversed(
+    tmp_path: Path,
+) -> None:
+    nested_root = tmp_path / "vendor-or-temp" / "nested-copy"
+    (nested_root / ".git").mkdir(parents=True)
+    decoy = nested_root / "knowledge" / "ARCHITECTURE_MAP.md"
+    _write(
+        decoy,
+        "# Architecture Map\narchitecture map knowledge sessions archive\n",
+    )
+    _write(tmp_path / "CURRENT_STATUS.md", "# status\n")
+
+    artifact = backlog_curation.curate_issue_payload(
+        _historical_only_payload(), repo_root=tmp_path
+    )
+
+    assert artifact is not None
+    assert artifact["curation_status"]["state"] == "fail_closed"
+    decoy_rel = decoy.relative_to(tmp_path).as_posix()
+    all_paths = _source_paths(artifact) | _handoff_paths(artifact)
+    assert decoy_rel not in all_paths
+    assert decoy_rel not in backlog_curation.iter_repo_files(tmp_path)
+    assert backlog_curation.is_nested_git_root(tmp_path, nested_root) is True
+    assert backlog_curation.is_nested_git_root(tmp_path, tmp_path) is False
+
+
+def test_nested_git_file_marker_is_treated_as_nested_root(tmp_path: Path) -> None:
+    nested_root = tmp_path / "scratch" / "linked-worktree"
+    nested_root.mkdir(parents=True)
+    (nested_root / ".git").write_text(
+        "gitdir: /tmp/fake-main/.git/worktrees/linked\n", encoding="utf-8"
+    )
+    decoy = nested_root / "knowledge" / "ARCHITECTURE_MAP.md"
+    _write(decoy, "# Architecture Map\narchitecture map\n")
+
+    assert backlog_curation.is_nested_git_root(tmp_path, nested_root) is True
+    assert decoy.relative_to(
+        tmp_path
+    ).as_posix() not in backlog_curation.iter_repo_files(tmp_path)
+
+
+def test_normal_canon_file_remains_discoverable(tmp_path: Path) -> None:
+    canon = tmp_path / "knowledge" / "ARCHITECTURE_MAP.md"
+    _write(canon, "# Architecture Map\nactive architecture map canon\n")
+    _write(
+        tmp_path / ".worktrees" / "noise" / "knowledge" / "ARCHITECTURE_MAP.md",
+        "# decoy architecture map\n",
+    )
+
+    files = backlog_curation.iter_repo_files(tmp_path)
+    assert "knowledge/ARCHITECTURE_MAP.md" in files
+    assert not any(path.startswith(".worktrees/") for path in files)
+
+    payload = _payload(
+        event_label="task",
+        labels=["task"],
+        title="Architecture map reconcile",
+        body="Update `knowledge/ARCHITECTURE_MAP.md` for the active architecture map.",
+    )
+    artifact = backlog_curation.curate_issue_payload(payload, repo_root=tmp_path)
+    assert artifact is not None
+    assert "knowledge/ARCHITECTURE_MAP.md" in (
+        _source_paths(artifact) | _handoff_paths(artifact)
+    )
+    assert not any(
+        ".worktrees/" in path
+        for path in (_source_paths(artifact) | _handoff_paths(artifact))
+    )
+
+
+@pytest.mark.parametrize(
+    ("rel_dir", "expected"),
+    [
+        (".worktrees", True),
+        (".worktrees/decoy-branch", True),
+        ("prefix/.worktrees/nested", True),
+        (r".worktrees\decoy-branch", True),
+        ("docs/worktrees-guide", False),
+        ("knowledge/not-a-.worktrees-name", False),
+        ("artifacts", True),
+        ("node_modules", True),
+        (".pytest_cache", True),
+        ("docs/archive/knowledge", True),
+        ("knowledge/logs/sessions", True),
+    ],
+)
+def test_should_skip_dir_segment_and_existing_skip_contract(
+    rel_dir: str, expected: bool
+) -> None:
+    assert backlog_curation.should_skip_dir(rel_dir) is expected
+
+
+def test_platform_path_normalization_for_skip_and_nested_git(tmp_path: Path) -> None:
+    assert backlog_curation.should_skip_dir(".worktrees/foo") is True
+    assert backlog_curation.should_skip_dir(r".worktrees\foo") is True
+
+    nested = tmp_path / "vendor" / "nested"
+    nested.mkdir(parents=True)
+    (nested / ".git").mkdir()
+    mixed = Path(str(nested).replace("/", "\\") if "\\" not in str(nested) else nested)
+    assert backlog_curation.is_nested_git_root(tmp_path, mixed) is True

--- a/tests/unit/scripts/test_backlog_curation.py
+++ b/tests/unit/scripts/test_backlog_curation.py
@@ -539,11 +539,29 @@ def test_should_skip_dir_segment_and_existing_skip_contract(
 
 
 def test_platform_path_normalization_for_skip_and_nested_git(tmp_path: Path) -> None:
+    """Separators and nested-.git markers must be decided on real paths."""
     assert backlog_curation.should_skip_dir(".worktrees/foo") is True
-    assert backlog_curation.should_skip_dir(r".worktrees\foo") is True
+    assert backlog_curation.should_skip_dir(".worktrees\\foo") is True
+    assert backlog_curation.should_skip_dir("docs/worktrees-guide") is False
 
-    nested = tmp_path / "vendor" / "nested"
-    nested.mkdir(parents=True)
-    (nested / ".git").mkdir()
-    mixed = Path(str(nested).replace("/", "\\") if "\\" not in str(nested) else nested)
-    assert backlog_curation.is_nested_git_root(tmp_path, mixed) is True
+    nested_dir = tmp_path / "vendor" / "nested-dir"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / ".git").mkdir()
+    assert backlog_curation.is_nested_git_root(tmp_path, nested_dir) is True
+    assert backlog_curation.is_nested_git_root(tmp_path, tmp_path) is False
+
+    nested_file = tmp_path / "vendor" / "nested-file"
+    nested_file.mkdir(parents=True)
+    (nested_file / ".git").write_text(
+        "gitdir: ../.git/worktrees/linked\n", encoding="utf-8"
+    )
+    assert backlog_curation.is_nested_git_root(tmp_path, nested_file) is True
+
+    outside = tmp_path.parent / f"{tmp_path.name}-outside-nested"
+    outside.mkdir(exist_ok=True)
+    (outside / ".git").mkdir(exist_ok=True)
+    try:
+        assert backlog_curation.is_nested_git_root(tmp_path, outside) is True
+    finally:
+        (outside / ".git").rmdir()
+        outside.rmdir()


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: ci-tooling
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: frozen
objective_key: backlog-curation-noncanon-tree-exclusion
planned_issues: #4224
contract_keys: backlog-curation-source-boundary-v1
risk_flags: none
-->

## Refs

Closes #4224

`Closes #4224` is the schema-required merge-closure link for the CDB Batch Ledger only. Issue #4224 stays open until the actual batch merge; this delivery session does not close it early.

**No premature merge claim.** LR remains **NO-GO**. Board stage `trade-capable` is not Live-Go.

## Summary

- Exclude `.worktrees/` path segments during `os.walk` source traversal in `backlog_curation`.
- Skip nested git roots (own `.git` file or directory) under `repo_root` without excluding `repo_root` itself.
- Keep historical-only curation deterministically `fail_closed` regardless of local nested worktrees.

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4224 | SLICE_DELIVERED | b57f4e8e2f69b2d46f8146cbfb99c3c52a397536 | 34+ unit PASS; historical-only PASS on polluted primary + clean detached worktree; ruff/black PASS; git diff --check PASS | none | Full Fast-CI and cdb-local-ci only after MERGE_CANDIDATE |

## Root Cause

`iter_repo_files` walked nested trees under `.worktrees/`. Keyword ranking then treated decoy canon-like files as active `must_read` sources, flipping historical-only curation from `fail_closed` to `partial`.

## Traversal / Source Boundary

- Named exclusion: exact path segment `.worktrees` via `SKIP_DIRS` / `should_skip_dir`.
- Structural exclusion: `is_nested_git_root(repo_root, directory)` for nested `.git` file or directory.
- Symlink escape: resolved paths outside `repo_root` are skipped; `os.walk(..., followlinks=False)`.
- Unchanged: ranking weights, curation states, `HISTORICAL_PREFIXES`, existing cache/artifact skips.

## Validation

- `pytest -q tests/unit/scripts/test_backlog_curation.py`: PASS
- historical-only on primary (with local `.worktrees`): `fail_closed`
- historical-only on clean detached worktree (no `.worktrees`): `fail_closed`
- `ruff check` / `black --check` on touched files: PASS
- `git diff --check`: PASS
- Hosted Actions red: billing account lock (jobs not started) = advisory infra, not a code gap

## Non-goals

- No score/ranking/status semantic changes
- No merge until Completeness + Conductor gates
- No Full Fast-CI / `cdb-local-ci` until frozen final head
- No deletion of local worktrees or ARVP artifacts
- No changes to #4218 / #4219

## Boundaries

- LR **NO-GO**
- Board `trade-capable` is not Live-Go
- No runtime/trading/risk/DB/MCP/secrets scope


