### PR TITLE
docs(security): HOLD CVE-2026-8286 curl on Trixie images (#4080)

### DIFF
--- a/docs/evidence/security/4080_CVE-2026-8286_UPSTREAM_HOLD.md
+++ b/docs/evidence/security/4080_CVE-2026-8286_UPSTREAM_HOLD.md
@@ -1,0 +1,185 @@
+# CVE-2026-8286 — Curl / libcurl Trixie Upstream HOLD
+
+**Date:** 2026-08-01
+**Primary issue:** #4080
+**Same-CVE trackers:** #4089–#4093 (remain open; owned by #4080 HOLD)
+**Adjacent same-package trackers:** #4096–#4098 (`CVE-2026-8927`) — included because the same concrete package floor (`curl`/`libcurl4t64` ≥ `8.21.0`) would clear both CVEs once suite-native FixedVersion lands
+**Verdict:** `HOLD_UPSTREAM_NO_FIXED_VERSION`
+**Decision code:** `UPSTREAM_NO_FIXED_VERSION`
+**Re-evaluation date:** **2026-08-15** (or earlier when any trigger below fires)
+**Design reference (pattern only):** #4106 / PR #4273 — different CVE; no CVE claims copied
+**LR:** NO-GO (unchanged)
+**Scope guard:** Evidence + static contract only. No Dockerfile remediation, no alert dismissal, no `.trivyignore`, no runtime/stack mutation, no `cdb-local-ci` publish, no merge, no issue close.
+
+---
+
+## Executive summary
+
+| Field | Value |
+|-------|-------|
+| Primary CVE | `CVE-2026-8286` (wrong STARTTLS connection reuse) |
+| Adjacent CVE (same package floor) | `CVE-2026-8927` (env-proxy Digest auth state leak) |
+| Severity | HIGH (Trivy / issue band); curl.se: Low (8286) / Medium (8927) |
+| Package | `curl` + transitive `libcurl4t64` (Debian source `curl`) |
+| InstalledVersion (Trixie layer) | `8.14.1-2+deb13u4` |
+| Trivy / Debian Trixie `FixedVersion` | **empty / unfixed** (`<no-dsa>`) |
+| Debian forky / sid FixedVersion | `8.21.0-2` (fixed) — not a silent suite migration |
+| Upstream curl FixedVersion | **`8.21.0`** |
+| Shared base | `python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6` |
+| Observed base digest (HOLD snapshot) | `sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6` |
+| Digest role | **Observed evidence snapshot only — not an eternal required digest** |
+| Digest bump evidence | D1 `b877e50` → `cea0e60` did **not** clear curl residuals |
+| Dockerfile remediations this slice | **none** (would be fake or out-of-scope suite change) |
+| `.trivyignore` / dismissals | **none** |
+| EXTERNAL_LIVE_CHECK | Static contract tests **cannot detect Debian FixedVersion offline**; live Debian/curl.se probe is mandatory at each re-eval |
+
+Observed base digest (HOLD snapshot): `sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6`
+
+---
+
+## Alert / fingerprint inventory
+
+| Surface | ID / marker | Notes |
+|---------|-------------|-------|
+| Issue group fingerprint (#4080) | `d903e05ff3d8dd8b` | Issue #4080 body |
+| GitHub Code Scanning Alert IDs | may be partial | Prefer live `gh api` when authorized; silence not claimed |
+| Manifestation issues (8286) | #4080, #4089–#4093 | Per-image trackers under shared root cause |
+| Adjacent issues (8927) | #4096–#4098 | Same package FixedVersion path |
+| Live scanner silence | **not claimed** | No post-merge / rebuild clearance without scan |
+
+---
+
+## Shared image lineage (7 Trixie services with explicit `curl`)
+
+All scoped Dockerfiles pin the identical base digest, run `apt-get upgrade -y`, and install `curl` (HEALTHCHECK):
+
+| Image | Dockerfile | Base digest |
+|-------|------------|-------------|
+| `library/cdb_allocation` | `services/allocation/Dockerfile` | `cea0e604…14a6` |
+| `library/cdb_execution` | `services/execution/Dockerfile` (runtime stage) | `cea0e604…14a6` |
+| `library/cdb_market` | `services/market/Dockerfile` | `cea0e604…14a6` |
+| `library/cdb_regime` | `services/regime/Dockerfile` | `cea0e604…14a6` |
+| `library/cdb_risk` | `services/risk/Dockerfile` | `cea0e604…14a6` |
+| `library/cdb_signal` | `services/signal/Dockerfile` | `cea0e604…14a6` |
+| `library/cdb_ws` | `services/ws/Dockerfile` | `cea0e604…14a6` |
+
+**Root cause class:** shared Debian Trixie `curl`/`libcurl4t64` package without suite-native FixedVersion — not service-specific application code.
+
+**Out of this shared pin (documented, not silently remixed):**
+- `services/candles/Dockerfile` and `services/reports/Dockerfile` use `python:3.14-slim-bookworm` (different suite/digest).
+- `services/db_writer/Dockerfile` does not install `curl` in the current Dockerfile.
+
+---
+
+## Advisory / FixedVersion evidence (live 2026-08-01)
+
+| Source | Finding |
+|--------|---------|
+| curl.se CVE-2026-8286 | Fixed in **`8.21.0`**; affects STARTTLS schemes IMAP/POP3/SMTP/FTP/LDAP; severity Low |
+| curl.se CVE-2026-8927 | Fixed in **`8.21.0`**; libcurl env-proxy Digest leak; does **not** affect CLI curl tool; severity Medium |
+| Debian Security Tracker CVE-2026-8286 | Trixie `8.14.1-2+deb13u4` **vulnerable** `<no-dsa>`; forky/sid `8.21.0-2` **fixed** |
+| Debian Security Tracker CVE-2026-8927 | Same suite matrix / same unstable fixed floor |
+| Repo D1 digest note | Shared residual matrix in `4106_CVE-2026-13221_UPSTREAM_HOLD.md` already listed this curl cluster as separate UPSTREAM HOLD |
+
+References:
+
+- https://curl.se/docs/CVE-2026-8286.html
+- https://curl.se/docs/CVE-2026-8927.html
+- https://security-tracker.debian.org/tracker/CVE-2026-8286
+- https://security-tracker.debian.org/tracker/CVE-2026-8927
+
+---
+
+## Fixability probes (rejected)
+
+| Probe | Result | Decision |
+|-------|--------|----------|
+| `apt-get upgrade -y` (already present) | Trixie still ships `8.14.1-2+deb13u4` | No gain |
+| Digest-only base refresh | D1 did not clear curl residuals | **Rejected** as remediation |
+| Pin `curl=8.21.0-2` from forky/sid into Trixie images | Cross-suite / ABI / policy explosion without approved suite migration | **Rejected** |
+| Silent suite migration to forky/sid | Out of scope; requires separate operational GO | **Rejected** |
+| Scanner ignore / alert dismiss | Forbidden by issue + prompt contract | **Rejected** |
+
+---
+
+## Exploitability
+
+| Aspect | Assessment |
+|--------|------------|
+| CVE-2026-8286 class | STARTTLS connection reuse with mismatched TLS config |
+| CDB application path (8286) | Services use `curl` for HTTP HEALTHCHECK only; no proven IMAP/POP3/SMTP/FTP/LDAP STARTTLS app path |
+| CVE-2026-8927 class | libcurl env-proxy Digest auth header leak on handle reuse |
+| CDB application path (8927) | No proven multi-proxy Digest handle-reuse path in trading services; CLI curl not affected per advisory |
+| Runtime reachability | **Low** practical exploitability in current CDB runtime |
+| Severity alone | Does **not** prove exploitability |
+
+---
+
+## Security-Cluster matrix
+
+| Issue | CVE | Severity | Image / Service | Base-Image-Tag | Base-Image-Digest | Debian-Suite | Paketname | InstalledVersion | FixedVersion (suite-native) | Layer-Herkunft | direkt / transitiv | Runtime-Erreichbarkeit | Exploitability | bestehender Fix oder PR | Entscheidung |
+|-------|-----|----------|-----------------|----------------|-------------------|--------------|-----------|------------------|-----------------------------|----------------|--------------------|------------------------|----------------|-------------------------|--------------|
+| #4080 | CVE-2026-8286 | high | library/cdb_allocation | python:3.14-slim-trixie | sha256:cea0e604…14a6 | trixie | curl + libcurl4t64 | 8.14.1-2+deb13u4 | **null / unfixed** | Dockerfile `apt-get install curl` | curl direkt / libcurl transitiv | HEALTHCHECK HTTP only | niedrig | none (this HOLD) | **UPSTREAM_NO_FIXED_VERSION** |
+| #4089 | CVE-2026-8286 | high | library/cdb_market | same | same | trixie | same | same | **null** | same | same | same | niedrig | none | **UPSTREAM_NO_FIXED_VERSION** |
+| #4090 | CVE-2026-8286 | high | library/cdb_regime | same | same | trixie | same | same | **null** | same | same | same | niedrig | none | **UPSTREAM_NO_FIXED_VERSION** |
+| #4091 | CVE-2026-8286 | high | library/cdb_risk | same | same | trixie | same | same | **null** | same | same | same | niedrig | none | **UPSTREAM_NO_FIXED_VERSION** |
+| #4092 | CVE-2026-8286 | high | library/cdb_signal | same | same | trixie | same | same | **null** | same | same | same | niedrig | none | **UPSTREAM_NO_FIXED_VERSION** |
+| #4093 | CVE-2026-8286 | high | library/cdb_ws | same | same | trixie | same | same | **null** | same | same | same | niedrig | none | **UPSTREAM_NO_FIXED_VERSION** |
+| #4096 | CVE-2026-8927 | high | library/cdb_allocation | same | same | trixie | same | same | **null** | same | same | CLI curl; no proven libcurl API reuse | niedrig | none (same HOLD) | **UPSTREAM_NO_FIXED_VERSION** |
+| #4097 | CVE-2026-8927 | high | library/cdb_execution | same | same | trixie | same | same | **null** | same | same | same | niedrig | none | **UPSTREAM_NO_FIXED_VERSION** |
+| #4098 | CVE-2026-8927 | high | library/cdb_market | same | same | trixie | same | same | **null** | same | same | same | niedrig | none | **UPSTREAM_NO_FIXED_VERSION** |
+
+### Dedupe notes
+
+- **#4080** owns the shared Trixie curl root cause for CVE-2026-8286 across the six listed images; #4089–#4093 remain open manifestation trackers.
+- **#4096–#4098** share the **same concrete FixedVersion unit** (`curl`/`libcurl4t64` ≥ `8.21.0`) and are therefore documented in this HOLD; they are **not** auto-bundled merely by package name — inclusion is because one remediation clears both CVEs.
+- Additional Trivy surfaces without matching issues (e.g. 8286 on `cdb_execution`, 8927 on other Trixie services) inherit the same root cause; do not invent separate fake fixes.
+- Grafana/Ubuntu curl FixedVersion paths are a **different** suite and out of this Trixie HOLD.
+- Open PR #4245 documents a **different** CVE (`CVE-2026-57432` / #4114) — not this root cause.
+- Perl HOLD #4106 / PR #4273 is design reference only.
+
+---
+
+## Re-evaluation triggers
+
+Refresh this HOLD and open a remediation slice when **any** of:
+
+1. Debian Trixie publishes a non-empty Fixed Version for `curl` covering CVE-2026-8286 (and preferably CVE-2026-8927 on the same package).
+2. Official `python:3.14-slim-trixie` ships a digest whose installed `curl`/`libcurl4t64` clears both CVEs in Trivy.
+3. A separately approved base-suite migration delivers a scanned FixedVersion path (e.g. forky/sid `8.21.0-2+`).
+4. Calendar: **2026-08-15** (next scheduled Debian/curl.se FixedVersion probe).
+
+Machine-checkable contract (repo-local):
+
+- Evidence must keep the line
+  `Observed base digest (HOLD snapshot): \`sha256:…\``
+  equal to the shared Dockerfile pin (consistency only).
+- A new shared digest is allowed without failing the HOLD contract **if** this
+  observed-digest marker is updated in the same change.
+- The observed digest is **not an eternal required digest**.
+- Flipping away from `HOLD_UPSTREAM_NO_FIXED_VERSION` requires a live
+  `EXTERNAL_LIVE_CHECK` that Debian FixedVersion is non-empty (or a scanned
+  cleared image). Static tests alone **cannot detect Debian FixedVersion offline**.
+
+On trigger: rebuild all scoped images, run Trivy/Code Scanning, document before/after InstalledVersion + Digest, then close only with post-merge scan evidence.
+
+---
+
+## Non-goals / Safety Boundaries
+
+- No fake package pin, no cross-suite curl install.
+- No alert dismissal before post-merge scan.
+- No merge, no issue auto-close (`Closes`/`Fixes` forbidden for this cluster in delivery).
+- No BLUE/RED runtime mutation, no productive DB/MCP writes, no LR/live/echtgeld.
+- LR remains **NO-GO**.
+- No alert dismissal.
+
+---
+
+## Delivered this slice
+
+| Artifact | Purpose |
+|----------|---------|
+| This evidence file | Belegter UPSTREAM-HOLD + Cluster-Matrix (8286 + adjacent 8927) |
+| `tests/unit/security/test_cve_2026_8286_image_contract.py` | Static contract: shared digest, apt upgrade, curl install, no silence, evidence fields |
+| Session log | `knowledge/logs/sessions/2026-08-01-4080-cve-2026-8286-hold.md` |

--- a/knowledge/logs/sessions/2026-08-01-4080-cve-2026-8286-hold.md
+++ b/knowledge/logs/sessions/2026-08-01-4080-cve-2026-8286-hold.md
@@ -32,6 +32,14 @@ floor clears both CVEs.
 - `docs/evidence/security/4080_CVE-2026-8286_UPSTREAM_HOLD.md`
 - `tests/unit/security/test_cve_2026_8286_image_contract.py`
 - This session log
+- PR [#4274](https://github.com/jannekbuengener/Claire_de_Binare/pull/4274) @ `6adfbb11b2dcd68a10da4929e0ef1949eebb7d0c`
+- Issue comments on #4080 and related #4089–#4093 / #4096–#4098
+
+## Validation
+
+- `pytest -q tests/unit/security/test_cve_2026_8286_image_contract.py` → 20 passed
+- black + ruff on contract test → PASS
+- `git diff --check` → PASS
 
 ## Non-goals
 

--- a/knowledge/logs/sessions/2026-08-01-4080-cve-2026-8286-hold.md
+++ b/knowledge/logs/sessions/2026-08-01-4080-cve-2026-8286-hold.md
@@ -1,0 +1,38 @@
+# Session: #4080 CVE-2026-8286 Curl UPSTREAM HOLD
+
+**Date:** 2026-08-01
+**Job:** W05-CURL-CVE-2026-8286
+**Branch:** `dedicated/runtime-risk-issue-4080`
+**Base:** `origin/main` @ `3ec928733ab4e94a13ab39c514c0ed991a07c7a2`
+**Verdict:** `HOLD_UPSTREAM_NO_FIXED_VERSION`
+
+## Control
+
+- Board stage: `trade-capable`
+- LR: NO-GO
+- Brain: Context tools available; `records_found=none` → `repo-only` / `insufficient_evidence`
+
+## Decision
+
+Debian Trixie has no suite-native FixedVersion for `curl`/`libcurl4t64`
+(`8.14.1-2+deb13u4`, `<no-dsa>`). Upstream/forky fix is `8.21.0`. No fake
+Dockerfile pin. HOLD evidence + static contract after #4106/#4273 pattern.
+
+CVE-2026-8927 (#4096–#4098) included in matrix because the same concrete package
+floor clears both CVEs.
+
+## Routing
+
+- `python -m tools.pr_routing route --issue 4080 --agent cursor`
+- Decision: `CREATE_DEDICATED_PR`
+- Target branch: `dedicated/runtime-risk-issue-4080`
+
+## Delivered
+
+- `docs/evidence/security/4080_CVE-2026-8286_UPSTREAM_HOLD.md`
+- `tests/unit/security/test_cve_2026_8286_image_contract.py`
+- This session log
+
+## Non-goals
+
+No merge, no issue close, no `.trivyignore`, no Dockerfile change, no runtime mutation.

--- a/tests/unit/security/test_cve_2026_8286_image_contract.py
+++ b/tests/unit/security/test_cve_2026_8286_image_contract.py
@@ -1,0 +1,262 @@
+"""CVE-2026-8286 HOLD contract for Trixie curl service images (#4080).
+
+Protects the evidence-based UPSTREAM HOLD for Debian Trixie ``curl`` /
+``libcurl4t64``: shared base lineage, apt upgrade, explicit curl install, no
+scanner silencing, and a machine-checkable re-evaluation rule. The currently
+observed digest is consistency-checked against the evidence snapshot — it is
+not an eternal required digest.
+
+Adjacent CVE-2026-8927 is documented in the same HOLD because the same concrete
+package floor (``>= 8.21.0``) would clear both findings; this test only asserts
+that the evidence names that adjacency and does not invent a dual fake pin.
+
+Static Dockerfile / evidence parsing only — no image build, no registry
+access, no live Debian FixedVersion probe, no runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CVE_ID = "CVE-2026-8286"
+ADJACENT_CVE_ID = "CVE-2026-8927"
+ISSUE_REF = "#4080"
+PACKAGE = "curl"
+INSTALLED_VERSION = "8.14.1-2+deb13u4"
+UPSTREAM_FIXED_VERSION = "8.21.0"
+VERDICT = "HOLD_UPSTREAM_NO_FIXED_VERSION"
+RE_EVAL_DATE = "2026-08-15"
+BASE_IMAGE = "python:3.14-slim-trixie"
+
+SCOPE_DOCKERFILES = (
+    REPO_ROOT / "services" / "allocation" / "Dockerfile",
+    REPO_ROOT / "services" / "execution" / "Dockerfile",
+    REPO_ROOT / "services" / "market" / "Dockerfile",
+    REPO_ROOT / "services" / "regime" / "Dockerfile",
+    REPO_ROOT / "services" / "risk" / "Dockerfile",
+    REPO_ROOT / "services" / "signal" / "Dockerfile",
+    REPO_ROOT / "services" / "ws" / "Dockerfile",
+)
+
+EVIDENCE_FILE = (
+    REPO_ROOT / "docs" / "evidence" / "security" / "4080_CVE-2026-8286_UPSTREAM_HOLD.md"
+)
+TRIVYIGNORE_FILE = REPO_ROOT / ".trivyignore"
+
+FROM_RE = re.compile(
+    r"^FROM\s+(?P<image>[^\s@]+)"
+    r"(?:@(?P<digest>sha256:[0-9a-f]{64}))?"
+    r"(?:\s+[Aa][Ss]\s+\S+)?"
+    r"\s*$",
+    re.MULTILINE,
+)
+APT_UPGRADE_RE = re.compile(r"apt-get\s+upgrade\s+-y")
+CURL_INSTALL_RE = re.compile(
+    r"apt-get\s+install[^\n]*\n(?:[^\n]*\n)*?[^\n]*\bcurl\b",
+    re.IGNORECASE,
+)
+OBSERVED_DIGEST_MARKER_RE = re.compile(
+    r"Observed\s+base\s+digest\s*\(HOLD\s+snapshot\)\s*:\s*"
+    r"`(?P<digest>sha256:[0-9a-f]{64})`",
+    re.IGNORECASE,
+)
+
+
+def _dockerfile_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _from_matches(path: Path) -> list[re.Match[str]]:
+    matches = list(FROM_RE.finditer(_dockerfile_text(path)))
+    assert matches, f"{path} must declare at least one FROM line"
+    return matches
+
+
+def _runtime_from_matches(path: Path) -> list[re.Match[str]]:
+    """Prefer the final runtime FROM (multi-stage safe)."""
+    matches = _from_matches(path)
+    return [matches[-1]]
+
+
+def _scope_digests_and_images() -> tuple[set[str | None], set[str]]:
+    digests: set[str | None] = set()
+    images: set[str] = set()
+    for path in SCOPE_DOCKERFILES:
+        for match in _runtime_from_matches(path):
+            digests.add(match.group("digest"))
+            images.add(match.group("image"))
+    return digests, images
+
+
+def test_scope_dockerfiles_share_one_pinned_base_digest() -> None:
+    """Shared lineage is the root-cause premise; digests must be pinned+identical.
+
+    Any future shared digest is allowed. This test does **not** require the
+    historically vulnerable HOLD snapshot digest forever.
+    """
+    digests, images = _scope_digests_and_images()
+    assert None not in digests, (
+        "all scoped service Dockerfiles must pin a sha256 digest "
+        f"(found unpinned FROM among {digests})"
+    )
+    assert len(digests) == 1, (
+        "all scoped service Dockerfiles must share one base digest for the "
+        f"shared OS-layer finding; found {digests}"
+    )
+    assert images == {BASE_IMAGE}
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    SCOPE_DOCKERFILES,
+    ids=lambda p: f"{p.parent.name}/{p.name}",
+)
+def test_scope_dockerfiles_still_run_apt_upgrade(dockerfile: Path) -> None:
+    text = _dockerfile_text(dockerfile)
+    assert APT_UPGRADE_RE.search(text), (
+        f"{dockerfile} must keep apt-get upgrade so suite-native security "
+        "updates land automatically once Debian publishes them"
+    )
+
+
+@pytest.mark.parametrize(
+    "dockerfile",
+    SCOPE_DOCKERFILES,
+    ids=lambda p: f"{p.parent.name}/{p.name}",
+)
+def test_scope_dockerfiles_install_curl(dockerfile: Path) -> None:
+    text = _dockerfile_text(dockerfile)
+    assert CURL_INSTALL_RE.search(text) or re.search(
+        r"apt-get\s+install[^\n]*\bcurl\b", text
+    ), f"{dockerfile} must still install curl (HEALTHCHECK / package surface)"
+
+
+def test_cve_is_not_silenced_by_trivyignore() -> None:
+    text = (
+        TRIVYIGNORE_FILE.read_text(encoding="utf-8")
+        if TRIVYIGNORE_FILE.exists()
+        else ""
+    )
+    entries = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    silenced = [
+        entry
+        for entry in entries
+        if CVE_ID in entry
+        or ADJACENT_CVE_ID in entry
+        or PACKAGE in entry
+        or "libcurl" in entry
+    ]
+    assert silenced == [], (
+        f"{CVE_ID}/{ADJACENT_CVE_ID}/{PACKAGE} must not be ignored in "
+        f".trivyignore: {silenced}"
+    )
+
+
+def test_upstream_hold_evidence_documents_required_fields() -> None:
+    assert EVIDENCE_FILE.is_file(), f"missing evidence file: {EVIDENCE_FILE}"
+    text = EVIDENCE_FILE.read_text(encoding="utf-8")
+    required = (
+        CVE_ID,
+        ADJACENT_CVE_ID,
+        ISSUE_REF,
+        PACKAGE,
+        "libcurl4t64",
+        INSTALLED_VERSION,
+        UPSTREAM_FIXED_VERSION,
+        VERDICT,
+        RE_EVAL_DATE,
+        "FixedVersion",
+        "Exploitability",
+        "cdb_allocation",
+        "cdb_execution",
+        "cdb_market",
+        "cdb_regime",
+        "cdb_risk",
+        "cdb_signal",
+        "cdb_ws",
+        "#4089",
+        "#4090",
+        "#4091",
+        "#4092",
+        "#4093",
+        "#4096",
+        "#4097",
+        "#4098",
+        "UPSTREAM_NO_FIXED_VERSION",
+        "No alert dismissal",
+        "Observed base digest (HOLD snapshot)",
+        "Re-evaluation triggers",
+        "EXTERNAL_LIVE_CHECK",
+        "same concrete",
+    )
+    missing = [item for item in required if item not in text]
+    assert missing == [], f"evidence file missing required markers: {missing}"
+
+
+def test_evidence_observed_digest_matches_current_dockerfiles() -> None:
+    """Evidence snapshot digest must match current pins (consistency, not eternity).
+
+    Updating Dockerfiles to a new shared digest requires updating the evidence
+    observed-digest marker in the same change. A suite-native FixedVersion
+    additionally requires flipping the HOLD verdict (live Debian check is
+    EXTERNAL_LIVE_CHECK, not this static test).
+    """
+    text = EVIDENCE_FILE.read_text(encoding="utf-8")
+    marker = OBSERVED_DIGEST_MARKER_RE.search(text)
+    assert marker is not None, (
+        "evidence must declare " "'Observed base digest (HOLD snapshot): `sha256:…`'"
+    )
+    observed = marker.group("digest")
+    digests, _images = _scope_digests_and_images()
+    assert digests == {observed}, (
+        "HOLD evidence observed digest must match the shared Dockerfile pin; "
+        f"evidence={observed}, dockerfiles={digests}. "
+        "Update the evidence observed-digest marker together with Dockerfile pins."
+    )
+
+
+def test_evidence_rejects_eternal_digest_and_fake_remediation() -> None:
+    text = EVIDENCE_FILE.read_text(encoding="utf-8")
+    lowered = text.lower()
+    assert "Rejected" in text
+    assert "no alert dismissal" in lowered
+    assert VERDICT in text
+    assert "Digest bump evidence" in text or "D1" in text
+    assert "not an eternal required digest" in lowered
+    assert "EXTERNAL_LIVE_CHECK" in text
+    assert "cannot detect debian fixedversion offline" in lowered
+    assert "eternal required digest" in lowered
+    assert "must always pin" not in lowered
+    assert "Sollzustand Digest" not in text
+    # Fixture-style future-proof: evidence must allow digest refresh path.
+    assert "new shared digest is allowed" in lowered or (
+        "a new shared digest is allowed" in lowered
+    )
+
+
+def test_evidence_fixture_variation_digest_marker_is_parseable() -> None:
+    """Changed digest in evidence must remain parseable by the consistency regex.
+
+    This is the offline fixture variation: a different sha256 still matches the
+    marker grammar so a future safe digest can be adopted without rewriting the
+    contract harness.
+    """
+    sample = (
+        "Observed base digest (HOLD snapshot): "
+        "`sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef`"
+    )
+    marker = OBSERVED_DIGEST_MARKER_RE.search(sample)
+    assert marker is not None
+    assert marker.group("digest").startswith("sha256:")
+    assert len(marker.group("digest")) == len("sha256:") + 64


### PR DESCRIPTION
## Summary

- Refs #4080 — belegter `UPSTREAM_NO_FIXED_VERSION`-HOLD für **CVE-2026-8286** (Curl/libcurl auf Trixie Service-Images).
- Verwandte Issues: #4089 #4090 #4091 #4092 #4093 (gleiche CVE); angrenzend #4096 #4097 #4098 (**CVE-2026-8927**, gleiche konkrete Paket-FixedVersion-Einheit `curl`/`libcurl4t64` ≥ `8.21.0`).
- Root Cause: gemeinsames Debian-Trixie-Paket `curl`/`libcurl4t64` `8.14.1-2+deb13u4` ohne suite-native FixedVersion (`<no-dsa>`); Upstream/forky fix `8.21.0` / `8.21.0-2`.
- Kein Dockerfile-/Dependency-Schein-Fix; Designreferenz PR #4273 / #4106 (andere CVE).

## CVE-/Image-/Paket-Matrix (Kurz)

| Issue | CVE | Image | InstalledVersion | Suite FixedVersion | Entscheidung |
|-------|-----|-------|------------------|--------------------|--------------|
| #4080 | 8286 | cdb_allocation | 8.14.1-2+deb13u4 | null | UPSTREAM_NO_FIXED_VERSION |
| #4089–#4093 | 8286 | market/regime/risk/signal/ws | same | null | UPSTREAM_NO_FIXED_VERSION |
| #4096–#4098 | 8927 | allocation/execution/market | same | null | UPSTREAM_NO_FIXED_VERSION (gleiche Fix-Einheit) |

Base: `python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6` (Observed HOLD snapshot — kein ewiger Sollzustand).

## Exploitability

- 8286: STARTTLS-Reuse — CDB nutzt curl primär für HTTP-HEALTHCHECK; praktische Ausnutzbarkeit **niedrig**.
- 8927: libcurl env-proxy Digest-Leak — kein belegter Multi-Proxy-App-Pfad; CLI curl laut Advisory nicht betroffen; **niedrig**.
- Severity allein ≠ Exploitability.

## Delivered

- `docs/evidence/security/4080_CVE-2026-8286_UPSTREAM_HOLD.md`
- `tests/unit/security/test_cve_2026_8286_image_contract.py` (Zukunftsfähigkeit: Digest-Konsistenz, Fixture-Variation, EXTERNAL_LIVE_CHECK-Trennung)
- Session-Log `knowledge/logs/sessions/2026-08-01-4080-cve-2026-8286-hold.md`

## Brain Evidence

- brain_source: repo-only
- brain_status: not-used
- context_tool_status: available; records_found: none; repo_fallback_reason: insufficient_evidence
- Live: GitHub issues, Debian Tracker, curl.se advisories, PR-Router, [cdb-security-triage](a2ebc960-ca34-4c6a-984d-b1fbcfd0e700)

## Validation

- `pytest -q tests/unit/security/test_cve_2026_8286_image_contract.py` → **20 passed**
- `black` + `ruff check` auf dem Test → PASS
- `git diff --check` → PASS
- Kein Image-Build/Trivy in diesem HOLD-Slice (kein behaupteter Fix) — Scan-Lücke: **post-merge Rescan weiterhin erforderlich**, sobald FixedVersion existiert und Images neu gebaut werden.

## Post-Merge-Rescan erforderlich

Ja — Issues erst nach Merge **und** erfolgreichem Rescan schließen. Keine Alert-Dismissals.

## Non-goals

- Kein Merge, kein `cdb-local-ci`-Publish, kein Issue-Close, kein `.trivyignore`, kein Suite-Wechsel, keine Runtime-/LR-/Echtgeld-Aktion.

## Safety Boundaries

- Shadow/Paper-first; LR **NO-GO**; keine Secrets; keine produktiven DB/MCP-Writes; keine BLUE/RED-Mutationen.

## Routing

- `CREATE_DEDICATED_PR` → `dedicated/runtime-risk-issue-4080` (lane `runtime-risk`)