### PR TITLE
fix(regime): fail-closed UNKNOWN for offline assign paths

### DIFF
--- a/knowledge/logs/sessions/2026-07-31-4188-regime-offline-unknown.md
+++ b/knowledge/logs/sessions/2026-07-31-4188-regime-offline-unknown.md
@@ -42,5 +42,10 @@ Mirror `services/candles/service.py:_lookup_regime_id`:
 - Forbidden paths untouched (`core/replay/dataset_provider.py`, `services/**`, CURRENT_STATUS, …)
 - LR: NO-GO
 
+## Delivery
+- Branch: `cloud-cursor/regime-offline-unknown-4188-5585` @ `fc5a557b`
+- PR: `#4241` (draft, base `main`)
+- Issue `#4188` bleibt OPEN (Refs only, kein Closes)
+
 ## Status
-`DONE_SLICE_ADDED_TO_BATCH_PR` (pending PR handoff)
+`DONE_SLICE_ADDED_TO_BATCH_PR`

--- a/knowledge/logs/sessions/2026-07-31-4188-regime-offline-unknown.md
+++ b/knowledge/logs/sessions/2026-07-31-4188-regime-offline-unknown.md
@@ -1,0 +1,46 @@
+# Session 2026-07-31 — #4188 Offline/Assign UNKNOWN fail-closed
+
+## Scope
+Offline-/Assign-/Replay-Helfer: fehlende/unbekannte/Warmup-Regimes dürfen nicht stillschweigend als TREND (`regime_id=0`) erscheinen. Alignment mit Runtime + `DBBackedDatasetProvider` (#4149).
+
+## Brain Evidence
+- `brain_source`: repo-only
+- `brain_status`: not-used
+- `context_tool_status`: absent (nur cursor-cloud MCP)
+- `repo_fallback_reason`: unavailable
+- `context_trust_level`: none
+- `records_found`: none
+
+## Git / Routing
+- Base: `origin/main` @ `e96f724c`
+- Issue #4188 OPEN; #4149 CLOSED
+- PR-Router: `CREATE_NEW_BATCH_PR` / lane `validation-research` / target_branch recommendation `batch/validation-research-issue-4188`
+- Working branch (cloud template): `cloud-cursor/regime-offline-unknown-4188-5585`
+
+## Fallback Inventory
+| Path | Prior silent fallback | Fix |
+| --- | --- | --- |
+| `tools/market_data/assign_regime_offline.py` | warmup `=0`; `.get(..., 0)` | `resolve_assigned_regime` → `None` + block reason |
+| `scripts/profitability/assign_regime_to_mexc_3091.py` | same | shared helpers |
+| `scripts/profitability/assign_regime_calibrate_3032_expansion.py` | same | shared helpers |
+| `scripts/profitability/generate_calibration_variants_3032.py` | same | shared helpers |
+
+## Canonical UNKNOWN Semantics
+Mirror `services/candles/service.py:_lookup_regime_id`:
+- TREND→0, RANGE→1, HIGH_VOL_*→2, CRISIS→3
+- UNKNOWN / missing / warmup → `regime_id=null` + `regime_name=UNKNOWN` + `regime_block_reason`
+
+## Validation
+- Targeted pytest: 12 new + 2 regression — PASS
+- ruff check / black --check — PASS
+- `git diff --check` — PASS
+- Repo search: no remaining `REGIME_NAME_TO_ID.get(..., 0)` / `assigned_regime_id = 0` in reserved scope
+
+## Non-goals / Boundaries
+- No Full Fast-CI, no `cdb-local-ci`, no merge, no issue close
+- No parameter tuning, no Stage/Risk/Live changes
+- Forbidden paths untouched (`core/replay/dataset_provider.py`, `services/**`, CURRENT_STATUS, …)
+- LR: NO-GO
+
+## Status
+`DONE_SLICE_ADDED_TO_BATCH_PR` (pending PR handoff)

--- a/scripts/profitability/assign_regime_calibrate_3032_expansion.py
+++ b/scripts/profitability/assign_regime_calibrate_3032_expansion.py
@@ -16,6 +16,13 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+from tools.market_data.assign_regime_offline import (
+    REGIME_ID_TO_NAME,
+    REGIME_NAME_TO_ID,
+    annotate_regime_row,
+    resolve_assigned_regime,
+)
+
 RAW_PATH = Path("artifacts/candles/mexc_sample_expansion_3032/candles.jsonl")
 DERIVED_DIR = Path("artifacts/candles/mexc_sample_expansion_3032_regime_calibrated")
 
@@ -32,13 +39,7 @@ BUFFER_MAXLEN = max(ADX_PERIOD, ATR_PERIOD) * 5
 # BTCUSDT at ~$92k in Jan 2026
 ATR_HIGH_VOL_THRESHOLD = 52.59
 
-REGIME_NAME_TO_ID = {
-    "TREND": 0,
-    "RANGE": 1,
-    "HIGH_VOL_CHAOTIC": 2,
-    "CRISIS": 3,
-}
-REGIME_ID_TO_NAME = {v: k for k, v in REGIME_NAME_TO_ID.items()}
+_VALID_REGIME_IDS = frozenset(REGIME_NAME_TO_ID.values())
 
 
 def compute_atr(candles: list[dict], period: int) -> float | None:
@@ -123,11 +124,10 @@ def compute_adx(candles: list[dict], period: int) -> float | None:
 
 def build_derived_candles(
     raw_candles: list[dict], atr_threshold: float
-) -> tuple[list[dict], Counter[int]]:
+) -> tuple[list[dict], Counter]:
     current_regime = "UNKNOWN"
     candidate_regime: str | None = None
     candidate_count = 0
-    assigned_regime_id = 0
 
     buffer: list[dict] = []
     derived: list[dict] = []
@@ -163,13 +163,23 @@ def build_derived_candles(
                 candidate_regime = None
                 candidate_count = 0
 
-            assigned_regime_id = REGIME_NAME_TO_ID.get(current_regime, 0)
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=True,
+                current_regime=current_regime,
+            )
         else:
-            assigned_regime_id = 0
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=False,
+                current_regime=current_regime,
+            )
 
-        row = dict(candle)
-        row["regime_id"] = assigned_regime_id
-        derived.append(row)
+        derived.append(
+            annotate_regime_row(
+                candle,
+                regime_id=assigned_regime_id,
+                block_reason=block_reason,
+            )
+        )
 
     distribution = Counter(r["regime_id"] for r in derived)
     return derived, distribution
@@ -213,16 +223,17 @@ def main() -> int:
 
     derived, distribution = build_derived_candles(raw_candles, ATR_HIGH_VOL_THRESHOLD)
 
-    # Integrity checks
-    null_count = sum(1 for r in derived if r["regime_id"] is None)
-    if null_count > 0:
-        print(f"ERROR: {null_count} rows have null regime_id", file=sys.stderr)
-        return 2
-
-    invalid = [i for i, r in enumerate(derived) if r["regime_id"] not in {0, 1, 2, 3}]
+    # Integrity checks — null/UNKNOWN is valid fail-closed semantics (#4188)
+    unknown_count = sum(1 for r in derived if r["regime_id"] is None)
+    invalid = [
+        i
+        for i, r in enumerate(derived)
+        if r["regime_id"] is not None and r["regime_id"] not in _VALID_REGIME_IDS
+    ]
     if invalid:
         print(f"ERROR: {len(invalid)} rows have invalid regime_id", file=sys.stderr)
         return 2
+    print(f"UNKNOWN/null regime_id rows (warmup or unmapped): {unknown_count}")
 
     DERIVED_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -241,8 +252,8 @@ def main() -> int:
     print()
     print("Regime distribution:")
     total = sum(distribution.values())
-    for rid in sorted(distribution):
-        name = REGIME_ID_TO_NAME.get(rid, "???")
+    for rid in sorted(distribution, key=lambda x: (-1 if x is None else x)):
+        name = "UNKNOWN" if rid is None else REGIME_ID_TO_NAME.get(rid, "???")
         count = distribution[rid]
         pct = count / total * 100
         print(f"  {name:<20} {count:>6} ({pct:5.1f}%)")
@@ -294,14 +305,25 @@ def main() -> int:
             "1": "RANGE",
             "2": "HIGH_VOL_CHAOTIC",
             "3": "CRISIS",
+            "null": "UNKNOWN",
         },
         "regime_distribution": {
-            str(rid): {
-                "regime_name": REGIME_ID_TO_NAME.get(rid, "UNKNOWN"),
+            ("null" if rid is None else str(rid)): {
+                "regime_name": (
+                    "UNKNOWN" if rid is None else REGIME_ID_TO_NAME.get(rid, "UNKNOWN")
+                ),
                 "count": count,
             }
-            for rid, count in sorted(distribution.items())
+            for rid, count in sorted(
+                distribution.items(),
+                key=lambda item: (-1 if item[0] is None else item[0]),
+            )
         },
+        "unknown_or_warmup_rows": unknown_count,
+        "fail_closed_semantics": (
+            "Warmup / UNKNOWN / unmapped regimes emit regime_id=null "
+            "(never silent TREND / regime_id=0). Refs #4188 #4149."
+        ),
         "output_rows": len(derived),
         "input_output_row_count_match": n_raw == len(derived),
         "output_sha256": derived_sha256,

--- a/scripts/profitability/assign_regime_to_mexc_3091.py
+++ b/scripts/profitability/assign_regime_to_mexc_3091.py
@@ -17,15 +17,20 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+from tools.market_data.assign_regime_offline import (
+    REGIME_ID_TO_NAME,
+    REGIME_NAME_TO_ID,
+    annotate_regime_row,
+    resolve_assigned_regime,
+)
+
 RAW_DIR = Path("artifacts/candles/mexc_strict_window_3091")
 RAW_PATH = RAW_DIR / "candles.jsonl"
 DERIVED_DIR = Path("artifacts/candles/mexc_strict_window_3091_regime_assigned")
 DERIVED_PATH = DERIVED_DIR / "candles.jsonl"
 MANIFEST_PATH = DERIVED_DIR / "regime_assignment_manifest.json"
 
-EXPECTED_RAW_SHA256 = (
-    "d79a1c3c81191dcf4418ae0c2b2775a6f354ed0cc6801a6955904871c4077605"
-)
+EXPECTED_RAW_SHA256 = "d79a1c3c81191dcf4418ae0c2b2775a6f354ed0cc6801a6955904871c4077605"
 EXPECTED_ROW_COUNT = 3496
 
 # ── Canonical regime config ──
@@ -38,15 +43,7 @@ ATR_HIGH_VOL_THRESHOLD = 2.0
 CONFIRMATION_BARS = 3
 BUFFER_MAXLEN = max(ADX_PERIOD, ATR_PERIOD) * 5  # 70
 
-# Canonical regime ID mapping from services/candles/service.py:_lookup_regime_id
-REGIME_NAME_TO_ID = {
-    "TREND": 0,
-    "RANGE": 1,
-    "HIGH_VOL_CHAOTIC": 2,
-    "CRISIS": 3,
-}
-
-REGIME_ID_TO_NAME = {v: k for k, v in REGIME_NAME_TO_ID.items()}
+_VALID_REGIME_IDS = frozenset(REGIME_NAME_TO_ID.values())
 
 
 def compute_atr(candles: list[dict], period: int) -> float | None:
@@ -135,12 +132,12 @@ def build_derived_candles(raw_candles: list[dict]) -> list[dict]:
     """Build derived candles with integer regime_id using offline ADX/ATR heuristic.
 
     Faithfully mirrors the regime derivation + confirmation logic from
-    services/regime/service.py:_derive_regime.
+    services/regime/service.py:_derive_regime. Warmup / UNKNOWN map to
+    ``regime_id=None`` (fail-closed; never silent TREND / 0). Refs #4188.
     """
     current_regime = "UNKNOWN"
     candidate_regime: str | None = None
     candidate_count = 0
-    assigned_regime_id = 0  # fallback for warmup
 
     buffer: list[dict] = []
     derived: list[dict] = []
@@ -176,13 +173,23 @@ def build_derived_candles(raw_candles: list[dict]) -> list[dict]:
                 candidate_regime = None
                 candidate_count = 0
 
-            assigned_regime_id = REGIME_NAME_TO_ID.get(current_regime, 0)
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=True,
+                current_regime=current_regime,
+            )
         else:
-            assigned_regime_id = 0
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=False,
+                current_regime=current_regime,
+            )
 
-        row = dict(candle)
-        row["regime_id"] = assigned_regime_id
-        derived.append(row)
+        derived.append(
+            annotate_regime_row(
+                candle,
+                regime_id=assigned_regime_id,
+                block_reason=block_reason,
+            )
+        )
 
     return derived
 
@@ -229,28 +236,45 @@ def write_manifest(
             "1": "RANGE",
             "2": "HIGH_VOL_CHAOTIC",
             "3": "CRISIS",
+            "null": "UNKNOWN",
         },
         "regime_distribution": {
-            str(regime_id): {
-                "regime_name": REGIME_ID_TO_NAME.get(regime_id, "UNKNOWN"),
+            ("null" if regime_id is None else str(regime_id)): {
+                "regime_name": (
+                    "UNKNOWN"
+                    if regime_id is None
+                    else REGIME_ID_TO_NAME.get(regime_id, "UNKNOWN")
+                ),
                 "count": count,
             }
-            for regime_id, count in sorted(distribution.items())
+            for regime_id, count in sorted(
+                distribution.items(),
+                key=lambda item: (-1 if item[0] is None else item[0]),
+            )
         },
         "regime_distribution_summary": {
-            str(regime_id): count
-            for regime_id, count in sorted(distribution.items())
+            ("null" if regime_id is None else str(regime_id)): count
+            for regime_id, count in sorted(
+                distribution.items(),
+                key=lambda item: (-1 if item[0] is None else item[0]),
+            )
         },
         "initial_fallback_regime": {
-            "regime_id": 0,
-            "regime_name": "TREND",
+            "regime_id": None,
+            "regime_name": "UNKNOWN",
+            "block_reason": "WARMUP_INSUFFICIENT_INDICATORS",
             "note": (
-                f"Regime defaulted to 0 (TREND) for first {ADX_PERIOD} candles "
-                f"(ADX/ATR require period+1={ADX_PERIOD+1} candles). "
+                f"Regime defaults to null/UNKNOWN for first {ADX_PERIOD} candles "
+                f"(ADX/ATR require period+1={ADX_PERIOD + 1} candles). "
+                f"Never silent TREND / regime_id=0. Refs #4188 #4149. "
                 f"Full buffer depth is {BUFFER_MAXLEN} candles."
             ),
         },
         "warmup_candles_defaulted": ADX_PERIOD,
+        "fail_closed_semantics": (
+            "Warmup / UNKNOWN / unmapped regimes emit regime_id=null "
+            "(never silent TREND / regime_id=0). Refs #4188 #4149."
+        ),
         "confirmation_bars_applied": True,
         "deterministic": True,
         "no_randomness": True,
@@ -309,17 +333,16 @@ def main() -> int:
 
     derived = build_derived_candles(raw_candles)
 
-    null_count = sum(1 for r in derived if r["regime_id"] is None)
-    if null_count > 0:
-        print(f"ERROR: {null_count} rows have null regime_id", file=sys.stderr)
-        return 2
-
-    invalid = [i for i, r in enumerate(derived) if r["regime_id"] not in {0, 1, 2, 3}]
+    unknown_count = sum(1 for r in derived if r["regime_id"] is None)
+    invalid = [
+        i
+        for i, r in enumerate(derived)
+        if r["regime_id"] is not None and r["regime_id"] not in _VALID_REGIME_IDS
+    ]
     if invalid:
-        print(
-            f"ERROR: {len(invalid)} rows have invalid regime_id", file=sys.stderr
-        )
+        print(f"ERROR: {len(invalid)} rows have invalid regime_id", file=sys.stderr)
         return 2
+    print(f"UNKNOWN/null regime_id rows (warmup or unmapped): {unknown_count}")
 
     distribution = Counter(r["regime_id"] for r in derived)
 
@@ -332,8 +355,10 @@ def main() -> int:
     print(f"Derived dataset: {DERIVED_PATH} ({len(derived)} rows)")
     print(f"Manifest:       {MANIFEST_PATH}")
     print("Regime distribution:")
-    for rid, count in sorted(distribution.items()):
-        name = REGIME_ID_TO_NAME.get(rid, "???")
+    for rid, count in sorted(
+        distribution.items(), key=lambda item: (-1 if item[0] is None else item[0])
+    ):
+        name = "UNKNOWN" if rid is None else REGIME_ID_TO_NAME.get(rid, "???")
         pct = count / len(derived) * 100
         print(f"  {rid} ({name}): {count} ({pct:.1f}%)")
     print("ALL REGIME LABELS ARE ESTIMATED. NOT runtime-derived.")
@@ -383,15 +408,20 @@ def verify_only() -> int:
     for i in range(len(derived)):
         rid = derived[i].get("regime_id")
         if rid is None:
-            print(f"FAIL: Null regime_id at row {i}", file=sys.stderr)
-            return 2
-        if not isinstance(rid, int):
+            # Fail-closed UNKNOWN/warmup is allowed (#4188).
+            if derived[i].get("regime_name") != "UNKNOWN":
+                print(
+                    f"FAIL: null regime_id without regime_name=UNKNOWN at row {i}",
+                    file=sys.stderr,
+                )
+                return 2
+        elif not isinstance(rid, int):
             print(
                 f"FAIL: non-int regime_id at row {i}: {type(rid).__name__}",
                 file=sys.stderr,
             )
             return 2
-        if rid not in {0, 1, 2, 3}:
+        elif rid not in _VALID_REGIME_IDS:
             print(f"FAIL: Invalid regime_id at row {i}: {rid}", file=sys.stderr)
             return 2
         if derived[i]["ts_ms"] != raw_candles[i]["ts_ms"]:
@@ -410,17 +440,18 @@ def verify_only() -> int:
                 )
                 return 2
 
-    null_in_derived = sum(
-        1 for r in derived if r["regime_id"] is None
+    null_in_derived = sum(1 for r in derived if r["regime_id"] is None)
+    print(f"PASS: null/UNKNOWN regime_id in derived: {null_in_derived}")
+    print(
+        "PASS: Non-null regime_id values are valid integers in "
+        f"{sorted(_VALID_REGIME_IDS)}"
     )
-    print(f"PASS: null regime_id in derived: {null_in_derived}")
-    print("PASS: All regime_id values are valid integers in {0,1,2,3}")
-    print(f"PASS: All ts_ms and OHLCV fields match raw dataset")
+    print("PASS: All ts_ms and OHLCV fields match raw dataset")
 
     distribution = Counter(r["regime_id"] for r in derived)
     print("Regime distribution:")
-    for rid in sorted(distribution):
-        name = REGIME_ID_TO_NAME.get(rid, "???")
+    for rid in sorted(distribution, key=lambda x: (-1 if x is None else x)):
+        name = "UNKNOWN" if rid is None else REGIME_ID_TO_NAME.get(rid, "???")
         pct = distribution[rid] / len(derived) * 100
         print(f"  {rid} ({name}): {distribution[rid]} ({pct:.1f}%)")
 

--- a/scripts/profitability/generate_calibration_variants_3032.py
+++ b/scripts/profitability/generate_calibration_variants_3032.py
@@ -19,12 +19,17 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+from tools.market_data.assign_regime_offline import (
+    REGIME_ID_TO_NAME,
+    REGIME_NAME_TO_ID,
+    annotate_regime_row,
+    resolve_assigned_regime,
+)
+
 RAW_PATH = Path("artifacts/candles/mexc_strict_window_3091/candles.jsonl")
 DERIVED_ROOT = Path("artifacts/candles/mexc_strict_window_3091_regime_calibration")
 
-EXPECTED_RAW_SHA256 = (
-    "d79a1c3c81191dcf4418ae0c2b2775a6f354ed0cc6801a6955904871c4077605"
-)
+EXPECTED_RAW_SHA256 = "d79a1c3c81191dcf4418ae0c2b2775a6f354ed0cc6801a6955904871c4077605"
 
 ADX_PERIOD = 14
 ATR_PERIOD = 14
@@ -33,13 +38,7 @@ ADX_RANGE_THRESHOLD = 20.0
 CONFIRMATION_BARS = 3
 BUFFER_MAXLEN = max(ADX_PERIOD, ATR_PERIOD) * 5
 
-REGIME_NAME_TO_ID = {
-    "TREND": 0,
-    "RANGE": 1,
-    "HIGH_VOL_CHAOTIC": 2,
-    "CRISIS": 3,
-}
-REGIME_ID_TO_NAME = {v: k for k, v in REGIME_NAME_TO_ID.items()}
+_VALID_REGIME_IDS = frozenset(REGIME_NAME_TO_ID.values())
 
 # Calibration grid: (variant_slug, atr_threshold, note)
 # Thresholds derived from data percentiles (see analyze_btcusdt_regime_calibration_3032.py output)
@@ -169,15 +168,15 @@ def compute_adx(candles: list[dict], period: int) -> float | None:
 
 def build_derived_candles(
     raw_candles: list[dict], atr_threshold: float
-) -> tuple[list[dict], Counter[int]]:
+) -> tuple[list[dict], Counter]:
     """Build derived candles with parameterized ATR threshold.
 
     Faithfully mirrors services/regime/service.py:_derive_regime.
+    Warmup / UNKNOWN map to ``regime_id=None`` (fail-closed). Refs #4188.
     """
     current_regime = "UNKNOWN"
     candidate_regime: str | None = None
     candidate_count = 0
-    assigned_regime_id = 0
 
     buffer: list[dict] = []
     derived: list[dict] = []
@@ -213,13 +212,23 @@ def build_derived_candles(
                 candidate_regime = None
                 candidate_count = 0
 
-            assigned_regime_id = REGIME_NAME_TO_ID.get(current_regime, 0)
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=True,
+                current_regime=current_regime,
+            )
         else:
-            assigned_regime_id = 0
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=False,
+                current_regime=current_regime,
+            )
 
-        row = dict(candle)
-        row["regime_id"] = assigned_regime_id
-        derived.append(row)
+        derived.append(
+            annotate_regime_row(
+                candle,
+                regime_id=assigned_regime_id,
+                block_reason=block_reason,
+            )
+        )
 
     distribution = Counter(r["regime_id"] for r in derived)
     return derived, distribution
@@ -230,7 +239,7 @@ def write_variant_manifest(
     slug: str,
     atr_threshold: float,
     note: str,
-    distribution: Counter[int],
+    distribution: Counter,
     raw_rows: int,
     derived_rows: int,
 ) -> None:
@@ -238,7 +247,7 @@ def write_variant_manifest(
         "schema_version": "calibration_variant_manifest.v1",
         "issue": "#3144",
         "parent": "#3032",
-        "refs": ["#3142", "#3143"],
+        "refs": ["#3142", "#3143", "#4188"],
         "variant_slug": slug,
         "atr_high_vol_threshold": atr_threshold,
         "threshold_note": note,
@@ -277,26 +286,42 @@ def write_variant_manifest(
             "1": "RANGE",
             "2": "HIGH_VOL_CHAOTIC",
             "3": "CRISIS",
+            "null": "UNKNOWN",
         },
         "regime_distribution": {
-            str(rid): {
-                "regime_name": REGIME_ID_TO_NAME.get(rid, "UNKNOWN"),
+            ("null" if rid is None else str(rid)): {
+                "regime_name": (
+                    "UNKNOWN" if rid is None else REGIME_ID_TO_NAME.get(rid, "UNKNOWN")
+                ),
                 "count": count,
             }
-            for rid, count in sorted(distribution.items())
+            for rid, count in sorted(
+                distribution.items(),
+                key=lambda item: (-1 if item[0] is None else item[0]),
+            )
         },
         "regime_distribution_summary": {
-            str(rid): count for rid, count in sorted(distribution.items())
+            ("null" if rid is None else str(rid)): count
+            for rid, count in sorted(
+                distribution.items(),
+                key=lambda item: (-1 if item[0] is None else item[0]),
+            )
         },
         "initial_fallback_regime": {
-            "regime_id": 0,
-            "regime_name": "TREND",
+            "regime_id": None,
+            "regime_name": "UNKNOWN",
+            "block_reason": "WARMUP_INSUFFICIENT_INDICATORS",
             "note": (
-                f"Regime defaulted to 0 (TREND) for first {ADX_PERIOD} candles "
-                f"(ADX/ATR require period+1={ADX_PERIOD + 1} candles)."
+                f"Regime defaults to null/UNKNOWN for first {ADX_PERIOD} candles "
+                f"(ADX/ATR require period+1={ADX_PERIOD + 1} candles). "
+                f"Never silent TREND / regime_id=0. Refs #4188 #4149."
             ),
         },
         "warmup_candles_defaulted": ADX_PERIOD,
+        "fail_closed_semantics": (
+            "Warmup / UNKNOWN / unmapped regimes emit regime_id=null "
+            "(never silent TREND / regime_id=0). Refs #4188 #4149."
+        ),
         "confirmation_bars_applied": True,
         "deterministic": True,
         "no_randomness": True,
@@ -313,9 +338,7 @@ def write_variant_manifest(
         ),
     }
     manifest_path = variant_dir / "calibration_manifest.json"
-    manifest_path.write_text(
-        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
-    )
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
 
 
 def main() -> int:
@@ -363,13 +386,11 @@ def main() -> int:
 
         derived, distribution = build_derived_candles(raw_candles, atr_threshold)
 
-        null_count = sum(1 for r in derived if r["regime_id"] is None)
-        if null_count > 0:
-            print(f"  ERROR: {null_count} rows have null regime_id", file=sys.stderr)
-            return 2
-
+        unknown_count = sum(1 for r in derived if r["regime_id"] is None)
         invalid = [
-            i for i, r in enumerate(derived) if r["regime_id"] not in {0, 1, 2, 3}
+            i
+            for i, r in enumerate(derived)
+            if r["regime_id"] is not None and r["regime_id"] not in _VALID_REGIME_IDS
         ]
         if invalid:
             print(
@@ -377,6 +398,7 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 2
+        print(f"  UNKNOWN/null regime_id rows: {unknown_count}")
 
         candles_path = variant_dir / "candles.jsonl"
         with candles_path.open("w") as f:
@@ -389,8 +411,8 @@ def main() -> int:
 
         total = sum(distribution.values())
         summary_dist = {}
-        for rid in sorted(distribution):
-            name = REGIME_ID_TO_NAME.get(rid, "???")
+        for rid in sorted(distribution, key=lambda x: (-1 if x is None else x)):
+            name = "UNKNOWN" if rid is None else REGIME_ID_TO_NAME.get(rid, "???")
             count = distribution[rid]
             pct = count / total * 100
             summary_dist[name] = {"count": count, "pct": round(pct, 1)}
@@ -402,7 +424,10 @@ def main() -> int:
                 "atr_threshold": atr_threshold,
                 "note": note,
                 "rows": len(derived),
-                "distribution": {str(k): v for k, v in distribution.items()},
+                "distribution": {
+                    ("null" if k is None else str(k)): v
+                    for k, v in distribution.items()
+                },
             }
         )
 

--- a/tests/unit/market_data/test_assign_regime_offline_unknown_4188.py
+++ b/tests/unit/market_data/test_assign_regime_offline_unknown_4188.py
@@ -1,0 +1,163 @@
+"""Fail-closed UNKNOWN semantics for offline regime assignment (#4188).
+
+Test-First:
+- Regel: missing / UNKNOWN / warmup darf nie stillschweigend TREND (regime_id=0)
+  werden; Runtime-/Candles-Semantik (None) ist kanonisch.
+- Testart: Schutz-Test (unit)
+- Entscheidung: Offline-Assign und Runtime teilen dieselbe fail-closed Mapping-Regel.
+- Metadata: issue_ref=#4188, refs=#4149
+- Weiterverarbeitung: PASS → Slice-Evidence; FAIL → HOLD / Fix im Assign-Pfad.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.market_data import assign_regime_offline as offline
+from tools.market_data.assign_regime_offline import (
+    REGIME_BLOCK_UNKNOWN,
+    REGIME_BLOCK_WARMUP,
+    REGIME_NAME_TO_ID,
+    annotate_regime_row,
+    assign_regime_ids,
+    regime_distribution,
+    regime_name_to_id,
+    resolve_assigned_regime,
+)
+
+
+def _candle(
+    i: int, *, close: float = 100.0, high: float | None = None, low: float | None = None
+) -> dict:
+    h = close + 0.5 if high is None else high
+    lo = close - 0.5 if low is None else low
+    return {
+        "ts_ms": 1_780_272_000_000 + i * 60_000,
+        "open": close,
+        "high": h,
+        "low": lo,
+        "close": close,
+        "volume": 1.0,
+        "trade_count": 1,
+    }
+
+
+@pytest.mark.unit
+def test_missing_regime_name_not_mapped_to_trend() -> None:
+    assert regime_name_to_id(None) is None
+    assert regime_name_to_id("") is None
+    assert regime_name_to_id("   ") is None
+    rid, reason = resolve_assigned_regime(indicators_ready=True, current_regime=None)
+    assert rid is None
+    assert reason == REGIME_BLOCK_UNKNOWN
+
+
+@pytest.mark.unit
+def test_unknown_name_not_mapped_to_regime_id_zero() -> None:
+    assert regime_name_to_id("UNKNOWN") is None
+    assert regime_name_to_id("unknown") is None
+    assert regime_name_to_id("NOT_A_REAL_REGIME") is None
+    # Explicit guard: dict.get(..., 0) must not be used as semantics.
+    assert REGIME_NAME_TO_ID.get("UNKNOWN", 0) == 0  # legacy trap value
+    assert regime_name_to_id("UNKNOWN") != 0
+    rid, reason = resolve_assigned_regime(
+        indicators_ready=True, current_regime="UNKNOWN"
+    )
+    assert rid is None
+    assert reason == REGIME_BLOCK_UNKNOWN
+    row = annotate_regime_row({}, regime_id=rid, block_reason=reason)
+    assert row["regime_id"] is None
+    assert row["regime_name"] == "UNKNOWN"
+    assert row["regime_block_reason"] == REGIME_BLOCK_UNKNOWN
+
+
+@pytest.mark.unit
+def test_warmup_rows_are_unknown_not_trend() -> None:
+    # Fewer than ADX/ATR period+1 candles → indicators not ready → UNKNOWN.
+    rows = [_candle(i) for i in range(10)]
+    out = assign_regime_ids(rows)
+    assert len(out) == 10
+    for row in out:
+        assert row["regime_id"] is None
+        assert row["regime_name"] == "UNKNOWN"
+        assert row["regime_block_reason"] == REGIME_BLOCK_WARMUP
+        assert row["regime_id"] != 0
+
+
+@pytest.mark.unit
+def test_known_trend_remains_trend() -> None:
+    assert regime_name_to_id("TREND") == 0
+    rid, reason = resolve_assigned_regime(indicators_ready=True, current_regime="TREND")
+    assert rid == 0
+    assert reason is None
+    row = annotate_regime_row({"ts_ms": 1}, regime_id=rid, block_reason=reason)
+    assert row["regime_id"] == 0
+    assert row["regime_name"] == "TREND"
+    assert "regime_block_reason" not in row
+
+
+@pytest.mark.unit
+def test_known_other_regimes_remain_correct() -> None:
+    assert regime_name_to_id("RANGE") == 1
+    assert regime_name_to_id("HIGH_VOL_CHAOTIC") == 2
+    assert regime_name_to_id("HIGH_VOL_SPIKE") == 2  # HIGH_VOL_* prefix
+    assert regime_name_to_id("CRISIS") == 3
+
+
+@pytest.mark.unit
+def test_offline_matches_runtime_null_semantics() -> None:
+    """Runtime candles: UNKNOWN/missing → None. Offline must match."""
+    # Warmup path
+    rid_w, reason_w = resolve_assigned_regime(
+        indicators_ready=False, current_regime="UNKNOWN"
+    )
+    assert rid_w is None and reason_w == REGIME_BLOCK_WARMUP
+    # Unknown name after indicators ready
+    rid_u, reason_u = resolve_assigned_regime(
+        indicators_ready=True, current_regime="UNKNOWN"
+    )
+    assert rid_u is None and reason_u == REGIME_BLOCK_UNKNOWN
+    # Known ids unchanged
+    assert resolve_assigned_regime(indicators_ready=True, current_regime="TREND") == (
+        0,
+        None,
+    )
+    assert resolve_assigned_regime(indicators_ready=True, current_regime="RANGE") == (
+        1,
+        None,
+    )
+
+
+@pytest.mark.unit
+def test_no_silent_numeric_fallback_in_distribution() -> None:
+    candles = [
+        {"regime_id": None, "regime_name": "UNKNOWN"},
+        {"regime_id": 0, "regime_name": "TREND"},
+        {"regime_id": 1, "regime_name": "RANGE"},
+    ]
+    dist = regime_distribution(candles)
+    assert dist["null"]["regime_name"] == "UNKNOWN"
+    assert dist["null"]["count"] == 1
+    assert dist["0"]["regime_name"] == "TREND"
+    assert dist["0"]["count"] == 1
+    assert dist["1"]["regime_name"] == "RANGE"
+
+
+@pytest.mark.unit
+def test_strong_trend_series_emits_trend_after_warmup() -> None:
+    """Known TREND path: after indicators warm, confirmed TREND stays 0."""
+    # Monotone rising close with small range → ADX high, ATR below absolute 2.0
+    rows = []
+    for i in range(80):
+        close = 100.0 + i * 0.5
+        rows.append(_candle(i, close=close, high=close + 0.05, low=close - 0.05))
+    out = assign_regime_ids(rows)
+    warmup = out[: offline.ADX_PERIOD]
+    assert all(r["regime_id"] is None for r in warmup)
+    assert all(r["regime_block_reason"] == REGIME_BLOCK_WARMUP for r in warmup)
+    # After confirmation, TREND (0) should appear among later bars.
+    later_ids = {r["regime_id"] for r in out[40:]}
+    assert 0 in later_ids
+    assert None not in later_ids or True  # UNKNOWN only if still unconfirmed
+    # Never coerce UNKNOWN via silent 0 during true warmup.
+    assert all(r["regime_id"] is None for r in warmup)

--- a/tests/unit/profitability/test_assign_regime_unknown_4188.py
+++ b/tests/unit/profitability/test_assign_regime_unknown_4188.py
@@ -1,0 +1,70 @@
+"""Profitability offline assign helpers share fail-closed UNKNOWN semantics (#4188)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.profitability import assign_regime_calibrate_3032_expansion as cal_3032
+from scripts.profitability import assign_regime_to_mexc_3091 as mexc_3091
+from scripts.profitability import generate_calibration_variants_3032 as variants_3032
+from tools.market_data.assign_regime_offline import REGIME_BLOCK_WARMUP
+
+
+def _candle(i: int, *, close: float = 100.0) -> dict:
+    return {
+        "ts_ms": 1_700_000_000_000 + i * 60_000,
+        "open": close,
+        "high": close + 0.1,
+        "low": close - 0.1,
+        "close": close,
+        "volume": 1.0,
+        "trade_count": 1,
+    }
+
+
+@pytest.mark.unit
+def test_mexc_3091_warmup_not_trend() -> None:
+    rows = [_candle(i) for i in range(8)]
+    out = mexc_3091.build_derived_candles(rows)
+    assert all(r["regime_id"] is None for r in out)
+    assert all(r["regime_block_reason"] == REGIME_BLOCK_WARMUP for r in out)
+    assert all(r["regime_id"] != 0 for r in out)
+
+
+@pytest.mark.unit
+def test_calibrate_3032_expansion_warmup_not_trend() -> None:
+    rows = [_candle(i) for i in range(8)]
+    out, dist = cal_3032.build_derived_candles(rows, atr_threshold=52.59)
+    assert None in dist
+    assert all(r["regime_id"] is None for r in out)
+    assert 0 not in dist or dist.get(0, 0) == 0
+
+
+@pytest.mark.unit
+def test_calibration_variants_warmup_not_trend() -> None:
+    rows = [_candle(i) for i in range(8)]
+    out, dist = variants_3032.build_derived_candles(rows, atr_threshold=2.0)
+    assert None in dist
+    assert all(r["regime_id"] is None for r in out)
+
+
+@pytest.mark.unit
+def test_known_trend_preserved_after_confirmation() -> None:
+    rows = []
+    for i in range(80):
+        close = 100.0 + i * 0.5
+        rows.append(
+            {
+                "ts_ms": 1_700_000_000_000 + i * 60_000,
+                "open": close,
+                "high": close + 0.05,
+                "low": close - 0.05,
+                "close": close,
+                "volume": 1.0,
+                "trade_count": 1,
+            }
+        )
+    # High ATR threshold so HIGH_VOL does not dominate; ADX should prefer TREND.
+    out, dist = cal_3032.build_derived_candles(rows, atr_threshold=10_000.0)
+    assert any(r["regime_id"] == 0 for r in out)
+    assert dist.get(0, 0) > 0

--- a/tools/market_data/assign_regime_offline.py
+++ b/tools/market_data/assign_regime_offline.py
@@ -23,6 +23,65 @@ REGIME_NAME_TO_ID = {
 }
 REGIME_ID_TO_NAME = {value: key for key, value in REGIME_NAME_TO_ID.items()}
 
+# Fail-closed block reasons — mirror services/candles._lookup_regime_id
+# (UNKNOWN/missing/stale → None, never silent TREND / regime_id=0).
+REGIME_BLOCK_WARMUP = "WARMUP_INSUFFICIENT_INDICATORS"
+REGIME_BLOCK_UNKNOWN = "UNKNOWN_OR_UNMAPPED_REGIME"
+REGIME_NAME_UNKNOWN = "UNKNOWN"
+
+
+def regime_name_to_id(regime_name: str | None) -> int | None:
+    """Map a regime name to its canonical integer id (fail-closed).
+
+    Matches ``services/candles/service.py:_lookup_regime_id``:
+    - TREND → 0, RANGE → 1, HIGH_VOL_* → 2, CRISIS → 3
+    - UNKNOWN / missing / unmapped → None (never default to TREND/0)
+    """
+    if regime_name is None:
+        return None
+    key = str(regime_name).strip().upper()
+    if not key or key == REGIME_NAME_UNKNOWN:
+        return None
+    if key.startswith("HIGH_VOL"):
+        return REGIME_NAME_TO_ID["HIGH_VOL_CHAOTIC"]
+    return REGIME_NAME_TO_ID.get(key)
+
+
+def resolve_assigned_regime(
+    *,
+    indicators_ready: bool,
+    current_regime: str | None,
+) -> tuple[int | None, str | None]:
+    """Resolve offline regime_id with explicit UNKNOWN / block-reason semantics.
+
+    Returns ``(regime_id, block_reason)``. ``block_reason`` is set iff
+    ``regime_id`` is None (warmup or unmapped/UNKNOWN name).
+    """
+    if not indicators_ready:
+        return None, REGIME_BLOCK_WARMUP
+    regime_id = regime_name_to_id(current_regime)
+    if regime_id is None:
+        return None, REGIME_BLOCK_UNKNOWN
+    return regime_id, None
+
+
+def annotate_regime_row(
+    candle: dict[str, Any],
+    *,
+    regime_id: int | None,
+    block_reason: str | None,
+) -> dict[str, Any]:
+    """Attach regime_id plus UNKNOWN/block-reason fields for offline outputs."""
+    row = dict(candle)
+    row["regime_id"] = regime_id
+    if block_reason is not None:
+        row["regime_name"] = REGIME_NAME_UNKNOWN
+        row["regime_block_reason"] = block_reason
+    else:
+        row["regime_name"] = REGIME_ID_TO_NAME[int(regime_id)]  # type: ignore[arg-type]
+        row.pop("regime_block_reason", None)
+    return row
+
 
 @dataclass
 class RegimeCarryState:
@@ -166,13 +225,23 @@ def assign_regime_ids_with_state(
                 candidate_regime = None
                 candidate_count = 0
 
-            assigned_regime_id = REGIME_NAME_TO_ID.get(current_regime, 0)
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=True,
+                current_regime=current_regime,
+            )
         else:
-            assigned_regime_id = 0
+            assigned_regime_id, block_reason = resolve_assigned_regime(
+                indicators_ready=False,
+                current_regime=current_regime,
+            )
 
-        row = dict(candle)
-        row["regime_id"] = assigned_regime_id
-        derived.append(row)
+        derived.append(
+            annotate_regime_row(
+                candle,
+                regime_id=assigned_regime_id,
+                block_reason=block_reason,
+            )
+        )
 
     return derived, RegimeCarryState(
         current_regime=current_regime,
@@ -251,8 +320,12 @@ def analyze_regime_plausibility(
             "avg_close": avg_close,
             "atr_min": min(atr_values) if atr_values else None,
             "atr_max": max(atr_values) if atr_values else None,
-            "atr_median": sorted(atr_values)[len(atr_values) // 2] if atr_values else None,
-            "adx_median": sorted(adx_values)[len(adx_values) // 2] if adx_values else None,
+            "atr_median": (
+                sorted(atr_values)[len(atr_values) // 2] if atr_values else None
+            ),
+            "adx_median": (
+                sorted(adx_values)[len(adx_values) // 2] if adx_values else None
+            ),
             "atr_above_threshold_pct": atr_above_threshold_pct,
             "thresholds": {
                 "adx_trend": ADX_TREND_THRESHOLD,
@@ -265,11 +338,29 @@ def analyze_regime_plausibility(
 
 
 def regime_distribution(candles: list[dict[str, Any]]) -> dict[str, Any]:
-    counts = Counter(int(row.get("regime_id", 0)) for row in candles)
-    return {
-        str(regime_id): {
-            "regime_name": REGIME_ID_TO_NAME.get(regime_id, "UNKNOWN"),
+    """Summarize regime_id counts without coercing missing → TREND/0."""
+    counts: Counter[int | None] = Counter()
+    for row in candles:
+        rid = row.get("regime_id", None)
+        if rid is None:
+            counts[None] += 1
+        else:
+            counts[int(rid)] += 1
+
+    def _sort_key(item: tuple[int | None, int]) -> tuple[int, int]:
+        regime_id, _count = item
+        # Place UNKNOWN/null first, then numeric ids ascending.
+        return (1, 0) if regime_id is None else (0, int(regime_id))
+
+    result: dict[str, Any] = {}
+    for regime_id, count in sorted(counts.items(), key=_sort_key):
+        key = "null" if regime_id is None else str(regime_id)
+        result[key] = {
+            "regime_name": (
+                REGIME_NAME_UNKNOWN
+                if regime_id is None
+                else REGIME_ID_TO_NAME.get(regime_id, REGIME_NAME_UNKNOWN)
+            ),
             "count": count,
         }
-        for regime_id, count in sorted(counts.items())
-    }
+    return result


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refs #4188 (follow-up to #4149). Offline-/Assign-/Profitability-Helfer mappen fehlende, unbekannte und Warmup-Regimes nicht mehr stillschweigend auf `TREND` / `regime_id=0`. Stattdessen fail-closed `regime_id=null` + `regime_name=UNKNOWN` + expliziter `regime_block_reason`, analog Runtime (`services/candles._lookup_regime_id`) und DB-Semantik.

## Fallback Inventory

| Path | Prior | Fix |
| --- | --- | --- |
| `tools/market_data/assign_regime_offline.py` | warmup `assigned_regime_id=0`; `REGIME_NAME_TO_ID.get(..., 0)` | `regime_name_to_id` / `resolve_assigned_regime` / `annotate_regime_row` |
| `scripts/profitability/assign_regime_to_mexc_3091.py` | same | shared helpers |
| `scripts/profitability/assign_regime_calibrate_3032_expansion.py` | same | shared helpers |
| `scripts/profitability/generate_calibration_variants_3032.py` | same | shared helpers |

Repo-Suche im Scope: keine verbleibenden `REGIME_NAME_TO_ID.get(..., 0)` / `assigned_regime_id = 0` / `fillna(0)`.

## Canonical UNKNOWN Semantics

- TREND→0, RANGE→1, HIGH_VOL_*→2, CRISIS→3 (unverändert)
- UNKNOWN / missing / unmapped / warmup → `None` (nie Default 0)
- Block reasons: `WARMUP_INSUFFICIENT_INDICATORS`, `UNKNOWN_OR_UNMAPPED_REGIME`
- Keine neue Regime-ID

## Changed Offline Paths

- Shared fail-closed mapping in `tools/market_data/assign_regime_offline.py`
- Drei Profitability-Assign-Skripte importieren die Helfer
- Manifests dokumentieren null/UNKNOWN statt TREND-Fallback
- Integrity-Checks erlauben null, lehnen nur ungültige non-null IDs ab

## Validation

- `pytest` targeted: `tests/unit/market_data/test_assign_regime_offline_unknown_4188.py` + `tests/unit/profitability/test_assign_regime_unknown_4188.py` (+ 2 Regression) — PASS
- `ruff check` / `black --check` auf geändertem Python-Scope — PASS
- `git diff --check` — PASS
- `gitleaks protect --staged` — no leaks

## Non-goals

- Kein Full Fast-CI / kein `cdb-local-ci` Publish / kein Merge / kein Issue-Close
- Kein Parameter-Tuning, keine Stage-A/B-/OOS-/Stress-/Risk-/Live-Grenzen
- Keine Replay-Kampagne
- `core/replay/dataset_provider.py` und `services/**` unverändert

## Status

`DONE_SLICE_ADDED_TO_BATCH_PR`

PR-Router: `CREATE_NEW_BATCH_PR` / lane `validation-research` / merge_mode=batch. Closure: Refs only (kein Closes). LR bleibt NO-GO.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-feda0aef-5e8b-4f33-99f3-251103d55585?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-feda0aef-5e8b-4f33-99f3-251103d55585&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

