### PR TITLE
feat(ci): Fast-CI slice gates and timing evidence (#4204)

### DIFF
--- a/.claude/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.claude/skills/cdb-ci-cd-guard/SKILL.md
@@ -75,20 +75,30 @@ This skill audits CI/CD tooling with external documentation dependencies:
 
 ## Slice Validation
 
-- targeted Tests und relevante Contract-Tests,
+- Deterministische Auswahl über `ci/config/slice_validation_policy.v1.yaml`
+  (Inputs: `changed_paths`, `routing_lane`, `validation_profile`).
+- Outputs maschinenlesbar: `selected_test_groups`, `selection_reasons`,
+  `unclassified_paths`, `fallback_reason`, immer `merge_evidence=false`.
+- Unbekannte Pfade, Policy-/Schemafehler, Runtime/Risk/Docker-Pfade →
+  fail-closed Full Fast-CI Unit-Selektor.
+- Targeted Tests und relevante Contract-Tests laut Selection,
 - Lint/Format für betroffene Dateien,
 - `git diff --check`,
-- kein Full Fast-CI als Default,
-- kein `cdb-local-ci` Publish.
+- kein Full Fast-CI als Default für Delivery-Slices,
+- **kein** `cdb-local-ci` Publish (Publisher rejected slice evidence).
+- Stage-/Unit-Timing: `reports/stage_timing.json`, `reports/unit_timing.json`
+  (`--durations`) — ändert nicht Pass/Fail.
 
 ## Final Batch Head Validation
 
 - PR ist `merge_candidate` und für neue Slices eingefroren,
-- Full Fast-CI auf dem exakten finalen Head,
+- Full Fast-CI auf dem exakten finalen Head
+  (`pytest -q -k "not test_mcp_time_server_runtime"` unverändert),
 - integrierter Base-SHA ist in der Evidence gebunden,
 - lokaler Policy-Gate-Mirror ist grün,
 - `cdb-local-ci=success` liegt als Commit Status auf exakt diesem Head,
 - Head-/Base-Drift erzwingt vollständige Revalidierung.
+- Slice-Validation ist **kein** Ersatz für Final-Head-Evidence.
 
 Check Runs und Commit Status sind getrennte GitHub-Typen. Ein namensgleicher
 Check Run erfüllt den Required Commit Status nicht.

--- a/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
+++ b/.codex/cdb_skills/cdb-ci-cd-guard/SKILL.md
@@ -75,20 +75,30 @@ This skill audits CI/CD tooling with external documentation dependencies:
 
 ## Slice Validation
 
-- targeted Tests und relevante Contract-Tests,
+- Deterministische Auswahl über `ci/config/slice_validation_policy.v1.yaml`
+  (Inputs: `changed_paths`, `routing_lane`, `validation_profile`).
+- Outputs maschinenlesbar: `selected_test_groups`, `selection_reasons`,
+  `unclassified_paths`, `fallback_reason`, immer `merge_evidence=false`.
+- Unbekannte Pfade, Policy-/Schemafehler, Runtime/Risk/Docker-Pfade →
+  fail-closed Full Fast-CI Unit-Selektor.
+- Targeted Tests und relevante Contract-Tests laut Selection,
 - Lint/Format für betroffene Dateien,
 - `git diff --check`,
-- kein Full Fast-CI als Default,
-- kein `cdb-local-ci` Publish.
+- kein Full Fast-CI als Default für Delivery-Slices,
+- **kein** `cdb-local-ci` Publish (Publisher rejected slice evidence).
+- Stage-/Unit-Timing: `reports/stage_timing.json`, `reports/unit_timing.json`
+  (`--durations`) — ändert nicht Pass/Fail.
 
 ## Final Batch Head Validation
 
 - PR ist `merge_candidate` und für neue Slices eingefroren,
-- Full Fast-CI auf dem exakten finalen Head,
+- Full Fast-CI auf dem exakten finalen Head
+  (`pytest -q -k "not test_mcp_time_server_runtime"` unverändert),
 - integrierter Base-SHA ist in der Evidence gebunden,
 - lokaler Policy-Gate-Mirror ist grün,
 - `cdb-local-ci=success` liegt als Commit Status auf exakt diesem Head,
 - Head-/Base-Drift erzwingt vollständige Revalidierung.
+- Slice-Validation ist **kein** Ersatz für Final-Head-Evidence.
 
 Check Runs und Commit Status sind getrennte GitHub-Typen. Ein namensgleicher
 Check Run erfüllt den Required Commit Status nicht.

--- a/.cursor/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.cursor/skills/cdb-ci-cd-guard/SKILL.md
@@ -75,20 +75,30 @@ This skill audits CI/CD tooling with external documentation dependencies:
 
 ## Slice Validation
 
-- targeted Tests und relevante Contract-Tests,
+- Deterministische Auswahl über `ci/config/slice_validation_policy.v1.yaml`
+  (Inputs: `changed_paths`, `routing_lane`, `validation_profile`).
+- Outputs maschinenlesbar: `selected_test_groups`, `selection_reasons`,
+  `unclassified_paths`, `fallback_reason`, immer `merge_evidence=false`.
+- Unbekannte Pfade, Policy-/Schemafehler, Runtime/Risk/Docker-Pfade →
+  fail-closed Full Fast-CI Unit-Selektor.
+- Targeted Tests und relevante Contract-Tests laut Selection,
 - Lint/Format für betroffene Dateien,
 - `git diff --check`,
-- kein Full Fast-CI als Default,
-- kein `cdb-local-ci` Publish.
+- kein Full Fast-CI als Default für Delivery-Slices,
+- **kein** `cdb-local-ci` Publish (Publisher rejected slice evidence).
+- Stage-/Unit-Timing: `reports/stage_timing.json`, `reports/unit_timing.json`
+  (`--durations`) — ändert nicht Pass/Fail.
 
 ## Final Batch Head Validation
 
 - PR ist `merge_candidate` und für neue Slices eingefroren,
-- Full Fast-CI auf dem exakten finalen Head,
+- Full Fast-CI auf dem exakten finalen Head
+  (`pytest -q -k "not test_mcp_time_server_runtime"` unverändert),
 - integrierter Base-SHA ist in der Evidence gebunden,
 - lokaler Policy-Gate-Mirror ist grün,
 - `cdb-local-ci=success` liegt als Commit Status auf exakt diesem Head,
 - Head-/Base-Drift erzwingt vollständige Revalidierung.
+- Slice-Validation ist **kein** Ersatz für Final-Head-Evidence.
 
 Check Runs und Commit Status sind getrennte GitHub-Typen. Ein namensgleicher
 Check Run erfüllt den Required Commit Status nicht.

--- a/.opencode/skills/cdb-ci-cd-guard/SKILL.md
+++ b/.opencode/skills/cdb-ci-cd-guard/SKILL.md
@@ -75,20 +75,30 @@ This skill audits CI/CD tooling with external documentation dependencies:
 
 ## Slice Validation
 
-- targeted Tests und relevante Contract-Tests,
+- Deterministische Auswahl über `ci/config/slice_validation_policy.v1.yaml`
+  (Inputs: `changed_paths`, `routing_lane`, `validation_profile`).
+- Outputs maschinenlesbar: `selected_test_groups`, `selection_reasons`,
+  `unclassified_paths`, `fallback_reason`, immer `merge_evidence=false`.
+- Unbekannte Pfade, Policy-/Schemafehler, Runtime/Risk/Docker-Pfade →
+  fail-closed Full Fast-CI Unit-Selektor.
+- Targeted Tests und relevante Contract-Tests laut Selection,
 - Lint/Format für betroffene Dateien,
 - `git diff --check`,
-- kein Full Fast-CI als Default,
-- kein `cdb-local-ci` Publish.
+- kein Full Fast-CI als Default für Delivery-Slices,
+- **kein** `cdb-local-ci` Publish (Publisher rejected slice evidence).
+- Stage-/Unit-Timing: `reports/stage_timing.json`, `reports/unit_timing.json`
+  (`--durations`) — ändert nicht Pass/Fail.
 
 ## Final Batch Head Validation
 
 - PR ist `merge_candidate` und für neue Slices eingefroren,
-- Full Fast-CI auf dem exakten finalen Head,
+- Full Fast-CI auf dem exakten finalen Head
+  (`pytest -q -k "not test_mcp_time_server_runtime"` unverändert),
 - integrierter Base-SHA ist in der Evidence gebunden,
 - lokaler Policy-Gate-Mirror ist grün,
 - `cdb-local-ci=success` liegt als Commit Status auf exakt diesem Head,
 - Head-/Base-Drift erzwingt vollständige Revalidierung.
+- Slice-Validation ist **kein** Ersatz für Final-Head-Evidence.
 
 Check Runs und Commit Status sind getrennte GitHub-Typen. Ein namensgleicher
 Check Run erfüllt den Required Commit Status nicht.

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,12 +3,14 @@
 **Status Class**: Claire de Binare repository / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-**Last Updated**: 2026-07-30
+**Last Updated**: 2026-07-31
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
 
 ---
 
 ## Repo / Engineering Status (2026-07-31)
+
+- **#4204 Fast-CI Slice Gates**: Delivery slice on `batch/ci-tooling-issue-4204` — versioned slice policy, fail-closed unknown-path → full Fast-CI, `merge_evidence=false` publish rejection, unit/stage timing evidence; Final-Head selector unchanged (collect-only 8957→8970 +13 tests). Merge/Issue-close/`cdb-local-ci` not in this session. LR **NO-GO** unchanged.
 
 - **#4228 PR-Router Real Conventions**: Delivery slice on `cloud-cursor/pr-router-real-conventions-5132` — policy/matcher aligned to live title tokens (`[AGENTS]`/`[SKILLS]`/`[OPS]`/…) and `scope:*`/`type:*` labels; missing metadata yields actionable `repair_hints` + safe `CREATE_NEW_BATCH_PR`; deleted override `governance/pr-steward-batch-routing` removed. Merge/Issue-close not in this session. LR **NO-GO** unchanged.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -62,10 +62,26 @@ pwsh -File ci/scripts/publish_status.ps1 -Command publish -EvidenceDir ci/artifa
 
 ## Profiles
 
-| Profile | Stages |
-|---------|--------|
-| `fast` (default) | lint, unit, docs, governance (+ report) |
-| `heavy` | fast + integration, security, containers (+ report) |
+| Profile | Stages | Merge evidence? |
+|---------|--------|-----------------|
+| `fast` (default) | lint, unit, docs, governance (+ report) | Eligible after publish (`merge_evidence=true`) |
+| `slice` (#4204) | same stages as fast; unit may use path-selected groups | **Never** (`merge_evidence=false`) |
+| `heavy` | fast + integration, security, containers (+ report) | Eligible after publish when clean |
+
+### Slice selection (#4204)
+
+```bash
+python ci/scripts/run.py --profile slice \
+  --changed-path ci/lib/slice_selection.py \
+  --routing-lane ci-tooling \
+  --validation-profile ci-tooling-v1
+```
+
+Policy: `ci/config/slice_validation_policy.v1.yaml`. Selection report:
+`ci/artifacts/<run_id>/reports/slice_selection.json`. Unknown paths and
+policy errors fall back to the full Fast-CI unit selector. Timing evidence:
+`--unit-durations 50` (default) writes `reports/unit_timing.json` and
+`reports/stage_timing.json` without changing pass/fail.
 
 ## Stage commands (reuse-first)
 

--- a/ci/config/slice_validation_policy.v1.yaml
+++ b/ci/config/slice_validation_policy.v1.yaml
@@ -1,0 +1,112 @@
+# Slice Validation Policy — selective Fast-CI test groups for delivery slices.
+# Schema: cdb-slice-validation-policy/v1
+#
+# Hard rules:
+# - Unknown / unclassified paths => full Fast-CI unit selector (fail-closed).
+# - Policy/schema/parse errors => full Fast-CI unit selector (fail-closed).
+# - Slice runs ALWAYS carry merge_evidence=false and must never publish cdb-local-ci.
+# - Final merge evidence remains profile=fast with the unchanged full unit selector.
+schema_version: "cdb-slice-validation-policy/v1"
+policy_id: "cdb-slice-validation-v1"
+
+full_fast_unit:
+  id: full_fast
+  description: "Complete Fast-CI unit selector (ci.yml / profile=fast SSOT)"
+  pytest_args:
+    - "-q"
+    - "-k"
+    - "not test_mcp_time_server_runtime"
+  # Supplemental marker exclusions for documentation only; selection is path-based.
+  complementary_marker_exclusions:
+    - e2e
+    - local_only
+    - chaos
+    - performance
+    - resilience
+    - external
+
+test_groups:
+  docs_guards:
+    description: "Docs/README/onboarding/canon guard unit tests"
+    pytest_paths:
+      - "tests/unit/tools/test_validate_readme_links.py"
+      - "tests/unit/tools/test_validate_onboarding_docs.py"
+      - "tests/unit/tools/ci/test_docs_conflict_guard.py"
+  ci_contracts:
+    description: "Local CI evidence, stage, and publisher contract tests"
+    pytest_paths:
+      - "tests/unit/ci/"
+  ci_tooling:
+    description: "CI tooling helpers under tests/unit/tools/ci"
+    pytest_paths:
+      - "tests/unit/tools/ci/"
+  full_fast:
+    description: "Complete Fast-CI unit selector"
+    inherits: full_fast_unit
+
+path_rules:
+  - id: docs_surface
+    match_prefixes:
+      - "docs/"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+    groups:
+      - docs_guards
+  - id: ci_surface
+    match_prefixes:
+      - "ci/"
+    groups:
+      - ci_contracts
+      - ci_tooling
+  - id: ci_unit_tests
+    match_prefixes:
+      - "tests/unit/ci/"
+      - "tests/unit/tools/ci/"
+    groups:
+      - ci_contracts
+      - ci_tooling
+  - id: runtime_risk_force_full
+    match_prefixes:
+      - "services/"
+      - "core/"
+      - "infrastructure/"
+    force_full_fallback: true
+    fallback_reason: "runtime_or_risk_path"
+  - id: docker_or_external_tests
+    match_prefixes:
+      - "tests/e2e/"
+      - "tests/local/"
+      - "tests/chaos/"
+    force_full_fallback: true
+    fallback_reason: "docker_or_external_tool_required"
+
+lane_rules:
+  - id: ci_tooling_lane
+    lanes:
+      - ci-tooling
+    validation_profiles:
+      - ci-tooling-v1
+    groups:
+      - ci_contracts
+      - ci_tooling
+  - id: docs_lane
+    lanes:
+      - docs
+      - documentation
+    validation_profiles:
+      - docs-v1
+    groups:
+      - docs_guards
+
+# Paths that always require full Fast-CI when touched (even if also matching a
+# narrower prefix rule). Matched after prefix rules; any hit forces full.
+always_full_path_globs: []
+
+fail_closed:
+  unknown_path_fallback: full_fast
+  empty_policy_fallback: full_fast
+  schema_error_fallback: full_fast
+  parse_error_fallback: full_fast
+  empty_selection_fallback: full_fast

--- a/ci/config/stages.yaml
+++ b/ci/config/stages.yaml
@@ -7,6 +7,13 @@ profiles:
     - unit
     - docs
     - governance
+  # Slice uses the same stage list as fast, but unit may run a path-selected
+  # subset. Slice evidence is always merge_evidence=false (#4204).
+  slice:
+    - lint
+    - unit
+    - docs
+    - governance
   heavy:
     - lint
     - unit

--- a/ci/lib/evidence.py
+++ b/ci/lib/evidence.py
@@ -172,11 +172,14 @@ def build_manifest(
     skipped_checks: list[dict[str, str]],
     artifact_hashes: dict[str, str],
     repo_name: str,
+    merge_evidence: bool = True,
 ) -> dict[str, Any]:
     validate_run_id(run_id)
     validate_repo_name(repo_name)
     validate_stage_skip_rules(stages)
     overall = aggregate_overall_status(stages, dirty_worktree=dirty_worktree)
+    # Slice / selective runs must never count as merge evidence (#4204).
+    effective_merge_evidence = bool(merge_evidence) and profile not in ("slice",)
     return {
         "schema_version": SCHEMA_VERSION,
         "run_id": run_id,
@@ -191,6 +194,7 @@ def build_manifest(
         "docker_version": docker_version,
         "compose_version": compose_version,
         "profile": profile,
+        "merge_evidence": effective_merge_evidence,
         "stages": [asdict(s) for s in stages],
         "skipped_checks": skipped_checks,
         "artifact_hashes": artifact_hashes,
@@ -345,6 +349,13 @@ def assert_publishable(
     """
     if manifest.get("dirty_worktree") is True:
         raise EvidenceError("Dirty worktree evidence cannot be published")
+    # Explicit slice / selective Fast-CI must never publish as cdb-local-ci (#4204).
+    if manifest.get("merge_evidence") is False:
+        raise EvidenceError(
+            "Evidence merge_evidence=false cannot be published as merge proof"
+        )
+    if str(manifest.get("profile") or "") == "slice":
+        raise EvidenceError("Slice profile evidence cannot be published as merge proof")
     if manifest.get("overall_status") != "PASS":
         raise EvidenceError(
             f"Evidence overall_status is {manifest.get('overall_status')!r}, not PASS"

--- a/ci/lib/slice_selection.py
+++ b/ci/lib/slice_selection.py
@@ -1,0 +1,370 @@
+"""Deterministic, fail-closed slice test-group selection for local Fast-CI.
+
+Slice selection never produces merge evidence. Unknown paths, schema/parse
+errors, and empty selections fall back to the full Fast-CI unit selector.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from ci.lib.config import load_yaml
+
+SCHEMA_VERSION = "cdb-slice-validation-policy/v1"
+SELECTION_REPORT_SCHEMA = "cdb-slice-selection-report/v1"
+DEFAULT_POLICY_RELATIVE = Path("ci/config/slice_validation_policy.v1.yaml")
+FULL_FAST_GROUP = "full_fast"
+FULL_FAST_PYTEST_ARGS = ("-q", "-k", "not test_mcp_time_server_runtime")
+
+
+class SlicePolicyError(ValueError):
+    """Raised when the slice policy cannot be loaded or validated."""
+
+
+@dataclass(frozen=True)
+class SliceSelectionInput:
+    changed_paths: tuple[str, ...]
+    routing_lane: str
+    validation_profile: str
+
+
+@dataclass
+class SliceSelectionResult:
+    schema_version: str = SELECTION_REPORT_SCHEMA
+    policy_id: str | None = None
+    policy_schema_version: str | None = None
+    selected_test_groups: list[str] = field(default_factory=list)
+    selection_reasons: list[str] = field(default_factory=list)
+    unclassified_paths: list[str] = field(default_factory=list)
+    fallback_reason: str | None = None
+    merge_evidence: bool = False
+    pytest_paths: list[str] = field(default_factory=list)
+    pytest_args: list[str] = field(default_factory=list)
+    used_full_fast: bool = False
+    inputs: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        # Contract: slice selection is never merge evidence.
+        payload["merge_evidence"] = False
+        return payload
+
+
+def normalize_changed_paths(paths: Iterable[str]) -> tuple[str, ...]:
+    """Deterministically normalize and sort changed paths (order-independent)."""
+    cleaned: set[str] = set()
+    for raw in paths:
+        text = str(raw or "").strip().replace("\\", "/")
+        if not text:
+            continue
+        while text.startswith("./"):
+            text = text[2:]
+        cleaned.add(text)
+    return tuple(sorted(cleaned))
+
+
+def default_policy_path(repo_root: Path) -> Path:
+    return repo_root / DEFAULT_POLICY_RELATIVE
+
+
+def load_slice_policy(path: Path) -> dict[str, Any]:
+    """Load YAML policy; raise SlicePolicyError on empty/invalid structure."""
+    if not path.is_file():
+        raise SlicePolicyError(f"Missing slice policy file: {path}")
+    try:
+        data = load_yaml(path)
+    except Exception as exc:  # noqa: BLE001 — fail-closed parse
+        raise SlicePolicyError(f"Policy parse error: {exc}") from exc
+    if not data:
+        raise SlicePolicyError("Empty slice policy")
+    if not isinstance(data, dict):
+        raise SlicePolicyError("Slice policy root must be a mapping")
+    return data
+
+
+def validate_slice_policy(policy: Mapping[str, Any]) -> None:
+    """Validate required schema fields; raise SlicePolicyError on violation."""
+    schema = policy.get("schema_version")
+    if schema != SCHEMA_VERSION:
+        raise SlicePolicyError(
+            f"Unsupported schema_version {schema!r}; expected {SCHEMA_VERSION!r}"
+        )
+    if not policy.get("policy_id"):
+        raise SlicePolicyError("Missing policy_id")
+    groups = policy.get("test_groups")
+    if not isinstance(groups, dict) or not groups:
+        raise SlicePolicyError("test_groups must be a non-empty mapping")
+    if FULL_FAST_GROUP not in groups and "full_fast_unit" not in policy:
+        raise SlicePolicyError("full_fast group or full_fast_unit definition required")
+    path_rules = policy.get("path_rules")
+    if not isinstance(path_rules, list) or not path_rules:
+        raise SlicePolicyError("path_rules must be a non-empty list")
+    for rule in path_rules:
+        if not isinstance(rule, dict):
+            raise SlicePolicyError("path_rules entries must be mappings")
+        if not rule.get("id"):
+            raise SlicePolicyError("path rule missing id")
+        prefixes = rule.get("match_prefixes")
+        if not isinstance(prefixes, list) or not prefixes:
+            raise SlicePolicyError(
+                f"path rule {rule.get('id')!r} missing match_prefixes"
+            )
+        if rule.get("force_full_fallback"):
+            continue
+        groups_ref = rule.get("groups")
+        if not isinstance(groups_ref, list) or not groups_ref:
+            raise SlicePolicyError(
+                f"path rule {rule.get('id')!r} missing groups (or force_full_fallback)"
+            )
+
+
+def _path_matches_prefix(path: str, prefix: str) -> bool:
+    norm_prefix = prefix.replace("\\", "/").rstrip("/")
+    if path == norm_prefix:
+        return True
+    if path.startswith(norm_prefix + "/"):
+        return True
+    # Allow exact file prefixes like README.md
+    if not norm_prefix.endswith("/") and path == prefix.replace("\\", "/"):
+        return True
+    return False
+
+
+def _full_fast_args(policy: Mapping[str, Any]) -> list[str]:
+    unit = policy.get("full_fast_unit") or {}
+    args = unit.get("pytest_args") if isinstance(unit, dict) else None
+    if isinstance(args, list) and args:
+        return [str(a) for a in args]
+    return list(FULL_FAST_PYTEST_ARGS)
+
+
+def _group_pytest_paths(policy: Mapping[str, Any], group_id: str) -> list[str]:
+    groups = policy.get("test_groups") or {}
+    meta = groups.get(group_id) or {}
+    if not isinstance(meta, dict):
+        return []
+    if meta.get("inherits") == "full_fast_unit" or group_id == FULL_FAST_GROUP:
+        return []
+    paths = meta.get("pytest_paths") or []
+    if not isinstance(paths, list):
+        return []
+    # Deterministic unique order
+    return sorted({str(p).replace("\\", "/") for p in paths if str(p).strip()})
+
+
+def _fallback_result(
+    *,
+    reason: str,
+    inputs: SliceSelectionInput,
+    policy: Mapping[str, Any] | None,
+    unclassified: Iterable[str] = (),
+    extra_reasons: Iterable[str] = (),
+) -> SliceSelectionResult:
+    policy_id = None
+    schema = None
+    args = list(FULL_FAST_PYTEST_ARGS)
+    if policy is not None:
+        policy_id = str(policy.get("policy_id") or "") or None
+        schema = str(policy.get("schema_version") or "") or None
+        args = _full_fast_args(policy)
+    reasons = [f"fallback:{reason}", *list(extra_reasons)]
+    return SliceSelectionResult(
+        policy_id=policy_id,
+        policy_schema_version=schema,
+        selected_test_groups=[FULL_FAST_GROUP],
+        selection_reasons=reasons,
+        unclassified_paths=list(normalize_changed_paths(unclassified)),
+        fallback_reason=reason,
+        merge_evidence=False,
+        pytest_paths=[],
+        pytest_args=args,
+        used_full_fast=True,
+        inputs={
+            "changed_paths": list(inputs.changed_paths),
+            "routing_lane": inputs.routing_lane,
+            "validation_profile": inputs.validation_profile,
+        },
+    )
+
+
+def select_slice_test_groups(
+    *,
+    changed_paths: Iterable[str],
+    routing_lane: str,
+    validation_profile: str,
+    policy: Mapping[str, Any] | None = None,
+    policy_path: Path | None = None,
+) -> SliceSelectionResult:
+    """Select test groups deterministically; fail closed to full_fast.
+
+    Always returns ``merge_evidence=False``.
+    """
+    paths = normalize_changed_paths(changed_paths)
+    inputs = SliceSelectionInput(
+        changed_paths=paths,
+        routing_lane=str(routing_lane or "").strip(),
+        validation_profile=str(validation_profile or "").strip(),
+    )
+
+    loaded: dict[str, Any] | None = None
+    try:
+        if policy is None:
+            if policy_path is None:
+                raise SlicePolicyError("policy or policy_path required")
+            loaded = load_slice_policy(policy_path)
+        else:
+            loaded = dict(policy)
+        validate_slice_policy(loaded)
+    except SlicePolicyError as exc:
+        reason = "policy_parse_error"
+        msg = str(exc).lower()
+        if "empty" in msg:
+            reason = "empty_policy"
+        elif "schema" in msg or "unsupported schema" in msg or "missing" in msg:
+            reason = "schema_error"
+        return _fallback_result(
+            reason=reason,
+            inputs=inputs,
+            policy=loaded,
+            unclassified=paths,
+            extra_reasons=[f"error:{exc}"],
+        )
+
+    assert loaded is not None
+    path_rules = list(loaded.get("path_rules") or [])
+    selected: set[str] = set()
+    reasons: list[str] = []
+    unclassified: list[str] = []
+
+    for path in paths:
+        matched_any = False
+        for rule in path_rules:
+            prefixes = [str(p) for p in (rule.get("match_prefixes") or [])]
+            if not any(_path_matches_prefix(path, p) for p in prefixes):
+                continue
+            matched_any = True
+            rule_id = str(rule.get("id") or "unnamed")
+            if rule.get("force_full_fallback"):
+                fb = str(rule.get("fallback_reason") or "force_full_fallback")
+                return _fallback_result(
+                    reason=fb,
+                    inputs=inputs,
+                    policy=loaded,
+                    unclassified=[],
+                    extra_reasons=[f"path_rule:{rule_id}:{path}"],
+                )
+            for group in rule.get("groups") or []:
+                selected.add(str(group))
+                reasons.append(f"path:{path}->group:{group}(rule={rule_id})")
+        if not matched_any:
+            unclassified.append(path)
+
+    if unclassified:
+        return _fallback_result(
+            reason="unclassified_paths",
+            inputs=inputs,
+            policy=loaded,
+            unclassified=unclassified,
+            extra_reasons=reasons,
+        )
+
+    # Lane / validation-profile contribution (union; never silent omit).
+    for rule in loaded.get("lane_rules") or []:
+        if not isinstance(rule, dict):
+            continue
+        lanes = {str(x) for x in (rule.get("lanes") or [])}
+        profiles = {str(x) for x in (rule.get("validation_profiles") or [])}
+        lane_hit = inputs.routing_lane in lanes if inputs.routing_lane else False
+        profile_hit = (
+            inputs.validation_profile in profiles
+            if inputs.validation_profile
+            else False
+        )
+        if not (lane_hit or profile_hit):
+            continue
+        rule_id = str(rule.get("id") or "lane")
+        for group in rule.get("groups") or []:
+            selected.add(str(group))
+            if lane_hit:
+                reasons.append(
+                    f"lane:{inputs.routing_lane}->group:{group}(rule={rule_id})"
+                )
+            if profile_hit:
+                reasons.append(
+                    f"validation_profile:{inputs.validation_profile}"
+                    f"->group:{group}(rule={rule_id})"
+                )
+
+    if not selected:
+        return _fallback_result(
+            reason="empty_selection",
+            inputs=inputs,
+            policy=loaded,
+            unclassified=[],
+            extra_reasons=reasons,
+        )
+
+    if FULL_FAST_GROUP in selected and len(selected) == 1:
+        return _fallback_result(
+            reason="selected_full_fast",
+            inputs=inputs,
+            policy=loaded,
+            unclassified=[],
+            extra_reasons=reasons,
+        )
+
+    # Narrow slice: never include full_fast alongside slice groups.
+    selected.discard(FULL_FAST_GROUP)
+    ordered_groups = sorted(selected)
+    pytest_paths: list[str] = []
+    for group_id in ordered_groups:
+        pytest_paths.extend(_group_pytest_paths(loaded, group_id))
+    # Deterministic unique path list
+    pytest_paths = sorted(dict.fromkeys(pytest_paths))
+    if not pytest_paths:
+        return _fallback_result(
+            reason="empty_pytest_paths",
+            inputs=inputs,
+            policy=loaded,
+            unclassified=[],
+            extra_reasons=reasons + [f"groups:{','.join(ordered_groups)}"],
+        )
+
+    reasons_sorted = sorted(set(reasons))
+    return SliceSelectionResult(
+        policy_id=str(loaded.get("policy_id")),
+        policy_schema_version=str(loaded.get("schema_version")),
+        selected_test_groups=ordered_groups,
+        selection_reasons=reasons_sorted,
+        unclassified_paths=[],
+        fallback_reason=None,
+        merge_evidence=False,
+        pytest_paths=pytest_paths,
+        pytest_args=["-q"],
+        used_full_fast=False,
+        inputs={
+            "changed_paths": list(paths),
+            "routing_lane": inputs.routing_lane,
+            "validation_profile": inputs.validation_profile,
+        },
+    )
+
+
+def build_unit_pytest_command(
+    selection: SliceSelectionResult,
+    *,
+    python_executable: str,
+    durations: int = 50,
+) -> list[str]:
+    """Build the unit-stage pytest argv from a selection result."""
+    cmd = [python_executable, "-m", "pytest"]
+    if selection.used_full_fast or not selection.pytest_paths:
+        cmd.extend(selection.pytest_args or list(FULL_FAST_PYTEST_ARGS))
+    else:
+        cmd.extend(selection.pytest_paths)
+        cmd.extend(selection.pytest_args or ["-q"])
+    if durations > 0:
+        cmd.append(f"--durations={int(durations)}")
+    return cmd

--- a/ci/scripts/run.py
+++ b/ci/scripts/run.py
@@ -10,6 +10,7 @@ This does NOT publish a GitHub Required Check. Branch Protection stays unchanged
 from __future__ import annotations
 
 import argparse
+import json
 import platform
 import subprocess
 import sys
@@ -34,6 +35,11 @@ from ci.lib.evidence import (  # noqa: E402
     write_manifest,
 )
 from ci.lib.gitinfo import collect_git_info  # noqa: E402
+from ci.lib.slice_selection import (  # noqa: E402
+    default_policy_path,
+    normalize_changed_paths,
+    select_slice_test_groups,
+)
 from ci.lib.temp_preflight import (  # noqa: E402
     prepare_ci_temp_root,
     temp_env_for,
@@ -125,21 +131,66 @@ def render_latest_report(artifacts_root: Path) -> int:
     return 0 if manifest["overall_status"] == "PASS" else 1
 
 
+def _changed_paths_vs_base(repo_root: Path, base_ref: str = "origin/main") -> list[str]:
+    """Return sorted changed paths vs base_ref (name-status, including renames)."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        # Fail closed: empty list triggers unclassified/full fallback upstream.
+        return []
+    return list(normalize_changed_paths(result.stdout.splitlines()))
+
+
 def run_ci(
     *,
     profile: str,
     stage: str | None,
     run_id: str | None,
     repo_root: Path,
+    slice_mode: bool = False,
+    changed_paths: list[str] | None = None,
+    routing_lane: str = "",
+    validation_profile: str = "",
+    unit_durations: int = 50,
 ) -> int:
     cfg_dir = repo_root / "ci" / "config"
     stages_cfg = load_yaml(cfg_dir / "stages.yaml")
     resources = load_yaml(cfg_dir / "resources.yaml")
     profiles = profiles_from_config(stages_cfg)
 
+    if slice_mode and profile == "fast":
+        profile = "slice"
     if profile not in profiles:
         raise SystemExit(
             f"Unknown profile {profile!r}; expected one of {sorted(profiles)}"
+        )
+
+    merge_evidence = profile != "slice" and not slice_mode
+    slice_selection_payload = None
+    if profile == "slice" or slice_mode:
+        merge_evidence = False
+        paths = list(
+            normalize_changed_paths(
+                changed_paths
+                if changed_paths is not None
+                else _changed_paths_vs_base(repo_root)
+            )
+        )
+        selection = select_slice_test_groups(
+            changed_paths=paths,
+            routing_lane=routing_lane,
+            validation_profile=validation_profile,
+            policy_path=default_policy_path(repo_root),
+        )
+        slice_selection_payload = selection.to_dict()
+        print(
+            f"slice_selection groups={selection.selected_test_groups} "
+            f"fallback={selection.fallback_reason!r} merge_evidence=false"
         )
 
     git = collect_git_info(repo_root)
@@ -155,6 +206,13 @@ def run_ci(
     (run_dir / "logs").mkdir()
     (run_dir / "reports").mkdir()
 
+    if slice_selection_payload is not None:
+        slice_report = run_dir / "reports" / "slice_selection.json"
+        slice_report.write_text(
+            json.dumps(slice_selection_payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
     started = utc_now()
     ctx = StageContext(
         repo_root=repo_root,
@@ -163,6 +221,9 @@ def run_ci(
         git=git,
         profile=profile,
         resources=resources,
+        slice_selection=slice_selection_payload,
+        merge_evidence=merge_evidence,
+        unit_durations=unit_durations,
     )
 
     selected = [stage] if stage else list(profiles[profile])
@@ -175,6 +236,13 @@ def run_ci(
             "skip_reason": "GitHub-native PR API evaluation; local mirror only in Phase 1",
         }
     ]
+    if not merge_evidence:
+        skipped_checks.append(
+            {
+                "check": "merge_evidence",
+                "skip_reason": "slice_profile_merge_evidence_false",
+            }
+        )
 
     # Temp-root preflight before any pytest/unit collection (#4205).
     print("==> stage temp_preflight")
@@ -233,6 +301,7 @@ def run_ci(
             skipped_checks=skipped_checks,
             artifact_hashes=artifact_hashes,
             repo_name=git.repo_name,
+            merge_evidence=merge_evidence,
         )
         write_manifest(run_dir, manifest)
         print(f"overall_status={manifest['overall_status']}")
@@ -281,12 +350,14 @@ def run_ci(
         skipped_checks=skipped_checks,
         artifact_hashes=artifact_hashes,
         repo_name=git.repo_name,
+        merge_evidence=merge_evidence,
     )
     write_manifest(run_dir, manifest)
 
     # Re-hash after manifest write is intentionally NOT included in artifact_hashes
     # inside manifest (manifest.sha256 covers the finalized JSON).
     print(f"overall_status={manifest['overall_status']}")
+    print(f"merge_evidence={manifest.get('merge_evidence')}")
     print(f"evidence={run_dir}")
     if manifest["overall_status"] == "PASS":
         return 0
@@ -300,11 +371,43 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--profile",
         default="fast",
-        choices=["fast", "heavy"],
-        help="fast=lint/unit/docs/governance; heavy adds integration/security/containers",
+        choices=["fast", "slice", "heavy"],
+        help=(
+            "fast=full lint/unit/docs/governance (merge evidence eligible); "
+            "slice=same stages with path-selected unit tests (merge_evidence=false); "
+            "heavy adds integration/security/containers"
+        ),
     )
     parser.add_argument("--stage", default=None, help="Run a single named stage")
     parser.add_argument("--run-id", default=None, help="Optional explicit run id")
+    parser.add_argument(
+        "--slice",
+        action="store_true",
+        help="Enable slice selection (forces merge_evidence=false)",
+    )
+    parser.add_argument(
+        "--changed-path",
+        action="append",
+        default=None,
+        dest="changed_paths",
+        help="Changed path for slice selection (repeatable); default: git vs origin/main",
+    )
+    parser.add_argument(
+        "--routing-lane",
+        default="",
+        help="PR-router lane input for slice selection",
+    )
+    parser.add_argument(
+        "--validation-profile",
+        default="",
+        help="PR-router validation_profile input for slice selection",
+    )
+    parser.add_argument(
+        "--unit-durations",
+        type=int,
+        default=50,
+        help="Pass --durations=N to pytest unit stage (0 disables)",
+    )
     parser.add_argument(
         "--cleanup",
         metavar="RUN_ID",
@@ -332,6 +435,11 @@ def main(argv: list[str] | None = None) -> int:
         stage=args.stage,
         run_id=args.run_id,
         repo_root=repo_root,
+        slice_mode=bool(args.slice),
+        changed_paths=args.changed_paths,
+        routing_lane=args.routing_lane,
+        validation_profile=args.validation_profile,
+        unit_durations=int(args.unit_durations),
     )
 
 

--- a/ci/stages/_common.py
+++ b/ci/stages/_common.py
@@ -27,6 +27,11 @@ class StageContext:
     resources: dict
     temp_root: Path | None = None
     temp_env: dict[str, str] | None = None
+    # Slice selection (optional). When set, unit stage uses selected paths and
+    # the run is always merge_evidence=false.
+    slice_selection: dict[str, Any] | None = None
+    merge_evidence: bool = True
+    unit_durations: int = 50
 
     @property
     def logs_dir(self) -> Path:

--- a/ci/stages/report.py
+++ b/ci/stages/report.py
@@ -9,19 +9,26 @@ from ci.lib.evidence import StageResult, utc_now
 from ci.stages._common import StageContext
 
 
-def build_check_matrix(stages: list[StageResult]) -> dict:
+def build_check_matrix(
+    stages: list[StageResult],
+    *,
+    merge_evidence: bool = True,
+) -> dict:
     return {
         "schema_version": "cdb-local-ci-check-matrix/v1",
         "note": (
             "Local evidence is not a GitHub Required Check in Phase 1. "
-            "Branch Protection remains unchanged."
+            "Branch Protection remains unchanged. "
+            "Slice evidence (merge_evidence=false) is never merge proof (#4204)."
         ),
+        "merge_evidence": bool(merge_evidence),
         "stages": [
             {
                 "name": s.name,
                 "status": s.status,
                 "required": s.required,
                 "skip_reason": s.skip_reason,
+                "duration_seconds": s.duration_seconds,
                 "command_summary": s.command_summary,
             }
             for s in stages
@@ -37,15 +44,51 @@ def build_check_matrix(stages: list[StageResult]) -> dict:
     }
 
 
+def build_stage_timing_report(
+    stages: list[StageResult],
+    *,
+    merge_evidence: bool,
+    profile: str,
+) -> dict:
+    """Machine-readable stage duration summary (does not alter pass/fail)."""
+    rows = [
+        {
+            "name": s.name,
+            "status": s.status,
+            "duration_seconds": s.duration_seconds,
+            "required": s.required,
+        }
+        for s in stages
+    ]
+    total = round(sum(float(s.duration_seconds or 0.0) for s in stages), 3)
+    return {
+        "schema_version": "cdb-local-ci-stage-timing/v1",
+        "merge_evidence": bool(merge_evidence),
+        "profile": profile,
+        "total_duration_seconds": total,
+        "stages": rows,
+    }
+
+
 def run(ctx: StageContext, prior_stages: list[StageResult]) -> StageResult:
     started = utc_now()
     wall = time.perf_counter()
-    matrix = build_check_matrix(prior_stages)
+    matrix = build_check_matrix(prior_stages, merge_evidence=bool(ctx.merge_evidence))
     matrix_path = ctx.reports_dir / "check-matrix.json"
     matrix_path.write_text(json.dumps(matrix, indent=2) + "\n", encoding="utf-8")
+    timing = build_stage_timing_report(
+        prior_stages,
+        merge_evidence=bool(ctx.merge_evidence),
+        profile=ctx.profile,
+    )
+    timing_path = ctx.reports_dir / "stage_timing.json"
+    timing_path.write_text(
+        json.dumps(timing, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     log_path = ctx.logs_dir / "report.log"
     log_path.write_text(
-        f"Wrote {matrix_path.relative_to(ctx.run_dir).as_posix()}\n",
+        f"Wrote {matrix_path.relative_to(ctx.run_dir).as_posix()}\n"
+        f"Wrote {timing_path.relative_to(ctx.run_dir).as_posix()}\n",
         encoding="utf-8",
     )
     ended = utc_now()
@@ -56,9 +99,12 @@ def run(ctx: StageContext, prior_stages: list[StageResult]) -> StageResult:
         started_at_utc=started,
         ended_at_utc=ended,
         duration_seconds=round(time.perf_counter() - wall, 3),
-        command_summary=["aggregate check-matrix.json"],
+        command_summary=["aggregate check-matrix.json", "aggregate stage_timing.json"],
         log_path=str(log_path.relative_to(ctx.run_dir).as_posix()),
-        artifacts=[str(matrix_path.relative_to(ctx.run_dir).as_posix())],
+        artifacts=[
+            str(matrix_path.relative_to(ctx.run_dir).as_posix()),
+            str(timing_path.relative_to(ctx.run_dir).as_posix()),
+        ],
         skip_reason=None,
         required=True,
     )

--- a/ci/stages/unit.py
+++ b/ci/stages/unit.py
@@ -2,39 +2,145 @@
 
 from __future__ import annotations
 
+import json
+import re
+from pathlib import Path
+
 from ci.lib.evidence import StageResult
+from ci.lib.slice_selection import (
+    SliceSelectionResult,
+    build_unit_pytest_command,
+)
 from ci.stages._common import StageContext, python_executable, run_commands_as_stage
 
+# SSOT filter for the fast profile / GitHub ci.yml thin wrapper (#4163).
+FULL_FAST_SELECTOR = "not test_mcp_time_server_runtime"
 
-def run(ctx: StageContext) -> StageResult:
-    # SSOT filter for the fast profile / GitHub ci.yml thin wrapper (#4163).
-    # Invoke via the orchestrator interpreter (-m pytest) for local venv parity.
+_DURATION_LINE_RE = re.compile(r"^\s*([\d.]+)s\s+(call|setup|teardown)\s+(.+)$")
+
+
+def _selection_from_ctx(ctx: StageContext) -> SliceSelectionResult | None:
+    raw = ctx.slice_selection
+    if not raw:
+        return None
+    return SliceSelectionResult(
+        schema_version=str(raw.get("schema_version") or ""),
+        policy_id=raw.get("policy_id"),
+        policy_schema_version=raw.get("policy_schema_version"),
+        selected_test_groups=list(raw.get("selected_test_groups") or []),
+        selection_reasons=list(raw.get("selection_reasons") or []),
+        unclassified_paths=list(raw.get("unclassified_paths") or []),
+        fallback_reason=raw.get("fallback_reason"),
+        merge_evidence=False,
+        pytest_paths=list(raw.get("pytest_paths") or []),
+        pytest_args=list(raw.get("pytest_args") or []),
+        used_full_fast=bool(raw.get("used_full_fast")),
+        inputs=dict(raw.get("inputs") or {}),
+    )
+
+
+def build_unit_command(ctx: StageContext) -> list[str]:
+    """Build the unit pytest command (full Fast-CI or slice selection)."""
+    durations = int(getattr(ctx, "unit_durations", 50) or 0)
+    selection = _selection_from_ctx(ctx)
+    if selection is not None:
+        return build_unit_pytest_command(
+            selection,
+            python_executable=python_executable(),
+            durations=durations,
+        )
+    # Default Fast-CI / heavy unit selector — semantically unchanged (#4163/#4204).
     command = [
         python_executable(),
         "-m",
         "pytest",
         "-q",
         "-k",
-        "not test_mcp_time_server_runtime",
+        FULL_FAST_SELECTOR,
     ]
+    if durations > 0:
+        command.append(f"--durations={durations}")
+    return command
+
+
+def parse_pytest_durations(
+    log_text: str, *, limit: int = 50
+) -> list[dict[str, object]]:
+    """Extract slowest pytest duration lines from a stage log (best-effort)."""
+    rows: list[dict[str, object]] = []
+    for line in log_text.splitlines():
+        match = _DURATION_LINE_RE.match(line)
+        if not match:
+            continue
+        rows.append(
+            {
+                "duration_seconds": float(match.group(1)),
+                "phase": match.group(2),
+                "nodeid": match.group(3).strip(),
+            }
+        )
+    rows.sort(key=lambda r: float(r["duration_seconds"]), reverse=True)
+    return rows[: max(0, int(limit))]
+
+
+def write_unit_timing_report(
+    ctx: StageContext,
+    *,
+    log_path: Path,
+    command: list[str],
+) -> str | None:
+    """Write reports/unit_timing.json; return relative path or None."""
+    try:
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    durations = parse_pytest_durations(log_text, limit=max(1, ctx.unit_durations))
+    report = {
+        "schema_version": "cdb-local-ci-unit-timing/v1",
+        "merge_evidence": bool(ctx.merge_evidence),
+        "profile": ctx.profile,
+        "command": command,
+        "slowest": durations,
+        "slowest_count": len(durations),
+    }
+    out = ctx.reports_dir / "unit_timing.json"
+    out.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return str(out.relative_to(ctx.run_dir).as_posix())
+
+
+def run(ctx: StageContext) -> StageResult:
+    # Invoke via the orchestrator interpreter (-m pytest) for local venv parity.
+    command = build_unit_command(ctx)
     env = None
     if ctx.temp_root is not None:
         basetemp = ctx.temp_root / "pytest-basetemp"
         cache_dir = ctx.temp_root / "pytest-cache"
         # Prefer controlled cache under run-scoped temp root (pytest ini via -o).
-        command.extend(
-            [
-                "--basetemp",
-                str(basetemp),
-                "-o",
-                f"cache_dir={cache_dir.as_posix()}",
-            ]
-        )
+        command = list(command) + [
+            "--basetemp",
+            str(basetemp),
+            "-o",
+            f"cache_dir={cache_dir.as_posix()}",
+        ]
         env = ctx.temp_env
-    return run_commands_as_stage(
+    result = run_commands_as_stage(
         ctx,
         name="unit",
         commands=[command],
         required=True,
         env=env,
     )
+    timing_rel = write_unit_timing_report(
+        ctx,
+        log_path=(
+            ctx.run_dir / result.log_path
+            if result.log_path
+            else ctx.logs_dir / "unit.log"
+        ),
+        command=command,
+    )
+    if timing_rel:
+        result.artifacts = list(result.artifacts) + [timing_rel]
+    return result

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -7,6 +7,19 @@ geliefert. Targeted Tests, betroffener Lint/Format-Scope und
 `git diff --check` reichen für den Slice-Handoff; Full Fast-CI,
 `cdb-local-ci`, Merge und Issue-Closure sind dabei `false`.
 
+### Slice Validation vs Merge Acceptance (#4204)
+
+| Oberfläche | Zweck | Merge-Evidence? |
+|---|---|---|
+| **Slice Validation** (`--profile slice` / `--slice`) | Deterministische, path-/lane-/profile-basierte Testgruppen für schnelle Entwicklungsprüfungen. Policy: `ci/config/slice_validation_policy.v1.yaml`. Report: `reports/slice_selection.json` mit `merge_evidence=false`. | **Nein** — Publisher lehnt `merge_evidence=false` und `profile=slice` ab. |
+| **Final-Head / Fast-CI** (`--profile fast`) | Unveränderter vollständiger Unit-Selektor `pytest -q -k "not test_mcp_time_server_runtime"` plus lint/docs/governance. | Nur nach Publish als Commit Status `cdb-local-ci` auf exaktem Head. |
+
+Fail-closed: unbekannte/nicht klassifizierte Pfade, Policy-/Schema-/Parsefehler
+oder Runtime-/Risk-/Docker-Pfade erzwingen automatisch das vollständige
+Fast-CI-Unit-Profil. Marker dürfen ergänzend dokumentiert sein, sind aber
+keine alleinige Auswahlgrundlage. Slice-Grün ersetzt niemals Final-Head-
+Abdeckung.
+
 Transport-`steward_state=merge_candidate` startet die Acceptance-Phase
 `COMPLETENESS_REVIEW` (`cdb-pr-completeness-review`). Nur ein schema-valides
 Completeness-Verdikt `MERGE_CANDIDATE` darf in die Conductor-Phase

--- a/docs/skills/cdb-ci-cd-guard/SKILL.md
+++ b/docs/skills/cdb-ci-cd-guard/SKILL.md
@@ -68,20 +68,30 @@ This skill audits CI/CD tooling with external documentation dependencies:
 
 ## Slice Validation
 
-- targeted Tests und relevante Contract-Tests,
+- Deterministische Auswahl über `ci/config/slice_validation_policy.v1.yaml`
+  (Inputs: `changed_paths`, `routing_lane`, `validation_profile`).
+- Outputs maschinenlesbar: `selected_test_groups`, `selection_reasons`,
+  `unclassified_paths`, `fallback_reason`, immer `merge_evidence=false`.
+- Unbekannte Pfade, Policy-/Schemafehler, Runtime/Risk/Docker-Pfade →
+  fail-closed Full Fast-CI Unit-Selektor.
+- Targeted Tests und relevante Contract-Tests laut Selection,
 - Lint/Format für betroffene Dateien,
 - `git diff --check`,
-- kein Full Fast-CI als Default,
-- kein `cdb-local-ci` Publish.
+- kein Full Fast-CI als Default für Delivery-Slices,
+- **kein** `cdb-local-ci` Publish (Publisher rejected slice evidence).
+- Stage-/Unit-Timing: `reports/stage_timing.json`, `reports/unit_timing.json`
+  (`--durations`) — ändert nicht Pass/Fail.
 
 ## Final Batch Head Validation
 
 - PR ist `merge_candidate` und für neue Slices eingefroren,
-- Full Fast-CI auf dem exakten finalen Head,
+- Full Fast-CI auf dem exakten finalen Head
+  (`pytest -q -k "not test_mcp_time_server_runtime"` unverändert),
 - integrierter Base-SHA ist in der Evidence gebunden,
 - lokaler Policy-Gate-Mirror ist grün,
 - `cdb-local-ci=success` liegt als Commit Status auf exakt diesem Head,
 - Head-/Base-Drift erzwingt vollständige Revalidierung.
+- Slice-Validation ist **kein** Ersatz für Final-Head-Evidence.
 
 Check Runs und Commit Status sind getrennte GitHub-Typen. Ein namensgleicher
 Check Run erfüllt den Required Commit Status nicht.

--- a/knowledge/logs/sessions/2026-07-31-4204-fast-ci-slice-gates.md
+++ b/knowledge/logs/sessions/2026-07-31-4204-fast-ci-slice-gates.md
@@ -1,0 +1,50 @@
+# Session 2026-07-31 — #4204 Fast-CI Slice Gates + Timing Evidence
+
+## Scope
+
+Delivery slice for Issue #4204: deterministic fail-closed slice validation policy,
+path/lane/profile selection, `merge_evidence=false`, timing evidence; Final-Head
+Fast-CI selector unchanged. Merge/Issue-close/publish out of scope.
+
+## Brain Evidence
+
+- brain_source: repo-only
+- brain_status: not-used
+- context_tool_status: absent
+- context_trust_level: none
+- records_found: none
+- repo_fallback_reason: unavailable
+- context_brain_attempted: true
+- context_brain_used: false
+- context_available: false
+- repo_fallback_used: true
+
+## Router
+
+- decision: CREATE_NEW_BATCH_PR
+- target_branch: batch/ci-tooling-issue-4204
+- lane: ci-tooling
+- validation_profile: ci-tooling-v1
+- lock_state: UNLOCKED
+
+## Delivered
+
+- `ci/config/slice_validation_policy.v1.yaml`
+- `ci/lib/slice_selection.py` + unit stage durations + report stage timing
+- Orchestrator `--profile slice` / `--slice` inputs
+- Publisher rejects `merge_evidence=false` / `profile=slice`
+- Docs: merge_policy_ci_gate, cdb-ci-cd-guard (surfaces synced), ci/README
+- Tests: `tests/unit/ci/test_slice_selection_policy.py`
+
+## Validation
+
+- Final-Head collect-only: before 8957/8958 → after 8970/8971 (+13 new slice tests)
+- Slice case + unknown-path fallback exercised
+- 170 CI/tools unit tests PASS with `--durations=20`
+- ruff/black/readme-links/git diff --check/gitleaks protect --staged PASS
+
+## Status
+
+DONE_SLICE_ADDED_TO_BATCH_PR
+
+LR remains NO-GO.

--- a/tests/unit/ci/test_slice_selection_policy.py
+++ b/tests/unit/ci/test_slice_selection_policy.py
@@ -281,7 +281,7 @@ def test_slice_manifest_rejected_by_publisher_gate():
         stages=stages,
         skipped_checks=[],
         artifact_hashes={},
-        repo_name="[REDACTED]",
+        repo_name="Claire_de_Binare",  # pragma: allowlist secret
         merge_evidence=False,
     )
     assert manifest["merge_evidence"] is False

--- a/tests/unit/ci/test_slice_selection_policy.py
+++ b/tests/unit/ci/test_slice_selection_policy.py
@@ -1,0 +1,327 @@
+"""Contract tests for fail-closed Fast-CI slice selection (#4204).
+
+Rules protected:
+- Path/lane/profile map deterministically to documented test groups.
+- Unknown paths, empty/broken policy, runtime/risk paths => full_fast fallback.
+- Slice reports always carry merge_evidence=false.
+- Full Fast-CI unit selector remains semantically unchanged.
+- Changed-path order does not affect selection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ci.lib.evidence import (
+    EvidenceError,
+    StageResult,
+    assert_publishable,
+    build_manifest,
+)
+from ci.lib.slice_selection import (
+    FULL_FAST_GROUP,
+    FULL_FAST_PYTEST_ARGS,
+    SCHEMA_VERSION,
+    build_unit_pytest_command,
+    normalize_changed_paths,
+    select_slice_test_groups,
+)
+from ci.stages.unit import (
+    FULL_FAST_SELECTOR,
+    build_unit_command,
+    parse_pytest_durations,
+)
+from ci.stages._common import StageContext
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POLICY_PATH = REPO_ROOT / "ci" / "config" / "slice_validation_policy.v1.yaml"
+
+
+def _load_policy() -> dict:
+    with POLICY_PATH.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def test_docs_path_selects_documented_slice_groups_only():
+    """Rule: known docs path selects only documented docs_guards groups."""
+    result = select_slice_test_groups(
+        changed_paths=["docs/runbooks/merge_policy_ci_gate.md"],
+        routing_lane="docs",
+        validation_profile="docs-v1",
+        policy_path=POLICY_PATH,
+    )
+    assert result.merge_evidence is False
+    assert result.fallback_reason is None
+    assert result.used_full_fast is False
+    assert result.selected_test_groups == ["docs_guards"]
+    assert result.pytest_paths
+    assert all(
+        p.startswith("tests/unit/tools/") or p.startswith("tests/unit/tools/ci/")
+        for p in result.pytest_paths
+    )
+    assert "tests/unit/ci/" not in result.pytest_paths
+
+
+def test_ci_path_selects_ci_contract_groups():
+    """Rule: known CI path selects ci_contracts (+ tooling) groups."""
+    result = select_slice_test_groups(
+        changed_paths=["ci/lib/slice_selection.py"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=POLICY_PATH,
+    )
+    assert result.merge_evidence is False
+    assert result.fallback_reason is None
+    assert "ci_contracts" in result.selected_test_groups
+    assert "ci_tooling" in result.selected_test_groups
+    assert any(p.startswith("tests/unit/ci/") for p in result.pytest_paths)
+
+
+def test_runtime_risk_path_falls_back_to_full_profile():
+    """Rule: runtime/risk path forces full Fast-CI selector."""
+    result = select_slice_test_groups(
+        changed_paths=["services/risk/service.py"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=POLICY_PATH,
+    )
+    assert result.used_full_fast is True
+    assert result.selected_test_groups == [FULL_FAST_GROUP]
+    assert result.fallback_reason == "runtime_or_risk_path"
+    assert result.merge_evidence is False
+    assert result.pytest_args == list(FULL_FAST_PYTEST_ARGS)
+
+
+def test_unknown_path_forces_full_fallback():
+    """Rule: unclassified path never silently greens a narrow slice."""
+    result = select_slice_test_groups(
+        changed_paths=["totally/unknown/widget.py"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=POLICY_PATH,
+    )
+    assert result.used_full_fast is True
+    assert result.fallback_reason == "unclassified_paths"
+    assert result.unclassified_paths == ["totally/unknown/widget.py"]
+    assert result.merge_evidence is False
+
+
+def test_empty_or_broken_policy_forces_full_fallback(tmp_path: Path):
+    """Rule: empty/broken policy fails closed to full Fast-CI."""
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("", encoding="utf-8")
+    empty_result = select_slice_test_groups(
+        changed_paths=["docs/readme.md"],
+        routing_lane="",
+        validation_profile="",
+        policy_path=empty,
+    )
+    assert empty_result.used_full_fast is True
+    assert empty_result.fallback_reason in {
+        "empty_policy",
+        "policy_parse_error",
+        "schema_error",
+    }
+    assert empty_result.merge_evidence is False
+
+    broken = tmp_path / "broken.yaml"
+    broken.write_text(
+        "schema_version: not-a-real-schema\npolicy_id: x\n", encoding="utf-8"
+    )
+    broken_result = select_slice_test_groups(
+        changed_paths=["ci/lib/config.py"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=broken,
+    )
+    assert broken_result.used_full_fast is True
+    assert broken_result.fallback_reason in {"schema_error", "policy_parse_error"}
+    assert broken_result.merge_evidence is False
+
+
+def test_unclassified_path_does_not_produce_silent_green_narrow_slice():
+    """Rule: unclassified path cannot yield a narrow green selection."""
+    result = select_slice_test_groups(
+        changed_paths=["docs/x.md", "mystery/file.py"],
+        routing_lane="docs",
+        validation_profile="docs-v1",
+        policy_path=POLICY_PATH,
+    )
+    assert result.used_full_fast is True
+    assert "mystery/file.py" in result.unclassified_paths
+    assert result.selected_test_groups == [FULL_FAST_GROUP]
+
+
+def test_slice_report_merge_evidence_false():
+    """Rule: slice selection report always sets merge_evidence=false."""
+    result = select_slice_test_groups(
+        changed_paths=["ci/config/stages.yaml"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=POLICY_PATH,
+    )
+    payload = result.to_dict()
+    assert payload["merge_evidence"] is False
+    assert "selected_test_groups" in payload
+    assert "selection_reasons" in payload
+    assert "unclassified_paths" in payload
+    assert "fallback_reason" in payload
+
+
+def test_full_fast_unit_selector_unchanged():
+    """Rule: default unit stage keeps the Fast-CI SSOT selector."""
+    ctx = StageContext(
+        repo_root=REPO_ROOT,
+        run_dir=REPO_ROOT / "ci" / "artifacts" / "_unused",
+        run_id="run_test_selector",
+        git=None,
+        profile="fast",
+        resources={},
+        merge_evidence=True,
+        unit_durations=0,
+    )
+    command = build_unit_command(ctx)
+    assert "-k" in command
+    assert command[command.index("-k") + 1] == FULL_FAST_SELECTOR
+    assert FULL_FAST_SELECTOR == "not test_mcp_time_server_runtime"
+    assert FULL_FAST_PYTEST_ARGS[-1] == FULL_FAST_SELECTOR
+
+
+def test_changed_path_order_does_not_change_selection():
+    """Rule: selection is deterministic regardless of path input order."""
+    a = select_slice_test_groups(
+        changed_paths=["ci/lib/config.py", "docs/index.md"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=POLICY_PATH,
+    )
+    b = select_slice_test_groups(
+        changed_paths=["docs/index.md", "ci/lib/config.py"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=POLICY_PATH,
+    )
+    assert a.selected_test_groups == b.selected_test_groups
+    assert a.selection_reasons == b.selection_reasons
+    assert a.pytest_paths == b.pytest_paths
+    assert normalize_changed_paths(["b", "a"]) == ("a", "b")
+
+
+def test_slice_manifest_rejected_by_publisher_gate():
+    """Rule: slice evidence cannot be published as cdb-local-ci merge proof."""
+    stages = [
+        StageResult(
+            name="lint",
+            status="PASS",
+            exit_code=0,
+            started_at_utc="2026-07-31T00:00:00Z",
+            ended_at_utc="2026-07-31T00:00:01Z",
+            duration_seconds=1.0,
+            command_summary=["ruff"],
+            log_path="logs/lint.log",
+        ),
+        StageResult(
+            name="unit",
+            status="PASS",
+            exit_code=0,
+            started_at_utc="2026-07-31T00:00:01Z",
+            ended_at_utc="2026-07-31T00:00:02Z",
+            duration_seconds=1.0,
+            command_summary=["pytest"],
+            log_path="logs/unit.log",
+        ),
+        StageResult(
+            name="docs",
+            status="PASS",
+            exit_code=0,
+            started_at_utc="2026-07-31T00:00:02Z",
+            ended_at_utc="2026-07-31T00:00:03Z",
+            duration_seconds=1.0,
+            command_summary=["docs"],
+            log_path="logs/docs.log",
+        ),
+        StageResult(
+            name="governance",
+            status="PASS",
+            exit_code=0,
+            started_at_utc="2026-07-31T00:00:03Z",
+            ended_at_utc="2026-07-31T00:00:04Z",
+            duration_seconds=1.0,
+            command_summary=["gov"],
+            log_path="logs/governance.log",
+        ),
+        StageResult(
+            name="report",
+            status="PASS",
+            exit_code=0,
+            started_at_utc="2026-07-31T00:00:04Z",
+            ended_at_utc="2026-07-31T00:00:05Z",
+            duration_seconds=1.0,
+            command_summary=["report"],
+            log_path="logs/report.log",
+        ),
+    ]
+    manifest = build_manifest(
+        run_id="run_slice4204",
+        commit_sha="abc",
+        branch="batch/ci-tooling-issue-4204",
+        dirty_worktree=False,
+        started_at_utc="2026-07-31T00:00:00Z",
+        ended_at_utc="2026-07-31T00:01:00Z",
+        host_platform="test",
+        tool_versions={},
+        docker_version="n/a",
+        compose_version="n/a",
+        profile="slice",
+        stages=stages,
+        skipped_checks=[],
+        artifact_hashes={},
+        repo_name="[REDACTED]",
+        merge_evidence=False,
+    )
+    assert manifest["merge_evidence"] is False
+    with pytest.raises(EvidenceError, match="merge_evidence=false|Slice profile"):
+        assert_publishable(manifest)
+
+
+def test_policy_schema_version_is_versioned():
+    """Rule: slice policy is versioned and machine-readable."""
+    policy = _load_policy()
+    assert policy["schema_version"] == SCHEMA_VERSION
+    assert policy["policy_id"] == "cdb-slice-validation-v1"
+    assert "test_groups" in policy
+    assert "path_rules" in policy
+
+
+def test_build_unit_pytest_command_includes_durations():
+    """Rule: timing evidence flag is appended without changing selector semantics."""
+    result = select_slice_test_groups(
+        changed_paths=["ci/lib/slice_selection.py"],
+        routing_lane="ci-tooling",
+        validation_profile="ci-tooling-v1",
+        policy_path=POLICY_PATH,
+    )
+    cmd = build_unit_pytest_command(result, python_executable="python", durations=50)
+    assert "--durations=50" in cmd
+    assert any(p.startswith("tests/unit/ci/") for p in cmd)
+
+
+def test_parse_pytest_durations_extracts_slowest():
+    """Rule: duration lines are parsed into machine-readable slowest rows."""
+    log = "\n".join(
+        [
+            "============================= slowest 50 durations =============================",
+            "12.50s call     tests/unit/ci/test_local_ci_evidence_contract.py::test_pass",
+            " 3.20s call     tests/unit/ci/test_black_timeout_contract.py::test_timeout",
+            "0.01s setup    tests/unit/ci/test_local_ci_evidence_contract.py::test_pass",
+        ]
+    )
+    rows = parse_pytest_durations(log, limit=2)
+    assert len(rows) == 2
+    assert rows[0]["duration_seconds"] == 12.5
+    assert "test_pass" in str(rows[0]["nodeid"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #4204

## Delivered

- Versionierte Slice-Policy `ci/config/slice_validation_policy.v1.yaml` (`cdb-slice-validation-policy/v1`)
- Deterministischer Selector `ci/lib/slice_selection.py` (Inputs: `changed_paths`, `routing_lane`, `validation_profile`)
- Outputs: `selected_test_groups`, `selection_reasons`, `unclassified_paths`, `fallback_reason`, immer `merge_evidence=false`
- Orchestrator: `--profile slice` / `--slice`, `--changed-path`, `--routing-lane`, `--validation-profile`, `--unit-durations`
- Unit-Stage: `--durations` + `reports/unit_timing.json`; Report-Stage: `reports/stage_timing.json`
- Publisher fail-closed: `merge_evidence=false` und `profile=slice` nicht als `cdb-local-ci` publishbar
- Docs: `merge_policy_ci_gate.md`, `cdb-ci-cd-guard`, `ci/README.md` (+ Skill-Surfaces)
- Contract-Tests: `tests/unit/ci/test_slice_selection_policy.py`

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_tool_status: absent
- context_trust_level: none
- records_found: none
- repo_fallback_reason: unavailable
- context_brain_attempted: true
- context_available: false

## Selection Policy

Pfadregeln (docs/ci) und Lane-/Validation-Profile-Regeln wählen dokumentierte Testgruppen. Marker nur ergänzend dokumentiert, nicht alleinige Grundlage. Docker-/E2E-/Runtime-/Risk-Pfade erzwingen Full-Fallback.

## Fail-closed Fallback

Unbekannte Pfade, leere/fehlerhafte Policy, Schemafehler, Runtime/Risk/Docker-Pfade → vollständiger Fast-CI-Unit-Selektor `pytest -q -k "not test_mcp_time_server_runtime"`. Kein stilles Grün.

## Final-Head Coverage

| Messung | Collect-only (`-k "not test_mcp_time_server_runtime"`) |
|---|---|
| vor Änderung (`origin/main` @ `2a10d416`) | 8957/8958 (1 deselected) |
| nach Änderung (dieser Branch) | 8970/8971 (1 deselected) |
| Delta | +13 neue Slice-Contract-Tests; Selektor semantisch unverändert |

## Timing Evidence

- `pytest -q tests/unit/ci/ tests/unit/tools/ci/ --durations=20` → 170 passed; slowest ~1.00s (`test_run_command_timeout_returns_exit_124_not_raise`)
- Stage-/Unit-Timing-Artefakte im Slice-/Fast-Lauf: `reports/stage_timing.json`, `reports/unit_timing.json`

## Validation

- Gezielte Unit-/Contract-Tests: 13/13 PASS
- CI-Unit-Suite `tests/unit/ci/` + `tests/unit/tools/ci/`: 170 PASS
- Known Slice-Fall + Unknown-Path-Fallback manuell ausgeübt
- `ruff check` + `black --check` auf geändertem Python-Scope PASS
- `python -m tools.validate_readme_links` PASS
- `git diff --check` PASS
- `gitleaks protect --staged` PASS (no leaks)

## Non-goals

- Kein Full Fast-CI als Delivery-Lauf
- Kein `cdb-local-ci` Publish
- Kein Merge, kein Issue-Close
- Keine Branch-Protection-Änderung
- Keine Runtime-/Trading-/Risk-Fachlogik

## Restunsicherheiten

- Policy deckt initial docs/ci-Surfaces ab; weitere Path-Familien folgen bei Bedarf fail-closed (Full-Fallback)
- Markerlose Repo-Tests bleiben im Final-Head vollständig; Slice greift nur explizit klassifizierte Gruppen
- Skill-Surface-Sync für `cdb-ci-cd-guard` mitgezogen; andere Surfaces unverändert

## Status

DONE_SLICE_ADDED_TO_BATCH_PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7590ebe3-bfe6-4149-b5b2-b806249a4ab1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7590ebe3-bfe6-4149-b5b2-b806249a4ab1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

