### PR TITLE
feat(economics): retire funding/limit surfaces and harden gross-to-net fail-closed (#4190)

### DIFF
--- a/core/replay/execution_economics_v1.py
+++ b/core/replay/execution_economics_v1.py
@@ -50,7 +50,72 @@ COMPONENT_STATUS_ACTIVE = "active"
 COMPONENT_STATUS_ZERO = "zero"
 COMPONENT_STATUS_NOT_APPLICABLE = "not_applicable"
 COMPONENT_STATUS_INACTIVE = "inactive_not_wired"
+COMPONENT_STATUS_UNAVAILABLE = "unavailable"
 COMPONENT_STATUS_EMBEDDED = "embedded_in_fill_price"
+
+VALID_COMPONENT_STATUSES: frozenset[str] = frozenset(
+    {
+        COMPONENT_STATUS_ACTIVE,
+        COMPONENT_STATUS_ZERO,
+        COMPONENT_STATUS_NOT_APPLICABLE,
+        COMPONENT_STATUS_INACTIVE,
+        COMPONENT_STATUS_UNAVAILABLE,
+        COMPONENT_STATUS_EMBEDDED,
+    }
+)
+
+# Statuses whose amount MUST be null: the component carries no billable number.
+NULL_AMOUNT_COMPONENT_STATUSES: frozenset[str] = frozenset(
+    {
+        COMPONENT_STATUS_NOT_APPLICABLE,
+        COMPONENT_STATUS_INACTIVE,
+        COMPONENT_STATUS_UNAVAILABLE,
+    }
+)
+
+# Statuses that are never subtracted from gross (null amounts plus amounts that
+# are already embedded in the fill price and would otherwise double-count).
+NON_SUBTRACTED_COMPONENT_STATUSES: frozenset[str] = NULL_AMOUNT_COMPONENT_STATUSES | {
+    COMPONENT_STATUS_EMBEDDED
+}
+
+ORDER_TYPE_MARKET = "market"
+ORDER_TYPE_LIMIT = "limit"
+VALID_ORDER_TYPES: frozenset[str] = frozenset({ORDER_TYPE_MARKET, ORDER_TYPE_LIMIT})
+
+FILL_STATUS_FILLED = "filled"
+FILL_STATUS_PARTIALLY_FILLED = "partially_filled"
+FILL_STATUS_NOT_FILLED = "not_filled"
+VALID_FILL_STATUSES: frozenset[str] = frozenset(
+    {FILL_STATUS_FILLED, FILL_STATUS_PARTIALLY_FILLED, FILL_STATUS_NOT_FILLED}
+)
+
+DEFAULT_FUNDING_SETTLEMENT_HOURS = Decimal("8")
+
+# Funding rate provenance that is NOT admissible as an active, billable input.
+# Activating funding on any of these would invent a venue cost (#4190).
+UNPROVEN_FUNDING_RATE_SOURCES: frozenset[str] = frozenset(
+    {
+        "",
+        "unknown",
+        "assumed",
+        "placeholder",
+        "synthetic_default",
+        "simulator_default",
+    }
+)
+FUNDING_RATE_SOURCE_SYNTHETIC_DEFAULT = "synthetic_default"
+
+# #4190 wire-or-retire verdict for the two surfaces inventoried by #4150.
+# Replay datasets are OHLCV only; no funding-rate series and no per-position
+# holding duration reach the active runner path, so funding stays unbillable.
+FUNDING_INPUT_AVAILABILITY = "unavailable_no_funding_rate_series"
+# services.execution.simulator.simulate_limit_order is parked: no runner calls
+# it and its fill trigger bills a marketable (taker) limit as a maker fill.
+LIMIT_ORDER_MODEL_STATUS = "parked_not_economics_billable"
+REQUIRED_FUNDING_BASIS_KEYS: frozenset[str] = frozenset(
+    {"position_value", "funding_rate", "funding_rate_source", "hours_held"}
+)
 
 # Scenario override key -> ExecutionSimulator config field
 SCENARIO_OVERRIDE_KEY_TO_SIMULATOR: dict[str, str] = {
@@ -397,6 +462,11 @@ class GrossToNetResult:
     net_pnl: Decimal
     reconciled: bool
     residual: Decimal
+    order_type: str = ORDER_TYPE_MARKET
+    fill_status: str = FILL_STATUS_FILLED
+    maker_fill_evidence: bool = False
+    funding_basis: Optional[dict[str, Any]] = None
+    reported_net_pnl: Optional[Decimal] = None
     assumptions_snapshot: dict[str, Any] = field(default_factory=dict)
     limitations: tuple[str, ...] = ()
 
@@ -404,6 +474,12 @@ class GrossToNetResult:
         return {
             "contract_version": self.contract_version,
             "formula": self.formula,
+            "execution_semantics": {
+                "order_type": self.order_type,
+                "fill_status": self.fill_status,
+                "maker_fill_evidence": self.maker_fill_evidence,
+                "funding_basis": self.funding_basis,
+            },
             "gross_pnl": str(_q_money(self.gross_pnl)),
             "fill_price_embedded_gross": (
                 str(_q_money(self.fill_price_embedded_gross))
@@ -422,6 +498,11 @@ class GrossToNetResult:
                 "funding_cost_when_active": self.funding_cost_when_active.to_dict(),
             },
             "net_pnl": str(_q_money(self.net_pnl)),
+            "reported_net_pnl": (
+                None
+                if self.reported_net_pnl is None
+                else str(_q_money(self.reported_net_pnl))
+            ),
             "reconciled": self.reconciled,
             "residual": str(_q_money(self.residual)),
             "assumptions_snapshot": self.assumptions_snapshot,
@@ -441,13 +522,32 @@ def build_assumptions_snapshot(
     usable_depth_fraction: Any = DEFAULT_USABLE_DEPTH_FRACTION,
     funding_rate: Any = DEFAULT_FUNDING_RATE,
     funding_active: bool = False,
+    funding_rate_source: str = FUNDING_RATE_SOURCE_SYNTHETIC_DEFAULT,
     limit_orders_active: bool = False,
+    limit_order_fill_model: str | None = None,
     spread_model: str = "not_modeled",
     reject_model: str = "not_modeled_in_replay_market_path",
     latency_model: str = "bar_delay_when_runner_implements",
     extras: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Versioned research assumptions (synthetic where marked). No secrets."""
+    """Versioned research assumptions (synthetic where marked). No secrets.
+
+    Activating funding or limit orders is fail-closed: the caller must name a
+    non-synthetic funding rate source, respectively a limit-order fill model,
+    otherwise the snapshot would advertise an active model that no proven input
+    backs (#4190).
+    """
+    if funding_active and funding_rate_source.strip() in UNPROVEN_FUNDING_RATE_SOURCES:
+        raise ExecutionEconomicsError(
+            "funding_active=True requires a non-synthetic funding_rate_source; "
+            f"got {funding_rate_source!r}. Replay datasets carry no funding-rate "
+            "series, so funding must stay inactive_not_wired."
+        )
+    if limit_orders_active and not (limit_order_fill_model or "").strip():
+        raise ExecutionEconomicsError(
+            "limit_orders_active=True requires an explicit limit_order_fill_model; "
+            "maker fills must never be assumed guaranteed."
+        )
     snapshot: dict[str, Any] = {
         "contract_version": CONTRACT_VERSION,
         "order_size": {
@@ -533,18 +633,30 @@ def build_assumptions_snapshot(
                 COMPONENT_STATUS_ACTIVE if funding_active else COMPONENT_STATUS_INACTIVE
             ),
             "funding_rate": str(_to_decimal(funding_rate, field_name="funding_rate")),
+            "funding_rate_source": funding_rate_source,
             "period": "8h",
-            "wired_into_replay_pnl": False,
-            "synthetic": True,
+            "wired_into_replay_pnl": bool(funding_active),
+            "input_availability": (
+                "available" if funding_active else FUNDING_INPUT_AVAILABILITY
+            ),
+            "synthetic": not funding_active,
         },
         "limit_order_model": {
             "status": (
                 COMPONENT_STATUS_ACTIVE
                 if limit_orders_active
-                else COMPONENT_STATUS_INACTIVE
+                else LIMIT_ORDER_MODEL_STATUS
             ),
-            "wired_into_arvp_runners": False,
-            "notes": "simulate_limit_order exists but ARVP/replay runners do not call it",
+            "fill_model": limit_order_fill_model,
+            "wired_into_arvp_runners": bool(limit_orders_active),
+            "notes": (
+                "Limit-order fill model declared by caller"
+                if limit_orders_active
+                else (
+                    "simulate_limit_order is parked: no ARVP/replay runner calls it "
+                    "and its fill trigger bills a marketable (taker) limit as maker"
+                )
+            ),
         },
         "mock_paper_comparison": dict(MOCK_PAPER_ECONOMICS_ASSUMPTIONS),
     }
@@ -559,52 +671,175 @@ def build_assumptions_snapshot(
     return snapshot
 
 
+def _validate_component_status(name: str, status: str) -> str:
+    if status not in VALID_COMPONENT_STATUSES:
+        raise ExecutionEconomicsError(
+            f"{name} status {status!r} is not a valid component status; "
+            f"allowed: {sorted(VALID_COMPONENT_STATUSES)}"
+        )
+    return status
+
+
 def _component(
     name: str,
-    amount: Optional[Decimal],
+    value: Any,
     status: str,
     *,
     notes: str = "",
 ) -> CostComponent:
-    if status in {
-        COMPONENT_STATUS_NOT_APPLICABLE,
-        COMPONENT_STATUS_INACTIVE,
-    }:
+    """Resolve one cost line, fail-closed on status/value contradictions.
+
+    ``value is None`` means "not supplied". A supplied value under a
+    null-amount status is rejected instead of being silently dropped.
+    """
+    _validate_component_status(name, status)
+    if status in NULL_AMOUNT_COMPONENT_STATUSES:
+        if value is not None:
+            raise ExecutionEconomicsError(
+                f"{name} must not carry a value when status={status!r} "
+                f"(got {value!r}); a supplied cost would be silently dropped"
+            )
         return CostComponent(name=name, amount=None, status=status, notes=notes)
-    if amount is None:
-        raise ExecutionEconomicsError(f"{name} amount required for status={status}")
+    amount = Decimal("0") if value is None else _to_decimal(value, field_name=name)
     if amount < 0:
         raise ExecutionEconomicsError(
             f"{name} cost amount must be >= 0 (got {amount}); "
             "costs are unsigned; subtract from gross"
         )
-    resolved_status = COMPONENT_STATUS_ZERO if amount == 0 else status
+    resolved_status = (
+        COMPONENT_STATUS_ZERO
+        if amount == 0 and status == COMPONENT_STATUS_ACTIVE
+        else status
+    )
     return CostComponent(
         name=name, amount=_q_money(amount), status=resolved_status, notes=notes
     )
 
 
-def _active_amount(component: CostComponent) -> Decimal:
-    if component.status in {
-        COMPONENT_STATUS_NOT_APPLICABLE,
-        COMPONENT_STATUS_INACTIVE,
-    }:
+def _billable_amount(component: CostComponent) -> Decimal:
+    if component.status in NON_SUBTRACTED_COMPONENT_STATUSES:
         return Decimal("0")
     if component.amount is None:
         return Decimal("0")
     return component.amount
 
 
+def funding_cost_from_rate(
+    *,
+    position_value: Any,
+    funding_rate: Any,
+    hours_held: Any,
+    settlement_hours: Any = DEFAULT_FUNDING_SETTLEMENT_HOURS,
+) -> Decimal:
+    """Deterministic funding cost = position_value * rate * settlement periods.
+
+    Decimal mirror of ``ExecutionSimulator.calculate_funding_fees`` for evidence
+    use. Requires real inputs; it does not supply a default rate.
+    """
+    value = _to_decimal(position_value, field_name="position_value")
+    if value < 0:
+        raise ExecutionEconomicsError("position_value must be >= 0")
+    rate = _to_decimal(funding_rate, field_name="funding_rate")
+    if rate < 0:
+        raise ExecutionEconomicsError(
+            "negative funding rates (funding received) are not supported in v1; "
+            "costs are unsigned"
+        )
+    hours = _to_decimal(hours_held, field_name="hours_held")
+    if hours < 0:
+        raise ExecutionEconomicsError("hours_held must be >= 0")
+    settlement = _to_decimal(settlement_hours, field_name="settlement_hours")
+    if settlement <= 0:
+        raise ExecutionEconomicsError("settlement_hours must be > 0")
+    return _q_money(value * rate * (hours / settlement))
+
+
+def resolve_funding_basis(basis: Mapping[str, Any]) -> tuple[Decimal, dict[str, Any]]:
+    """Validate a funding basis and derive its deterministic cost.
+
+    Fail-closed: an active funding component needs notional, rate, holding
+    duration and a named non-synthetic rate provenance (#4190).
+    """
+    if not isinstance(basis, Mapping):
+        raise ExecutionEconomicsError("funding_basis must be a mapping")
+    missing = sorted(REQUIRED_FUNDING_BASIS_KEYS - set(basis))
+    if missing:
+        raise ExecutionEconomicsError(
+            f"funding_basis is missing required keys: {missing}"
+        )
+    source = str(basis["funding_rate_source"]).strip()
+    if source in UNPROVEN_FUNDING_RATE_SOURCES:
+        raise ExecutionEconomicsError(
+            f"funding_rate_source {source!r} is not admissible as an active cost; "
+            "funding must stay inactive_not_wired until a sourced rate series exists"
+        )
+    settlement = basis.get("settlement_hours", DEFAULT_FUNDING_SETTLEMENT_HOURS)
+    cost = funding_cost_from_rate(
+        position_value=basis["position_value"],
+        funding_rate=basis["funding_rate"],
+        hours_held=basis["hours_held"],
+        settlement_hours=settlement,
+    )
+    resolved = {
+        "position_value": str(
+            _to_decimal(basis["position_value"], field_name="position_value")
+        ),
+        "funding_rate": str(
+            _to_decimal(basis["funding_rate"], field_name="funding_rate")
+        ),
+        "funding_rate_source": source,
+        "hours_held": str(_to_decimal(basis["hours_held"], field_name="hours_held")),
+        "settlement_hours": str(_to_decimal(settlement, field_name="settlement_hours")),
+        "derived_cost": str(cost),
+    }
+    return cost, resolved
+
+
+def _validate_fill_semantics(
+    *,
+    fill_status: str,
+    gross: Decimal,
+    total_fee: CostComponent,
+    slip: CostComponent,
+    partial: CostComponent,
+) -> None:
+    """Keep fill, no-fill and partial-fill cases mutually unambiguous."""
+    if fill_status == FILL_STATUS_NOT_FILLED:
+        if gross != 0:
+            raise ExecutionEconomicsError(
+                f"fill_status='not_filled' requires gross_pnl == 0 (got {gross})"
+            )
+        for component in (total_fee, slip):
+            if _billable_amount(component) != 0:
+                raise ExecutionEconomicsError(
+                    f"fill_status='not_filled' forbids a non-zero "
+                    f"{component.name} (got {component.amount})"
+                )
+        return
+    if fill_status == FILL_STATUS_PARTIALLY_FILLED:
+        if partial.status in NULL_AMOUNT_COMPONENT_STATUSES:
+            raise ExecutionEconomicsError(
+                "fill_status='partially_filled' requires a billable "
+                f"partial_fill_impact (got status={partial.status!r})"
+            )
+        return
+    if _billable_amount(partial) != 0:
+        raise ExecutionEconomicsError(
+            "fill_status='filled' forbids a non-zero partial_fill_impact "
+            f"(got {partial.amount}); use 'partially_filled' or 'not_filled'"
+        )
+
+
 def reconcile_gross_to_net(
     *,
     gross_pnl: Any,
-    maker_fee_cost: Any = 0,
-    taker_fee_cost: Any = 0,
+    maker_fee_cost: Any | None = None,
+    taker_fee_cost: Any | None = None,
     spread_cost: Any | None = None,
     spread_status: str = COMPONENT_STATUS_NOT_APPLICABLE,
-    slippage_cost: Any = 0,
+    slippage_cost: Any | None = None,
     slippage_status: str = COMPONENT_STATUS_ACTIVE,
-    partial_fill_impact: Any = 0,
+    partial_fill_impact: Any | None = None,
     partial_fill_status: str = COMPONENT_STATUS_ACTIVE,
     reject_impact: Any | None = None,
     reject_status: str = COMPONENT_STATUS_NOT_APPLICABLE,
@@ -612,29 +847,60 @@ def reconcile_gross_to_net(
     latency_status: str = COMPONENT_STATUS_NOT_APPLICABLE,
     funding_cost: Any | None = None,
     funding_status: str = COMPONENT_STATUS_INACTIVE,
+    funding_basis: Mapping[str, Any] | None = None,
+    order_type: str = ORDER_TYPE_MARKET,
+    maker_fill_evidence: bool = False,
+    fill_status: str = FILL_STATUS_FILLED,
     fill_price_embedded_gross: Any | None = None,
+    reported_net_pnl: Any | None = None,
     assumptions_snapshot: Mapping[str, Any] | None = None,
     limitations: Sequence[str] | None = None,
     residual_tolerance: Any = "0.00000001",
 ) -> GrossToNetResult:
-    """Reconcile gross -> costs -> net with fail-closed invariant.
+    """Reconcile gross -> costs -> net with fail-closed invariants.
 
     ``gross_pnl`` must be reference/mid PnL that does **not** already embed
     slippage that is also passed as ``slippage_cost``.
+
+    Cost arguments use ``None`` for "not supplied". Supplying a value under a
+    non-billable status raises instead of dropping the cost silently, and an
+    active status without a proven input raises instead of inventing a value.
     """
+    if order_type not in VALID_ORDER_TYPES:
+        raise ExecutionEconomicsError(
+            f"order_type {order_type!r} invalid; allowed: {sorted(VALID_ORDER_TYPES)}"
+        )
+    if fill_status not in VALID_FILL_STATUSES:
+        raise ExecutionEconomicsError(
+            f"fill_status {fill_status!r} invalid; allowed: {sorted(VALID_FILL_STATUSES)}"
+        )
+    if maker_fill_evidence and order_type != ORDER_TYPE_LIMIT:
+        raise ExecutionEconomicsError(
+            "maker_fill_evidence requires order_type='limit'; a market order is "
+            "always a taker fill"
+        )
+
     gross = _q_money(_to_decimal(gross_pnl, field_name="gross_pnl"))
     maker = _component(
         "maker_fee_cost",
-        _to_decimal(maker_fee_cost, field_name="maker_fee_cost"),
+        maker_fee_cost,
         COMPONENT_STATUS_ACTIVE,
-        notes="Market-only ARVP path typically zero; maker unused",
+        notes="Maker fees require a proven limit-order maker fill",
     )
+    if _billable_amount(maker) > 0 and not (
+        order_type == ORDER_TYPE_LIMIT and maker_fill_evidence
+    ):
+        raise ExecutionEconomicsError(
+            "maker_fee_cost > 0 requires order_type='limit' and "
+            "maker_fill_evidence=True; maker fills must not be assumed on the "
+            "market-only replay path"
+        )
     taker = _component(
         "taker_fee_cost",
-        _to_decimal(taker_fee_cost, field_name="taker_fee_cost"),
+        taker_fee_cost,
         COMPONENT_STATUS_ACTIVE,
     )
-    total_fee_amount = _active_amount(maker) + _active_amount(taker)
+    total_fee_amount = _billable_amount(maker) + _billable_amount(taker)
     total_fee = _component(
         "total_fee_cost",
         total_fee_amount,
@@ -642,23 +908,17 @@ def reconcile_gross_to_net(
         notes="maker_fee_cost + taker_fee_cost",
     )
 
-    if spread_status in {COMPONENT_STATUS_NOT_APPLICABLE, COMPONENT_STATUS_INACTIVE}:
-        spread = _component(
-            "spread_cost",
-            None,
-            spread_status,
-            notes="Spread not modeled in ExecutionSimulator; not silently zeroed as measured",
-        )
-    else:
-        spread = _component(
-            "spread_cost",
-            _to_decimal(spread_cost, field_name="spread_cost"),
-            COMPONENT_STATUS_ACTIVE,
-        )
-
+    spread = _component(
+        "spread_cost",
+        spread_cost,
+        spread_status,
+        notes=(
+            "Spread not modeled in ExecutionSimulator; not silently zeroed as measured"
+        ),
+    )
     slip = _component(
         "slippage_cost",
-        _to_decimal(slippage_cost, field_name="slippage_cost"),
+        slippage_cost,
         slippage_status,
         notes=(
             "Attributed from fill vs reference; do not subtract again from "
@@ -667,66 +927,89 @@ def reconcile_gross_to_net(
     )
     partial = _component(
         "partial_fill_impact",
-        _to_decimal(partial_fill_impact, field_name="partial_fill_impact"),
+        partial_fill_impact,
         partial_fill_status,
         notes="Impact of unfilled quantity; filled quantity carries PnL",
     )
+    reject = _component(
+        "reject_impact",
+        reject_impact,
+        reject_status,
+        notes="Replay market path has no reject model",
+    )
+    latency = _component(
+        "latency_or_delay_impact",
+        latency_or_delay_impact,
+        latency_status,
+        notes="Set active when delay-vs-baseline money impact is measured",
+    )
 
-    if reject_status in {COMPONENT_STATUS_NOT_APPLICABLE, COMPONENT_STATUS_INACTIVE}:
-        reject = _component(
-            "reject_impact",
-            None,
-            reject_status,
-            notes="Replay market path has no reject model",
-        )
-    else:
-        reject = _component(
-            "reject_impact",
-            _to_decimal(reject_impact, field_name="reject_impact"),
-            COMPONENT_STATUS_ACTIVE,
-        )
-
-    if latency_status in {COMPONENT_STATUS_NOT_APPLICABLE, COMPONENT_STATUS_INACTIVE}:
-        latency = _component(
-            "latency_or_delay_impact",
-            None,
-            latency_status,
-            notes="Set active when delay-vs-baseline money impact is measured",
-        )
-    else:
-        latency = _component(
-            "latency_or_delay_impact",
-            _to_decimal(latency_or_delay_impact, field_name="latency_or_delay_impact"),
-            COMPONENT_STATUS_ACTIVE,
-        )
-
-    if funding_status in {COMPONENT_STATUS_NOT_APPLICABLE, COMPONENT_STATUS_INACTIVE}:
+    _validate_component_status("funding_cost_when_active", funding_status)
+    resolved_funding_basis: dict[str, Any] | None = None
+    if funding_status in NULL_AMOUNT_COMPONENT_STATUSES:
+        if funding_basis is not None:
+            raise ExecutionEconomicsError(
+                f"funding_basis must not be supplied when funding_status="
+                f"{funding_status!r}"
+            )
         funding = _component(
             "funding_cost_when_active",
-            None,
+            funding_cost,
             funding_status,
-            notes="Funding API exists but is not wired into replay PnL (CDB-032)",
+            notes=(
+                "Funding API exists on the simulator but no funding-rate series "
+                "reaches the active replay/paper path (#4190)"
+            ),
         )
     else:
+        if funding_basis is None:
+            raise ExecutionEconomicsError(
+                "an active funding_status requires funding_basis "
+                f"({sorted(REQUIRED_FUNDING_BASIS_KEYS)}); a bare funding_cost "
+                "would be an invented venue cost"
+            )
+        derived, resolved_funding_basis = resolve_funding_basis(funding_basis)
+        if funding_cost is not None:
+            supplied = _q_money(_to_decimal(funding_cost, field_name="funding_cost"))
+            if supplied != derived:
+                raise ExecutionEconomicsError(
+                    f"funding_cost {supplied} does not reconcile with the funding "
+                    f"basis ({derived}); funding must be derived deterministically"
+                )
         funding = _component(
             "funding_cost_when_active",
-            _to_decimal(funding_cost, field_name="funding_cost"),
-            COMPONENT_STATUS_ACTIVE,
+            derived,
+            funding_status,
+            notes="Derived from funding_basis: position_value * rate * periods",
         )
+
+    _validate_fill_semantics(
+        fill_status=fill_status,
+        gross=gross,
+        total_fee=total_fee,
+        slip=slip,
+        partial=partial,
+    )
 
     total_costs = (
-        _active_amount(total_fee)
-        + _active_amount(spread)
-        + _active_amount(slip)
-        + _active_amount(partial)
-        + _active_amount(reject)
-        + _active_amount(latency)
-        + _active_amount(funding)
+        _billable_amount(total_fee)
+        + _billable_amount(spread)
+        + _billable_amount(slip)
+        + _billable_amount(partial)
+        + _billable_amount(reject)
+        + _billable_amount(latency)
+        + _billable_amount(funding)
     )
     net = _q_money(gross - total_costs)
     tolerance = _to_decimal(residual_tolerance, field_name="residual_tolerance")
-    # Identity residual vs recomputed net is definitionally zero; expose for evidence.
-    residual = _q_money(Decimal("0"))
+    if tolerance < 0:
+        raise ExecutionEconomicsError("residual_tolerance must be >= 0")
+    if reported_net_pnl is None:
+        residual = _q_money(Decimal("0"))
+    else:
+        residual = _q_money(
+            _to_decimal(reported_net_pnl, field_name="reported_net_pnl") - net
+        )
     reconciled = abs(residual) <= tolerance
 
     embedded: Optional[Decimal] = None
@@ -769,6 +1052,15 @@ def reconcile_gross_to_net(
         net_pnl=net,
         reconciled=reconciled,
         residual=residual,
+        order_type=order_type,
+        fill_status=fill_status,
+        maker_fill_evidence=maker_fill_evidence,
+        funding_basis=resolved_funding_basis,
+        reported_net_pnl=(
+            None
+            if reported_net_pnl is None
+            else _q_money(_to_decimal(reported_net_pnl, field_name="reported_net_pnl"))
+        ),
         assumptions_snapshot=snap,
         limitations=lims,
     )
@@ -863,10 +1155,7 @@ def compare_economics_components(
                 if not isinstance(body, Mapping):
                     continue
                 status = str(body.get("status") or "")
-                if status in {
-                    COMPONENT_STATUS_NOT_APPLICABLE,
-                    COMPONENT_STATUS_INACTIVE,
-                }:
+                if status in NON_SUBTRACTED_COMPONENT_STATUSES:
                     out[str(name)] = None
                     continue
                 amount = body.get("amount")

--- a/core/replay/replay_vs_paper_compare.py
+++ b/core/replay/replay_vs_paper_compare.py
@@ -28,7 +28,10 @@ from typing import Any, Mapping
 
 from core.replay.canonical_json import canonical_json_dumps
 from core.replay.execution_economics_v1 import (
+    COMPONENT_STATUS_ACTIVE,
+    COMPONENT_STATUS_NOT_APPLICABLE,
     MOCK_PAPER_ECONOMICS_ASSUMPTIONS,
+    ORDER_TYPE_MARKET,
     compare_economics_components,
     reconcile_gross_to_net,
 )
@@ -328,17 +331,18 @@ def economics_payload_from_metrics(metrics: Mapping[str, Any]) -> dict[str, Any]
         taker = fees
     slippage = metrics_map.get("slippage_cost_quote", metrics_map.get("slippage_cost"))
     if slippage is not None:
-        slippage_status = "active"
+        slippage_status = COMPONENT_STATUS_ACTIVE
         reference_gross = float(embedded or 0) + float(slippage)
     else:
-        slippage_status = "not_applicable"
+        slippage_status = COMPONENT_STATUS_NOT_APPLICABLE
         reference_gross = float(embedded or 0)
     return reconcile_gross_to_net(
         gross_pnl=reference_gross,
         maker_fee_cost=maker if maker is not None else 0,
         taker_fee_cost=taker if taker is not None else 0,
-        slippage_cost=0 if slippage is None else slippage,
+        slippage_cost=slippage,
         slippage_status=slippage_status,
+        order_type=ORDER_TYPE_MARKET,
         fill_price_embedded_gross=embedded,
     ).to_dict()
 
@@ -359,15 +363,17 @@ def compare_economics_from_reports(
         paper_econ = reconcile_gross_to_net(
             gross_pnl=0,
             taker_fee_cost=0,
-            slippage_cost=0,
-            slippage_status="not_applicable",
+            slippage_cost=None,
+            slippage_status=COMPONENT_STATUS_NOT_APPLICABLE,
             reject_impact=0,
-            reject_status="active",
+            reject_status=COMPONENT_STATUS_ACTIVE,
             latency_or_delay_impact=0,
-            latency_status="active",
+            latency_status=COMPONENT_STATUS_ACTIVE,
+            order_type=ORDER_TYPE_MARKET,
             limitations=(
                 "Paper economics omitted; mock defaults documented only.",
                 "MockExecutor has no fee/spread model; reject/latency are seeded.",
+                "Funding is inactive_not_wired on both sides; limit orders are parked.",
             ),
         ).to_dict()
         paper_econ["mock_paper_assumptions"] = dict(MOCK_PAPER_ECONOMICS_ASSUMPTIONS)

--- a/docs/contracts/EXECUTION_ECONOMICS_GROSS_TO_NET_V1.md
+++ b/docs/contracts/EXECUTION_ECONOMICS_GROSS_TO_NET_V1.md
@@ -1,6 +1,6 @@
 # Execution Economics Gross-to-Net Contract v1
 
-**Status:** Canonical research contract for #4150
+**Status:** Canonical research contract for #4150, funding/limit verdict from #4190
 
 **Version:** `execution_economics_gross_to_net.v1`
 
@@ -10,7 +10,9 @@
 
 **Live-Readiness:** NO-GO
 
-**Runtime impact:** none (no BLUE/RED/Paper/Live start; no `services/execution/**` edits in this slice)
+**Runtime impact:** none. #4190 touches `services/execution/simulator.py` only in
+docstrings, log text and additive result metadata; no fill, fee or slippage
+arithmetic changes, and no BLUE/RED/Paper/Live start.
 
 ## Purpose
 
@@ -43,8 +45,45 @@ Rules:
 - Slippage that is applied inside `avg_fill_price` must be attributed as
   `slippage_cost` against reference gross, or marked embedded via
   `fill_price_embedded_gross` (informational; never double-subtract).
-- Not applicable / inactive components use `amount=null` with explicit status
-  (`not_applicable` or `inactive_not_wired`), not silent omission.
+- Not applicable / inactive / unavailable components use `amount=null` with an
+  explicit status, not silent omission and not a measured zero.
+- `reported_net_pnl` is optional. When supplied, `residual = reported - computed`
+  and `reconciled` is only true within `residual_tolerance`.
+
+### Component status vocabulary
+
+| Status | Amount | Subtracted | Meaning |
+|---|---|---|---|
+| `active` | number | yes | Measured cost |
+| `zero` | `0` | yes | Measured and genuinely zero |
+| `embedded_in_fill_price` | number | **no** | Already inside the fill price; informational only |
+| `not_applicable` | `null` | no | Does not apply to this path |
+| `inactive_not_wired` | `null` | no | Surface exists but no runner consumes it |
+| `unavailable` | `null` | no | Applies in principle, but the input cannot be sourced |
+
+### Fail-closed status/value rules
+
+- Supplying a value under a null-amount status raises `ExecutionEconomicsError`.
+  A cost is never silently dropped, and a missing input is never silently zeroed.
+- Unknown status, `order_type` or `fill_status` strings are rejected.
+
+## Execution semantics
+
+`execution_semantics` disambiguates the maker/taker, fill and funding cases:
+
+| Field | Values | Rule |
+|---|---|---|
+| `order_type` | `market`, `limit` | ARVP/replay is market-only |
+| `fill_status` | `filled`, `partially_filled`, `not_filled` | See below |
+| `maker_fill_evidence` | boolean | Required for any non-zero `maker_fee_cost` |
+| `funding_basis` | object or `null` | Present only when funding is active |
+
+- `maker_fee_cost > 0` requires `order_type="limit"` **and**
+  `maker_fill_evidence=True`. Maker fills are never assumed on the market path.
+- `fill_status="not_filled"` requires `gross_pnl == 0` and zero fees/slippage;
+  the forgone PnL belongs in `partial_fill_impact`.
+- `fill_status="partially_filled"` requires a billable `partial_fill_impact`.
+- `fill_status="filled"` forbids a non-zero `partial_fill_impact`.
 
 ## Units and boundaries
 
@@ -92,18 +131,79 @@ Required snapshot fields include `order_size`, `book_depth.depth_multiplier`,
 Defaults remain the historical research hardcodes (`order_size=1.0`,
 `depth_multiplier=10000`) and are marked **synthetic**.
 
-## Inactive surfaces (CDB-032)
+## Funding and limit orders: wire-or-retire verdict (#4190)
 
-- **Funding:** `calculate_funding_fees` / `FUNDING_RATE` exist on the simulator
-  but are not wired into ARVP/replay PnL → `inactive_not_wired`.
-- **Limit orders:** `simulate_limit_order` exists but ARVP runners do not call it
-  → `inactive_not_wired`. No new limit-order engine in this issue.
+Both surfaces inventoried by #4150 were re-examined against the **active** data
+and runner path. Verdict: `RETIRE_OR_PARK_DEAD_SURFACES` for both. Neither is
+deleted — each stays visible and explicitly labelled as not active and not
+billable.
+
+### Funding — retired, `inactive_not_wired`, input `unavailable`
+
+Evidence:
+
+- Replay datasets are OHLCV only (`open, high, low, close, volume`); the
+  repository contains no funding-rate series.
+- `ExecutionSimulator.FUNDING_RATE` defaults to `0.0001` with provenance
+  `synthetic_default` — an unverified venue assumption, not a measurement.
+- No runner tracks per-position holding duration across settlement boundaries,
+  so `hours_held` has no measured source either.
+- `calculate_funding_fees` has no production caller.
+
+Contract behaviour:
+
+- `funding_cost_when_active` stays `inactive_not_wired` with `amount=null`, and
+  `assumptions_snapshot.funding_model.input_availability` reports
+  `unavailable_no_funding_rate_series`.
+- Activating funding is fail-closed. It requires a complete `funding_basis`
+  (`position_value`, `funding_rate`, `funding_rate_source`, `hours_held`,
+  optional `settlement_hours`) whose source is **not** in
+  `UNPROVEN_FUNDING_RATE_SOURCES`. The cost is then derived by
+  `funding_cost_from_rate` — a bare `funding_cost` scalar is rejected.
+- A supplied `funding_cost` that disagrees with the derived value is rejected.
+
+This is the wiring seam: once a sourced funding-rate series and holding
+durations exist, funding activates through `funding_basis` without further
+contract changes.
+
+### Limit orders — retired from the economics path, parked in the simulator
+
+Evidence:
+
+- `simulate_limit_order` has no production caller; the only references live in
+  `tests/unit/verlosung/`, which `pytest.ini` excludes via `norecursedirs` and
+  which cannot import (`ModuleNotFoundError: services.execution_simulator`).
+- Its fill trigger is economically inverted: a buy limit at or above market is
+  marketable and crosses the book, yet it is booked at the **maker** rate with
+  zero slippage. That guarantees maker fills, which is exactly the assumption
+  this contract forbids.
+
+Contract behaviour:
+
+- `ExecutionResult` now carries `order_type`, `fee_role` and
+  `economics_billable`. Limit results are `economics_billable=False` with
+  `fee_role="maker_assumed_unproven"`; market results are billable takers.
+- `assumptions_snapshot.limit_order_model.status` is
+  `parked_not_economics_billable`, matched by
+  `services.execution.simulator.LIMIT_ORDER_MODEL_STATUS` and asserted by a
+  parity test.
+- Activating limit orders in the snapshot requires an explicit
+  `limit_order_fill_model`; there is no default.
+
+A real limit-order model needs queue position and venue fill evidence and is
+out of scope here.
 
 ## Replay vs Paper
 
 Component diffs use `compare_economics_components`. Mock economics assumptions
 (seeded success/reject, 50–200 ms latency, % slippage, no fees/spread) are
 documented under `mock_paper_comparison` and must not be read as venue proof.
+
+Replay, paper and candidate evidence all go through `reconcile_gross_to_net`, so
+they share one contract semantics: identical funding/limit status, identical
+`execution_semantics`, and an identical `assumptions_snapshot.fingerprint` for
+identical assumptions. Components that are null on either side are reported as
+`incomparable` or `both_not_applicable_or_missing` — never as a zero delta.
 
 ## Relationship to Profitability Economics v1 (#3039)
 

--- a/docs/contracts/execution_economics_gross_to_net.v1.schema.json
+++ b/docs/contracts/execution_economics_gross_to_net.v1.schema.json
@@ -8,6 +8,7 @@
   "required": [
     "contract_version",
     "formula",
+    "execution_semantics",
     "gross_pnl",
     "components",
     "net_pnl",
@@ -23,6 +24,47 @@
     "formula": {
       "type": "string",
       "minLength": 1
+    },
+    "execution_semantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["order_type", "fill_status", "maker_fill_evidence", "funding_basis"],
+      "description": "Disambiguates maker/taker, fill/partial/no-fill and funding provenance for this reconciliation.",
+      "properties": {
+        "order_type": {
+          "type": "string",
+          "enum": ["market", "limit"]
+        },
+        "fill_status": {
+          "type": "string",
+          "enum": ["filled", "partially_filled", "not_filled"]
+        },
+        "maker_fill_evidence": {
+          "type": "boolean",
+          "description": "True only when a proven maker fill backs a non-zero maker_fee_cost."
+        },
+        "funding_basis": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "description": "Present only when funding is active; funding is then derived, never asserted.",
+          "required": [
+            "position_value",
+            "funding_rate",
+            "funding_rate_source",
+            "hours_held",
+            "settlement_hours",
+            "derived_cost"
+          ],
+          "properties": {
+            "position_value": { "type": "string" },
+            "funding_rate": { "type": "string" },
+            "funding_rate_source": { "type": "string", "minLength": 1 },
+            "hours_held": { "type": "string" },
+            "settlement_hours": { "type": "string" },
+            "derived_cost": { "type": "string" }
+          }
+        }
+      }
     },
     "gross_pnl": {
       "type": "string",
@@ -61,6 +103,10 @@
     "net_pnl": {
       "type": "string"
     },
+    "reported_net_pnl": {
+      "type": ["string", "null"],
+      "description": "Independently reported net PnL to reconcile against; null when the caller supplies none."
+    },
     "reconciled": {
       "type": "boolean"
     },
@@ -85,15 +131,17 @@
         "name": { "type": "string", "minLength": 1 },
         "amount": {
           "type": ["string", "null"],
-          "description": "Unsigned quote cost when status is active/zero; null when not_applicable or inactive_not_wired."
+          "description": "Unsigned quote cost when status is active/zero/embedded_in_fill_price; null when not_applicable, inactive_not_wired or unavailable."
         },
         "status": {
           "type": "string",
+          "description": "active/zero are subtracted; embedded_in_fill_price is informational; not_applicable, inactive_not_wired and unavailable carry a null amount and are never treated as a measured zero.",
           "enum": [
             "active",
             "zero",
             "not_applicable",
             "inactive_not_wired",
+            "unavailable",
             "embedded_in_fill_price"
           ]
         },

--- a/services/execution/simulator.py
+++ b/services/execution/simulator.py
@@ -5,10 +5,15 @@ including:
 - Slippage (base + volatility-adjusted + depth impact)
 - Trading fees (maker/taker)
 - Partial fills
-- Funding fees
 - Order book depth impact
 
 Designed for backtesting and paper trading to minimize backtest bias.
+
+Parked surfaces (#4190): ``simulate_limit_order`` and ``calculate_funding_fees``
+are retired from the economics path. No replay/ARVP/paper runner calls them and
+neither has a proven input, so their results are marked
+``parked_not_economics_billable`` and must not feed
+``core.replay.execution_economics_v1``.
 
 References:
 - Almgren & Chriss (2000): "Optimal Execution of Portfolio Transactions"
@@ -24,6 +29,21 @@ from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+# Wire-or-retire verdict for the surfaces inventoried by #4150 (resolved #4190).
+# Both are retired from the economics path: no replay/ARVP/paper runner calls
+# them and neither has a proven input, so their numbers must never reach
+# core.replay.execution_economics_v1.reconcile_gross_to_net.
+PARKED_NOT_ECONOMICS_BILLABLE = "parked_not_economics_billable"
+LIMIT_ORDER_MODEL_STATUS = PARKED_NOT_ECONOMICS_BILLABLE
+FUNDING_MODEL_STATUS = PARKED_NOT_ECONOMICS_BILLABLE
+FUNDING_RATE_SOURCE = "synthetic_default"
+
+ORDER_TYPE_MARKET = "market"
+ORDER_TYPE_LIMIT = "limit"
+
+FEE_ROLE_TAKER = "taker"
+FEE_ROLE_MAKER_ASSUMED_UNPROVEN = "maker_assumed_unproven"
+
 
 @dataclass
 class ExecutionResult:
@@ -38,6 +58,9 @@ class ExecutionResult:
         fill_ratio: Ratio of filled to requested size (0.0-1.0).
         execution_posture: Execution posture from scenario (baseline/pessimistic/etc).
         notes: Optional execution notes.
+        order_type: "market" or "limit".
+        fee_role: Which side of the fee schedule produced ``fees``.
+        economics_billable: False when the result must not feed gross-to-net.
     """
 
     filled_size: float
@@ -48,6 +71,9 @@ class ExecutionResult:
     fill_ratio: float
     execution_posture: Optional[str] = None
     notes: Optional[str] = None
+    order_type: str = ORDER_TYPE_MARKET
+    fee_role: str = FEE_ROLE_TAKER
+    economics_billable: bool = True
 
 
 class ExecutionSimulator:
@@ -177,6 +203,9 @@ class ExecutionSimulator:
             fill_ratio=fill_ratio,
             execution_posture=self.execution_posture,
             notes=f"Market order {side} with {slippage_bps:.1f}bps slippage",
+            order_type=ORDER_TYPE_MARKET,
+            fee_role=FEE_ROLE_TAKER,
+            economics_billable=True,
         )
 
     def simulate_limit_order(
@@ -187,11 +216,23 @@ class ExecutionSimulator:
         current_price: float,
         time_in_force: str = "GTC",
     ) -> ExecutionResult:
-        """Simulate limit order execution (simplified model).
+        """PARKED research stub for limit orders — not economics-billable (#4190).
 
-        For limit orders, we use a simplified model:
-        - If limit price is better than market: no fill (too aggressive)
-        - If limit price is at or worse than market: fill as maker
+        Status: ``LIMIT_ORDER_MODEL_STATUS``. Retired from the economics path:
+
+        1. No replay, ARVP or paper runner calls this method.
+        2. Its fill trigger is marketable — a buy limit at or above the market
+           crosses the book — yet it books the fill at the **maker** rate with
+           zero slippage. Real venues bill a marketable limit as a taker fill,
+           so the maker fee here is an unproven assumption, not a measurement.
+
+        Results are therefore returned with ``economics_billable=False`` and
+        ``fee_role=FEE_ROLE_MAKER_ASSUMED_UNPROVEN``. They must not be passed
+        into ``core.replay.execution_economics_v1.reconcile_gross_to_net``,
+        which rejects maker fees unless a proven maker fill is declared.
+
+        Wiring this for real requires a queue-position / maker-fill model plus
+        venue evidence; that is out of scope here.
 
         Args:
             side: Order side ("buy" or "sell").
@@ -201,13 +242,7 @@ class ExecutionSimulator:
             time_in_force: Time in force (default "GTC").
 
         Returns:
-            ExecutionResult with fill details.
-
-        Example:
-            >>> sim = ExecutionSimulator()
-            >>> result = sim.simulate_limit_order("buy", 0.5, 49000, 50000)
-            >>> result.filled_size
-            0.5  # Fill at limit price (maker fee)
+            ExecutionResult with ``economics_billable=False``.
         """
         notional = size * limit_price
 
@@ -230,11 +265,11 @@ class ExecutionSimulator:
                 avg_fill_price = 0.0
 
         if filled:
-            # Filled as maker
+            # Assumed maker fill; see the parked-model warning in the docstring.
             fees = notional * self.maker_fee
             logger.info(
-                f"Limit Order: {side} {size:.4f} @ {avg_fill_price:.2f} "
-                f"(maker fee={fees:.2f})"
+                f"Limit Order [{LIMIT_ORDER_MODEL_STATUS}]: {side} {size:.4f} "
+                f"@ {avg_fill_price:.2f} (assumed maker fee={fees:.2f})"
             )
             return ExecutionResult(
                 filled_size=size,
@@ -243,12 +278,20 @@ class ExecutionSimulator:
                 fees=fees,
                 partial_fill=False,
                 fill_ratio=1.0,
-                notes=f"Limit order {side} filled as maker",
+                notes=(
+                    f"[{LIMIT_ORDER_MODEL_STATUS}] Limit order {side} filled at "
+                    "an assumed maker rate; a marketable limit is a taker fill "
+                    "on a real venue"
+                ),
+                order_type=ORDER_TYPE_LIMIT,
+                fee_role=FEE_ROLE_MAKER_ASSUMED_UNPROVEN,
+                economics_billable=False,
             )
         else:
             # Not filled
             logger.info(
-                f"Limit Order: {side} {size:.4f} @ {limit_price:.2f} NOT FILLED"
+                f"Limit Order [{LIMIT_ORDER_MODEL_STATUS}]: {side} {size:.4f} "
+                f"@ {limit_price:.2f} NOT FILLED"
             )
             return ExecutionResult(
                 filled_size=0.0,
@@ -257,7 +300,13 @@ class ExecutionSimulator:
                 fees=0.0,
                 partial_fill=False,
                 fill_ratio=0.0,
-                notes=f"Limit order {side} not filled (price not reached)",
+                notes=(
+                    f"[{LIMIT_ORDER_MODEL_STATUS}] Limit order {side} not filled "
+                    "(price not reached)"
+                ),
+                order_type=ORDER_TYPE_LIMIT,
+                fee_role=FEE_ROLE_MAKER_ASSUMED_UNPROVEN,
+                economics_billable=False,
             )
 
     def calculate_funding_fees(
@@ -267,30 +316,39 @@ class ExecutionSimulator:
         funding_rate: Optional[float] = None,
         hours_held: float = 8.0,
     ) -> float:
-        """Calculate funding fees for a perpetual position.
+        """PARKED funding helper — not economics-billable by default (#4190).
+
+        Status: ``FUNDING_MODEL_STATUS``. The arithmetic is sound, but the
+        active replay/paper path cannot bill it:
+
+        1. Replay datasets are OHLCV only; no funding-rate series exists in the
+           repository, so ``self.funding_rate`` is a synthetic default whose
+           provenance is ``FUNDING_RATE_SOURCE``.
+        2. No runner tracks per-position holding duration across settlement
+           boundaries, so ``hours_held`` has no measured source either.
+
+        ``core.replay.execution_economics_v1`` keeps
+        ``funding_cost_when_active`` at ``inactive_not_wired`` and refuses to
+        activate it from a synthetic rate source. Use
+        ``execution_economics_v1.funding_cost_from_rate`` with a sourced rate
+        once a funding-rate series and holding durations exist.
 
         Args:
             position_size: Position size in base currency.
             position_value: Position value in quote currency.
-            funding_rate: Funding rate (default from config).
+            funding_rate: Funding rate (default from config, synthetic).
             hours_held: Hours position was held (default 8h = 1 settlement).
 
         Returns:
             Funding fee in quote currency. Positive = pay, Negative = receive.
-
-        Example:
-            >>> sim = ExecutionSimulator()
-            >>> fee = sim.calculate_funding_fees(0.1, 5000, 0.0001, 8.0)
-            >>> fee
-            0.5  # Pay 0.5 USDT per 8h settlement
         """
         rate = funding_rate if funding_rate is not None else self.funding_rate
         settlement_periods = hours_held / 8.0
         fee = position_value * rate * settlement_periods
 
         logger.debug(
-            f"Funding Fee: value={position_value:.0f} rate={rate:.6f} "
-            f"hours={hours_held:.1f} → fee={fee:.4f}"
+            f"Funding Fee [{FUNDING_MODEL_STATUS}]: value={position_value:.0f} "
+            f"rate={rate:.6f} hours={hours_held:.1f} → fee={fee:.4f}"
         )
 
         return fee

--- a/services/validation/arvp_candidate_evidence_assembler.py
+++ b/services/validation/arvp_candidate_evidence_assembler.py
@@ -23,6 +23,7 @@ from core.replay.canonical_json import canonical_hash, canonical_json_dumps
 from core.replay.execution_economics_v1 import (
     COMPONENT_STATUS_ACTIVE,
     COMPONENT_STATUS_NOT_APPLICABLE,
+    ORDER_TYPE_MARKET,
     build_assumptions_snapshot,
     reconcile_gross_to_net,
 )
@@ -603,14 +604,17 @@ def _build_gross_to_net_block(
         gross_pnl=reference_gross,
         maker_fee_cost=maker_fee_cost,
         taker_fee_cost=taker_fee_cost,
-        slippage_cost=0 if slippage_cost is None else slippage_cost,
+        slippage_cost=slippage_cost,
         slippage_status=slippage_status,
+        order_type=ORDER_TYPE_MARKET,
         fill_price_embedded_gross=embedded_gross,
         assumptions_snapshot=build_assumptions_snapshot(),
         limitations=(
             "Top-level PEP gross_return/net_return remain descriptive medians.",
             "Spread is not modeled in ExecutionSimulator (not_applicable).",
             "Slippage is not_applicable unless slippage_cost_quote is present on metrics.",
+            "Funding is inactive_not_wired: no funding-rate series reaches the runner path.",
+            "Limit orders are parked and not economics-billable; ARVP fills are market/taker.",
             "Synthetic research assumptions; not venue-verified.",
             "Does not prove profitability, live readiness, or venue realism.",
         ),

--- a/tests/fixtures/arvp/candidate_evidence/slice_bundle_manifest.v1.json
+++ b/tests/fixtures/arvp/candidate_evidence/slice_bundle_manifest.v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "arvp_candidate_evidence_bundle.v1",
-  "bundle_hash": "a4ebce8627fdf020729279e2ab54bfc076a0fb980c37b2eaeaec3c6be52619ca",
+  "bundle_hash": "57648b2a3cf51c0b82a4cf74295f92a0a0ce1409c0d9b26ab319e349494e6e77",
   "packet_count": 2,
   "source_record_count": 6,
   "candidates": [
@@ -10,12 +10,12 @@
   "packets": [
     {
       "strategy_id": "donchian_breakout_v1",
-      "content_hash": "e792cb49710a1c1cfaeb77ef9deb5864089ad71c95a58014f2f9fc1a18599381",
+      "content_hash": "7f5abdd0e6bc44df8082432db7457b15d5f096023edddd7cc5b59cc2f8e74eb8",
       "rankability_status": "NOT_RANKABLE"
     },
     {
       "strategy_id": "primary_breakout_v1",
-      "content_hash": "5ea52f698c696940d321c1266050a13a038911f0fab4c4540ad22845e7af9d5f",
+      "content_hash": "89b31341c67dbe027a4d0fb5a817f295f0f51c3d0e12b936215f867e25172e23",
       "rankability_status": "NOT_RANKABLE"
     }
   ]

--- a/tests/unit/replay/test_execution_economics_v1.py
+++ b/tests/unit/replay/test_execution_economics_v1.py
@@ -12,8 +12,12 @@ from jsonschema import Draft202012Validator
 
 from core.replay.execution_economics_v1 import (
     ALLOWED_SCENARIO_OVERRIDE_KEYS,
+    COMPONENT_STATUS_INACTIVE,
+    COMPONENT_STATUS_UNAVAILABLE,
     CONTRACT_VERSION,
+    FUNDING_INPUT_AVAILABILITY,
     LEGACY_SCENARIO_OVERRIDE_KEYS,
+    LIMIT_ORDER_MODEL_STATUS,
     SCENARIO_OVERRIDE_KEY_TO_SIMULATOR,
     ExecutionEconomicsError,
     bps_to_rate,
@@ -21,14 +25,27 @@ from core.replay.execution_economics_v1 import (
     compare_economics_components,
     economics_evidence_fingerprint,
     fill_price_embedded_gross_pnl,
+    funding_cost_from_rate,
     partial_fill_impact_quote,
     rate_to_bps,
     reconcile_gross_to_net,
     reference_gross_pnl,
+    resolve_funding_basis,
     resolve_scenario_overrides,
     slippage_cost_from_bps,
     validate_bps,
 )
+from services.execution.simulator import (
+    ExecutionSimulator,
+    PARKED_NOT_ECONOMICS_BILLABLE,
+)
+
+SOURCED_FUNDING_BASIS = {
+    "position_value": "50000",
+    "funding_rate": "0.0001",
+    "funding_rate_source": "mexc_funding_history_export",
+    "hours_held": "8",
+}
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = (
@@ -95,7 +112,11 @@ class TestGrossToNet:
 
     def test_fees_only(self) -> None:
         result = reconcile_gross_to_net(
-            gross_pnl="100", maker_fee_cost="1", taker_fee_cost="2"
+            gross_pnl="100",
+            maker_fee_cost="1",
+            taker_fee_cost="2",
+            order_type="limit",
+            maker_fill_evidence=True,
         )
         assert result.total_fee_cost.amount == Decimal("3.00000000")
         assert result.net_pnl == Decimal("97.00000000")
@@ -128,6 +149,7 @@ class TestGrossToNet:
             gross_pnl="5",
             taker_fee_cost="0.1",
             partial_fill_impact=impact,
+            fill_status="partially_filled",
         )
         assert result.net_pnl == Decimal("-0.10000000")
 
@@ -183,6 +205,7 @@ class TestGrossToNet:
     def test_funding_inactive(self) -> None:
         result = reconcile_gross_to_net(gross_pnl="10", taker_fee_cost="0")
         assert result.funding_cost_when_active.status == "inactive_not_wired"
+        assert result.funding_cost_when_active.amount is None
 
     def test_reference_gross_uses_filled_size(self) -> None:
         gross = reference_gross_pnl(
@@ -192,6 +215,354 @@ class TestGrossToNet:
             exit_reference_price="110",
         )
         assert gross == Decimal("5.00000000")
+
+
+class TestStatusValueContradictions:
+    """A supplied cost must never be silently dropped by a non-billable status."""
+
+    @pytest.mark.parametrize(
+        ("kwargs", "component"),
+        [
+            ({"spread_cost": "1", "spread_status": "not_applicable"}, "spread_cost"),
+            (
+                {"slippage_cost": "1", "slippage_status": "not_applicable"},
+                "slippage_cost",
+            ),
+            ({"slippage_cost": "0", "slippage_status": "unavailable"}, "slippage_cost"),
+            (
+                {"reject_impact": "1", "reject_status": "inactive_not_wired"},
+                "reject_impact",
+            ),
+            (
+                {"latency_or_delay_impact": "1", "latency_status": "not_applicable"},
+                "latency_or_delay_impact",
+            ),
+            (
+                {"partial_fill_impact": "1", "partial_fill_status": "unavailable"},
+                "partial_fill_impact",
+            ),
+            (
+                {"funding_cost": "1", "funding_status": "inactive_not_wired"},
+                "funding_cost_when_active",
+            ),
+        ],
+    )
+    def test_value_under_non_billable_status_rejected(
+        self, kwargs: dict, component: str
+    ) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="silently dropped"):
+            reconcile_gross_to_net(gross_pnl="10", taker_fee_cost="0", **kwargs)
+
+    def test_unknown_component_status_rejected(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="not a valid component"):
+            reconcile_gross_to_net(
+                gross_pnl="10", taker_fee_cost="0", spread_status="probably_fine"
+            )
+
+    def test_unavailable_status_is_null_not_measured_zero(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="10",
+            taker_fee_cost="1",
+            spread_status=COMPONENT_STATUS_UNAVAILABLE,
+        )
+        assert result.spread_cost.status == COMPONENT_STATUS_UNAVAILABLE
+        assert result.spread_cost.amount is None
+        # Missing input must not be subtracted as if it were measured.
+        assert result.net_pnl == Decimal("9.00000000")
+
+    def test_embedded_slippage_is_not_subtracted_again(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="100",
+            taker_fee_cost="0",
+            slippage_cost="5",
+            slippage_status="embedded_in_fill_price",
+        )
+        assert result.slippage_cost.amount == Decimal("5.00000000")
+        assert result.net_pnl == Decimal("100.00000000")
+
+
+class TestMakerTakerSemantics:
+    def test_market_path_rejects_maker_fee(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="maker_fee_cost > 0"):
+            reconcile_gross_to_net(
+                gross_pnl="100", maker_fee_cost="1", taker_fee_cost="0"
+            )
+
+    def test_limit_without_evidence_rejects_maker_fee(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="maker_fill_evidence"):
+            reconcile_gross_to_net(
+                gross_pnl="100",
+                maker_fee_cost="1",
+                taker_fee_cost="0",
+                order_type="limit",
+            )
+
+    def test_maker_evidence_requires_limit_order_type(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="order_type='limit'"):
+            reconcile_gross_to_net(
+                gross_pnl="100", taker_fee_cost="0", maker_fill_evidence=True
+            )
+
+    def test_zero_maker_fee_allowed_on_market_path(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="100", maker_fee_cost="0", taker_fee_cost="2"
+        )
+        assert result.maker_fee_cost.status == "zero"
+        assert result.total_fee_cost.amount == Decimal("2.00000000")
+
+    def test_unknown_order_type_rejected(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="order_type"):
+            reconcile_gross_to_net(
+                gross_pnl="100", taker_fee_cost="0", order_type="iceberg"
+            )
+
+
+class TestFillSemantics:
+    def test_no_fill_requires_zero_gross(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="requires gross_pnl == 0"):
+            reconcile_gross_to_net(
+                gross_pnl="10", taker_fee_cost="0", fill_status="not_filled"
+            )
+
+    def test_no_fill_forbids_fees(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="non-zero total_fee_cost"):
+            reconcile_gross_to_net(
+                gross_pnl="0", taker_fee_cost="1", fill_status="not_filled"
+            )
+
+    def test_no_fill_is_representable(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="0",
+            taker_fee_cost="0",
+            slippage_status="not_applicable",
+            partial_fill_impact="7",
+            fill_status="not_filled",
+        )
+        assert result.fill_status == "not_filled"
+        assert result.net_pnl == Decimal("-7.00000000")
+
+    def test_partial_fill_requires_billable_impact(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="partially_filled"):
+            reconcile_gross_to_net(
+                gross_pnl="10",
+                taker_fee_cost="0",
+                partial_fill_status="not_applicable",
+                fill_status="partially_filled",
+            )
+
+    def test_full_fill_forbids_partial_impact(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="forbids a non-zero"):
+            reconcile_gross_to_net(
+                gross_pnl="10", taker_fee_cost="0", partial_fill_impact="1"
+            )
+
+    def test_unknown_fill_status_rejected(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="fill_status"):
+            reconcile_gross_to_net(
+                gross_pnl="10", taker_fee_cost="0", fill_status="maybe"
+            )
+
+
+class TestFundingWireOrRetire:
+    """Funding stays retired unless a sourced rate and duration are supplied."""
+
+    def test_active_funding_requires_basis(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="requires funding_basis"):
+            reconcile_gross_to_net(
+                gross_pnl="100",
+                taker_fee_cost="0",
+                funding_cost="5",
+                funding_status="active",
+            )
+
+    def test_synthetic_rate_source_rejected(self) -> None:
+        basis = dict(SOURCED_FUNDING_BASIS, funding_rate_source="synthetic_default")
+        with pytest.raises(ExecutionEconomicsError, match="not admissible"):
+            reconcile_gross_to_net(
+                gross_pnl="100",
+                taker_fee_cost="0",
+                funding_status="active",
+                funding_basis=basis,
+            )
+
+    def test_incomplete_basis_rejected(self) -> None:
+        basis = dict(SOURCED_FUNDING_BASIS)
+        basis.pop("hours_held")
+        with pytest.raises(ExecutionEconomicsError, match="missing required keys"):
+            reconcile_gross_to_net(
+                gross_pnl="100",
+                taker_fee_cost="0",
+                funding_status="active",
+                funding_basis=basis,
+            )
+
+    def test_basis_under_inactive_status_rejected(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="funding_basis must not"):
+            reconcile_gross_to_net(
+                gross_pnl="100",
+                taker_fee_cost="0",
+                funding_status=COMPONENT_STATUS_INACTIVE,
+                funding_basis=SOURCED_FUNDING_BASIS,
+            )
+
+    def test_supplied_cost_must_match_basis(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="does not reconcile"):
+            reconcile_gross_to_net(
+                gross_pnl="100",
+                taker_fee_cost="0",
+                funding_cost="99",
+                funding_status="active",
+                funding_basis=SOURCED_FUNDING_BASIS,
+            )
+
+    def test_sourced_funding_is_derived_and_subtracted(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="100",
+            taker_fee_cost="0",
+            funding_status="active",
+            funding_basis=SOURCED_FUNDING_BASIS,
+        )
+        assert result.funding_cost_when_active.amount == Decimal("5.00000000")
+        assert result.net_pnl == Decimal("95.00000000")
+        assert result.funding_basis is not None
+        assert (
+            result.funding_basis["funding_rate_source"] == "mexc_funding_history_export"
+        )
+
+    def test_funding_cost_from_rate_scales_with_periods(self) -> None:
+        eight = funding_cost_from_rate(
+            position_value="50000", funding_rate="0.0001", hours_held="8"
+        )
+        sixteen = funding_cost_from_rate(
+            position_value="50000", funding_rate="0.0001", hours_held="16"
+        )
+        assert eight == Decimal("5.00000000")
+        assert sixteen == eight * 2
+
+    def test_funding_cost_from_rate_matches_simulator_arithmetic(self) -> None:
+        simulator = ExecutionSimulator()
+        legacy = simulator.calculate_funding_fees(
+            position_size=1.0,
+            position_value=50000.0,
+            funding_rate=0.0001,
+            hours_held=8.0,
+        )
+        derived = funding_cost_from_rate(
+            position_value="50000", funding_rate="0.0001", hours_held="8"
+        )
+        assert derived == Decimal(str(legacy)).quantize(Decimal("0.00000001"))
+
+    def test_negative_funding_rate_rejected(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="negative funding rates"):
+            funding_cost_from_rate(
+                position_value="50000", funding_rate="-0.0001", hours_held="8"
+            )
+
+    def test_resolve_funding_basis_is_deterministic(self) -> None:
+        first = resolve_funding_basis(SOURCED_FUNDING_BASIS)
+        second = resolve_funding_basis(dict(SOURCED_FUNDING_BASIS))
+        assert first == second
+
+
+class TestParkedSurfaceParity:
+    """Contract status and simulator status must not drift apart."""
+
+    def test_limit_order_model_status_matches_simulator(self) -> None:
+        assert LIMIT_ORDER_MODEL_STATUS == PARKED_NOT_ECONOMICS_BILLABLE
+
+    def test_simulator_limit_result_is_not_economics_billable(self) -> None:
+        simulator = ExecutionSimulator()
+        filled = simulator.simulate_limit_order(
+            side="buy", size=0.5, limit_price=50000.0, current_price=50000.0
+        )
+        assert filled.economics_billable is False
+        assert filled.order_type == "limit"
+        assert filled.fee_role == "maker_assumed_unproven"
+
+    def test_simulator_market_result_is_billable_taker(self) -> None:
+        simulator = ExecutionSimulator()
+        result = simulator.simulate_market_order(
+            side="buy",
+            size=0.5,
+            current_price=50000.0,
+            order_book_depth=1_000_000.0,
+            volatility=0.02,
+        )
+        assert result.economics_billable is True
+        assert result.fee_role == "taker"
+
+    def test_snapshot_reports_parked_limit_and_unavailable_funding(self) -> None:
+        snap = build_assumptions_snapshot()
+        assert snap["limit_order_model"]["status"] == LIMIT_ORDER_MODEL_STATUS
+        assert snap["limit_order_model"]["wired_into_arvp_runners"] is False
+        assert snap["funding_model"]["status"] == COMPONENT_STATUS_INACTIVE
+        assert snap["funding_model"]["input_availability"] == FUNDING_INPUT_AVAILABILITY
+        assert snap["funding_model"]["wired_into_replay_pnl"] is False
+
+    def test_snapshot_funding_active_requires_sourced_rate(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="non-synthetic"):
+            build_assumptions_snapshot(funding_active=True)
+
+    def test_snapshot_limit_active_requires_fill_model(self) -> None:
+        with pytest.raises(ExecutionEconomicsError, match="limit_order_fill_model"):
+            build_assumptions_snapshot(limit_orders_active=True)
+
+    def test_snapshot_activation_flips_wiring_flags(self) -> None:
+        snap = build_assumptions_snapshot(
+            funding_active=True,
+            funding_rate_source="mexc_funding_history_export",
+            limit_orders_active=True,
+            limit_order_fill_model="queue_position_v1",
+        )
+        assert snap["funding_model"]["wired_into_replay_pnl"] is True
+        assert snap["limit_order_model"]["wired_into_arvp_runners"] is True
+
+
+class TestReconciliationInvariant:
+    def test_reported_net_matching_reconciles(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="100",
+            taker_fee_cost="2",
+            slippage_cost="3",
+            reported_net_pnl="95",
+        )
+        assert result.net_pnl == Decimal("95.00000000")
+        assert result.residual == Decimal("0E-8")
+        assert result.reconciled is True
+
+    def test_reported_net_mismatch_fails_reconciliation(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="100",
+            taker_fee_cost="2",
+            slippage_cost="3",
+            reported_net_pnl="97",
+        )
+        assert result.reconciled is False
+        assert result.residual == Decimal("2.00000000")
+
+    def test_gross_minus_active_costs_equals_net(self) -> None:
+        result = reconcile_gross_to_net(
+            gross_pnl="100",
+            taker_fee_cost="2",
+            spread_cost="1",
+            spread_status="active",
+            slippage_cost="3",
+            reject_impact="0.5",
+            reject_status="active",
+            latency_or_delay_impact="0.25",
+            latency_status="active",
+            funding_status="active",
+            funding_basis=SOURCED_FUNDING_BASIS,
+        )
+        active_costs = (
+            result.total_fee_cost.amount
+            + result.spread_cost.amount
+            + result.slippage_cost.amount
+            + result.reject_impact.amount
+            + result.latency_or_delay_impact.amount
+            + result.funding_cost_when_active.amount
+        )
+        assert result.gross_pnl - active_costs == result.net_pnl
 
 
 class TestRatesAndBps:
@@ -281,3 +652,33 @@ class TestSchema:
         ).to_dict()
         errors = sorted(validator.iter_errors(result), key=lambda e: e.path)
         assert not errors, errors[0].message if errors else ""
+
+    def test_active_funding_and_maker_fill_validate(self) -> None:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        validator = Draft202012Validator(schema)
+        result = reconcile_gross_to_net(
+            gross_pnl="100",
+            maker_fee_cost="0.5",
+            taker_fee_cost="0",
+            order_type="limit",
+            maker_fill_evidence=True,
+            funding_status="active",
+            funding_basis=SOURCED_FUNDING_BASIS,
+            reported_net_pnl="94.5",
+        ).to_dict()
+        errors = sorted(validator.iter_errors(result), key=lambda e: e.path)
+        assert not errors, errors[0].message if errors else ""
+        assert result["execution_semantics"]["order_type"] == "limit"
+        assert result["execution_semantics"]["funding_basis"] is not None
+
+    def test_unavailable_status_validates(self) -> None:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        validator = Draft202012Validator(schema)
+        result = reconcile_gross_to_net(
+            gross_pnl="10",
+            taker_fee_cost="0",
+            slippage_status=COMPONENT_STATUS_UNAVAILABLE,
+        ).to_dict()
+        errors = sorted(validator.iter_errors(result), key=lambda e: e.path)
+        assert not errors, errors[0].message if errors else ""
+        assert result["components"]["slippage_cost"]["status"] == "unavailable"

--- a/tests/unit/replay/test_replay_vs_paper_economics.py
+++ b/tests/unit/replay/test_replay_vs_paper_economics.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+from core.replay.execution_economics_v1 import (
+    CONTRACT_VERSION,
+    FUNDING_INPUT_AVAILABILITY,
+    LIMIT_ORDER_MODEL_STATUS,
+)
 from core.replay.replay_vs_paper_compare import (
     compare_economics_from_reports,
     economics_payload_from_metrics,
@@ -38,3 +43,40 @@ def test_compare_economics_component_diff() -> None:
     assert diff["component_diffs"]["total_fee_cost"]["delta"] == "1.00000000"
     assert diff["component_diffs"]["slippage_cost"]["delta"] == "2.00000000"
     assert "fingerprint" in diff
+
+
+def test_replay_and_paper_share_contract_semantics() -> None:
+    """Replay and paper must describe funding/limit identically (#4190)."""
+    metrics = {"gross_pnl_quote": 100.0, "fees_total_quote": 2.0}
+    replay = economics_payload_from_metrics(metrics)
+    paper = economics_payload_from_metrics(dict(metrics, gross_pnl_quote=90.0))
+
+    for payload in (replay, paper):
+        assert payload["contract_version"] == CONTRACT_VERSION
+        assert payload["execution_semantics"]["order_type"] == "market"
+        assert payload["execution_semantics"]["fill_status"] == "filled"
+        assert payload["execution_semantics"]["maker_fill_evidence"] is False
+        assert payload["execution_semantics"]["funding_basis"] is None
+        funding = payload["components"]["funding_cost_when_active"]
+        assert funding["status"] == "inactive_not_wired"
+        assert funding["amount"] is None
+        snapshot = payload["assumptions_snapshot"]
+        assert snapshot["funding_model"]["input_availability"] == (
+            FUNDING_INPUT_AVAILABILITY
+        )
+        assert snapshot["limit_order_model"]["status"] == LIMIT_ORDER_MODEL_STATUS
+
+    assert (
+        replay["assumptions_snapshot"]["fingerprint"]
+        == paper["assumptions_snapshot"]["fingerprint"]
+    )
+
+
+def test_inactive_funding_is_incomparable_not_a_zero_delta() -> None:
+    diff = compare_economics_from_reports(
+        {"metrics": {"gross_pnl_quote": 100.0, "fees_total_quote": 2.0}},
+        {"gross_pnl_quote": 90.0, "fees_total_quote": 1.0},
+    )
+    funding = diff["component_diffs"]["funding_cost_when_active"]
+    assert funding["delta"] is None
+    assert funding["status"] == "both_not_applicable_or_missing"

--- a/tests/unit/validation/test_arvp_candidate_evidence_economics.py
+++ b/tests/unit/validation/test_arvp_candidate_evidence_economics.py
@@ -42,6 +42,40 @@ def test_cost_evidence_includes_gross_to_net_block() -> None:
         assert "fingerprint" in g2n["assumptions_snapshot"]
 
 
+def test_funding_and_limit_orders_are_not_billed() -> None:
+    """#4190: both surfaces stay retired and never become a measured zero."""
+    result = assemble_arvp_candidate_evidence(_bundle())
+    for packet in result.packets:
+        g2n = packet["arvp_evidence"]["cost_evidence"][
+            "execution_economics_gross_to_net"
+        ]
+        funding = g2n["components"]["funding_cost_when_active"]
+        assert funding["status"] == "inactive_not_wired"
+        assert funding["amount"] is None
+        snapshot = g2n["assumptions_snapshot"]
+        assert snapshot["funding_model"]["wired_into_replay_pnl"] is False
+        assert snapshot["funding_model"]["input_availability"] == (
+            "unavailable_no_funding_rate_series"
+        )
+        assert snapshot["limit_order_model"]["status"] == (
+            "parked_not_economics_billable"
+        )
+        assert snapshot["limit_order_model"]["wired_into_arvp_runners"] is False
+
+
+def test_market_only_path_reports_taker_semantics() -> None:
+    result = assemble_arvp_candidate_evidence(_bundle())
+    for packet in result.packets:
+        g2n = packet["arvp_evidence"]["cost_evidence"][
+            "execution_economics_gross_to_net"
+        ]
+        semantics = g2n["execution_semantics"]
+        assert semantics["order_type"] == "market"
+        assert semantics["maker_fill_evidence"] is False
+        assert semantics["funding_basis"] is None
+        assert g2n["components"]["maker_fee_cost"]["status"] == "zero"
+
+
 def test_limitations_document_placeholder_zeros() -> None:
     result = assemble_arvp_candidate_evidence(_bundle())
     for packet in result.packets:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

Refs #4190, #4150, #4147.

## Summary

Resolves the #4150 follow-up with a **`RETIRE_OR_PARK_DEAD_SURFACES`** verdict for both funding and limit orders, and hardens the Gross-to-Net contract so the retirement cannot silently drift into a fake cost.

- Funding stays `inactive_not_wired`; activating it now requires a complete, sourced `funding_basis` instead of an invented scalar.
- `simulate_limit_order` is parked as `parked_not_economics_billable`; the contract rejects maker fees on the market-only path.
- Component statuses gain `unavailable`, and supplying a cost under a null-amount status is rejected instead of dropped.
- Maker/taker, filled/partially_filled/not_filled and funding provenance are now explicit in a new `execution_semantics` block shared by replay, paper and candidate evidence.
- `residual` reconciles an optional `reported_net_pnl` against the recomputed net instead of being definitionally zero.

## Why

`funding_active` and `limit_orders_active` existed as parameters but contradicted hardcoded `wired_into_replay_pnl: False` / `wired_into_arvp_runners: False` flags, so the snapshot could advertise an active model no input backed. Meanwhile a caller could pass `funding_cost=500` under the default inactive status and have it silently discarded.

### Wire-or-retire evidence

**Funding — cannot be billed deterministically.**

- Replay datasets are OHLCV only (`open, high, low, close, volume`); `find . -iname "*funding*"` returns only `.github/FUNDING.yml`. No funding-rate series exists.
- `ExecutionSimulator.FUNDING_RATE` defaults to `0.0001` from an unverified "MEXC 2024" comment — provenance `synthetic_default`.
- No runner tracks per-position holding duration across settlement boundaries, so `hours_held` has no measured source.
- `calculate_funding_fees` has no production caller.

**Limit orders — dead and actively misleading.**

- `simulate_limit_order` has no production caller. Its only references live in `tests/unit/verlosung/`, which `pytest.ini` excludes via `norecursedirs` **and** which cannot import at all (`ModuleNotFoundError: services.execution_simulator`). Zero live coverage.
- Its fill trigger is economically inverted: a buy limit at or above market is marketable and crosses the book, yet it is booked at the **maker** rate with zero slippage — precisely the guaranteed-maker-fill assumption this contract forbids.

Neither surface is deleted. Both remain visible and explicitly labelled as not active and not billable, with the wiring seam documented.

## Validation

Local, on head `b2d0976a`:

```
pytest -q -k "not test_mcp_time_server_runtime"
  1 failed, 8883 passed, 91 skipped, 1 deselected in 117.84s
```

The single failure is `tests/unit/arvp/test_arvp_np_parallel_signal_compose_contract_3909.py::test_docker_compose_config_merge_is_valid`, which fails identically on base `379d031d` with `FileNotFoundError: [Errno 2] No such file or directory: 'docker'` — Docker is not installed in the Cloud Agent environment. Pre-existing, unrelated to this diff.

Targeted slice:

```
pytest -q tests/unit/replay/test_execution_economics_v1.py            74 passed
pytest -q tests/unit/replay/ tests/unit/validation/ tests/unit/arvp/  1745 passed, 10 skipped (+1 docker-env failure)
ruff check .                                                          All checks passed!
black --check (changed .py files)                                     7 files unchanged
git diff --check                                                      clean
diff-based secret scan (added lines)                                  no findings
```

Both commits are independently green: `dad8b22f` alone passes `tests/unit/replay/ tests/unit/validation/` (1476 passed, 1 skipped).

New coverage includes negative tests for contradictory status/value combinations, funding basis rejection paths, maker-fee rejection on the market path, no-fill and partial-fill invariants, deterministic `funding_cost_from_rate` vs. the simulator arithmetic, replay/paper contract parity, and schema validation of the new statuses.

`tests/fixtures/arvp/candidate_evidence/slice_bundle_manifest.v1.json` is regenerated because the evidence payload gained `execution_semantics`.

## Risk / Rollback

- **No productive execution change.** `services/execution/simulator.py` changes are docstrings, log text and additive `ExecutionResult` metadata. Fill, fee and slippage arithmetic are byte-identical. `live_executor.py` and MEXC adapters are untouched.
- **Behaviour tightening, by design.** `reconcile_gross_to_net` now raises on call shapes it previously accepted (value under a non-billable status; maker fee on a market path; non-zero partial impact under `fill_status="filled"`). Both in-repo consumers are updated; external research callers may need the explicit status.
- Rollback: revert `b2d0976a` and `dad8b22f`.
- LR stays `NO-GO`; no Stage-A/B, OOS, risk or live gate is touched; no parameter tuning; no DB writes or migrations.

## Checklist
- [x] Scope is focused
- [x] Validation evidence included
- [x] Docs updated (if needed)
- [x] Breaking changes documented (if any)

## Merge / Closure Guardrails
- [x] No auto-merge used (`gh pr merge --auto` is forbidden in this repo)
- [ ] Final human review completed before merge
- [ ] `Closes #...` used only when acceptance is satisfied against merged `main`

This PR does **not** close #4190; merge and issue closure are out of this session's scope.

## Breaking Changes

`core.replay.execution_economics_v1.reconcile_gross_to_net` is stricter:

| Previously accepted | Now |
|---|---|
| Cost value under `not_applicable` / `inactive_not_wired` | Raises — pass `None` and let the status carry the meaning |
| `funding_cost` scalar with `funding_status="active"` | Raises — supply `funding_basis` with a sourced rate |
| `maker_fee_cost > 0` on the default market path | Raises — set `order_type="limit"` + `maker_fill_evidence=True` |
| Non-zero `partial_fill_impact` with the default fill status | Raises — set `fill_status="partially_filled"` |

Payload additions (schema updated): `execution_semantics`, `reported_net_pnl`, and the `unavailable` component status.

## Routing note

`python -m tools.pr_routing route --issue 4190` returned `CREATE_DEDICATED_PR` (`lane=runtime-risk`, `merge_mode=dedicated`, `DEDICATED_RULE_MATCH`, `target_branch=dedicated/runtime-risk-issue-4190`). The Cursor Cloud Agent environment mandates the `cloud-cursor/<name>-0725` branch prefix, so the dedicated branch carries that prefix instead of the router's suggested name. Routing decision and lane are otherwise unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-469c6e83-e662-42c8-99e2-375022420725?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-469c6e83-e662-42c8-99e2-375022420725&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

