### PR TITLE
ci(security): reduce Security Scan cadence to bimonthly

### DIFF
--- a/.github/control-plane/generated/agent-workflow-map.json
+++ b/.github/control-plane/generated/agent-workflow-map.json
@@ -1,1043 +1,26 @@
 {
-  "catalog_scope": "workflow-inventory",
+  "schema_version": "1",
   "coverage": "complete",
-  "disk_workflow_count": 57,
-  "entries": [
-    {
-      "file": "add_to_project.yml",
-      "has_schedule": false,
-      "name": "Add issues and PRs to CDB Control Board",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Add issues and PRs to CDB Control Board",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "issues"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "ai-review-router.yml",
-      "has_schedule": true,
-      "name": "AI Review Router",
-      "permissions": [
-        "pull-requests:write"
-      ],
-      "purpose": "AI Review Router",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "auto-milestone-label-dispatch.yml",
-      "has_schedule": false,
-      "name": "Auto Milestone Label Dispatch",
-      "permissions": [
-        "contents:write"
-      ],
-      "purpose": "Auto Milestone Label Dispatch",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "high",
-      "status": "active",
-      "triggers": [
-        "issues"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "auto-milestone-pr-apply.yml",
-      "has_schedule": false,
-      "name": "Auto Milestone PR Apply",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "Auto Milestone PR Apply",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "workflow_run"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "auto-milestone-pr-intent.yml",
-      "has_schedule": false,
-      "name": "Auto Milestone PR Intent",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Auto Milestone PR Intent",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "pull_request"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "auto-milestone.yml",
-      "has_schedule": false,
-      "name": "Auto Milestone",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "Auto Milestone",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "high",
-      "status": "active",
-      "triggers": [
-        "issues",
-        "repository_dispatch",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "branch-policy.yml",
-      "has_schedule": true,
-      "name": "Branch Policy Enforcement",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Branch Policy Enforcement",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "cdb-backlog-anomaly-escalation.yml",
-      "has_schedule": false,
-      "name": "CDB Backlog Anomaly Escalation",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "CDB Backlog Anomaly Escalation",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "workflow_dispatch",
-        "workflow_run"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "cdb-backlog-curation.yml",
-      "has_schedule": false,
-      "name": "CDB Backlog Curation",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "CDB Backlog Curation",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "issues"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "cdb-context-refresh-report.yml",
-      "has_schedule": true,
-      "name": "CDB Context Refresh Report",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "CDB Context Refresh Report",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "cdb-control-followup-classifier.yml",
-      "has_schedule": false,
-      "name": "CDB Control Follow-up Classifier",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "CDB Control Follow-up Classifier",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "cdb-daily-delta-triage.yml",
-      "has_schedule": true,
-      "name": "CDB Daily Delta Triage",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "CDB Daily Delta Triage",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "cdb-dependabot-autopilot.yml",
-      "has_schedule": true,
-      "name": "CDB Dependabot Autopilot",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "CDB Dependabot Autopilot",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "cdb-post-merge-followup-scanner.yml",
-      "has_schedule": false,
-      "name": "CDB Post-Merge Follow-up Scanner",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "CDB Post-Merge Follow-up Scanner",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "pull_request",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "cdb-weekly-control-hygiene-classifier.yml",
-      "has_schedule": true,
-      "name": "CDB Weekly Control Hygiene Classifier",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "CDB Weekly Control Hygiene Classifier",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "ci.yml",
-      "has_schedule": false,
-      "name": "ci",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "ci",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "pull_request",
-        "push"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "codeql-python.yml",
-      "has_schedule": true,
-      "name": "CodeQL Python",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "CodeQL Python",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "pull_request",
-        "push",
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "contracts.yml",
-      "has_schedule": true,
-      "name": "Contract Validation",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Contract Validation",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "control_board_upsert.yml",
-      "has_schedule": true,
-      "name": "Control Board Upsert",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Control Board Upsert",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "copilot-housekeeping.yml",
-      "has_schedule": true,
-      "name": "Copilot Housekeeping",
-      "permissions": [
-        "issues:write",
-        "pull-requests:write"
-      ],
-      "purpose": "Copilot Housekeeping",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "copilot-setup-steps.yml",
-      "has_schedule": false,
-      "name": "Copilot Setup Steps",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Copilot Setup Steps",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "core-guard.yml",
-      "has_schedule": true,
-      "name": "Core Guard",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Core Guard",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "delivery-gate.yml",
-      "has_schedule": true,
-      "name": "Delivery Gate",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Delivery Gate",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "docker-publish.yml",
-      "has_schedule": false,
-      "name": "Build & Push Containers (GHCR)",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Build & Push Containers (GHCR)",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "docs-conflict-guard.yml",
-      "has_schedule": false,
-      "name": "Docs Conflict Guard",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Docs Conflict Guard",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "pull_request",
-        "push",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "e2e-happy-path.yaml",
-      "has_schedule": true,
-      "name": "E2E Happy Path",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "E2E Happy Path",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "e2e-tests.yml",
-      "has_schedule": true,
-      "name": "E2E Tests - Paper Trading",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "E2E Tests - Paper Trading",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "e2e.yml",
-      "has_schedule": true,
-      "name": "E2E Tests",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "E2E Tests",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "emoji-bot.yml",
-      "has_schedule": false,
-      "name": "\ud83e\udd16 Emoji Fix Bot",
-      "permissions": [
-        "contents:write",
-        "issues:write"
-      ],
-      "purpose": "\ud83e\udd16 Emoji Fix Bot",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "issue_comment",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "emoji-filter.yml",
-      "has_schedule": false,
-      "name": "\ud83d\udeab Advanced Emoji Filter",
-      "permissions": [
-        "contents:write",
-        "issues:write"
-      ],
-      "purpose": "\ud83d\udeab Advanced Emoji Filter",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "gitleaks.yml",
-      "has_schedule": true,
-      "name": "Gitleaks Secret Scan",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Gitleaks Secret Scan",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "governance-audit.yml",
-      "has_schedule": false,
-      "name": "Governance Audit",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Governance Audit",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "label-bootstrap.yml",
-      "has_schedule": false,
-      "name": "Label Bootstrap (Copilot)",
-      "permissions": [
-        "issues:write",
-        "pull-requests:write"
-      ],
-      "purpose": "Label Bootstrap (Copilot)",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "lr021_replay_smoke.yml",
-      "has_schedule": true,
-      "name": "lr021-replay-smoke",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "lr021-replay-smoke",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "mcp_runtime.yml",
-      "has_schedule": false,
-      "name": "mcp-runtime",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "mcp-runtime",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "milestone_stage_label_sync.yml",
-      "has_schedule": false,
-      "name": "Sync Stage Labels From Milestone",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Sync Stage Labels From Milestone",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "issues"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "opencode.yml",
-      "has_schedule": false,
-      "name": "opencode",
-      "permissions": [
-        "id-token:write"
-      ],
-      "purpose": "opencode",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "issue_comment",
-        "pull_request_review_comment"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "performance-monitor.yml",
-      "has_schedule": false,
-      "name": "Performance Monitor",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Performance Monitor",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "policy-gate.yml",
-      "has_schedule": false,
-      "name": "Policy Gate",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Policy Gate",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "pull_request"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "project_reconcile_daily.yml",
-      "has_schedule": true,
-      "name": "Reconcile CDB Control Board (Daily)",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Reconcile CDB Control Board (Daily)",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "project_status_label_map.yml",
-      "has_schedule": false,
-      "name": "Sync CDB Control Board Status (Label Map)",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Sync CDB Control Board Status (Label Map)",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "issues"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "project_status_sync.yml",
-      "has_schedule": false,
-      "name": "Sync CDB Control Board Status",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Sync CDB Control Board Status",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "issues"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "python-compat.yml",
-      "has_schedule": true,
-      "name": "python-compat",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "python-compat",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "repository-canon-guard.yml",
-      "has_schedule": false,
-      "name": "Repository Canon Guard",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Repository Canon Guard",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "pull_request",
-        "push",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "required-checks-audit.yml",
-      "has_schedule": false,
-      "name": "required-checks-audit (Sentinel)",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "required-checks-audit (Sentinel)",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "root-session-hygiene-warning.yml",
-      "has_schedule": false,
-      "name": "Root Session Hygiene Warning",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Root Session Hygiene Warning",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "security-alert-readout.yml",
-      "has_schedule": true,
-      "name": "Security Alert Readout",
-      "permissions": [
-        "issues:write",
-        "pull-requests:write"
-      ],
-      "purpose": "Security Alert Readout",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "security-scan.yml",
-      "has_schedule": true,
-      "name": "Security Scan",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Security Scan",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "shadow-soak-evidence.yml",
-      "has_schedule": true,
-      "name": "Shadow + Soak Evidence",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Shadow + Soak Evidence",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "smart-insights.yml",
-      "has_schedule": true,
-      "name": "Smart Insights & Continuous Improvement",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Smart Insights & Continuous Improvement",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "stale.yml",
-      "has_schedule": true,
-      "name": "Close stale issues and PRs",
-      "permissions": [
-        "issues:write",
-        "pull-requests:write"
-      ],
-      "purpose": "Close stale issues and PRs",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "surrealdb-memory-proof.yml",
-      "has_schedule": false,
-      "name": "Optional SurrealDB Memory Proof",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Optional SurrealDB Memory Proof",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "manual_only",
-      "triggers": [
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "sync-labels.yml",
-      "has_schedule": false,
-      "name": "\ud83c\udff7\ufe0f Sync Repository Labels",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "\ud83c\udff7\ufe0f Sync Repository Labels",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "high",
-      "status": "active",
-      "triggers": [
-        "push",
-        "workflow_dispatch"
-      ],
-      "writes_github": true
-    },
-    {
-      "file": "triage_guard.yml",
-      "has_schedule": false,
-      "name": "Triage Guard (Missing Milestone)",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Triage Guard (Missing Milestone)",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "issues"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "trivy.yml",
-      "has_schedule": true,
-      "name": "trivy",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "trivy",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "push",
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "weekly_digest.yml",
-      "has_schedule": true,
-      "name": "Weekly Project Digest",
-      "permissions": [
-        "read-only"
-      ],
-      "purpose": "Weekly Project Digest",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "low",
-      "status": "active",
-      "triggers": [
-        "schedule",
-        "workflow_dispatch"
-      ],
-      "writes_github": false
-    },
-    {
-      "file": "weekly_digest_failure_alert.yml",
-      "has_schedule": false,
-      "name": "Weekly Digest Failure Alert",
-      "permissions": [
-        "issues:write"
-      ],
-      "purpose": "Weekly Digest Failure Alert",
-      "registered_in_markdown_register": true,
-      "required_check_producer": false,
-      "risk": "medium",
-      "status": "active",
-      "triggers": [
-        "workflow_dispatch",
-        "workflow_run"
-      ],
-      "writes_github": true
-    }
-  ],
-  "entry_count": 57,
+  "catalog_scope": "workflow-inventory",
   "limitations": [
     "Control-plane generated unit register is partial by design.",
     "Graph workflow references are relationship-focused, not a full inventory.",
     "Graph parser ignores issue-template and root-config backtick references."
   ],
-  "register_table_count": 57,
   "required_check_contexts": [
     "cdb-local-ci"
   ],
+  "unregistered_on_disk": [],
+  "risky_schedule_collisions": {
+    "0 6 * * 0": [
+      "e2e-tests.yml",
+      "trivy.yml"
+    ],
+    "0 8 * * 1": [
+      "cdb-context-refresh-report.yml",
+      "weekly_digest.yml"
+    ]
+  },
   "risky_cascade_families": {
     "label_event_cascade": [
       "add_to_project.yml",
@@ -1053,16 +36,1032 @@
       "auto-milestone-pr-apply.yml"
     ]
   },
-  "risky_schedule_collisions": {
-    "0 6 * * 0": [
-      "e2e-tests.yml",
-      "trivy.yml"
-    ],
-    "0 8 * * 1": [
-      "cdb-context-refresh-report.yml",
-      "weekly_digest.yml"
-    ]
-  },
-  "schema_version": "1",
-  "unregistered_on_disk": []
+  "entry_count": 57,
+  "disk_workflow_count": 57,
+  "register_table_count": 57,
+  "entries": [
+    {
+      "file": "add_to_project.yml",
+      "name": "Add issues and PRs to CDB Control Board",
+      "purpose": "Add issues and PRs to CDB Control Board",
+      "triggers": [
+        "issues"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "ai-review-router.yml",
+      "name": "AI Review Router",
+      "purpose": "AI Review Router",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "pull-requests:write"
+      ],
+      "writes_github": true,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "auto-milestone-label-dispatch.yml",
+      "name": "Auto Milestone Label Dispatch",
+      "purpose": "Auto Milestone Label Dispatch",
+      "triggers": [
+        "issues"
+      ],
+      "permissions": [
+        "contents:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "high"
+    },
+    {
+      "file": "auto-milestone-pr-apply.yml",
+      "name": "Auto Milestone PR Apply",
+      "purpose": "Auto Milestone PR Apply",
+      "triggers": [
+        "workflow_run"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "auto-milestone-pr-intent.yml",
+      "name": "Auto Milestone PR Intent",
+      "purpose": "Auto Milestone PR Intent",
+      "triggers": [
+        "pull_request"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "auto-milestone.yml",
+      "name": "Auto Milestone",
+      "purpose": "Auto Milestone",
+      "triggers": [
+        "issues",
+        "repository_dispatch",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "high"
+    },
+    {
+      "file": "branch-policy.yml",
+      "name": "Branch Policy Enforcement",
+      "purpose": "Branch Policy Enforcement",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "cdb-backlog-anomaly-escalation.yml",
+      "name": "CDB Backlog Anomaly Escalation",
+      "purpose": "CDB Backlog Anomaly Escalation",
+      "triggers": [
+        "workflow_dispatch",
+        "workflow_run"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "cdb-backlog-curation.yml",
+      "name": "CDB Backlog Curation",
+      "purpose": "CDB Backlog Curation",
+      "triggers": [
+        "issues"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "cdb-context-refresh-report.yml",
+      "name": "CDB Context Refresh Report",
+      "purpose": "CDB Context Refresh Report",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "cdb-control-followup-classifier.yml",
+      "name": "CDB Control Follow-up Classifier",
+      "purpose": "CDB Control Follow-up Classifier",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "cdb-daily-delta-triage.yml",
+      "name": "CDB Daily Delta Triage",
+      "purpose": "CDB Daily Delta Triage",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "cdb-dependabot-autopilot.yml",
+      "name": "CDB Dependabot Autopilot",
+      "purpose": "CDB Dependabot Autopilot",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "cdb-post-merge-followup-scanner.yml",
+      "name": "CDB Post-Merge Follow-up Scanner",
+      "purpose": "CDB Post-Merge Follow-up Scanner",
+      "triggers": [
+        "pull_request",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "cdb-weekly-control-hygiene-classifier.yml",
+      "name": "CDB Weekly Control Hygiene Classifier",
+      "purpose": "CDB Weekly Control Hygiene Classifier",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "ci.yml",
+      "name": "ci",
+      "purpose": "ci",
+      "triggers": [
+        "pull_request",
+        "push"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "codeql-python.yml",
+      "name": "CodeQL Python",
+      "purpose": "CodeQL Python",
+      "triggers": [
+        "pull_request",
+        "push",
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "contracts.yml",
+      "name": "Contract Validation",
+      "purpose": "Contract Validation",
+      "triggers": [
+        "push",
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "control_board_upsert.yml",
+      "name": "Control Board Upsert",
+      "purpose": "Control Board Upsert",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "copilot-housekeeping.yml",
+      "name": "Copilot Housekeeping",
+      "purpose": "Copilot Housekeeping",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write",
+        "pull-requests:write"
+      ],
+      "writes_github": true,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "copilot-setup-steps.yml",
+      "name": "Copilot Setup Steps",
+      "purpose": "Copilot Setup Steps",
+      "triggers": [
+        "push",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "core-guard.yml",
+      "name": "Core Guard",
+      "purpose": "Core Guard",
+      "triggers": [
+        "push",
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "delivery-gate.yml",
+      "name": "Delivery Gate",
+      "purpose": "Delivery Gate",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "docker-publish.yml",
+      "name": "Build & Push Containers (GHCR)",
+      "purpose": "Build & Push Containers (GHCR)",
+      "triggers": [
+        "push",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "docs-conflict-guard.yml",
+      "name": "Docs Conflict Guard",
+      "purpose": "Docs Conflict Guard",
+      "triggers": [
+        "pull_request",
+        "push",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "e2e-happy-path.yaml",
+      "name": "E2E Happy Path",
+      "purpose": "E2E Happy Path",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "e2e-tests.yml",
+      "name": "E2E Tests - Paper Trading",
+      "purpose": "E2E Tests - Paper Trading",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "e2e.yml",
+      "name": "E2E Tests",
+      "purpose": "E2E Tests",
+      "triggers": [
+        "push",
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "emoji-bot.yml",
+      "name": "\ud83e\udd16 Emoji Fix Bot",
+      "purpose": "\ud83e\udd16 Emoji Fix Bot",
+      "triggers": [
+        "issue_comment",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "contents:write",
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "emoji-filter.yml",
+      "name": "\ud83d\udeab Advanced Emoji Filter",
+      "purpose": "\ud83d\udeab Advanced Emoji Filter",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "contents:write",
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "gitleaks.yml",
+      "name": "Gitleaks Secret Scan",
+      "purpose": "Gitleaks Secret Scan",
+      "triggers": [
+        "push",
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "governance-audit.yml",
+      "name": "Governance Audit",
+      "purpose": "Governance Audit",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "label-bootstrap.yml",
+      "name": "Label Bootstrap (Copilot)",
+      "purpose": "Label Bootstrap (Copilot)",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write",
+        "pull-requests:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "lr021_replay_smoke.yml",
+      "name": "lr021-replay-smoke",
+      "purpose": "lr021-replay-smoke",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "mcp_runtime.yml",
+      "name": "mcp-runtime",
+      "purpose": "mcp-runtime",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "milestone_stage_label_sync.yml",
+      "name": "Sync Stage Labels From Milestone",
+      "purpose": "Sync Stage Labels From Milestone",
+      "triggers": [
+        "issues"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "opencode.yml",
+      "name": "opencode",
+      "purpose": "opencode",
+      "triggers": [
+        "issue_comment",
+        "pull_request_review_comment"
+      ],
+      "permissions": [
+        "id-token:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "performance-monitor.yml",
+      "name": "Performance Monitor",
+      "purpose": "Performance Monitor",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "policy-gate.yml",
+      "name": "Policy Gate",
+      "purpose": "Policy Gate",
+      "triggers": [
+        "pull_request"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "project_reconcile_daily.yml",
+      "name": "Reconcile CDB Control Board (Daily)",
+      "purpose": "Reconcile CDB Control Board (Daily)",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "project_status_label_map.yml",
+      "name": "Sync CDB Control Board Status (Label Map)",
+      "purpose": "Sync CDB Control Board Status (Label Map)",
+      "triggers": [
+        "issues"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "project_status_sync.yml",
+      "name": "Sync CDB Control Board Status",
+      "purpose": "Sync CDB Control Board Status",
+      "triggers": [
+        "issues"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "python-compat.yml",
+      "name": "python-compat",
+      "purpose": "python-compat",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "repository-canon-guard.yml",
+      "name": "Repository Canon Guard",
+      "purpose": "Repository Canon Guard",
+      "triggers": [
+        "pull_request",
+        "push",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "required-checks-audit.yml",
+      "name": "required-checks-audit (Sentinel)",
+      "purpose": "required-checks-audit (Sentinel)",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "root-session-hygiene-warning.yml",
+      "name": "Root Session Hygiene Warning",
+      "purpose": "Root Session Hygiene Warning",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "security-alert-readout.yml",
+      "name": "Security Alert Readout",
+      "purpose": "Security Alert Readout",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write",
+        "pull-requests:write"
+      ],
+      "writes_github": true,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "security-scan.yml",
+      "name": "Security Scan",
+      "purpose": "Security Scan",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "shadow-soak-evidence.yml",
+      "name": "Shadow + Soak Evidence",
+      "purpose": "Shadow + Soak Evidence",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "smart-insights.yml",
+      "name": "Smart Insights & Continuous Improvement",
+      "purpose": "Smart Insights & Continuous Improvement",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "stale.yml",
+      "name": "Close stale issues and PRs",
+      "purpose": "Close stale issues and PRs",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write",
+        "pull-requests:write"
+      ],
+      "writes_github": true,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    },
+    {
+      "file": "surrealdb-memory-proof.yml",
+      "name": "Optional SurrealDB Memory Proof",
+      "purpose": "Optional SurrealDB Memory Proof",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "manual_only",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "sync-labels.yml",
+      "name": "\ud83c\udff7\ufe0f Sync Repository Labels",
+      "purpose": "\ud83c\udff7\ufe0f Sync Repository Labels",
+      "triggers": [
+        "push",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "high"
+    },
+    {
+      "file": "triage_guard.yml",
+      "name": "Triage Guard (Missing Milestone)",
+      "purpose": "Triage Guard (Missing Milestone)",
+      "triggers": [
+        "issues"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "trivy.yml",
+      "name": "trivy",
+      "purpose": "trivy",
+      "triggers": [
+        "push",
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "weekly_digest.yml",
+      "name": "Weekly Project Digest",
+      "purpose": "Weekly Project Digest",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "permissions": [
+        "read-only"
+      ],
+      "writes_github": false,
+      "has_schedule": true,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "low"
+    },
+    {
+      "file": "weekly_digest_failure_alert.yml",
+      "name": "Weekly Digest Failure Alert",
+      "purpose": "Weekly Digest Failure Alert",
+      "triggers": [
+        "workflow_dispatch",
+        "workflow_run"
+      ],
+      "permissions": [
+        "issues:write"
+      ],
+      "writes_github": true,
+      "has_schedule": false,
+      "status": "active",
+      "required_check_producer": false,
+      "registered_in_markdown_register": true,
+      "risk": "medium"
+    }
+  ]
 }

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,14 +1,11 @@
 name: Security Scan
 
-# Weekly scan + PR trigger for infrastructure changes
-# Issue #97: Trivy Container Scanning
+# Bimonthly automatic image scan (1st of even months, 02:00 UTC) plus manual
+# workflow_dispatch override for urgent CVE checks. Push/PR triggers removed
+# to avoid per-merge cost (#4275). Issue #97: Trivy Container Scanning.
 on:
-  push:
-    branches: [main]
-  # NOISE-FREEZE (#2613): push auto-trigger disabled due to billing/account-locked
-  # RESTORED (#3659): billing recovery complete, trigger re-enabled
   schedule:
-    - cron: '0 2 * * 1'  # Monday 02:00 UTC
+    - cron: '0 2 1 2,4,6,8,10,12 *'  # 1st of even months, 02:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -395,7 +392,7 @@ jobs:
 # 1. Base image scans (Redis/Postgres) set exit-code: false
 #    - gosu CVEs are documented in docs/security/TRIAGE_RUNBOOK.md
 #    - Attack surface: minimal (startup-only, no network exposure)
-#    - Weekly scans monitor for NEW vulnerabilities
+#    - Bimonthly scans monitor for NEW vulnerabilities
 #
 # 2. Custom image scans are report-only
 #    - pip 25.3 resolves CVE-2025-8869

--- a/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
+++ b/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
@@ -91,7 +91,7 @@ nicht `cdb-local-ci`.
 | `required-checks-audit.yml` | manual-only | workflow_dispatch | read-only | low |
 | `root-session-hygiene-warning.yml` | manual-only | workflow_dispatch | read-only | low |
 | `security-alert-readout.yml` | aktiv | schedule, workflow_dispatch | issues:write, pull-requests:write | medium |
-| `security-scan.yml` | aktiv | push, schedule, workflow_dispatch | read-only | low |
+| `security-scan.yml` | aktiv | schedule, workflow_dispatch | read-only | low |
 | `shadow-soak-evidence.yml` | aktiv | schedule, workflow_dispatch | read-only | low |
 | `smart-insights.yml` | aktiv | schedule, workflow_dispatch | read-only | low |
 | `stale.yml` | aktiv | schedule, workflow_dispatch | issues:write, pull-requests:write | medium |

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -11,7 +11,7 @@
 | Scanner | Workflow | Trigger | SARIF-Upload |
 |---------|----------|---------|-------------|
 | **Trivy FS** | `trivy.yml` | Push (services/, infrastructure/), weekly | Ja |
-| **Trivy Image** | `security-scan.yml` | Push, weekly Monday | Ja |
+| **Trivy Image** | `security-scan.yml` | Bimonthly (1st of even months), workflow_dispatch | Ja |
 | **Gitleaks** | `gitleaks.yml` | Push main, weekly Sunday | Ja |
 | **CodeQL** | `codeql-python.yml` (custom) | Push main, PR, weekly | Ja (auto) |
 

--- a/tests/unit/scripts/test_scheduled_workflow_cadence_contract.py
+++ b/tests/unit/scripts/test_scheduled_workflow_cadence_contract.py
@@ -86,3 +86,12 @@ def test_weekly_digest_and_context_refresh_share_monday_08_utc_collision() -> No
     assert "0 8 * * 1" in collisions
     assert "weekly_digest.yml" in collisions["0 8 * * 1"]
     assert "cdb-context-refresh-report.yml" in collisions["0 8 * * 1"]
+
+
+def test_security_scan_uses_bimonthly_cron_not_weekly_monday() -> None:
+    """#4275: security-scan cadence is bimonthly, not weekly Monday."""
+    entry = helpers.build_schedule_entry(helpers.WORKFLOWS_DIR / "security-scan.yml")
+    assert entry.has_schedule is True
+    assert entry.has_workflow_dispatch is True
+    assert entry.crons == ("0 2 1 2,4,6,8,10,12 *",)
+    assert "0 2 * * 1" not in entry.crons

--- a/tests/unit/scripts/test_scheduled_workflow_cadence_contract.py
+++ b/tests/unit/scripts/test_scheduled_workflow_cadence_contract.py
@@ -33,8 +33,14 @@ def test_schedule_map_is_deterministic_and_visible() -> None:
     "filename,expected_crons",
     [
         ("weekly_digest.yml", ("0 8 * * 1",)),
-        ("cdb-daily-delta-triage.yml", ("20 6 * * 0", "20 6 * * 2", "20 6 * * 3", "20 6 * * 5")),
-        ("cdb-weekly-control-hygiene-classifier.yml", ("30 7 * * 1", "30 7 * * 4", "30 7 * * 5")),
+        (
+            "cdb-daily-delta-triage.yml",
+            ("20 6 * * 0", "20 6 * * 2", "20 6 * * 3", "20 6 * * 5"),
+        ),
+        (
+            "cdb-weekly-control-hygiene-classifier.yml",
+            ("30 7 * * 1", "30 7 * * 4", "30 7 * * 5"),
+        ),
         ("cdb-context-refresh-report.yml", ("0 8 * * 1", "0 8 * * 4")),
         ("stale.yml", ("0 0 * * *",)),
         ("python-compat.yml", ("0 0 * * 0",)),

--- a/tests/unit/scripts/test_security_workflow_boundary_contract.py
+++ b/tests/unit/scripts/test_security_workflow_boundary_contract.py
@@ -85,6 +85,19 @@ def test_security_scan_uses_summary_artifacts_not_secret_payloads() -> None:
     assert "secrets.json" not in content
 
 
+def test_security_scan_bimonthly_trigger_contract() -> None:
+    """#4275: no push/PR noise; bimonthly schedule + manual dispatch only."""
+    path = helpers.WORKFLOWS_DIR / "security-scan.yml"
+    row = helpers.build_security_boundary_row(path)
+    schedule = helpers.build_schedule_entry(path)
+    assert row.has_workflow_dispatch is True
+    assert row.has_schedule is True
+    assert "push" not in row.triggers
+    assert "pull_request" not in row.triggers
+    assert set(row.triggers) == {"schedule", "workflow_dispatch"}
+    assert schedule.crons == ("0 2 1 2,4,6,8,10,12 *",)
+
+
 def test_security_alert_readout_scheduled_vs_manual_boundary_is_documented() -> None:
     content = (
         helpers.WORKFLOWS_DIR / "security-alert-readout.yml"

--- a/tests/unit/scripts/test_security_workflow_boundary_contract.py
+++ b/tests/unit/scripts/test_security_workflow_boundary_contract.py
@@ -99,8 +99,8 @@ def test_security_scan_bimonthly_trigger_contract() -> None:
 
 
 def test_security_alert_readout_scheduled_vs_manual_boundary_is_documented() -> None:
-    content = (
-        helpers.WORKFLOWS_DIR / "security-alert-readout.yml"
-    ).read_text(encoding="utf-8")
+    content = (helpers.WORKFLOWS_DIR / "security-alert-readout.yml").read_text(
+        encoding="utf-8"
+    )
     assert 'LIVE_MODE="true"' in content
     assert 'if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then' in content


### PR DESCRIPTION
## Summary
- Problem: Push/Merge auf `main` startete den teuren Trivy-Image-Scan bei jedem Merge (zahlreiche Runs 2026-07-31 / 2026-08-01).
- Änderung: `push`-Trigger entfernt; Cron von wöchentlich `0 2 * * 1` auf zweimonatlich `0 2 1 2,4,6,8,10,12 *` (1. Tag gerader Monate, 02:00 UTC).
- `workflow_dispatch` bleibt für dringende CVE-Prüfungen erhalten.
- Canon/Runbook und Contract-Tests nachgezogen; Scan-Jobs, Permissions, Trivy/SARIF unverändert.

## Trigger-Contract
| | Vorher | Nachher |
|---|---|---|
| push | ja (`main`) | nein |
| pull_request | nein | nein |
| schedule | `0 2 * * 1` (Montag) | `0 2 1 2,4,6,8,10,12 *` |
| workflow_dispatch | ja | ja |

Erwarteter nächster Auto-Lauf nach 2026-08-01 02:00 UTC: **2026-10-01T02:00:00Z**.

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_tool_status: available; context_trust_level: none; records_found: none
- repo_fallback_reason: insufficient_evidence
- Keine DB-backed Claims.

## Validation
- YAML parse: OK
- `git diff --check`: clean
- `pytest -q` boundary + cadence + agent-workflow-map: **57 passed**
- actionlint: nicht installiert (übersprungen)

## Non-goals
- Keine Änderung an Scan-Jobs, Matrizen, Trivy-Severity, Ignore-/Allowlists
- Keine SARIF-/Permission-/Gate-Semantik-Änderung
- Keine anderen Security-Workflows (`trivy.yml`, `gitleaks.yml`, `codeql-python.yml`, `security-alert-readout.yml`)
- Kein Merge / kein Issue-Close in dieser Delivery-Session

## Kosten-/Noise-Auswirkung
- Pro-Merge Image-Scans entfallen vollständig.
- Automatische Läufe sinken von ~52/Jahr (wöchentlich) auf 6/Jahr (bimonthlich), plus manuelle Dispatches bei Bedarf.

## Refs
Refs #4275