### PR TITLE
test(evidence_harvester): isolate install run_task.cmd under tmp_path (#4229)

### DIFF
--- a/knowledge/logs/sessions/2026-07-31-4229-evidence-harvester-test-isolation.md
+++ b/knowledge/logs/sessions/2026-07-31-4229-evidence-harvester-test-isolation.md
@@ -1,0 +1,52 @@
+# Session Log — Issue 4229 Evidence Harvester Test Isolation
+
+Date: 2026-07-31
+Agent: Cursor Cloud
+Branch: cloud-cursor/evidence-harvester-test-isolation-222f
+PR: 4238
+Head: 61c148d66e950e1050cc997dcd48ae48f4e6a0fb
+Base: origin/main @ e96f724c6a6615fea8bda8adc707b51fbd6bcf84
+
+## Scope
+
+Isolate test_install_path_is_patchable so it cannot write run_task.cmd
+into the repo worktree. Delivery slice only; no merge, no issue close.
+
+## Brain Evidence
+
+- brain_source=repo-only, brain_status=not-used
+- Context MCP absent (repo_fallback_reason=unavailable)
+- PR-Router: CREATE_NEW_BATCH_PR / lane ci-tooling / unlock
+
+## Root Cause
+
+Install unit test omitted --output-dir; productive default
+artifacts/evidence_harvester/scheduled/ received run_task.cmd.
+
+## Delivered
+
+- tests/unit/tools/evidence_harvester/test_scheduler.py
+  - inject --output-dir under tmp_path
+  - regression test_install_run_task_cmd_stays_under_injected_output_dir
+- No productive scheduler/boot/collector/supervisor changes
+- No .gitignore change
+
+## Validation
+
+| Check | Result |
+|---|---|
+| pytest isolated install-path test | PASS |
+| git status before/after that test | identical (empty) |
+| artifacts scheduled run_task.cmd after test | absent |
+| pytest -q tests/unit/tools/evidence_harvester | 286 passed |
+| ruff check / black --check (changed file) | PASS |
+| git diff --check | PASS |
+| gitleaks protect --staged | no leaks |
+
+## Status
+
+DONE_SLICE_ADDED_TO_BATCH_PR
+
+## Boundaries
+
+LR NO-GO; no productive runtime/DB/MCP/merge.

--- a/tests/unit/tools/evidence_harvester/test_scheduler.py
+++ b/tests/unit/tools/evidence_harvester/test_scheduler.py
@@ -172,7 +172,18 @@ def test_install_path_is_patchable_and_does_not_run_real_task_install_in_tests(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """
+    test_id: tc_evidence_harvester_scheduler_install_tmp_path_001
+    test_type: Bauteil-Test
+    cdb_area: tools/evidence_harvester
+    rule_ref: test isolation — no repo worktree writes
+    issue_ref: #4229
+    security_relevant: false
+    live_relevant: false
+    profitability_relevant: false
+    """
     fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "scheduled"
     calls: list[list[str]] = []
 
     def _fake_run(command: list[str], check: bool) -> subprocess.CompletedProcess[str]:
@@ -187,6 +198,8 @@ def test_install_path_is_patchable_and_does_not_run_real_task_install_in_tests(
             "install",
             "--fixture",
             str(fixture_path),
+            "--output-dir",
+            str(output_dir),
             "--explicit",
             "--start-time",
             "04:30",
@@ -204,4 +217,59 @@ def test_install_path_is_patchable_and_does_not_run_real_task_install_in_tests(
     payload = json.loads(capsys.readouterr().out)
     assert payload["installed"] is True
     assert payload["start_time"] == "04:30"
-    assert Path(payload["run_task_cmd"]).exists()
+    run_task_cmd = Path(payload["run_task_cmd"])
+    assert run_task_cmd.exists()
+    assert run_task_cmd == (output_dir / "run_task.cmd").resolve()
+    assert run_task_cmd.is_relative_to(tmp_path.resolve())
+    assert str(output_dir.resolve()) in run_task_cmd.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_install_run_task_cmd_stays_under_injected_output_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    test_id: tc_evidence_harvester_scheduler_install_isolation_002
+    test_type: Schutz-Test
+    cdb_area: tools/evidence_harvester
+    rule_ref: unit tests must not leave untracked artifacts in the repo worktree
+    issue_ref: #4229
+    security_relevant: false
+    live_relevant: false
+    profitability_relevant: false
+    """
+    from tools.evidence_harvester.scheduler import _default_output_dir
+
+    fixture_path = _write_fixture(tmp_path)
+    output_dir = tmp_path / "isolated_scheduled"
+    repo_default = _default_output_dir().resolve()
+    repo_default_cmd = repo_default / "run_task.cmd"
+    existed_before = repo_default_cmd.exists()
+
+    monkeypatch.setattr(
+        "tools.evidence_harvester.scheduler.subprocess.run",
+        lambda command, check: subprocess.CompletedProcess(command, 0),
+    )
+
+    exit_code = main(
+        [
+            "install",
+            "--fixture",
+            str(fixture_path),
+            "--output-dir",
+            str(output_dir),
+            "--explicit",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    run_task_cmd = Path(payload["run_task_cmd"]).resolve()
+    assert run_task_cmd.parent == output_dir.resolve()
+    assert run_task_cmd.is_relative_to(tmp_path.resolve())
+    assert not run_task_cmd.is_relative_to(repo_default)
+    assert payload["output_dir"] == str(output_dir.resolve())
+    # Productive default path must remain untouched by the isolated install.
+    assert repo_default_cmd.exists() is existed_before


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Refs #4229

## Root Cause
`test_install_path_is_patchable_and_does_not_run_real_task_install_in_tests` called `scheduler install` without `--output-dir`. The productive default resolves to `artifacts/evidence_harvester/scheduled/`, so `_write_run_task_cmd` left an untracked `run_task.cmd` in the repo worktree.

## Temporary-Path Isolation
- Install unit tests now inject `--output-dir` under pytest `tmp_path`.
- Added regression `test_install_run_task_cmd_stays_under_injected_output_dir` asserting `run_task.cmd` lands only under the injected temp directory and that the productive default path remains untouched.
- Productive scheduler defaults, 72h final-validation logic, and collector/supervisor semantics are unchanged.
- No `.gitignore` workaround.

## Worktree Cleanliness Evidence
- Before isolated install-path test: `git status --porcelain --untracked-files=all` empty
- After isolated install-path test: empty (identical)
- `artifacts/evidence_harvester/scheduled/run_task.cmd` absent after run
- Session log: `knowledge/logs/sessions/2026-07-31-4229-evidence-harvester-test-isolation.md`

## Validation
- `pytest …::test_install_path_is_patchable*` PASS
- `pytest -q tests/unit/tools/evidence_harvester` 286 passed
- `ruff check` / `black --check` on changed Python scope PASS
- `git diff --check` PASS
- `gitleaks protect --staged` no leaks
- Head: `ca0ec3a899260b9408459580dfad87c548b81554`

## Non-goals
- No productive Evidence-Harvester behavior change
- No merge, no issue close, no Full Fast-CI, no `cdb-local-ci` publish

## Status: DONE_SLICE_ADDED_TO_BATCH_PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2c5576e-9fa6-467d-9085-1050f1d2222f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2c5576e-9fa6-467d-9085-1050f1d2222f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

