### PR TITLE
[DOCS][GOV] Reconcile repository status SSOT and add semantic freshness guard

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -12,16 +12,18 @@
 
 ## Repo / Engineering Status (2026-07-31)
 
-<!-- cdb:live-claim type=main_sha value=e96f724c -->
-- **Confirmed main state**: `origin/main` @ `e96f724c` — same snapshot as the [`README.md`](README.md) Current-main section. Both surfaces are reconciled against this commit.
+<!-- cdb:live-claim type=main_sha value=eddcd1bc -->
+- **Confirmed main state**: `origin/main` @ `eddcd1bc` — same snapshot as the [`README.md`](README.md) Current-main section. Both surfaces are reconciled against this commit (post wave PRs [#4238](https://github.com/jannekbuengener/Claire_de_Binare/pull/4238)–[#4241](https://github.com/jannekbuengener/Claire_de_Binare/pull/4241)).
 
 <!-- cdb:live-claim type=issue_state issue=3995 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4005 state=closed -->
+<!-- cdb:live-claim type=issue_state issue=4204 state=closed -->
+<!-- cdb:live-claim type=issue_state issue=4228 state=closed -->
 - **#4119 Status-SSOT reconcile**: Delivery slice — README-Snapshot und dieser Block referenzieren denselben bestaetigten Main-Stand. GitHub-live nachgezogen: [#3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) **CLOSED** (PR [#4018](https://github.com/jannekbuengener/Claire_de_Binare/pull/4018) @ `60ddf8b3`) und [#4005](https://github.com/jannekbuengener/Claire_de_Binare/issues/4005) **CLOSED** (PR [#4024](https://github.com/jannekbuengener/Claire_de_Binare/pull/4024) @ `13eab660`); beide erscheinen nicht mehr als aktuelle offene Delivery. Aeltere Ledger-Zeilen, die sie damals als offen fuehrten, bleiben unveraendert im historischen Block. Reconciles auf `main`: PR [#4099](https://github.com/jannekbuengener/Claire_de_Binare/pull/4099) (kanonische Root-Informationsarchitektur), PR [#4103](https://github.com/jannekbuengener/Claire_de_Binare/pull/4103) (Workflow-Bereinigung + Control-Plane-Docs), PR [#4104](https://github.com/jannekbuengener/Claire_de_Binare/pull/4104) (Post-Merge-Workflow-Audit-Luecken), PR [#4105](https://github.com/jannekbuengener/Claire_de_Binare/pull/4105) (Single Repository Canon). Neu: semantischer Freshness-Guard `tools/validate_status_freshness.py` in der CI-Docs-Stage. LR **NO-GO** unchanged.
 
-- **#4204 Fast-CI Slice Gates**: Delivery slice on `batch/ci-tooling-issue-4204` — versioned slice policy, fail-closed unknown-path → full Fast-CI, `merge_evidence=false` publish rejection, unit/stage timing evidence; Final-Head selector unchanged (collect-only 8957→8970 +13 tests). Merge/Issue-close/`cdb-local-ci` not in this session. LR **NO-GO** unchanged.
+- **#4204 Fast-CI Slice Gates**: **DONE_MERGED_CLOSED** — PR [#4236](https://github.com/jannekbuengener/Claire_de_Binare/pull/4236) squash-merged @ `e96f724c` (2026-07-31). Versioned slice policy, fail-closed unknown-path → full Fast-CI, `merge_evidence=false` publish rejection, unit/stage timing evidence; Final-Head selector unchanged. LR **NO-GO** unchanged.
 
-- **#4228 PR-Router Real Conventions**: Delivery slice on `cloud-cursor/pr-router-real-conventions-5132` — policy/matcher aligned to live title tokens (`[AGENTS]`/`[SKILLS]`/`[OPS]`/…) and `scope:*`/`type:*` labels; missing metadata yields actionable `repair_hints` + safe `CREATE_NEW_BATCH_PR`; deleted override `governance/pr-steward-batch-routing` removed. Merge/Issue-close not in this session. LR **NO-GO** unchanged.
+- **#4228 PR-Router Real Conventions**: **DONE_MERGED_CLOSED** — PR [#4231](https://github.com/jannekbuengener/Claire_de_Binare/pull/4231) squash-merged @ `e5711c2a` (2026-07-31). Policy/matcher aligned to live title tokens and `scope:*`/`type:*` labels; actionable `repair_hints` + safe `CREATE_NEW_BATCH_PR`. LR **NO-GO** unchanged.
 
 <!-- cdb:historical-as-of date=2026-07-30 -->
 > Historical as of 2026-07-30 — append-only ledger. Entries below record the

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,16 +3,30 @@
 **Status Class**: Claire de Binare repository / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+<!-- cdb:status-freshness header-date=2026-07-31 -->
 **Last Updated**: 2026-07-31
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
+**Freshness Guard**: Only the newest dated block below is a live claim. Everything from the previous dated block onward is marked `historical as of` and is append-only. Marker convention: [`docs/meta/REPOSITORY_CANON.md`](docs/meta/REPOSITORY_CANON.md); validator: `python -m tools.validate_status_freshness`.
 
 ---
 
 ## Repo / Engineering Status (2026-07-31)
 
+<!-- cdb:live-claim type=main_sha value=e96f724c -->
+- **Confirmed main state**: `origin/main` @ `e96f724c` — same snapshot as the [`README.md`](README.md) Current-main section. Both surfaces are reconciled against this commit.
+
+<!-- cdb:live-claim type=issue_state issue=3995 state=closed -->
+<!-- cdb:live-claim type=issue_state issue=4005 state=closed -->
+- **#4119 Status-SSOT reconcile**: Delivery slice — README-Snapshot und dieser Block referenzieren denselben bestaetigten Main-Stand. GitHub-live nachgezogen: [#3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) **CLOSED** (PR [#4018](https://github.com/jannekbuengener/Claire_de_Binare/pull/4018) @ `60ddf8b3`) und [#4005](https://github.com/jannekbuengener/Claire_de_Binare/issues/4005) **CLOSED** (PR [#4024](https://github.com/jannekbuengener/Claire_de_Binare/pull/4024) @ `13eab660`); beide erscheinen nicht mehr als aktuelle offene Delivery. Aeltere Ledger-Zeilen, die sie damals als offen fuehrten, bleiben unveraendert im historischen Block. Reconciles auf `main`: PR [#4099](https://github.com/jannekbuengener/Claire_de_Binare/pull/4099) (kanonische Root-Informationsarchitektur), PR [#4103](https://github.com/jannekbuengener/Claire_de_Binare/pull/4103) (Workflow-Bereinigung + Control-Plane-Docs), PR [#4104](https://github.com/jannekbuengener/Claire_de_Binare/pull/4104) (Post-Merge-Workflow-Audit-Luecken), PR [#4105](https://github.com/jannekbuengener/Claire_de_Binare/pull/4105) (Single Repository Canon). Neu: semantischer Freshness-Guard `tools/validate_status_freshness.py` in der CI-Docs-Stage. LR **NO-GO** unchanged.
+
 - **#4204 Fast-CI Slice Gates**: Delivery slice on `batch/ci-tooling-issue-4204` — versioned slice policy, fail-closed unknown-path → full Fast-CI, `merge_evidence=false` publish rejection, unit/stage timing evidence; Final-Head selector unchanged (collect-only 8957→8970 +13 tests). Merge/Issue-close/`cdb-local-ci` not in this session. LR **NO-GO** unchanged.
 
 - **#4228 PR-Router Real Conventions**: Delivery slice on `cloud-cursor/pr-router-real-conventions-5132` — policy/matcher aligned to live title tokens (`[AGENTS]`/`[SKILLS]`/`[OPS]`/…) and `scope:*`/`type:*` labels; missing metadata yields actionable `repair_hints` + safe `CREATE_NEW_BATCH_PR`; deleted override `governance/pr-steward-batch-routing` removed. Merge/Issue-close not in this session. LR **NO-GO** unchanged.
+
+<!-- cdb:historical-as-of date=2026-07-30 -->
+> Historical as of 2026-07-30 — append-only ledger. Entries below record the
+> state at their own date and are intentionally not rewritten when reality
+> moves on. They are exempt from live freshness verification.
 
 ## Repo / Engineering Status (2026-07-30)
 
@@ -484,6 +498,8 @@
 - **Session 2026-05-29 (#2606 follow-up roadmap)**: Parent-DoD follow-up issues angelegt: #2701 (agent output contract), #2702 (DB stale scan), #2703 (write path v1), #2704 (MCP write design), #2705 (closure audit). Index-Kommentar: https://github.com/jannekbuengener/Claire_de_Binare/issues/2606#issuecomment-4573401988. #2606 bleibt OPEN; Gatekeeper **BLOCKED**. Kein Code/DB/MCP-Change. Session-Log: `knowledge/logs/sessions/2026-05-29-2606-followup-roadmap-issues.md`.
 
 ---
+
+<!-- cdb:historical-end -->
 
 ## Live-Readiness
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,18 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 ## Current-main Snapshot
 
-Auf `origin/main` (`f9e0cb0a`, Stand 2026-07-13) sind die juengsten relevanten Merge-Cluster u. a.:
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+<!-- cdb:live-claim type=main_sha value=e96f724c -->
+Auf `origin/main` (`e96f724c`, Stand 2026-07-31) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **README / canon link guard ([#3994](https://github.com/jannekbuengener/Claire_de_Binare/issues/3994) / PR [#4011](https://github.com/jannekbuengener/Claire_de_Binare/pull/4011)):** Shared `markdown_link_utils`, offline README- und explizite Entry-Point-Linkpruefung in CI; CONTRIBUTING § README Link Convention.
-- **Nav-/Snapshot-Reconcile ([#3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) / PR [#4018](https://github.com/jannekbuengener/Claire_de_Binare/pull/4018)):** Entry-Point-Reconcile, Snapshot-Reconcile, Cross-Hub-Navigation.
-- **ARVP candidate evidence ([#4022](https://github.com/jannekbuengener/Claire_de_Binare/pull/4022)):** Deterministic candidate evidence packet assembly (shadow/research scope).
+- **Fast-CI Slice Gates ([#4204](https://github.com/jannekbuengener/Claire_de_Binare/issues/4204) / PR [#4236](https://github.com/jannekbuengener/Claire_de_Binare/pull/4236)):** Versionierte Slice-Policy, fail-closed unbekannte Pfade, Timing-Evidence.
+- **PR-Router Live-Konventionen ([#4228](https://github.com/jannekbuengener/Claire_de_Binare/issues/4228) / PR [#4231](https://github.com/jannekbuengener/Claire_de_Binare/pull/4231)):** Policy/Matcher an reale Titel-Token und `scope:*`/`type:*` Labels angeglichen.
+- **PR-Acceptance Skill Family ([#4211](https://github.com/jannekbuengener/Claire_de_Binare/pull/4211) / [#4216](https://github.com/jannekbuengener/Claire_de_Binare/pull/4216)):** Wiring-Audit, Gap-Classifier, Completeness-Review und Batch-Merge-Conductor.
 
-Operatives Cockpit: [Issue #1445](https://github.com/jannekbuengener/Claire_de_Binare/issues/1445). Community-Health-Reconcile: [Issue #4005](https://github.com/jannekbuengener/Claire_de_Binare/issues/4005) (in delivery). Vollstaendiges Session-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md).
+<!-- cdb:live-claim type=issue_state issue=1445 state=open -->
+Operatives Cockpit: [Issue #1445](https://github.com/jannekbuengener/Claire_de_Binare/issues/1445) (offen). Der Nav-/Snapshot-Reconcile [#3995](https://github.com/jannekbuengener/Claire_de_Binare/issues/3995) (PR [#4018](https://github.com/jannekbuengener/Claire_de_Binare/pull/4018)) und der Community-Health-Reconcile [#4005](https://github.com/jannekbuengener/Claire_de_Binare/issues/4005) (PR [#4024](https://github.com/jannekbuengener/Claire_de_Binare/pull/4024)) sind abgeschlossen. Vollstaendiges Session-Ledger: [`CURRENT_STATUS.md`](CURRENT_STATUS.md).
+
+Dieser Abschnitt ist ein Live-Claim und wird von `python -m tools.validate_status_freshness` semantisch geprueft; die Markerkonvention steht in [`docs/meta/REPOSITORY_CANON.md`](docs/meta/REPOSITORY_CANON.md).
 
 LR bleibt **NO-GO** — SSOT: [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md).
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 ## Current-main Snapshot
 
 <!-- cdb:status-freshness header-date=2026-07-31 -->
-<!-- cdb:live-claim type=main_sha value=e96f724c -->
-Auf `origin/main` (`e96f724c`, Stand 2026-07-31) sind die juengsten relevanten Merge-Cluster u. a.:
+<!-- cdb:live-claim type=main_sha value=eddcd1bc -->
+Auf `origin/main` (`eddcd1bc`, Stand 2026-07-31) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **Fast-CI Slice Gates ([#4204](https://github.com/jannekbuengener/Claire_de_Binare/issues/4204) / PR [#4236](https://github.com/jannekbuengener/Claire_de_Binare/pull/4236)):** Versionierte Slice-Policy, fail-closed unbekannte Pfade, Timing-Evidence.
-- **PR-Router Live-Konventionen ([#4228](https://github.com/jannekbuengener/Claire_de_Binare/issues/4228) / PR [#4231](https://github.com/jannekbuengener/Claire_de_Binare/pull/4231)):** Policy/Matcher an reale Titel-Token und `scope:*`/`type:*` Labels angeglichen.
+- **Multitask-Welle [#4238](https://github.com/jannekbuengener/Claire_de_Binare/pull/4238)–[#4241](https://github.com/jannekbuengener/Claire_de_Binare/pull/4241):** Evidence-harvester Test-Isolation, Dockerfile Discovery Guard, TLS-Overlay Quarantine, Regime Offline-UNKNOWN — Tip `eddcd1bc`.
+- **Fast-CI Slice Gates ([#4204](https://github.com/jannekbuengener/Claire_de_Binare/issues/4204) / PR [#4236](https://github.com/jannekbuengener/Claire_de_Binare/pull/4236)):** **CLOSED/MERGED** — Versionierte Slice-Policy, fail-closed unbekannte Pfade, Timing-Evidence.
+- **PR-Router Live-Konventionen ([#4228](https://github.com/jannekbuengener/Claire_de_Binare/issues/4228) / PR [#4231](https://github.com/jannekbuengener/Claire_de_Binare/pull/4231)):** **CLOSED/MERGED** — Policy/Matcher an reale Titel-Token und `scope:*`/`type:*` Labels angeglichen.
 - **PR-Acceptance Skill Family ([#4211](https://github.com/jannekbuengener/Claire_de_Binare/pull/4211) / [#4216](https://github.com/jannekbuengener/Claire_de_Binare/pull/4216)):** Wiring-Audit, Gap-Classifier, Completeness-Review und Batch-Merge-Conductor.
 
 <!-- cdb:live-claim type=issue_state issue=1445 state=open -->

--- a/ci/stages/docs.py
+++ b/ci/stages/docs.py
@@ -14,6 +14,7 @@ def run(ctx: StageContext) -> StageResult:
         commands=[
             [py, "-m", "tools.validate_onboarding_docs"],
             [py, "-m", "tools.validate_readme_links"],
+            [py, "-m", "tools.validate_status_freshness"],
             [py, "-m", "tools.ci.docs_conflict_guard"],
             [py, "-m", "tools.ci.repository_canon_guard"],
         ],

--- a/docs/meta/REPOSITORY_CANON.md
+++ b/docs/meta/REPOSITORY_CANON.md
@@ -56,6 +56,58 @@ einzigen generischen "Current Status"-Datei gebuendelt.
 - Neue Reports, Pass-Reports oder Audit-Snapshots duerfen scope-lokale Findings
   dokumentieren, aber nicht als aktuelle repo-weite Wahrheit auftreten.
 
+## Status Freshness Rule
+
+Status-Flaechen mischen zwei Sorten von Aussagen: **Live-Claims**, die nur
+solange stimmen wie die Realitaet sie stuetzt, und **append-only Historie**,
+die den Stand eines vergangenen Zeitpunkts festhaelt und bewusst nicht
+nachgezogen wird. Beides muss maschinell unterscheidbar sein.
+
+Der Guard `python -m tools.validate_status_freshness` prueft die Live-Claims
+von `README.md`, `CURRENT_STATUS.md` und `docs/runbooks/CONTROL_REGISTER.md`
+semantisch. Er vergleicht bewusst **kein** Alter und kein Aenderungsdatum: ein
+altes Dokument besteht, solange jeder Live-Claim weiterhin zutrifft, und ein
+heute editiertes Dokument faellt durch, sobald es einen ueberholten Zustand
+behauptet.
+
+### Markerkonvention
+
+| Marker | Bedeutung |
+| --- | --- |
+| `<!-- cdb:status-freshness header-date=YYYY-MM-DD -->` | Header-Datum des Dokuments; muss im sichtbaren Text neben dem Marker stehen und darf nicht aelter sein als das juengste im Body verwendete Datum |
+| `<!-- cdb:live-claim type=main_sha value=<sha> -->` | Das Dokument behauptet einen bestaetigten `origin/main`-Stand |
+| `<!-- cdb:live-claim type=issue_state issue=<n> state=open\|closed\|merged -->` | Das Dokument behauptet einen aktuellen Issue-/PR-Zustand |
+| `<!-- cdb:historical-as-of date=YYYY-MM-DD -->` … `<!-- cdb:historical-end -->` | Absichtlicher historischer Snapshot; von Live-Pruefungen ausgenommen |
+
+### Ergebnisklassen
+
+- `PASS` — Claim ist gegen Git bzw. GitHub belegt.
+- `FAIL` — Claim widerspricht dem belegten Zustand, oder die Markierung ist
+  strukturell defekt.
+- `UNVERIFIED` — Git- oder GitHub-Zugriff fehlt. Ein GitHub-abhaengiger Claim
+  gilt bei API-Ausfall nie als `PASS`; `--strict` macht `UNVERIFIED` zum Fehler.
+
+### Semantik der Claim-Typen
+
+- `main_sha`: Der genannte Commit muss von `origin/main` aus erreichbar sein und
+  alle Flaechen muessen denselben Stand nennen. Ein fortschreitendes `main`
+  entwertet einen korrekten Snapshot damit nicht, ein erfundener oder
+  divergierender Snapshot dagegen schon.
+- `issue_state`: Der deklarierte Zustand wird gegen GitHub live geprueft.
+- `header_date`: Reine Konsistenzpruefung innerhalb des Dokuments.
+
+### Regeln fuer Autoren
+
+- Ein absichtlicher historischer Snapshot wird durch ein
+  `historical-as-of`/`historical-end`-Paar markiert; sein Datum darf nicht
+  neuer sein als das Header-Datum.
+- In einem historischen Block darf kein `live-claim` stehen.
+- Live-Claims in Prosa (`origin/main` mit Commit, `in delivery` mit
+  Issue-Referenz) brauchen einen passenden Marker, sonst schlaegt der Guard
+  fehl. Damit kann Drift nicht unbemerkt neu entstehen.
+- Historische Ledger-Eintraege werden nicht umgeschrieben. Ein Reconcile-Ergebnis
+  gehoert in den aktuellen Block, nicht in den historischen.
+
 ## Operational Runbook Canon Rule
 
 - Aktive Operating Rules und operator-nahe Runbooks gehoeren unter `knowledge/operating_rules/`.

--- a/docs/runbooks/CONTROL_REGISTER.md
+++ b/docs/runbooks/CONTROL_REGISTER.md
@@ -1,9 +1,11 @@
 # Control Register
 
-**Letzte Aktualisierung:** 2026-07-14 (Reconcile-Batch #4041/#4043/#4045/#4053/#4057/#4060/#4066/#4084/#4086)
+<!-- cdb:status-freshness header-date=2026-07-16 -->
+**Letzte Aktualisierung:** 2026-07-16 (Workflow-Hygiene und Action-Bump-Reconciles #4100/#4101; vorheriger Stand 2026-07-14 mit Reconcile-Batch #4041/#4043/#4045/#4053/#4057/#4060/#4066/#4084/#4086)
 **SSOT Live-Readiness:** [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../live-readiness/LR-AUDIT-STATUS-2026-03-05.md)
 **Verdict:** NO-GO
 **Control-Board Stage:** `trade-capable` (ratifiziert 2026-04-08 via Issue [#1492](https://github.com/jannekbuengener/Claire_de_Binare/issues/1492))
+**Freshness Guard:** Header- und Body-Datum werden von `python -m tools.validate_status_freshness` gegeneinander geprueft; append-only Notizbloecke sind als `historical as of` markiert. Markerkonvention: [`docs/meta/REPOSITORY_CANON.md`](../meta/REPOSITORY_CANON.md).
 
 ---
 
@@ -127,7 +129,12 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 
 ---
 
+<!-- cdb:historical-as-of date=2026-07-16 -->
 ## Workflow-Control-Notizen
+
+Append-only Notizen zu einzelnen Workflow-Merges. Jeder Eintrag beschreibt den
+Stand zu seinem eigenen Zeitpunkt und wird nicht rueckwirkend umgeschrieben;
+der Block ist daher von der Live-Freshness-Pruefung ausgenommen.
 
 - Dependabot Autopilot (PRs #4062, #4067): Der fail-closed Klassifikator liest normalisierte Fakten gegen die versionierte Phase-1-Allowlist. Der Broker ist **report-only**; `ELIGIBLE` autorisiert keinen Merge, `merge_authorized=false`, keine GitHub-Mutation und keine Runtime-/LR-Ableitung. Phase-1-Kill-Switch/Merge-Ausführung bleibt außerhalb dieses Control-Stands.
 - `security-scan.yml` / Prometheus (PR #4083, gemergt 2026-07-14, Commit `2081d41d`): Scan-cleared Pin `prom/prometheus:v3.13.0@sha256:c6b27ea…` → `v3.13.1@sha256:3c42b892…` in Security-Matrix, Shared Base, RED und v3-Overlay synchron nachgezogen. `CVE-2026-39822` ist im validierten Kandidaten nicht mehr vorhanden; Postgres/Grafana bleiben upstream-abhaengig und unveraendert. Keine Alert-Dismissals, kein Runtime-Deploy, LR **NO-GO**.
@@ -184,6 +191,8 @@ Kontext-Issue-Nummern sind historische Anker (alle CLOSED) — nicht als offene 
 - Action-Dependency-Bump (PR #4050, gemergt 2026-07-16T11:59:57Z, Commit `ef101952`): Konsolidierter `github/codeql-action` Bump 4.36.3→4.37.0 (`99df26d4f13ea111d4ec1a7dddef6063f76b97e9`) fuer `init`/`analyze`/`upload-sarif` in `codeql-python.yml`, `gitleaks.yml`, `security-scan.yml` und `trivy.yml`. Repo-seitig bleiben Trigger, Permissions, Queries, lokale `config-file`-Referenz, SARIF-Kategorien und die `upload: false`-Posture des Advanced-CodeQL-Workflows unveraendert; upstream wechselt das Default-CodeQL-Bundle auf 2.26.0 und ergaenzt schrittweise ein alternatives `config-file`-Kurzformat, das der lokale Pfad nicht nutzt. Control-Reconcile [#4101](https://github.com/jannekbuengener/Claire_de_Binare/issues/4101). Kein LR-/Live-/Echtgeld-Signal.
 
 ---
+
+<!-- cdb:historical-end -->
 
 ## Manuelle HITL-Klassifikation
 

--- a/knowledge/logs/sessions/2026-07-31-status-ssot-freshness-guard-4119.md
+++ b/knowledge/logs/sessions/2026-07-31-status-ssot-freshness-guard-4119.md
@@ -1,0 +1,80 @@
+# Session Log — 2026-07-31 — Status-SSOT Reconcile + Freshness-Guard (#4119)
+
+Issue: [#4119](https://github.com/jannekbuengener/Claire_de_Binare/issues/4119)
+Branch: `cloud-cursor/status-ssot-freshness-guard-0c03`
+Base: `origin/main` @ `e96f724c6a6615fea8bda8adc707b51fbd6bcf84`
+Status: `DONE_SLICE_ADDED_TO_BATCH_PR`
+
+## Bootloader
+
+- `AGENTS.md` → `agents/AGENTS.md` → Read Order ausgefuehrt.
+- Context-Brain-Preflight versucht: kein Context-/SurrealDB-/MCP-Tool im aktiven
+  MCP-Surface (`GetMcpTools` Suche nach `context|surreal|brain|cdb` → 0 Treffer;
+  nur `cursor-cloud` verfuegbar). Repo-Fallback mit
+  `repo_fallback_reason=unavailable`, `context_tool_status=absent`,
+  `context_trust_level=none`, `records_found=0`.
+- PR-Router (`python -m tools.pr_routing route --issue 4119`):
+  `routing_decision=CREATE_NEW_BATCH_PR`, `lane=docs-governance`,
+  `lock_state=UNLOCKED`, kein HOLD. Keine Wiederverwendung eines PR mit
+  anderen Wave-Issues.
+
+## Claim Inventory (Live-Abgleich)
+
+| Fläche | Claim (vorher) | Live-Befund | Ergebnis |
+|---|---|---|---|
+| `README.md` | `origin/main` @ `f9e0cb0a`, Stand 2026-07-13 | `origin/main` @ `e96f724c` | reconciled |
+| `README.md` | #4005 „in delivery“ | #4005 CLOSED (PR #4024 @ `13eab660`) | reconciled |
+| `README.md` | #3995 als Merge-Cluster | #3995 CLOSED (PR #4018 @ `60ddf8b3`) | reconciled |
+| `CURRENT_STATUS.md` | Header `Last Updated: 2026-07-31` | jüngstes Bodydatum 2026-07-31 | konsistent |
+| `CURRENT_STATUS.md` | Reconciles #4099/#4103/#4104/#4105 fehlten | alle vier MERGED | in aktuellen Block aufgenommen |
+| `CONTROL_REGISTER.md` | Header 2026-07-14 | Bodyeinträge bis 2026-07-16 | Header auf 2026-07-16 korrigiert |
+
+`#1445` bleibt OPEN und ist als Live-Claim deklariert.
+
+## Historical Boundaries
+
+- `CURRENT_STATUS.md`: `historical-as-of=2026-07-30` ab dem zweitneuesten
+  Datumsblock bis vor `## Live-Readiness`. Alle Altzeilen (u. a. „#3995 OPEN —
+  nav/snapshot reconcile in delivery“ vom 2026-07-12) bleiben wortgleich.
+- `CONTROL_REGISTER.md`: `historical-as-of=2026-07-16` für den append-only
+  Block `## Workflow-Control-Notizen`.
+- Kein historischer Eintrag wurde umgeschrieben oder gelöscht.
+
+## Freshness Semantics
+
+Neu: `tools/validate_status_freshness.py`, eingehängt in `ci/stages/docs.py`.
+Bewusst kein Alters- oder Datumsvergleich.
+
+- `main_sha`: deklarierter Commit muss existieren und von `origin/main` aus
+  erreichbar sein; alle Flächen müssen denselben Stand nennen.
+- `issue_state`: deklarierter Zustand wird gegen GitHub live geprüft.
+- `header_date`: Header-Datum muss neben dem Marker sichtbar sein und darf
+  nicht älter sein als das jüngste Bodydatum.
+- Ergebnisklassen `PASS` / `FAIL` / `UNVERIFIED`; GitHub-abhängige Claims gelten
+  bei API-Ausfall nie als `PASS`. `--strict` macht `UNVERIFIED` zum Fehler.
+- Historische Blöcke sind von Live-Prüfungen ausgenommen, ihre Markierung wird
+  aber validiert (Datum vorhanden, nicht neuer als Header, Regionen balanciert,
+  kein `live-claim` innerhalb).
+- Prosa-Live-Claims ohne Marker schlagen fehl, damit dieselbe Drift nicht
+  unbemerkt neu entsteht.
+
+Markerkonvention dokumentiert in `docs/meta/REPOSITORY_CANON.md`
+§ Status Freshness Rule.
+
+## Validation
+
+- `pytest -q tests/unit/tools/test_validate_status_freshness.py` — 21 passed
+- `pytest -q tests/unit/tools tests/unit/agents tests/unit/docs tests/unit/governance tests/unit/ci tests/smoke` — 2729 passed
+- `python -m tools.validate_status_freshness --strict` — 11 PASS, 0 FAIL, 0 UNVERIFIED
+- Negative Gegenprobe (synthetische Fläche): 3 FAIL, exit 1
+- `python ci/scripts/run.py --stage docs` — Stage `docs` PASS inkl. neuem Validator
+- `python -m tools.validate_root_layout` — ROOT LAYOUT PASS
+- `python -m tools.validate_readme_links` — PASS
+- `ruff check` + `black --check` auf geändertem Python-Scope — PASS
+- `git diff --check`, `gitleaks protect --staged` — PASS
+
+## Boundaries
+
+- LR bleibt **NO-GO**; Trennung `trade-capable` ↔ Live-Go unverändert.
+- Keine Runtime-, Docker-, DB-, MCP- oder Secret-Änderung.
+- Kein Full Fast-CI, kein `cdb-local-ci` Publish, kein Merge, kein Issue-Close.

--- a/tests/unit/tools/test_validate_status_freshness.py
+++ b/tests/unit/tools/test_validate_status_freshness.py
@@ -1,0 +1,433 @@
+"""Targeted tests for the semantic status freshness guard (#4119).
+
+The guard must fail on genuinely stale live claims, must accept correctly
+marked historical blocks, and must accept an old-but-still-correct document.
+A pure age or date comparison would violate all three expectations at once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools import validate_status_freshness as guard
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CURRENT_SHA = "aaaaaaaabbbbbbbbccccccccdddddddd11111111"
+UNKNOWN_SHA = "ffffffffeeeeeeeeddddddddcccccccc22222222"
+
+
+class FakeGit:
+    def __init__(
+        self,
+        reachable: set[str] | None = None,
+        resolvable: bool = True,
+        known: set[str] | None = None,
+    ):
+        self._reachable = reachable if reachable is not None else {CURRENT_SHA}
+        self._known = known if known is not None else self._reachable
+        self._resolvable = resolvable
+
+    def reachability_from_main(self, sha: str) -> str:
+        if not self._resolvable:
+            return guard.GIT_UNAVAILABLE
+        if not any(candidate.startswith(sha) for candidate in self._known):
+            return guard.UNKNOWN_OBJECT
+        if any(candidate.startswith(sha) for candidate in self._reachable):
+            return guard.REACHABLE
+        return guard.NOT_REACHABLE
+
+
+class FakeIssues:
+    def __init__(self, states: dict[int, str] | None = None):
+        self._states = states or {}
+
+    def state(self, number: int) -> str | None:
+        return self._states.get(number)
+
+
+def run(
+    documents: dict[str, str],
+    *,
+    git: FakeGit | None = None,
+    issues: FakeIssues | None = None,
+) -> list[guard.ClaimResult]:
+    docs = [guard.parse_surface(name, text) for name, text in documents.items()]
+    return guard.validate_documents(docs, git or FakeGit(), issues or FakeIssues())
+
+
+def statuses(results: list[guard.ClaimResult], claim_type: str) -> set[str]:
+    return {r.status for r in results if r.claim_type == claim_type}
+
+
+def failures(results: list[guard.ClaimResult]) -> list[guard.ClaimResult]:
+    return [r for r in results if r.status == guard.FAIL]
+
+
+CORRECT_DOC = f"""# Current Status
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:live-claim type=main_sha value={CURRENT_SHA[:8]} -->
+Auf `origin/main` (`{CURRENT_SHA[:8]}`) steht der bestaetigte Stand.
+
+<!-- cdb:live-claim type=issue_state issue=1445 state=open -->
+Operatives Cockpit: #1445.
+
+<!-- cdb:historical-as-of date=2026-07-12 -->
+## Repo / Engineering Status (2026-07-12)
+
+- #3995 (OPEN — nav/snapshot reconcile in delivery)
+<!-- cdb:historical-end -->
+"""
+
+
+@pytest.mark.unit
+def test_correct_document_passes_without_failures():
+    results = run({"doc.md": CORRECT_DOC}, issues=FakeIssues({1445: "open"}))
+
+    assert failures(results) == []
+    assert statuses(results, "main_sha") == {guard.PASS}
+    assert statuses(results, "issue_state") == {guard.PASS}
+    assert statuses(results, "header_date") == {guard.PASS}
+
+
+@pytest.mark.unit
+def test_stale_issue_state_claim_fails():
+    doc = CORRECT_DOC.replace("issue=1445 state=open", "issue=4005 state=open").replace(
+        "#1445.", "#4005."
+    )
+
+    results = run({"doc.md": doc}, issues=FakeIssues({4005: "closed"}))
+
+    detail = [r.detail for r in failures(results) if r.claim_type == "issue_state"]
+    assert detail == ["#4005 is declared open but GitHub reports closed"]
+
+
+@pytest.mark.unit
+def test_main_sha_claim_not_reachable_from_main_fails():
+    doc = CORRECT_DOC.replace(CURRENT_SHA[:8], UNKNOWN_SHA[:8])
+
+    results = run(
+        {"doc.md": doc},
+        git=FakeGit(reachable={CURRENT_SHA}, known={CURRENT_SHA, UNKNOWN_SHA}),
+        issues=FakeIssues({1445: "open"}),
+    )
+
+    assert any(
+        r.claim_type == "main_sha" and "not reachable from origin/main" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_fabricated_main_sha_claim_fails_instead_of_unverified():
+    doc = CORRECT_DOC.replace(CURRENT_SHA[:8], "deadbee")
+
+    results = run({"doc.md": doc}, issues=FakeIssues({1445: "open"}))
+
+    assert any(
+        r.claim_type == "main_sha" and "does not exist in this repository" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_header_date_older_than_newest_body_date_fails():
+    doc = """# Control Register
+
+<!-- cdb:status-freshness header-date=2026-07-14 -->
+**Letzte Aktualisierung:** 2026-07-14
+
+- Workflow-Hygiene (2026-07-16): Bestand nachgezogen.
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any(
+        r.claim_type == "header_date"
+        and "older than the newest body date 2026-07-16" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_header_date_not_anchored_to_visible_text_fails():
+    doc = """# Control Register
+
+<!-- cdb:status-freshness header-date=2026-07-16 -->
+**Letzte Aktualisierung:** 2026-07-14
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any(
+        r.claim_type == "header_date"
+        and "is not visible in the document text" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_marked_historical_block_is_exempt_from_live_verification():
+    doc = f"""# Ledger
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:historical-as-of date=2026-07-12 -->
+## Repo / Engineering Status (2026-07-12)
+
+- Auf `origin/main` (`{UNKNOWN_SHA[:8]}`) stand damals der Cluster.
+- #3995 OPEN — nav/snapshot reconcile in delivery.
+<!-- cdb:historical-end -->
+"""
+
+    results = run({"doc.md": doc})
+
+    assert failures(results) == []
+    assert statuses(results, "historical_marking") == {guard.PASS}
+
+
+@pytest.mark.unit
+def test_old_but_still_correct_document_passes():
+    doc = f"""# Legacy Status Surface
+
+<!-- cdb:status-freshness header-date=2024-01-05 -->
+**Last Updated**: 2024-01-05
+
+<!-- cdb:live-claim type=main_sha value={CURRENT_SHA[:8]} -->
+Bestaetigter Stand auf `origin/main` (`{CURRENT_SHA[:8]}`).
+
+<!-- cdb:live-claim type=issue_state issue=1445 state=open -->
+Cockpit #1445 bleibt offen.
+"""
+
+    results = run({"doc.md": doc}, issues=FakeIssues({1445: "open"}))
+
+    assert failures(results) == []
+    assert statuses(results, "header_date") == {guard.PASS}
+
+
+@pytest.mark.unit
+def test_unmarked_historical_block_is_treated_as_live_and_fails():
+    doc = f"""# Ledger
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+## Repo / Engineering Status (2026-07-12)
+
+- Auf `origin/main` (`{UNKNOWN_SHA[:8]}`) stand damals der Cluster.
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any(
+        r.claim_type == "main_sha" and "without a matching cdb:live-claim" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_live_claim_inside_historical_block_fails():
+    doc = f"""# Ledger
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:historical-as-of date=2026-07-12 -->
+<!-- cdb:live-claim type=main_sha value={CURRENT_SHA[:8]} -->
+<!-- cdb:historical-end -->
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any(
+        r.claim_type == "historical_marking"
+        and "must not assert live state" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_unclosed_historical_region_fails():
+    doc = """# Ledger
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:historical-as-of date=2026-07-12 -->
+- historischer Eintrag
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any("never closed" in r.detail for r in failures(results))
+
+
+@pytest.mark.unit
+def test_historical_marker_without_date_fails():
+    doc = """# Ledger
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:historical-as-of -->
+- historischer Eintrag
+<!-- cdb:historical-end -->
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any(
+        "missing or malformed date attribute" in r.detail for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_historical_block_newer_than_header_date_fails():
+    doc = """# Ledger
+
+<!-- cdb:status-freshness header-date=2026-07-12 -->
+**Last Updated**: 2026-07-12
+
+<!-- cdb:historical-as-of date=2026-07-31 -->
+- angeblich historischer Eintrag aus der Zukunft
+<!-- cdb:historical-end -->
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any(
+        r.claim_type == "historical_marking"
+        and "is newer than the header-date" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_prose_in_delivery_without_declaration_fails():
+    doc = """# Front Door
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+Community-Health-Reconcile: Issue #4005 (in delivery).
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any(
+        r.claim_type == "issue_state" and "#4005" in r.detail for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_prose_in_delivery_with_declaration_is_verified_against_github():
+    doc = """# Front Door
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:live-claim type=issue_state issue=4005 state=open -->
+Community-Health-Reconcile: Issue #4005 (in delivery).
+"""
+
+    results = run({"doc.md": doc}, issues=FakeIssues({4005: "closed"}))
+
+    assert [r.detail for r in failures(results)] == [
+        "#4005 is declared open but GitHub reports closed"
+    ]
+
+
+@pytest.mark.unit
+def test_diverging_main_sha_between_surfaces_fails():
+    readme = f"""# README
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:live-claim type=main_sha value={CURRENT_SHA[:8]} -->
+Stand `origin/main` (`{CURRENT_SHA[:8]}`).
+"""
+    status = f"""# Status
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:live-claim type=main_sha value={UNKNOWN_SHA[:8]} -->
+Stand `origin/main` (`{UNKNOWN_SHA[:8]}`).
+"""
+
+    results = run(
+        {"README.md": readme, "CURRENT_STATUS.md": status},
+        git=FakeGit(reachable={CURRENT_SHA, UNKNOWN_SHA}),
+    )
+
+    assert any(
+        "status surfaces must agree on one confirmed main state" in r.detail
+        for r in failures(results)
+    )
+
+
+@pytest.mark.unit
+def test_github_unavailable_yields_unverified_not_pass():
+    results = run({"doc.md": CORRECT_DOC}, issues=FakeIssues({}))
+
+    assert statuses(results, "issue_state") == {guard.UNVERIFIED}
+    assert failures(results) == []
+
+
+@pytest.mark.unit
+def test_git_unavailable_yields_unverified_not_pass():
+    results = run(
+        {"doc.md": CORRECT_DOC},
+        git=FakeGit(resolvable=False),
+        issues=FakeIssues({1445: "open"}),
+    )
+
+    assert statuses(results, "main_sha") == {guard.UNVERIFIED}
+    assert failures(results) == []
+
+
+@pytest.mark.unit
+def test_unsupported_claim_type_fails():
+    doc = """# Doc
+
+<!-- cdb:status-freshness header-date=2026-07-31 -->
+**Last Updated**: 2026-07-31
+
+<!-- cdb:live-claim type=vibes value=good -->
+"""
+
+    results = run({"doc.md": doc})
+
+    assert any("unsupported live-claim type" in r.detail for r in failures(results))
+
+
+@pytest.mark.unit
+def test_missing_surface_is_reported_as_failure(tmp_path: Path):
+    results = guard.validate_all(
+        tmp_path,
+        surfaces=("does-not-exist.md",),
+        git=FakeGit(),
+        issues=FakeIssues(),
+    )
+
+    assert [r.detail for r in failures(results)] == ["registered surface is missing"]
+
+
+@pytest.mark.unit
+def test_repository_status_surfaces_have_no_failing_claims():
+    """The real repository surfaces must be reconciled and marker-consistent."""
+    results = guard.validate_all(
+        REPO_ROOT,
+        git=FakeGit(resolvable=False),
+        issues=FakeIssues({}),
+    )
+
+    assert [f"{r.surface}:{r.line} {r.detail}" for r in failures(results)] == []

--- a/tools/validate_status_freshness.py
+++ b/tools/validate_status_freshness.py
@@ -1,0 +1,805 @@
+"""Semantic freshness guard for repository status surfaces.
+
+The guard validates *declared* live claims on the canonical status surfaces
+(`README.md`, `CURRENT_STATUS.md`, `docs/runbooks/CONTROL_REGISTER.md`).
+It is deliberately **not** an age or "last touched" comparison: a document may
+be arbitrarily old and still pass as long as every live claim it makes is still
+true. Conversely, a document edited today fails if it asserts a stale issue
+state.
+
+Marker grammar (HTML comments, invisible in rendered Markdown)::
+
+    <!-- cdb:status-freshness header-date=YYYY-MM-DD -->
+    <!-- cdb:live-claim type=main_sha value=<sha> -->
+    <!-- cdb:live-claim type=issue_state issue=<n> state=open|closed|merged -->
+    <!-- cdb:historical-as-of date=YYYY-MM-DD -->
+    <!-- cdb:historical-end -->
+
+Claim semantics:
+
+``main_sha``
+    The declared commit must exist and be reachable from ``origin/main``, and
+    every surface declaring a main SHA must declare the same one. A moving
+    ``main`` therefore does not invalidate a correct snapshot, but a
+    fabricated, rewritten or diverging snapshot does.
+
+``issue_state``
+    The declared state must match the live GitHub state. Without a working
+    ``gh`` CLI the claim is reported ``UNVERIFIED`` — never ``PASS``.
+
+``header_date``
+    The declared header date must be visible in the rendered text next to the
+    marker and must not be older than the newest date used anywhere in the
+    body. This is an internal-consistency check, not a freshness-by-age check.
+
+Historical regions are exempt from live verification, but their marking is
+validated: the ``date`` attribute is mandatory, must not be newer than the
+header date, regions must be balanced, and a historical region must not assert
+live state.
+
+Usage::
+
+    python -m tools.validate_status_freshness
+    python -m tools.validate_status_freshness --strict
+    python -m tools.validate_status_freshness --json
+
+Exit codes:
+    0 - no FAIL results (UNVERIFIED tolerated unless ``--strict``)
+    1 - at least one FAIL result, or an UNVERIFIED result under ``--strict``
+
+Issue: #4119
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Iterable, Protocol, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_SURFACES: tuple[str, ...] = (
+    "README.md",
+    "CURRENT_STATUS.md",
+    "docs/runbooks/CONTROL_REGISTER.md",
+)
+
+PASS = "PASS"
+FAIL = "FAIL"
+UNVERIFIED = "UNVERIFIED"
+
+_MARKER_RE = re.compile(r"<!--\s*cdb:(?P<kind>[a-z-]+)(?P<attrs>[^>]*?)-->")
+_ATTR_RE = re.compile(r"(?P<key>[a-z-]+)=(?P<value>[^\s]+)")
+_ISO_DATE_RE = re.compile(r"\b(20\d{2})-(\d{2})-(\d{2})\b")
+_SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+
+# Prose patterns that constitute a live claim and therefore must be declared.
+_PROSE_MAIN_SHA_RE = re.compile(r"origin/main[^\n]*?`(?P<sha>[0-9a-f]{7,40})`")
+_PROSE_IN_DELIVERY_RE = re.compile(r"in delivery", re.IGNORECASE)
+_PROSE_ISSUE_REF_RE = re.compile(r"#(?P<issue>\d{2,6})\b")
+
+# How far from the marker the declared header date must be visible in prose.
+_HEADER_ANCHOR_RADIUS = 5
+
+
+REACHABLE = "reachable"
+NOT_REACHABLE = "not_reachable"
+UNKNOWN_OBJECT = "unknown_object"
+GIT_UNAVAILABLE = "unavailable"
+
+
+class GitResolver(Protocol):
+    """Resolves git facts needed by the ``main_sha`` claim."""
+
+    def reachability_from_main(self, sha: str) -> str:
+        """One of REACHABLE, NOT_REACHABLE, UNKNOWN_OBJECT, GIT_UNAVAILABLE."""
+
+
+class IssueStateResolver(Protocol):
+    """Resolves the live GitHub state of an issue or pull request."""
+
+    def state(self, number: int) -> str | None: ...
+
+
+class SubprocessGitResolver:
+    def __init__(self, root: Path, ref: str = "origin/main") -> None:
+        self._root = root
+        self._ref = ref
+
+    def _run(self, args: Sequence[str]) -> subprocess.CompletedProcess[str] | None:
+        try:
+            return subprocess.run(
+                list(args),
+                cwd=self._root,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    def _resolve_main_sha(self) -> str | None:
+        result = self._run(["git", "rev-parse", self._ref])
+        if result is None or result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
+
+    def reachability_from_main(self, sha: str) -> str:
+        if self._resolve_main_sha() is None:
+            return GIT_UNAVAILABLE
+        exists = self._run(["git", "cat-file", "-e", f"{sha}^{{commit}}"])
+        if exists is None:
+            return GIT_UNAVAILABLE
+        if exists.returncode != 0:
+            return UNKNOWN_OBJECT
+        result = self._run(["git", "merge-base", "--is-ancestor", sha, self._ref])
+        if result is None:
+            return GIT_UNAVAILABLE
+        if result.returncode == 0:
+            return REACHABLE
+        if result.returncode == 1:
+            return NOT_REACHABLE
+        return GIT_UNAVAILABLE
+
+
+class GhIssueStateResolver:
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self._cache: dict[int, str | None] = {}
+
+    def state(self, number: int) -> str | None:
+        if number in self._cache:
+            return self._cache[number]
+        resolved = self._query(number)
+        self._cache[number] = resolved
+        return resolved
+
+    def _query(self, number: int) -> str | None:
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "view", str(number), "--json", "state"],
+                cwd=self._root,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return None
+        state = payload.get("state")
+        return str(state).lower() if state else None
+
+
+@dataclass(frozen=True)
+class Marker:
+    kind: str
+    attrs: dict[str, str]
+    line: int
+
+
+@dataclass(frozen=True)
+class ClaimResult:
+    surface: str
+    line: int
+    claim_type: str
+    status: str
+    detail: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "surface": self.surface,
+            "line": self.line,
+            "claim_type": self.claim_type,
+            "status": self.status,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class HistoricalRegion:
+    start_line: int
+    end_line: int
+    as_of: date | None
+
+    def contains(self, line: int) -> bool:
+        return self.start_line <= line <= self.end_line
+
+
+@dataclass
+class SurfaceDocument:
+    surface: str
+    lines: list[str]
+    markers: list[Marker]
+    historical_regions: list[HistoricalRegion]
+    structural_failures: list[ClaimResult]
+
+    def in_historical_region(self, line: int) -> bool:
+        return any(region.contains(line) for region in self.historical_regions)
+
+
+def _parse_attrs(raw: str) -> dict[str, str]:
+    return {m.group("key"): m.group("value") for m in _ATTR_RE.finditer(raw)}
+
+
+def _parse_iso_date(raw: str) -> date | None:
+    match = _ISO_DATE_RE.fullmatch(raw.strip())
+    if match is None:
+        return None
+    try:
+        return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except ValueError:
+        return None
+
+
+def parse_surface(surface: str, content: str) -> SurfaceDocument:
+    lines = content.splitlines()
+    markers: list[Marker] = []
+    for index, line in enumerate(lines, start=1):
+        for match in _MARKER_RE.finditer(line):
+            markers.append(
+                Marker(
+                    kind=match.group("kind"),
+                    attrs=_parse_attrs(match.group("attrs")),
+                    line=index,
+                )
+            )
+
+    regions: list[HistoricalRegion] = []
+    failures: list[ClaimResult] = []
+    open_marker: Marker | None = None
+
+    for marker in markers:
+        if marker.kind == "historical-as-of":
+            if open_marker is not None:
+                failures.append(
+                    ClaimResult(
+                        surface,
+                        marker.line,
+                        "historical_marking",
+                        FAIL,
+                        f"nested historical region; previous region opened at line {open_marker.line}",
+                    )
+                )
+                continue
+            open_marker = marker
+        elif marker.kind == "historical-end":
+            if open_marker is None:
+                failures.append(
+                    ClaimResult(
+                        surface,
+                        marker.line,
+                        "historical_marking",
+                        FAIL,
+                        "historical-end without a matching historical-as-of",
+                    )
+                )
+                continue
+            regions.append(
+                HistoricalRegion(
+                    start_line=open_marker.line,
+                    end_line=marker.line,
+                    as_of=_parse_iso_date(open_marker.attrs.get("date", "")),
+                )
+            )
+            open_marker = None
+
+    if open_marker is not None:
+        failures.append(
+            ClaimResult(
+                surface,
+                open_marker.line,
+                "historical_marking",
+                FAIL,
+                "historical region is never closed with historical-end",
+            )
+        )
+
+    return SurfaceDocument(
+        surface=surface,
+        lines=lines,
+        markers=markers,
+        historical_regions=regions,
+        structural_failures=failures,
+    )
+
+
+def _header_date(doc: SurfaceDocument) -> tuple[date | None, int]:
+    for marker in doc.markers:
+        if marker.kind != "status-freshness":
+            continue
+        raw = marker.attrs.get("header-date", "")
+        return _parse_iso_date(raw), marker.line
+    return None, 0
+
+
+def _body_dates(doc: SurfaceDocument) -> list[tuple[date, int]]:
+    found: list[tuple[date, int]] = []
+    for index, line in enumerate(doc.lines, start=1):
+        stripped = _MARKER_RE.sub("", line)
+        for match in _ISO_DATE_RE.finditer(stripped):
+            try:
+                found.append(
+                    (
+                        date(
+                            int(match.group(1)),
+                            int(match.group(2)),
+                            int(match.group(3)),
+                        ),
+                        index,
+                    )
+                )
+            except ValueError:
+                continue
+    return found
+
+
+def _check_header_date(doc: SurfaceDocument) -> list[ClaimResult]:
+    declared, marker_line = _header_date(doc)
+    if declared is None:
+        if marker_line:
+            return [
+                ClaimResult(
+                    doc.surface,
+                    marker_line,
+                    "header_date",
+                    FAIL,
+                    "status-freshness marker has a missing or malformed header-date",
+                )
+            ]
+        return []
+
+    results: list[ClaimResult] = []
+    anchor_start = max(0, marker_line - 1 - _HEADER_ANCHOR_RADIUS)
+    anchor_end = marker_line + _HEADER_ANCHOR_RADIUS
+    anchor = "\n".join(doc.lines[anchor_start:anchor_end])
+    if declared.isoformat() not in _MARKER_RE.sub("", anchor):
+        results.append(
+            ClaimResult(
+                doc.surface,
+                marker_line,
+                "header_date",
+                FAIL,
+                f"declared header-date {declared.isoformat()} is not visible in the "
+                f"document text within {_HEADER_ANCHOR_RADIUS} lines of the marker",
+            )
+        )
+
+    body = _body_dates(doc)
+    newest = max(body, default=None, key=lambda item: item[0])
+    if newest is not None and newest[0] > declared:
+        results.append(
+            ClaimResult(
+                doc.surface,
+                newest[1],
+                "header_date",
+                FAIL,
+                f"header-date {declared.isoformat()} is older than the newest body date "
+                f"{newest[0].isoformat()} (line {newest[1]})",
+            )
+        )
+
+    if not results:
+        results.append(
+            ClaimResult(
+                doc.surface,
+                marker_line,
+                "header_date",
+                PASS,
+                f"header-date {declared.isoformat()} covers every date used in the body",
+            )
+        )
+    return results
+
+
+def _check_historical_marking(doc: SurfaceDocument) -> list[ClaimResult]:
+    results = list(doc.structural_failures)
+    declared_header, _ = _header_date(doc)
+
+    for region in doc.historical_regions:
+        if region.as_of is None:
+            results.append(
+                ClaimResult(
+                    doc.surface,
+                    region.start_line,
+                    "historical_marking",
+                    FAIL,
+                    "historical-as-of marker has a missing or malformed date attribute",
+                )
+            )
+            continue
+        if declared_header is not None and region.as_of > declared_header:
+            results.append(
+                ClaimResult(
+                    doc.surface,
+                    region.start_line,
+                    "historical_marking",
+                    FAIL,
+                    f"historical-as-of {region.as_of.isoformat()} is newer than the "
+                    f"header-date {declared_header.isoformat()}",
+                )
+            )
+            continue
+        results.append(
+            ClaimResult(
+                doc.surface,
+                region.start_line,
+                "historical_marking",
+                PASS,
+                f"historical block marked as-of {region.as_of.isoformat()} and exempt "
+                "from live verification",
+            )
+        )
+
+    for marker in doc.markers:
+        if marker.kind == "live-claim" and doc.in_historical_region(marker.line):
+            results.append(
+                ClaimResult(
+                    doc.surface,
+                    marker.line,
+                    "historical_marking",
+                    FAIL,
+                    "live-claim declared inside a historical block; historical blocks "
+                    "must not assert live state",
+                )
+            )
+
+    return results
+
+
+def _live_claim_markers(doc: SurfaceDocument) -> list[Marker]:
+    return [
+        marker
+        for marker in doc.markers
+        if marker.kind == "live-claim" and not doc.in_historical_region(marker.line)
+    ]
+
+
+def _check_main_sha(
+    doc: SurfaceDocument, marker: Marker, git: GitResolver
+) -> ClaimResult:
+    value = marker.attrs.get("value", "").strip().lower()
+    if not _SHA_RE.fullmatch(value):
+        return ClaimResult(
+            doc.surface,
+            marker.line,
+            "main_sha",
+            FAIL,
+            f"main_sha claim has a missing or malformed value: {value!r}",
+        )
+
+    verdict = git.reachability_from_main(value)
+    if verdict == GIT_UNAVAILABLE:
+        return ClaimResult(
+            doc.surface,
+            marker.line,
+            "main_sha",
+            UNVERIFIED,
+            f"origin/main could not be resolved; claimed SHA {value} not verified",
+        )
+    if verdict == UNKNOWN_OBJECT:
+        return ClaimResult(
+            doc.surface,
+            marker.line,
+            "main_sha",
+            FAIL,
+            f"claimed main SHA {value} does not exist in this repository",
+        )
+    if verdict == NOT_REACHABLE:
+        return ClaimResult(
+            doc.surface,
+            marker.line,
+            "main_sha",
+            FAIL,
+            f"claimed main SHA {value} is not reachable from origin/main",
+        )
+    return ClaimResult(
+        doc.surface,
+        marker.line,
+        "main_sha",
+        PASS,
+        f"claimed main SHA {value} is reachable from origin/main",
+    )
+
+
+def _check_issue_state(
+    doc: SurfaceDocument, marker: Marker, issues: IssueStateResolver
+) -> ClaimResult:
+    raw_issue = marker.attrs.get("issue", "")
+    declared = marker.attrs.get("state", "").strip().lower()
+    if not raw_issue.isdigit() or not declared:
+        return ClaimResult(
+            doc.surface,
+            marker.line,
+            "issue_state",
+            FAIL,
+            "issue_state claim needs a numeric issue= and a non-empty state=",
+        )
+
+    number = int(raw_issue)
+    actual = issues.state(number)
+    if actual is None:
+        return ClaimResult(
+            doc.surface,
+            marker.line,
+            "issue_state",
+            UNVERIFIED,
+            f"GitHub state for #{number} is unavailable; declared {declared} not verified",
+        )
+    if actual != declared:
+        return ClaimResult(
+            doc.surface,
+            marker.line,
+            "issue_state",
+            FAIL,
+            f"#{number} is declared {declared} but GitHub reports {actual}",
+        )
+    return ClaimResult(
+        doc.surface,
+        marker.line,
+        "issue_state",
+        PASS,
+        f"#{number} is {actual} on GitHub as declared",
+    )
+
+
+def _check_undeclared_prose_claims(doc: SurfaceDocument) -> list[ClaimResult]:
+    """Reject live claims written in prose without a machine-checkable marker."""
+    results: list[ClaimResult] = []
+    declared_shas = {
+        marker.attrs.get("value", "").strip().lower()
+        for marker in _live_claim_markers(doc)
+        if marker.attrs.get("type") == "main_sha"
+    }
+    declared_issues = {
+        marker.attrs.get("issue", "")
+        for marker in _live_claim_markers(doc)
+        if marker.attrs.get("type") == "issue_state"
+    }
+
+    for index, line in enumerate(doc.lines, start=1):
+        if doc.in_historical_region(index):
+            continue
+
+        for match in _PROSE_MAIN_SHA_RE.finditer(line):
+            sha = match.group("sha").lower()
+            if not any(
+                sha.startswith(declared) or declared.startswith(sha)
+                for declared in declared_shas
+                if declared
+            ):
+                results.append(
+                    ClaimResult(
+                        doc.surface,
+                        index,
+                        "main_sha",
+                        FAIL,
+                        f"prose asserts origin/main at {sha} without a matching "
+                        "cdb:live-claim type=main_sha marker",
+                    )
+                )
+
+        if _PROSE_IN_DELIVERY_RE.search(line):
+            referenced = {m.group("issue") for m in _PROSE_ISSUE_REF_RE.finditer(line)}
+            missing = sorted(referenced - declared_issues)
+            if not referenced:
+                results.append(
+                    ClaimResult(
+                        doc.surface,
+                        index,
+                        "issue_state",
+                        FAIL,
+                        "prose claims 'in delivery' without an issue reference to verify",
+                    )
+                )
+            elif missing:
+                results.append(
+                    ClaimResult(
+                        doc.surface,
+                        index,
+                        "issue_state",
+                        FAIL,
+                        "prose claims 'in delivery' for "
+                        + ", ".join(f"#{n}" for n in missing)
+                        + " without a matching cdb:live-claim type=issue_state marker",
+                    )
+                )
+
+    return results
+
+
+def _check_cross_surface_main_sha(
+    docs: Iterable[SurfaceDocument],
+) -> list[ClaimResult]:
+    declared: list[tuple[str, int, str]] = []
+    for doc in docs:
+        for marker in _live_claim_markers(doc):
+            if marker.attrs.get("type") != "main_sha":
+                continue
+            value = marker.attrs.get("value", "").strip().lower()
+            if value:
+                declared.append((doc.surface, marker.line, value))
+
+    if len(declared) < 2:
+        return []
+
+    reference = declared[0][2]
+    results: list[ClaimResult] = []
+    for surface, line, value in declared[1:]:
+        if not (value.startswith(reference) or reference.startswith(value)):
+            results.append(
+                ClaimResult(
+                    surface,
+                    line,
+                    "main_sha",
+                    FAIL,
+                    f"declares main SHA {value} while {declared[0][0]} declares "
+                    f"{reference}; status surfaces must agree on one confirmed main state",
+                )
+            )
+    if not results:
+        results.append(
+            ClaimResult(
+                declared[0][0],
+                declared[0][1],
+                "main_sha",
+                PASS,
+                f"all {len(declared)} surfaces declare the same main state {reference}",
+            )
+        )
+    return results
+
+
+def validate_documents(
+    docs: Sequence[SurfaceDocument],
+    git: GitResolver,
+    issues: IssueStateResolver,
+) -> list[ClaimResult]:
+    results: list[ClaimResult] = []
+    for doc in docs:
+        results.extend(_check_historical_marking(doc))
+        results.extend(_check_header_date(doc))
+        results.extend(_check_undeclared_prose_claims(doc))
+        for marker in _live_claim_markers(doc):
+            claim_type = marker.attrs.get("type", "")
+            if claim_type == "main_sha":
+                results.append(_check_main_sha(doc, marker, git))
+            elif claim_type == "issue_state":
+                results.append(_check_issue_state(doc, marker, issues))
+            else:
+                results.append(
+                    ClaimResult(
+                        doc.surface,
+                        marker.line,
+                        claim_type or "unknown",
+                        FAIL,
+                        f"unsupported live-claim type: {claim_type!r}",
+                    )
+                )
+    results.extend(_check_cross_surface_main_sha(docs))
+    return results
+
+
+def load_documents(
+    root: Path, surfaces: Sequence[str]
+) -> tuple[list[SurfaceDocument], list[ClaimResult]]:
+    docs: list[SurfaceDocument] = []
+    errors: list[ClaimResult] = []
+    for surface in surfaces:
+        path = root / surface
+        if not path.is_file():
+            errors.append(
+                ClaimResult(
+                    surface, 0, "surface", FAIL, "registered surface is missing"
+                )
+            )
+            continue
+        docs.append(
+            parse_surface(surface, path.read_text(encoding="utf-8", errors="replace"))
+        )
+    return docs, errors
+
+
+def validate_all(
+    root: Path | None = None,
+    surfaces: Sequence[str] | None = None,
+    git: GitResolver | None = None,
+    issues: IssueStateResolver | None = None,
+) -> list[ClaimResult]:
+    r = root or REPO_ROOT
+    docs, errors = load_documents(r, surfaces or DEFAULT_SURFACES)
+    results = validate_documents(
+        docs,
+        git or SubprocessGitResolver(r),
+        issues or GhIssueStateResolver(r),
+    )
+    return errors + results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate declared live claims on status surfaces (#4119)."
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat UNVERIFIED claims as failures (requires git and gh access)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Print machine-readable results",
+    )
+    parser.add_argument(
+        "--surface",
+        action="append",
+        dest="surfaces",
+        help="Restrict validation to the given surface (repeatable)",
+    )
+    args = parser.parse_args(argv)
+
+    results = validate_all(REPO_ROOT, args.surfaces or DEFAULT_SURFACES)
+    failures = [r for r in results if r.status == FAIL]
+    unverified = [r for r in results if r.status == UNVERIFIED]
+
+    if args.as_json:
+        print(
+            json.dumps(
+                {
+                    "results": [r.as_dict() for r in results],
+                    "counts": {
+                        PASS: len(results) - len(failures) - len(unverified),
+                        FAIL: len(failures),
+                        UNVERIFIED: len(unverified),
+                    },
+                    "strict": args.strict,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for result in results:
+            stream = sys.stderr if result.status != PASS else sys.stdout
+            print(
+                f"{result.status}: {result.surface}:{result.line} "
+                f"[{result.claim_type}] {result.detail}",
+                file=stream,
+            )
+
+    if failures:
+        print(
+            f"STATUS FRESHNESS VALIDATION FAILED ({len(failures)} failing claim(s))",
+            file=sys.stderr,
+        )
+        return 1
+    if unverified and args.strict:
+        print(
+            f"STATUS FRESHNESS UNVERIFIED under --strict ({len(unverified)} claim(s))",
+            file=sys.stderr,
+        )
+        return 1
+    if unverified:
+        print(
+            f"OK: no failing live claims ({len(unverified)} UNVERIFIED, not counted as PASS)"
+        )
+        return 0
+    print("OK: all declared live claims on status surfaces verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: docs-governance
lane: docs-governance
base_branch: main
validation_profile: docs-governance-v1
merge_mode: batch
steward_state: accepting_slices
objective_key: issue-4119
planned_issues: #4119
contract_keys: none
risk_flags: none
-->

Refs #4119

## Kurzbefund

Die drei Status-Flächen behaupteten überholte Live-Zustände: das README nannte einen `origin/main`-Stand von vor 34+ Commits und führte einen abgeschlossenen Reconcile als „in delivery“, dem aktuellen Status-Block fehlten vier gemergte Reconciles, und das Control Register trug ein Header-Datum, das älter war als sein jüngster Body-Eintrag. Dieser Slice reconciliiert die aktuellen Claims gegen Git und GitHub, markiert die append-only Historie explizit statt sie umzuschreiben, und ergänzt einen semantischen Freshness-Guard, damit dieselbe Drift nicht unbemerkt neu entsteht.

## Claim Inventory

Alle im Präsens formulierten Main-, Open-, Delivery- und Last-Updated-Claims der drei Flächen, geprüft gegen `origin/main` @ `e96f724c` und GitHub live.

| Fläche | Claim vorher | Live-Befund | Ergebnis |
| --- | --- | --- | --- |
| `README.md` | `origin/main` @ `f9e0cb0a`, Stand 2026-07-13 | `origin/main` @ `e96f724c` | auf bestätigten Stand gebracht |
| `README.md` | #4005 „(in delivery)“ | #4005 CLOSED, PR #4024 @ `13eab660` | nicht mehr als offene Delivery dargestellt |
| `README.md` | Merge-Cluster vom 2026-07-13 | #4204/#4236, #4228/#4231, #4211/#4216 sind der aktuelle Stand | Cluster ersetzt |
| `CURRENT_STATUS.md` | kein expliziter Main-Stand im aktuellen Block | `origin/main` @ `e96f724c` | Main-Stand deklariert, identisch zum README |
| `CURRENT_STATUS.md` | #3995 nur im historischen Block als offen | #3995 CLOSED, PR #4018 @ `60ddf8b3` | Closure im aktuellen Block dokumentiert |
| `CURRENT_STATUS.md` | Reconciles #4099/#4103/#4104/#4105 fehlten | alle vier MERGED | in den aktuellen Block aufgenommen |
| `CURRENT_STATUS.md` | `Last Updated: 2026-07-31` | jüngstes Bodydatum 2026-07-31 | konsistent, unverändert |
| `CONTROL_REGISTER.md` | Header `2026-07-14` | Bodyeinträge bis `2026-07-16` | Header auf 2026-07-16 korrigiert, alter Stand im Header vermerkt |
| alle | `#1445` als operatives Cockpit | #1445 OPEN | als Live-Claim deklariert und verifiziert |

## Historical Boundaries

Kein historischer Ledger-Eintrag wurde umgeschrieben, gekürzt oder gelöscht. Die Grenze zwischen aktuellem Block und append-only Historie ist jetzt maschinenlesbar:

- `CURRENT_STATUS.md`: `historical-as-of=2026-07-30` ab dem zweitneuesten Datumsblock bis vor `## Live-Readiness`. Altzeilen wie „#3995 (OPEN — nav/snapshot reconcile in delivery)“ vom 2026-07-12 bleiben wortgleich stehen und sind von der Live-Prüfung ausgenommen.
- `docs/runbooks/CONTROL_REGISTER.md`: `historical-as-of=2026-07-16` für den append-only Block `## Workflow-Control-Notizen`.
- Reconcile-Ergebnisse stehen ausschließlich im aktuellen, nicht im historischen Block.

## Freshness Semantics

Neu: `tools/validate_status_freshness.py`, eingehängt in `ci/stages/docs.py`. Der Guard vergleicht bewusst **kein** Alter und kein Änderungsdatum — ein altes Dokument besteht, solange jeder Live-Claim weiterhin zutrifft.

| Claim-Typ | Prüfung | Ergebnisklassen |
| --- | --- | --- |
| `main_sha` | Commit muss existieren und von `origin/main` erreichbar sein; alle Flächen müssen denselben Stand nennen | PASS / FAIL / UNVERIFIED |
| `issue_state` | Deklarierter Issue-/PR-Zustand gegen GitHub live | PASS / FAIL / UNVERIFIED |
| `header_date` | Header-Datum sichtbar neben dem Marker und nicht älter als das jüngste Bodydatum | PASS / FAIL |

- Ein fortschreitendes `main` entwertet einen korrekten Snapshot nicht; ein erfundener, nicht erreichbarer oder zwischen Flächen divergierender Snapshot schlägt fehl.
- GitHub-abhängige Claims gelten bei API-Ausfall nie als PASS, sondern als `UNVERIFIED`; `--strict` macht `UNVERIFIED` zum Fehler.
- Historische Blöcke sind von Live-Prüfungen ausgenommen, ihre Markierung wird aber validiert: Datum vorhanden, nicht neuer als das Header-Datum, Regionen balanciert, kein `live-claim` innerhalb.
- Live-Claims in Prosa (`origin/main` mit Commit, `in delivery` mit Issue-Referenz) ohne passenden Marker schlagen fehl.
- Markerkonvention und Autorenregeln: `docs/meta/REPOSITORY_CANON.md` § Status Freshness Rule.

## Validation

Zielgerichtet, kein Full Fast-CI, kein `cdb-local-ci` Publish, kein repo-weiter Gitleaks-Scan.

- `pytest -q tests/unit/tools/test_validate_status_freshness.py` — **21 passed**, darunter die geforderten Fixtures: falscher Live-Claim schlägt fehl (stale `issue_state`, nicht erreichbarer und erfundener `main_sha`, Header älter als Bodydatum), korrekt markierter historischer Block besteht, altes aber weiterhin korrektes Dokument (Header 2024-01-05) besteht.
- `pytest -q tests/unit/tools tests/unit/agents tests/unit/docs tests/unit/governance tests/unit/ci tests/smoke` — **2729 passed**
- `python -m tools.validate_status_freshness --strict` — 11 PASS, 0 FAIL, 0 UNVERIFIED gegen echtes Git und echtes GitHub
- Negative Gegenprobe auf einer synthetischen Fläche — 3 FAIL, exit 1
- `python ci/scripts/run.py --stage docs` — Stage `docs` **PASS** mit dem neuen Validator in der Kommandokette
- `python -m tools.validate_root_layout` — ROOT LAYOUT PASS
- `python -m tools.validate_readme_links` — PASS
- `ruff check` und `black --check` auf dem geänderten Python-Scope — PASS
- `git diff --check` — sauber
- `gitleaks protect --staged --config gitleaks.toml` — no leaks found

## Guardrails

- LR bleibt **NO-GO**; die Trennung zwischen Board-Stage `trade-capable` und Live-Go bleibt unverändert.
- Keine Runtime-, Docker-, DB-, MCP- oder Secret-Änderung; keine produktiven Writes.
- Merge-Trigger ist keine Merge-Autorisierung; kein Zwischenstands-Publish.
- Issue #4119 bleibt offen; dieser Slice schließt es nicht.

Status: `DONE_SLICE_ADDED_TO_BATCH_PR`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0a2fc86-d136-4bca-b081-16fba2d80c03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0a2fc86-d136-4bca-b081-16fba2d80c03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

