### PR TITLE
[CI] Limit Dockerfile discovery to git-tracked surfaces (#4237)

### DIFF
--- a/knowledge/logs/sessions/2026-07-31-4237-dockerfile-discovery-tracked-only.md
+++ b/knowledge/logs/sessions/2026-07-31-4237-dockerfile-discovery-tracked-only.md
@@ -1,0 +1,51 @@
+# Session: #4237 discover_dockerfiles tracked-only
+
+**Date:** 2026-07-31  
+**Agent:** cursor-cloud  
+**Wave:** parallel-wave-2026-07-31-b  
+**Status:** DONE_SLICE_ADDED_TO_BATCH_PR (pending PR handoff)
+
+## Brain Evidence
+
+- context_brain_attempted: true
+- context_brain_used: false
+- context_available: false
+- repo_fallback_used: true
+- repo_fallback_reason: unavailable (active MCP surface: cursor-cloud only)
+- context_tool_status: absent
+- context_trust_level: none
+- records_found: none
+- brain_source: repo-only
+- brain_status: not-used
+
+## Git / Control
+
+- origin/main: `e96f724c6a6615fea8bda8adc707b51fbd6bcf84` (ancestor prerequisite OK)
+- Issue #4237: OPEN
+- PR-Router: `CREATE_NEW_BATCH_PR` → `batch/ci-tooling-issue-4237` (lane `ci-tooling`)
+- Board stage: `trade-capable`
+- LR: NO-GO
+- Issue LOCK comment: blocked (`Resource not accessible by integration`)
+
+## Delivered
+
+- `discover_dockerfiles` switched from filesystem `Path.rglob` to fail-closed `git ls-files`
+- Segment excludes for `.worktrees`, `.worktrees_backup`, `.venv`, `.git`, `third_party`
+- Classification SSOT (`PRODUCTIVE_IMAGE_DOCKERFILES` / `NON_PRODUCTIVE_DOCKERFILES`) unchanged
+- No productive Dockerfile / pip pin changes
+- Regression suite: `tests/unit/infra/test_dockerfile_discovery_tracked_only.py`
+
+## Validation
+
+- `pytest` discovery + pip-pin contracts: 20 passed
+- `ruff check` on changed Python scope: pass
+- `black --check` on changed Python scope: pass
+- `git diff --check`: pass
+- `gitleaks protect --staged`: no leaks
+- `git status` before/after tests: unchanged (no pollution)
+
+## Boundaries
+
+- No Full Fast-CI, no `cdb-local-ci` publish, no merge, no issue close
+- CURRENT_STATUS / CONTROL_REGISTER / productive Dockerfiles: untouched (wave isolation)
+- LR remains NO-GO

--- a/knowledge/logs/sessions/2026-07-31-4237-dockerfile-discovery-tracked-only.md
+++ b/knowledge/logs/sessions/2026-07-31-4237-dockerfile-discovery-tracked-only.md
@@ -3,7 +3,11 @@
 **Date:** 2026-07-31  
 **Agent:** cursor-cloud  
 **Wave:** parallel-wave-2026-07-31-b  
-**Status:** DONE_SLICE_ADDED_TO_BATCH_PR (pending PR handoff)
+**Status:** DONE_SLICE_ADDED_TO_BATCH_PR  
+**PR:** #4239  
+**Head:** `a088fcbdba6170a4a1d96fddf5f61f62a8b12cf6`  
+**Branch:** `batch/ci-tooling-issue-4237`  
+**Issue LOCK comment:** blocked (`Resource not accessible by integration`)
 
 ## Brain Evidence
 

--- a/tests/unit/infra/_dockerfile_pip_pin_helpers.py
+++ b/tests/unit/infra/_dockerfile_pip_pin_helpers.py
@@ -7,10 +7,23 @@ mutation.
 from __future__ import annotations
 
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Path segments that must never contribute Dockerfiles to the security inventory,
+# even if somehow present in the git index (local worktrees, vendor trees, venvs).
+_DISCOVERY_EXCLUDED_PATH_SEGMENTS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".venv",
+        ".worktrees",
+        ".worktrees_backup",
+        "third_party",
+    }
+)
 
 # Advisory SSOT for the pinned floor:
 #   CVE-2026-8643 / GHSA-wf93-45jw-7689 / PYSEC-2026-196 -> fixed in pip 26.1.2
@@ -117,16 +130,65 @@ def has_unpinned_pip_upgrade(relative_path: str) -> bool:
     return False
 
 
-def discover_dockerfiles() -> list[str]:
-    """Every tracked Dockerfile in the repo, as repo-relative POSIX paths."""
+def _is_excluded_discovery_path(relative_posix: str) -> bool:
+    """Return True when any path segment is a known non-canon discovery surface."""
+    return any(
+        part in _DISCOVERY_EXCLUDED_PATH_SEGMENTS for part in Path(relative_posix).parts
+    )
+
+
+def _is_dockerfile_basename(relative_posix: str) -> bool:
+    """Match Dockerfile / Dockerfile.* basenames (same semantics as Path.rglob)."""
+    return Path(relative_posix).name.startswith("Dockerfile")
+
+
+def discover_dockerfiles(repo_root: Path | None = None) -> list[str]:
+    """Every git-tracked Dockerfile* under *repo_root*, as repo-relative POSIX paths.
+
+    Discovery is intentionally bound to ``git ls-files`` so nested worktrees,
+    backups, vendor copies, and untracked local files cannot pollute the
+    productive/non-productive classification contract (#4237).
+
+    Fail-closed: if git evidence cannot be collected, raise rather than silently
+    returning a filesystem subset.
+    """
+    root = Path(repo_root) if repo_root is not None else REPO_ROOT
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(root),
+                "ls-files",
+                "-z",
+                "--",
+                "*Dockerfile*",
+                "*/Dockerfile*",
+            ],
+            check=False,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"cannot enumerate tracked Dockerfiles in {root}: git unavailable ({exc})"
+        ) from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        detail = f": {stderr}" if stderr else ""
+        raise RuntimeError(
+            f"cannot enumerate tracked Dockerfiles in {root} "
+            f"(git ls-files exit {result.returncode}{detail})"
+        )
+
     found: list[str] = []
-    for path in REPO_ROOT.rglob("Dockerfile*"):
-        if not path.is_file():
+    for raw in result.stdout.split(b"\0"):
+        if not raw:
             continue
-        relative = path.relative_to(REPO_ROOT).as_posix()
-        if relative.startswith(
-            (".git/", ".venv/", "third_party/", ".worktrees_backup/")
-        ):
+        relative = raw.decode("utf-8").replace("\\", "/")
+        if not _is_dockerfile_basename(relative):
+            continue
+        if _is_excluded_discovery_path(relative):
             continue
         found.append(relative)
     return sorted(found)

--- a/tests/unit/infra/test_dockerfile_discovery_tracked_only.py
+++ b/tests/unit/infra/test_dockerfile_discovery_tracked_only.py
@@ -1,0 +1,190 @@
+"""Regression: Dockerfile discovery is git-tracked only (#4237).
+
+Protects the pip-pin classification inventory from local worktrees, backups,
+vendor copies, and untracked Dockerfiles that previously leaked in via
+filesystem-wide Path.rglob.
+
+test_id: tc_dockerfile_discovery_tracked_only_4237
+test_type: contract / bauteil
+cdb_area: infra/ci
+rule_ref: discover_dockerfiles tracked-only semantics
+issue_ref: #4237
+security_relevant: true
+live_relevant: false
+profitability_relevant: false
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.unit.infra import _dockerfile_pip_pin_helpers as helpers
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_git_repo(repo: Path) -> None:
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "cdb-test@example.com")
+    _git(repo, "config", "user.name", "CDB Test")
+
+
+def _write(repo: Path, relative: str, content: str = "FROM scratch\n") -> Path:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _commit_tracked(repo: Path, *relative_paths: str) -> None:
+    _git(repo, "add", "--", *relative_paths)
+    _git(repo, "commit", "-m", "track dockerfiles")
+
+
+@pytest.fixture
+def discovery_repo(tmp_path: Path) -> Path:
+    """Temporary git repo with tracked, untracked, and nested-worktree Dockerfiles."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+
+    tracked = (
+        "services/alpha/Dockerfile",
+        "ci/Dockerfile",
+        "infrastructure/compose/Dockerfile.test",
+    )
+    for relative in tracked:
+        _write(repo, relative)
+
+    # Untracked local pollution — must not appear in discovery.
+    _write(repo, "services/local-scratch/Dockerfile")
+    _write(repo, ".worktrees/decoy-branch/services/ws/Dockerfile")
+    _write(repo, "prefix/.worktrees/nested/Dockerfile")
+    _write(repo, ".worktrees_backup/old/Dockerfile")
+    _write(repo, "third_party/vendor/Dockerfile")
+    _write(repo, ".venv/lib/Dockerfile")
+
+    _commit_tracked(repo, *tracked)
+    return repo
+
+
+def test_tracked_dockerfile_is_discovered(discovery_repo: Path) -> None:
+    found = helpers.discover_dockerfiles(discovery_repo)
+    assert "services/alpha/Dockerfile" in found
+    assert "ci/Dockerfile" in found
+    assert "infrastructure/compose/Dockerfile.test" in found
+
+
+def test_untracked_dockerfile_is_ignored(discovery_repo: Path) -> None:
+    found = helpers.discover_dockerfiles(discovery_repo)
+    assert "services/local-scratch/Dockerfile" not in found
+
+
+def test_nested_worktrees_dockerfile_is_ignored(discovery_repo: Path) -> None:
+    found = helpers.discover_dockerfiles(discovery_repo)
+    assert not any(".worktrees/" in path for path in found)
+    assert ".worktrees/decoy-branch/services/ws/Dockerfile" not in found
+    assert "prefix/.worktrees/nested/Dockerfile" not in found
+
+
+def test_worktrees_backup_dockerfile_is_ignored(discovery_repo: Path) -> None:
+    found = helpers.discover_dockerfiles(discovery_repo)
+    assert ".worktrees_backup/old/Dockerfile" not in found
+    assert not any(".worktrees_backup/" in path for path in found)
+
+
+def test_discovery_order_is_deterministic(discovery_repo: Path) -> None:
+    first = helpers.discover_dockerfiles(discovery_repo)
+    second = helpers.discover_dockerfiles(discovery_repo)
+    assert first == second
+    assert first == sorted(first)
+
+
+def test_new_tracked_dockerfile_surface_remains_classification_duty(
+    discovery_repo: Path,
+) -> None:
+    """A newly tracked Dockerfile* must still surface for productive/non-productive SSOT."""
+    relative = "services/brand-new/Dockerfile"
+    _write(discovery_repo, relative)
+    _commit_tracked(discovery_repo, relative)
+
+    found = helpers.discover_dockerfiles(discovery_repo)
+    assert relative in found
+
+    known = set(helpers.PRODUCTIVE_IMAGE_DOCKERFILES) | set(
+        helpers.NON_PRODUCTIVE_DOCKERFILES
+    )
+    # Against the real repo SSOT the fixture path is unclassified — that is the
+    # contract signal the inventory test guards on the live tree.
+    assert relative not in known
+
+
+def test_tracked_excluded_segments_still_filtered(tmp_path: Path) -> None:
+    """Even if a non-canon tree is force-added to the index, discovery drops it."""
+    repo = tmp_path / "forced"
+    repo.mkdir()
+    _init_git_repo(repo)
+    _write(repo, "services/ok/Dockerfile")
+    _write(repo, ".worktrees/forced/Dockerfile")
+    _write(repo, ".worktrees_backup/forced/Dockerfile")
+    _write(repo, "third_party/forced/Dockerfile")
+    # Bypass ignore rules and force-add pollution into the index.
+    _git(
+        repo,
+        "add",
+        "-f",
+        "--",
+        "services/ok/Dockerfile",
+        ".worktrees/forced/Dockerfile",
+        ".worktrees_backup/forced/Dockerfile",
+        "third_party/forced/Dockerfile",
+    )
+    _git(repo, "commit", "-m", "force-add excluded dockerfiles")
+
+    found = helpers.discover_dockerfiles(repo)
+    assert found == ["services/ok/Dockerfile"]
+
+
+def test_discover_dockerfiles_fail_closed_outside_git_repo(tmp_path: Path) -> None:
+    bare = tmp_path / "not-a-git-repo"
+    bare.mkdir()
+    _write(bare, "Dockerfile")
+    with pytest.raises(RuntimeError, match="cannot enumerate tracked Dockerfiles"):
+        helpers.discover_dockerfiles(bare)
+
+
+def test_live_repo_discovery_matches_git_ls_files_dockerfile_basenames() -> None:
+    """Sanity: live checkout discovery stays within the git index."""
+    found = helpers.discover_dockerfiles()
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(helpers.REPO_ROOT),
+            "ls-files",
+            "-z",
+            "--",
+            "*Dockerfile*",
+            "*/Dockerfile*",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    indexed = sorted(
+        path.decode("utf-8").replace("\\", "/")
+        for path in result.stdout.split(b"\0")
+        if path and Path(path.decode("utf-8")).name.startswith("Dockerfile")
+    )
+    assert found == indexed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refs #4237

Dockerfile-Discovery für den pip-pin Security-Contract auf **git-getrackte** Repo-Flächen begrenzen. Lokale Worktrees, Backups, Vendor-Kopien und ungetrackte Dateien dürfen den Contract nicht mehr beeinflussen.

## Root Cause

`discover_dockerfiles` nutzte `Path.rglob("Dockerfile*")` und schloss nur `.git/`, `.venv/`, `third_party/`, `.worktrees_backup/` aus — **nicht** `.worktrees/`, Vendor-Kopien oder ungetrackte lokale Bäume. Die Docstring behauptete „tracked Dockerfiles“, die Implementierung war filesystem-weit. In verschmutzten Acceptance-Worktrees schlug Full Fast-CI fehl; in sauberen Worktrees PASS.

## Tracked-File Semantics

- Discovery über fail-closed `git ls-files -z -- '*Dockerfile*' '*/Dockerfile*'`
- Basename-Filter `Dockerfile*` (gleiche Semantik wie zuvor `rglob`)
- Zusätzliche Segment-Excludes: `.worktrees`, `.worktrees_backup`, `.venv`, `.git`, `third_party`
- Ausgabe deterministisch sortiert
- Bei fehlender Git-Evidence: `RuntimeError` statt stiller Teilmenge
- `PRODUCTIVE_IMAGE_DOCKERFILES` / `NON_PRODUCTIVE_DOCKERFILES` unverändert
- Keine Dockerfile-Pins geändert, keine Security-Findings ausgeblendet

## Regression Tests

Neue Suite `tests/unit/infra/test_dockerfile_discovery_tracked_only.py` (temporäres Git-Repo-Fixture):

- getracktes Dockerfile erkannt
- ungetracktes Dockerfile ignoriert
- `.worktrees` / nested `.worktrees` ignoriert
- `.worktrees_backup` ignoriert
- Reihenfolge deterministisch
- neue getrackte Fläche bleibt klassifizierungspflichtig
- force-addierte Exclude-Segmente werden gefiltert
- fail-closed außerhalb eines Git-Repos
- bestehender pip-pin Contract bleibt grün

## Validation

- `pytest -q tests/unit/infra/test_dockerfile_discovery_tracked_only.py tests/unit/infra/test_dockerfile_pip_pin_contract.py` → **20 passed**
- `ruff check` auf geändertem Python-Scope → pass
- `black --check` auf geändertem Python-Scope → pass
- `git diff --check` → pass
- `gitleaks protect --staged` → no leaks
- `git status` vor/nach Tests unverändert
- Head: `4b338b0c53264cb4c6bda8a93709b13158592c58`

## Non-goals

- Kein Full Fast-CI, kein `cdb-local-ci` Publish
- Kein Merge, kein Issue-Close (`Closes` bewusst nicht verwendet)
- Keine produktiven Dockerfiles / Images / Pins
- `CURRENT_STATUS.md` / `CONTROL_REGISTER.md` / `.gitignore` unberührt (Wave-Isolation)

## Risk / Rollback

Gering: nur Test-Helper-Discovery. Rollback = Commit revert.

## Status

**DONE_SLICE_ADDED_TO_BATCH_PR**

## Checklist

- [x] Scope is focused
- [x] Validation evidence included
- [x] Docs updated (session log only; ledger surfaces wave-forbidden)
- [x] No auto-merge / no `Closes #4237`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ff25f46-807c-48db-a7cf-2895b9060ff8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ff25f46-807c-48db-a7cf-2895b9060ff8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

