### PR TITLE
fix(security): pin pip 26.1.2 in productive service images (CVE-2026-8643)

### DIFF
--- a/docs/evidence/security/CDB_SECURITY_PIP_CVE-2026-8643_4095_2026-07-31.md
+++ b/docs/evidence/security/CDB_SECURITY_PIP_CVE-2026-8643_4095_2026-07-31.md
@@ -1,0 +1,160 @@
+# pip `26.1` → `26.1.2` — CVE-2026-8643 in produktiven Service-Images
+
+**Date:** 2026-07-31
+**Issue:** #4095
+**Code-Scanning-Alerts:** 5526, 5527 (dieselbe Root Cause, siehe unten)
+**Scope:** Dockerfile pip-Pins + Contract-Test + Triage-Korrektur
+**Tool:** Trivy 0.72.0, `--scanners vuln --pkg-types library`, Docker 29.7.0
+
+---
+
+## §1 Advisory-Grundlage
+
+| Feld | Wert |
+|---|---|
+| CVE | `CVE-2026-8643` |
+| Aliases | `GHSA-wf93-45jw-7689`, `PYSEC-2026-196` |
+| Summary | pip can extract `console_scripts` / `gui_scripts` outside installation directory |
+| Betroffen | pip `>= 0`, `< 26.1.2` |
+| **Fixed** | **`26.1.2`** |
+| Quelle | `https://api.osv.dev/v1/vulns/CVE-2026-8643` (abgefragt 2026-07-31) |
+
+Der gewählte Pin `26.1.2` deckt zusätzlich alle älteren offenen pip-Advisories ab:
+
+| CVE | Fixed in | Durch `26.1.2` abgedeckt |
+|---|---|---|
+| `CVE-2025-8869` | 25.3 | ja |
+| `CVE-2026-1703` | 26.0 | ja |
+| `CVE-2026-3219` | 26.1 | ja |
+| `CVE-2026-6357` | 26.1 | ja |
+| `CVE-2026-8643` | **26.1.2** | ja |
+
+`26.1.2` ist die exakte Fix-Version des Advisories, nicht der Latest-Release
+(`26.2`, veröffentlicht 2026-07-29). Damit bleibt die Reparatur minimal und
+advisory-gebunden statt eine Feature-Version mitzuziehen.
+
+---
+
+## §2 Root Cause und Alert-Zwilling
+
+Der Alert-Pfad aus Issue #4095 lautet
+`venv/lib/python3.14/site-packages/pip-26.1.dist-info/metadata`.
+
+Das ist **kein** Dev-venv, sondern das Build-venv aus
+`services/execution/Dockerfile`: die Build-Stage legt `/venv` an und die
+Runtime-Stage übernimmt es per `COPY --from=build /venv /venv`. Im Image-Scan
+erscheint dieser Produktionspfad ohne führenden Slash als `venv/...`.
+
+Dasselbe Dockerfile installierte pip an **zwei** Stellen — im Build-venv und
+global in der Runtime-Stage. Der Trivy-Scan des ungefixten Images (Basis
+`origin/main` @ `e5711c2a`) belegt genau diese zwei Findings:
+
+```
+BEFORE (origin/main) | pip pkgs seen by scanner: 2 | pip CVEs: 2
+   pkg   26.1 usr/local/lib/python3.14/site-packages/pip-26.1.dist-info/METADATA
+   pkg   26.1 venv/lib/python3.14/site-packages/pip-26.1.dist-info/METADATA
+   CVE   CVE-2026-8643 MEDIUM 26.1 ->fix 26.1.2  usr/local/.../pip-26.1.dist-info/METADATA
+   CVE   CVE-2026-8643 MEDIUM 26.1 ->fix 26.1.2  venv/.../pip-26.1.dist-info/METADATA
+```
+
+Alert **5526** (venv-Pfad, Subject von #4095) und Alert **5527** sind damit
+zwei Instanzen **derselben** Root Cause: ein einziger verwundbarer pip-Pin,
+der zweimal im selben Image landet. Beide werden von einer Änderung erledigt.
+
+---
+
+## §3 Geänderte Image-Flächen
+
+| Dockerfile | vorher | nachher | Klasse |
+|---|---|---|---|
+| `services/allocation/Dockerfile` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
+| `services/candles/Dockerfile` | `pip==25.3` | `pip==26.1.2` | vulnerabel (4 CVEs) |
+| `services/db_writer/Dockerfile` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
+| `services/execution/Dockerfile` (Build-venv) | `pip==26.1` | `pip==26.1.2` | vulnerabel — **Alert 5526** |
+| `services/execution/Dockerfile` (Runtime-global) | `pip==26.1` | `pip==26.1.2` | vulnerabel — **Alert 5527** |
+| `services/market/Dockerfile` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
+| `services/regime/Dockerfile` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
+| `services/risk/Dockerfile` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
+| `services/signal/Dockerfile` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
+| `services/ws/Dockerfile` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
+| `services/reports/Dockerfile` | kein Pin | `pip==26.1.2` | **nicht vulnerabel** — Determinismus |
+| `tools/paper_trading/Dockerfile` | kein Pin | `pip==26.1.2` | **nicht vulnerabel** — Determinismus |
+
+`services/reports` und `tools/paper_trading` bezogen pip implizit aus dem
+Base-Image. Der Pre-Fix-Build belegt, dass dieses Base-Image bereits `26.1.2`
+liefert:
+
+```
+BEFORE cdb_reports pip pkgs: [('26.1.2', 'usr/local/.../pip-26.1.2.dist-info/METADATA')]
+BEFORE cdb_reports pip CVEs: NONE
+```
+
+Der Pin wurde dort trotzdem gesetzt, damit der Contract-Test in §5 eine
+belastbare Aussage treffen kann: ohne expliziten Pin würde der Guard für ein
+Image mit floatendem Base-Image-pip stillschweigend durchlaufen. Es ist eine
+Determinismus-Maßnahme, kein Vulnerability-Fix.
+
+### Nicht geändert (bewusst)
+
+| Dockerfile | Grund |
+|---|---|
+| `ci/Dockerfile` | Lokale CI, kein produktives Service-Image; `pip install --upgrade pip` ohne Pin löst stets auf Latest (`>= 26.1.2`) auf |
+| `infrastructure/compose/Dockerfile.test` | CI-Lab-Testrunner, kein deployed Service-Image |
+| `infrastructure/actions-runner/Dockerfile` | Distro-`python3-pip`, kein PyPI-Pin; Self-hosted Runner aus aktiver CI ausgebaut (#3575) |
+
+---
+
+## §4 Verifikation am gebauten Image
+
+Vier Images real gebaut (Docker 29.7.0, `fuse-overlayfs`) und gescannt.
+
+**`cdb_execution` — Before/After am identischen Dockerfile:**
+
+```
+BEFORE (origin/main) | pip pkgs seen by scanner: 2 | pip CVEs: 2
+   pkg   26.1 usr/local/lib/python3.14/site-packages/pip-26.1.dist-info/METADATA
+   pkg   26.1 venv/lib/python3.14/site-packages/pip-26.1.dist-info/METADATA
+   CVE   CVE-2026-8643 MEDIUM 26.1 ->fix 26.1.2 (beide Pfade)
+
+AFTER  (this branch) | pip pkgs seen by scanner: 2 | pip CVEs: 0
+   pkg   26.1.2 usr/local/lib/python3.14/site-packages/pip-26.1.2.dist-info/METADATA
+   pkg   26.1.2 venv/lib/python3.14/site-packages/pip-26.1.2.dist-info/METADATA
+```
+
+Der Scanner sieht nach dem Fix **weiterhin beide** pip-Flächen — die
+Sichtbarkeit wurde nicht reduziert, nur das Finding beseitigt.
+
+**Weitere Images:**
+
+| Image | Build | pip im Image | pip-CVEs |
+|---|---|---|---|
+| `cdb_execution:pinscan` | exit 0 | `26.1.2` (global + `/venv`) | 0 |
+| `cdb_candles:pinscan` | exit 0 | `26.1.2` | 0 |
+| `cdb_reports:pinscan` | exit 0 | `26.1.2` | 0 |
+| `cdb_paper_runner:pinscan` | exit 0 | `26.1.2` | 0 |
+
+---
+
+## §5 Regressionsschutz
+
+`tests/unit/infra/test_dockerfile_pip_pin_contract.py` (11 Tests, `unit` +
+`contract`, rein statisch) sichert:
+
+- jedes produktive Image pinnt pip explizit
+- kein Pin liegt unter irgendeinem bekannten pip-Advisory-Floor
+- alle produktiven Images teilen genau eine Version
+- `services/execution` pinnt **beide** pip-Instanzen (Build-venv + Runtime)
+- kein produktives Image lässt pip ungepinnt floaten
+- eine neue Dockerfile-Fläche muss klassifiziert werden, bevor sie pip mitbringt
+- keines der pip-CVEs steht in `.trivyignore`
+
+---
+
+## §6 Boundaries
+
+- Reine Dockerfile-/Doku-/Test-Änderung. Keine funktionale Service-Änderung.
+- Kein Scanner-Ausschluss, kein `.trivyignore`-Eintrag, kein Skip.
+- Keine Alert-Mutation: 5526 und 5527 bleiben offen bis zur Post-Merge-Verifikation
+  durch `security-scan.yml` auf `main`.
+- Kein Runtime-Start, keine produktiven DB-Writes, kein Secrets-Zugriff.
+- LR bleibt **NO-GO**. Kein Echtgeld-Go aus diesem Dokument ableitbar.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -8,7 +8,7 @@ Security triage, CodeQL/Trivy readouts, und Alert-Inventar — **kein** Live-Go-
 |---|---|
 | [`TRIAGE_RUNBOOK.md`](TRIAGE_RUNBOOK.md) | Alert triage, dismiss rules, workflow modes |
 | [`code-scanning-alert-inventory.md`](code-scanning-alert-inventory.md) | CodeQL inventory (Python) |
-| [`TRIVY_TRIAGE_1651.md`](TRIVY_TRIAGE_1651.md) | Trivy cluster notes |
+| [`TRIVY_TRIAGE_1651.md`](TRIVY_TRIAGE_1651.md) | Trivy cluster notes (§3 `venv-pip` korrigiert via #4095 — `venv/`-Pfad ist kein False-Positive-Kriterium) |
 
 ## Readouts
 

--- a/docs/security/TRIVY_TRIAGE_1651.md
+++ b/docs/security/TRIVY_TRIAGE_1651.md
@@ -128,7 +128,29 @@ Runbook: docs/security/TRIAGE_RUNBOOK.md §5
 
 ### Cluster: venv-pip (1 Alert)
 
-**Begründung:**
+> [!CAUTION]
+> **Korrigiert 2026-07-31 (Issue #4095).**
+> Die untenstehende Begründung war als **generelle Regel** falsch. „Pfad beginnt
+> mit `venv/`" ist **kein** Beleg für ein Dev-venv und **kein** False-Positive-Kriterium.
+> `services/execution/Dockerfile` baut ein venv unter `/venv` und kopiert es per
+> `COPY --from=build /venv /venv` in die Runtime-Stage. Im Image-Scan erscheint
+> dieses produktive venv als `venv/lib/python3.14/site-packages/pip-*.dist-info/METADATA`
+> — also exakt in der Form, die hier als „nicht Teil des produktiven Builds"
+> eingestuft wurde. Ein solcher Alert ist ein **Image-Pfad und ein reales Finding**.
+>
+> Die konkrete Alert-ID 2736 bleibt unverändert dismissed: sie nennt
+> `python3.11`, und kein CDB-Image nutzt Python 3.11 (produktiv: 3.14, lokale CI:
+> 3.12). Für diesen Einzelfall bleibt die Dev-venv-Einordnung plausibel. Der
+> historische Dismissal wird nicht angefasst.
+>
+> **Verbindliches Triage-Kriterium ab sofort:** Ein `venv/`-Pfad ist nur dann ein
+> Dev-Artefakt, wenn die Python-Minor-Version **keinem** produktiven Image
+> entspricht **und** die Quelle ein FS-Scan (`trivy.yml`, `scan-type: fs`) ist.
+> Stammt der Alert aus dem Image-Scan (`security-scan.yml`, `trivy-scan-custom`)
+> oder passt die Python-Version zu einem Service-Image, ist er zu fixen — nicht
+> zu dismissen.
+
+**Ursprüngliche Begründung (historisch, nicht mehr als Regel gültig):**
 FS-Scan hat ein Python-venv gescannt (`venv/lib/python3.11/site-packages/pip-25.3.dist-info/METADATA`). Das venv ist nicht Teil des produktiven Builds.
 
 **Alert-ID:** 2736

--- a/knowledge/logs/sessions/2026-07-31-4095-pip-cve-2026-8643.md
+++ b/knowledge/logs/sessions/2026-07-31-4095-pip-cve-2026-8643.md
@@ -1,0 +1,34 @@
+# Session 2026-07-31 — #4095 pip CVE-2026-8643
+
+**Agent:** Cursor Cloud  
+**Status:** `DONE_SLICE_ADDED_TO_BATCH_PR`  
+**Branch:** `cloud-cursor/security-pip-cve-2026-8643-0835`  
+**Commit:** `77533add656c5beea7b8f20e9bab19b9446a536f`  
+**PR:** #4235 (Draft, open)  
+**Issue:** #4095 (OPEN, kein Close)
+
+## Scope
+
+Produktive pip-Pins für `CVE-2026-8643` anheben; Alert 5526/5527 als eine Root
+Cause; falsche venv-False-Positive-Triage in `TRIVY_TRIAGE_1651.md` korrigieren.
+Kein Merge, kein Alert-Dismissal, kein Issue-Close.
+
+## Delivered
+
+- 12 Dockerfiles → `pip==26.1.2` (10 vulnerabel; 2 Determinismus: reports, paper_trading)
+- Contract-Tests: `tests/unit/infra/test_dockerfile_pip_pin_contract.py` (11)
+- Triage-Korrektur: `docs/security/TRIVY_TRIAGE_1651.md` §3 `venv-pip`
+- Evidence: `docs/evidence/security/CDB_SECURITY_PIP_CVE-2026-8643_4095_2026-07-31.md`
+
+## Evidence highlights
+
+- OSV: `CVE-2026-8643` fixed in pip `26.1.2`
+- Trivy Before/After auf `cdb_execution`: 2× CVE → 0; Scanner sieht weiterhin beide Pfade
+- Builds: execution, candles, reports, paper_runner — alle pip `26.1.2`
+- Router: `CREATE_DEDICATED_PR`, kein HOLD
+- Alert-API: HTTP 403 (nicht lesbar); keine Alert-Mutation
+
+## Handoff
+
+Nächstes Fenster: **PR #4235 Acceptance und Merge** (Completeness → Conductor).  
+Diese Session: Delivery-Slice abgeschlossen, Merge bewusst nicht ausgeführt.

--- a/knowledge/logs/sessions/2026-07-31-4095-pip-cve-2026-8643.md
+++ b/knowledge/logs/sessions/2026-07-31-4095-pip-cve-2026-8643.md
@@ -1,10 +1,10 @@
 # Session 2026-07-31 — #4095 pip CVE-2026-8643
 
-**Agent:** Cursor Cloud  
-**Status:** `DONE_SLICE_ADDED_TO_BATCH_PR`  
-**Branch:** `cloud-cursor/security-pip-cve-2026-8643-0835`  
-**Commit:** `77533add656c5beea7b8f20e9bab19b9446a536f`  
-**PR:** #4235 (Draft, open)  
+**Agent:** Cursor Cloud
+**Status:** `DONE_SLICE_ADDED_TO_BATCH_PR`
+**Branch:** `cloud-cursor/security-pip-cve-2026-8643-0835`
+**Commit:** `77533add656c5beea7b8f20e9bab19b9446a536f`
+**PR:** #4235 (Draft, open)
 **Issue:** #4095 (OPEN, kein Close)
 
 ## Scope
@@ -30,5 +30,5 @@ Kein Merge, kein Alert-Dismissal, kein Issue-Close.
 
 ## Handoff
 
-Nächstes Fenster: **PR #4235 Acceptance und Merge** (Completeness → Conductor).  
+Nächstes Fenster: **PR #4235 Acceptance und Merge** (Completeness → Conductor).
 Diese Session: Delivery-Slice abgeschlossen, Merge bewusst nicht ausgeführt.

--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # System-Dependencies

--- a/services/candles/Dockerfile
+++ b/services/candles/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084
 
 WORKDIR /app
 
-# Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==25.3
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # System-Dependencies

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # Install dependencies

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -22,8 +22,10 @@ RUN apt-get update \
 
 # Python Requirements
 COPY services/execution/requirements.txt ./
+# The build venv is copied into the runtime image, so its pip is a production
+# image path — Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643.
 RUN python -m venv /venv \
-    && /venv/bin/pip install --upgrade pip==26.1 \
+    && /venv/bin/pip install --upgrade pip==26.1.2 \
     && /venv/bin/pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2 \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
@@ -47,7 +49,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643 (global runtime pip)
+RUN pip install --upgrade pip==26.1.2
 
 COPY --from=build /venv /venv
 ENV PATH="/venv/bin:$PATH"

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y \
     curl \
   && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 COPY services/market/requirements.txt .

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # System-Dependencies

--- a/services/reports/Dockerfile
+++ b/services/reports/Dockerfile
@@ -5,6 +5,9 @@ LABEL description="Daily Orders Summary Report Service"
 
 WORKDIR /app
 
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643
+RUN pip install --upgrade pip==26.1.2
+
 # Fix CVE-2026-23949 (jaraco.context), CVE-2026-24049 (wheel)
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y \
     curl \
   && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 COPY services/risk/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Python deps
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 COPY services/signal/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade pip to fix CVE-2025-8869 (CVSS 5.9)
-RUN pip install --upgrade pip==26.1
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
+RUN pip install --upgrade pip==26.1.2
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 
 # System dependencies

--- a/tests/unit/infra/README.md
+++ b/tests/unit/infra/README.md
@@ -12,6 +12,7 @@ Static and fixture-backed guards for infra ops contracts. Parent meta: **#3855**
 | Monitoring config | #3861 | Prometheus/Grafana/Loki/Promtail parse, datasource UID drift |
 | Legacy quarantine | #3862 | `infrastructure/scripts/legacy/` banners and drift markers |
 | Infra runbook drift | #3863 | Runbook vs repo-live path drift (no auto-fix) |
+| Dockerfile pip pins | #4095 | pip advisory floor (CVE-2026-8643), one shared pin, no `.trivyignore` silencing |
 
 ## What these tests prove
 
@@ -29,6 +30,10 @@ Static and fixture-backed guards for infra ops contracts. Parent meta: **#3855**
 - Monitoring provisioning YAML/JSON parseability and Grafana alert operator contract
 - Legacy scripts under `infrastructure/scripts/legacy/` carry `LEGACY` banners
 - Infra runbooks reference repo paths that exist (drift surfaced, not auto-corrected)
+- Productive service images pin pip at or above every known pip advisory floor, on one shared version
+- `services/execution` pins both its build venv pip and its global runtime pip (both are image paths)
+- New Dockerfile surfaces must be classified productive vs. non-productive before shipping pip
+- pip advisories are fixed rather than silenced via `.trivyignore`
 
 ## What these tests do **not** prove
 
@@ -39,6 +44,7 @@ Static and fixture-backed guards for infra ops contracts. Parent meta: **#3855**
 - No operator authorization to mutate production stacks
 - No certificate generation, Docker network creation, or live Grafana/Prometheus queries
 - No legacy script reactivation or automatic runbook repair
+- No image build, no registry access, no Trivy execution — the pip pin guard is static text parsing
 
 Run targeted checks:
 
@@ -48,5 +54,6 @@ pytest -q tests/unit/infra/test_tls_network_contract.py
 pytest -q tests/unit/infra/test_monitoring_config_contract.py
 pytest -q tests/unit/infra/test_legacy_script_quarantine_contract.py
 pytest -q tests/unit/infra/test_infra_runbook_drift_contract.py
+pytest -q tests/unit/infra/test_dockerfile_pip_pin_contract.py
 pytest -q tests/unit/scripts -k "backup_manifest or grafana_alerting"
 ```

--- a/tests/unit/infra/_dockerfile_pip_pin_helpers.py
+++ b/tests/unit/infra/_dockerfile_pip_pin_helpers.py
@@ -1,0 +1,141 @@
+"""Shared helpers for the Dockerfile pip pin security contract (#4095).
+
+Static Dockerfile parsing only — no image build, no registry access, no runtime
+mutation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Advisory SSOT for the pinned floor:
+#   CVE-2026-8643 / GHSA-wf93-45jw-7689 / PYSEC-2026-196 -> fixed in pip 26.1.2
+# Earlier pip advisories that this floor also covers:
+#   CVE-2025-8869 (25.3), CVE-2026-1703 (26.0), CVE-2026-3219 (26.1),
+#   CVE-2026-6357 (26.1)
+SAFE_PIP_VERSION = "26.1.2"
+PIP_ADVISORY_FLOORS: dict[str, str] = {
+    "CVE-2025-8869": "25.3",
+    "CVE-2026-1703": "26.0",
+    "CVE-2026-3219": "26.1",
+    "CVE-2026-6357": "26.1",
+    "CVE-2026-8643": "26.1.2",
+}
+
+# Image surfaces that ship pip into a productive service image. `services/*` are
+# the BLUE/RED stack images; `tools/paper_trading` is the BLUE paper runner.
+PRODUCTIVE_IMAGE_DOCKERFILES: tuple[str, ...] = (
+    "services/allocation/Dockerfile",
+    "services/candles/Dockerfile",
+    "services/db_writer/Dockerfile",
+    "services/execution/Dockerfile",
+    "services/market/Dockerfile",
+    "services/regime/Dockerfile",
+    "services/reports/Dockerfile",
+    "services/risk/Dockerfile",
+    "services/signal/Dockerfile",
+    "services/ws/Dockerfile",
+    "tools/paper_trading/Dockerfile",
+)
+
+# Non-productive build surfaces. They are still scanned, but they are CI/test
+# labs rather than deployed service images and are allowed to float pip.
+# `infrastructure/actions-runner` installs the distro `python3-pip` and carries
+# no PyPI pip pin; self-hosted runners are decommissioned from active CI (#3575).
+NON_PRODUCTIVE_DOCKERFILES: tuple[str, ...] = (
+    "ci/Dockerfile",
+    "infrastructure/actions-runner/Dockerfile",
+    "infrastructure/compose/Dockerfile.test",
+)
+
+# `services/execution` builds a venv that is copied into the runtime image, so
+# both the venv pip and the global runtime pip are production image paths.
+EXECUTION_DOCKERFILE = "services/execution/Dockerfile"
+EXPECTED_EXECUTION_PIN_COUNT = 2
+
+TRIVYIGNORE_FILE = ".trivyignore"
+
+PINNED_PIP_PATTERN = re.compile(
+    r"pip\s+install[^\n]*?\bpip==(?P<version>[0-9][0-9A-Za-z.\-_]*)"
+)
+UNPINNED_PIP_UPGRADE_PATTERN = re.compile(
+    r"pip\s+install\s+(?:--[\w-]+\s+)*--upgrade\s+pip(?:\s|\\|$)"
+)
+
+
+@dataclass(frozen=True)
+class PipPin:
+    dockerfile: str
+    line_number: int
+    version: str
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Parse a numeric-only pip version into a comparable tuple."""
+    parts = version.split(".")
+    if not all(part.isdigit() for part in parts):
+        raise ValueError(f"non-numeric pip version pin: {version!r}")
+    return tuple(int(part) for part in parts)
+
+
+def collect_pip_pins(relative_path: str) -> list[PipPin]:
+    pins: list[PipPin] = []
+    for line_number, line in enumerate(_read(relative_path).splitlines(), start=1):
+        match = PINNED_PIP_PATTERN.search(line)
+        if match:
+            pins.append(
+                PipPin(
+                    dockerfile=relative_path,
+                    line_number=line_number,
+                    version=match.group("version"),
+                )
+            )
+    return pins
+
+
+def collect_all_productive_pins() -> list[PipPin]:
+    pins: list[PipPin] = []
+    for dockerfile in PRODUCTIVE_IMAGE_DOCKERFILES:
+        pins.extend(collect_pip_pins(dockerfile))
+    return pins
+
+
+def has_unpinned_pip_upgrade(relative_path: str) -> bool:
+    for line in _read(relative_path).splitlines():
+        if PINNED_PIP_PATTERN.search(line):
+            continue
+        if UNPINNED_PIP_UPGRADE_PATTERN.search(line):
+            return True
+    return False
+
+
+def discover_dockerfiles() -> list[str]:
+    """Every tracked Dockerfile in the repo, as repo-relative POSIX paths."""
+    found: list[str] = []
+    for path in REPO_ROOT.rglob("Dockerfile*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(REPO_ROOT).as_posix()
+        if relative.startswith(
+            (".git/", ".venv/", "third_party/", ".worktrees_backup/")
+        ):
+            continue
+        found.append(relative)
+    return sorted(found)
+
+
+def trivyignore_entries() -> list[str]:
+    raw = _read(TRIVYIGNORE_FILE)
+    return [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]

--- a/tests/unit/infra/test_dockerfile_pip_pin_contract.py
+++ b/tests/unit/infra/test_dockerfile_pip_pin_contract.py
@@ -1,0 +1,80 @@
+"""pip pin security contract for productive service images (#4095).
+
+Guards the remediation of CVE-2026-8643 (pip < 26.1.2): every productive image
+that installs pip must pin a version at or above the advisory floor, all images
+must agree on one version, and the finding must not be silenced via
+`.trivyignore`.
+
+Static Dockerfile parsing only — no image build, no registry access, no runtime.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.infra import _dockerfile_pip_pin_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_every_productive_image_pins_pip() -> None:
+    missing = [
+        dockerfile
+        for dockerfile in helpers.PRODUCTIVE_IMAGE_DOCKERFILES
+        if not helpers.collect_pip_pins(dockerfile)
+    ]
+    assert missing == [], f"productive images without an explicit pip pin: {missing}"
+
+
+@pytest.mark.parametrize("cve, floor", sorted(helpers.PIP_ADVISORY_FLOORS.items()))
+def test_productive_pip_pins_meet_every_known_advisory_floor(
+    cve: str, floor: str
+) -> None:
+    floor_version = helpers.parse_version(floor)
+    violations = [
+        (pin.dockerfile, pin.line_number, pin.version)
+        for pin in helpers.collect_all_productive_pins()
+        if helpers.parse_version(pin.version) < floor_version
+    ]
+    assert violations == [], f"pip pins below the {cve} floor {floor}: {violations}"
+
+
+def test_productive_pip_pins_use_one_agreed_version() -> None:
+    versions = {pin.version for pin in helpers.collect_all_productive_pins()}
+    assert versions == {
+        helpers.SAFE_PIP_VERSION
+    }, f"productive images must share pip=={helpers.SAFE_PIP_VERSION}, found {sorted(versions)}"
+
+
+def test_execution_pins_both_build_venv_and_runtime_pip() -> None:
+    pins = helpers.collect_pip_pins(helpers.EXECUTION_DOCKERFILE)
+    assert len(pins) == helpers.EXPECTED_EXECUTION_PIN_COUNT, (
+        "the execution image copies its build venv into the runtime stage, so the "
+        f"venv pip and the global pip must both be pinned; found {pins}"
+    )
+
+
+def test_productive_images_do_not_float_pip_unpinned() -> None:
+    floating = [
+        dockerfile
+        for dockerfile in helpers.PRODUCTIVE_IMAGE_DOCKERFILES
+        if helpers.has_unpinned_pip_upgrade(dockerfile)
+    ]
+    assert floating == [], f"productive images with an unpinned pip upgrade: {floating}"
+
+
+def test_dockerfile_inventory_has_no_unclassified_surface() -> None:
+    known = set(helpers.PRODUCTIVE_IMAGE_DOCKERFILES) | set(
+        helpers.NON_PRODUCTIVE_DOCKERFILES
+    )
+    unclassified = sorted(set(helpers.discover_dockerfiles()) - known)
+    assert unclassified == [], (
+        "new Dockerfile surface must be classified as productive or non-productive "
+        f"before it can ship pip: {unclassified}"
+    )
+
+
+def test_pip_cve_is_not_silenced_by_trivyignore() -> None:
+    entries = helpers.trivyignore_entries()
+    silenced = sorted(set(entries) & set(helpers.PIP_ADVISORY_FLOORS))
+    assert silenced == [], f"pip advisories must be fixed, not ignored: {silenced}"

--- a/tools/paper_trading/Dockerfile
+++ b/tools/paper_trading/Dockerfile
@@ -13,6 +13,9 @@ RUN useradd -m -u 1000 paperuser
 # Set working directory
 WORKDIR /app
 
+# Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643
+RUN pip install --upgrade pip==26.1.2
+
 # Fix CVE-2026-23949 (jaraco.context), CVE-2026-24049 (wheel)
 RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request

Refs #4095 — Code-Scanning **Alert 5526** und **Alert 5527**.

## Summary

`CVE-2026-8643` (pip `< 26.1.2`) traf zehn pip-Pins in produktiven Service-Images. Alle betroffenen Dockerfiles heben jetzt auf `pip==26.1.2` an — die exakte Fix-Version des Advisories, nicht den Latest-Release. `services/candles` verließ dabei zusätzlich den älteren, mehrfach verwundbaren `25.3`-Pin.

Ein neuer statischer Contract-Test sichert den Advisory-Floor gegen Regression, und die falsche „`venv/` ⇒ False Positive"-Regel in `docs/security/TRIVY_TRIAGE_1651.md` §3 ist korrigiert.

## Why

### Security Root Cause

Der Alert-Pfad aus #4095 lautet `venv/lib/python3.14/site-packages/pip-26.1.dist-info/metadata`. Das ist **kein** Dev-venv: `services/execution/Dockerfile` legt in der Build-Stage `/venv` an und übernimmt es per `COPY --from=build /venv /venv` in die Runtime-Stage. Im Image-Scan erscheint dieser Produktionspfad ohne führenden Slash als `venv/…`.

Dasselbe Dockerfile installiert pip an **zwei** Stellen — im Build-venv und global in der Runtime-Stage. **Alert 5526** (venv-Pfad) und **Alert 5527** (globaler Pfad) sind damit zwei Instanzen **derselben** Root Cause: ein einziger verwundbarer Pin, der zweimal im selben Image landet. Der Trivy-Scan des ungefixten Images belegt genau diese beiden Findings.

### Advisory-Grundlage (live geprüft)

| Feld | Wert |
|---|---|
| CVE | `CVE-2026-8643` |
| Aliases | `GHSA-wf93-45jw-7689`, `PYSEC-2026-196` |
| Betroffen | pip `>= 0`, `< 26.1.2` |
| **Fixed** | **`26.1.2`** |
| Quelle | `https://api.osv.dev/v1/vulns/CVE-2026-8643` (abgefragt 2026-07-31) |

`26.1.2` deckt zusätzlich `CVE-2025-8869` (25.3), `CVE-2026-1703` (26.0), `CVE-2026-3219` (26.1) und `CVE-2026-6357` (26.1) ab.

## Delivered

| Dockerfile | vorher | nachher | Klasse |
|---|---|---|---|
| `services/allocation` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
| `services/candles` | `pip==25.3` | `pip==26.1.2` | vulnerabel (4 CVEs) |
| `services/db_writer` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
| `services/execution` (Build-venv) | `pip==26.1` | `pip==26.1.2` | vulnerabel — **Alert 5526** |
| `services/execution` (Runtime-global) | `pip==26.1` | `pip==26.1.2` | vulnerabel — **Alert 5527** |
| `services/market` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
| `services/regime` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
| `services/risk` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
| `services/signal` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
| `services/ws` | `pip==26.1` | `pip==26.1.2` | vulnerabel |
| `services/reports` | kein Pin | `pip==26.1.2` | **nicht vulnerabel** — Determinismus |
| `tools/paper_trading` | kein Pin | `pip==26.1.2` | **nicht vulnerabel** — Determinismus |

Weiter geliefert:
- `tests/unit/infra/test_dockerfile_pip_pin_contract.py` + Helper (11 Tests)
- `docs/security/TRIVY_TRIAGE_1651.md` §3 korrigiert
- Evidence + Session-Log unter `docs/evidence/security/` und `knowledge/logs/sessions/`

## Validation

Before/After Trivy 0.72.0 am gebauten `cdb_execution`-Image (`origin/main` vs. dieser Branch):

```
BEFORE | pip pkgs: 2 | pip CVEs: 2 (CVE-2026-8643 @ 26.1, beide Pfade)
AFTER  | pip pkgs: 2 | pip CVEs: 0 (26.1.2, beide Pfade weiterhin sichtbar)
```

Weitere Checks: Contract-Tests 11/11; `tests/unit/infra` 148; breiter Sweep 1196 passed; ruff/black OK; readme-links OK; gitleaks staged clean; keine verwundbaren pip-Pins mehr im Repo.

## Non-goals / Safety

Kein Merge, kein Issue-Close, kein Alert-Dismissal, kein `.trivyignore`. LR **NO-GO**. Kein Runtime-Start, keine DB-Writes, keine Secrets.

## Restunsicherheiten

- Code-Scanning-API in dieser Session HTTP 403; Alert-Zuordnung über reproduzierten Before-Scan
- 8/12 Images nicht einzeln gebaut (gleiches Pin-Muster)
- Post-Merge-Scan auf `main` ausstehend

## Status

**DONE_SLICE_ADDED_TO_BATCH_PR** — nächstes Fenster: PR #4235 Acceptance und Merge.

Head: `1caf29d9` (Fix `77533add` + Session-Log)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45b7d750-beb7-488c-9606-be8f98790835?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45b7d750-beb7-488c-9606-be8f98790835&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

