### PR TITLE
feat(ci): Phase-C GitHub App auth auto-mint for Check Runs (#4170)

### DIFF
--- a/ci/publisher/app_auth.py
+++ b/ci/publisher/app_auth.py
@@ -1,0 +1,275 @@
+"""GitHub App JWT + installation-token minting for Check Run publisher (#4170 Phase C).
+
+Credentials stay in memory only. Never log PEM, JWT, or installation tokens.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
+
+from ci.publisher.exceptions import AuthenticationError, GitHubApiError, PublisherError
+from ci.publisher.github_client import (
+    DEFAULT_TIMEOUT_SECONDS,
+    GITHUB_API,
+    GitHubResponse,
+    Transport,
+    _default_transport,
+)
+from ci.publisher.redaction import redact_mapping, redact_text
+
+# Canonical env names
+APP_ID_ENV = "CDB_GH_APP_ID"
+INSTALLATION_ID_ENV = "CDB_GH_APP_INSTALLATION_ID"
+PRIVATE_KEY_ENV = "CDB_GH_APP_PRIVATE_KEY"
+PRIVATE_KEY_PATH_ENV = "CDB_GH_APP_PRIVATE_KEY_PATH"
+
+# Documented read aliases (operator User-env convenience)
+APP_ID_ALIAS_ENV = "CDB_GITHUB_APP_ID"
+INSTALLATION_ID_ALIAS_ENV = "CDB_GITHUB_APP_INSTALLATION_ID"
+PRIVATE_KEY_PATH_ALIAS_ENV = "CDB_GITHUB_APP_PRIVATE_KEY_PATH"
+
+# GitHub App JWT TTL: max 10 minutes; use ~9 minutes with 60s past iat skew.
+JWT_IAT_SKEW_SECONDS = 60
+JWT_TTL_SECONDS = 540
+
+
+def _env_first(*names: str) -> str:
+    for name in names:
+        value = (os.environ.get(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _parse_positive_int(value: object, *, field_name: str) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise PublisherError(
+            f"{field_name} must be a positive integer, got {value!r}"
+        ) from exc
+    if parsed <= 0:
+        raise PublisherError(f"{field_name} must be a positive integer, got {parsed}")
+    return parsed
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def resolve_app_id_from_env() -> int:
+    """Resolve App ID from canonical env, then documented alias."""
+    raw = _env_first(APP_ID_ENV, APP_ID_ALIAS_ENV)
+    if not raw:
+        raise AuthenticationError(
+            f"Missing {APP_ID_ENV} (alias {APP_ID_ALIAS_ENV} also unset)"
+        )
+    return _parse_positive_int(raw, field_name=APP_ID_ENV)
+
+
+def resolve_installation_id_from_env() -> int:
+    """Resolve Installation ID from canonical env, then documented alias."""
+    raw = _env_first(INSTALLATION_ID_ENV, INSTALLATION_ID_ALIAS_ENV)
+    if not raw:
+        raise AuthenticationError(
+            f"Missing {INSTALLATION_ID_ENV} "
+            f"(alias {INSTALLATION_ID_ALIAS_ENV} also unset)"
+        )
+    return _parse_positive_int(raw, field_name=INSTALLATION_ID_ENV)
+
+
+def _normalize_pem_text(raw: str) -> bytes:
+    text = raw.strip()
+    if not text:
+        raise AuthenticationError("GitHub App private key is empty")
+    # Support env values that escaped newlines as literal \n
+    if "\\n" in text and "-----BEGIN" in text:
+        text = text.replace("\\n", "\n")
+    if "-----BEGIN" not in text:
+        raise AuthenticationError("GitHub App private key is not a PEM block")
+    return text.encode("utf-8")
+
+
+def load_private_key_pem() -> bytes:
+    """Load PEM bytes: inline env wins over path env (canonical before alias path)."""
+    inline = (os.environ.get(PRIVATE_KEY_ENV) or "").strip()
+    if inline:
+        return _normalize_pem_text(inline)
+    path_raw = _env_first(PRIVATE_KEY_PATH_ENV, PRIVATE_KEY_PATH_ALIAS_ENV)
+    if not path_raw:
+        raise AuthenticationError(
+            f"Missing {PRIVATE_KEY_ENV} and {PRIVATE_KEY_PATH_ENV} "
+            f"(alias {PRIVATE_KEY_PATH_ALIAS_ENV} also unset)"
+        )
+    path = Path(path_raw).expanduser()
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise AuthenticationError(
+            f"Unable to read GitHub App private key path "
+            f"({PRIVATE_KEY_PATH_ENV}): {redact_text(type(exc).__name__)}"
+        ) from exc
+    if not data.strip():
+        raise AuthenticationError("GitHub App private key file is empty")
+    try:
+        return _normalize_pem_text(data.decode("utf-8"))
+    except UnicodeDecodeError as exc:
+        raise AuthenticationError(
+            "GitHub App private key file is not valid UTF-8 PEM text"
+        ) from exc
+
+
+def _load_rsa_private_key(pem: bytes) -> PrivateKeyTypes:
+    try:
+        key = serialization.load_pem_private_key(pem, password=None)
+    except (TypeError, ValueError) as exc:
+        raise AuthenticationError(
+            "GitHub App private key PEM is invalid or unreadable"
+        ) from exc
+    if not hasattr(key, "sign"):
+        raise AuthenticationError("GitHub App private key is not an RSA signing key")
+    return key
+
+
+def mint_app_jwt(
+    *,
+    app_id: int,
+    private_key_pem: bytes,
+    now: int | None = None,
+) -> str:
+    """Create a short-lived RS256 App JWT (in memory only)."""
+    issued_at = int(now if now is not None else time.time())
+    payload = {
+        "iat": issued_at - JWT_IAT_SKEW_SECONDS,
+        "exp": issued_at - JWT_IAT_SKEW_SECONDS + JWT_TTL_SECONDS,
+        "iss": str(app_id),
+    }
+    header = {"alg": "RS256", "typ": "JWT"}
+    signing_input = (
+        f"{_b64url(json.dumps(header, separators=(',', ':')).encode('utf-8'))}."
+        f"{_b64url(json.dumps(payload, separators=(',', ':')).encode('utf-8'))}"
+    ).encode("ascii")
+    key = _load_rsa_private_key(private_key_pem)
+    try:
+        signature = key.sign(  # type: ignore[union-attr]
+            signing_input,
+            padding.PKCS1v15(),
+            hashes.SHA256(),
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-closed; never surface key material
+        raise AuthenticationError(
+            f"Failed to sign GitHub App JWT: {type(exc).__name__}"
+        ) from exc
+    return f"{signing_input.decode('ascii')}.{_b64url(signature)}"
+
+
+def request_installation_token(
+    *,
+    app_jwt: str,
+    installation_id: int,
+    transport: Transport | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    """POST /app/installations/{id}/access_tokens; return token (memory only)."""
+    if not app_jwt.strip():
+        raise AuthenticationError("Empty GitHub App JWT")
+    installation_id = _parse_positive_int(
+        installation_id, field_name=INSTALLATION_ID_ENV
+    )
+    path = f"/app/installations/{installation_id}/access_tokens"
+    url = f"{GITHUB_API}{path}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {app_jwt}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "cdb-local-ci-app-auth",
+        "Content-Type": "application/json",
+    }
+    runner = transport or _default_transport
+    try:
+        response: GitHubResponse = runner("POST", url, headers, b"{}", timeout_seconds)
+    except TimeoutError as exc:
+        raise GitHubApiError("GitHub App installation token request timed out") from exc
+    except GitHubApiError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise GitHubApiError(
+            f"GitHub App installation token request failed: {type(exc).__name__}"
+        ) from exc
+
+    if response.status_code in {401, 403}:
+        raise AuthenticationError(
+            "GitHub App JWT rejected or insufficient permission to mint "
+            f"installation token (HTTP {response.status_code})"
+        )
+    if response.status_code == 404:
+        raise AuthenticationError(
+            f"GitHub App installation {installation_id} not found (HTTP 404)"
+        )
+    if response.status_code >= 400:
+        raise GitHubApiError(
+            f"Installation token mint failed HTTP {response.status_code}: "
+            f"{redact_mapping(response.body)}"
+        )
+    body = response.body
+    if not isinstance(body, dict):
+        raise GitHubApiError("Ambiguous installation token response")
+    token = str(body.get("token") or "").strip()
+    if not token:
+        raise AuthenticationError("Installation token response missing token field")
+    return token
+
+
+def mint_installation_token(
+    *,
+    transport: Transport | None = None,
+    now: int | None = None,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    """Resolve App credentials from env, mint JWT, exchange for installation token."""
+    app_id = resolve_app_id_from_env()
+    installation_id = resolve_installation_id_from_env()
+    pem = load_private_key_pem()
+    jwt = mint_app_jwt(app_id=app_id, private_key_pem=pem, now=now)
+    return request_installation_token(
+        app_jwt=jwt,
+        installation_id=installation_id,
+        transport=transport,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def app_credentials_configured() -> bool:
+    """True when App ID, Installation ID, and a private-key source are present."""
+    try:
+        resolve_app_id_from_env()
+        resolve_installation_id_from_env()
+        load_private_key_pem()
+    except (AuthenticationError, PublisherError):
+        return False
+    return True
+
+
+def credential_summary() -> dict[str, Any]:
+    """Non-secret diagnostic for probe/logs (never includes PEM/JWT/token)."""
+    return {
+        "app_id_env_present": bool(_env_first(APP_ID_ENV, APP_ID_ALIAS_ENV)),
+        "installation_id_env_present": bool(
+            _env_first(INSTALLATION_ID_ENV, INSTALLATION_ID_ALIAS_ENV)
+        ),
+        "private_key_inline_present": bool(
+            (os.environ.get(PRIVATE_KEY_ENV) or "").strip()
+        ),
+        "private_key_path_present": bool(
+            _env_first(PRIVATE_KEY_PATH_ENV, PRIVATE_KEY_PATH_ALIAS_ENV)
+        ),
+    }

--- a/ci/publisher/backends.py
+++ b/ci/publisher/backends.py
@@ -9,6 +9,13 @@ from typing import Any, Protocol
 from urllib.parse import quote
 
 from ci.publisher import EXPECTED_REPOSITORY
+from ci.publisher.app_auth import (
+    APP_ID_ALIAS_ENV,
+    APP_ID_ENV,
+    INSTALLATION_ID_ALIAS_ENV,
+    INSTALLATION_ID_ENV,
+    mint_installation_token,
+)
 from ci.publisher.exceptions import AuthenticationError, GitHubApiError, PublisherError
 from ci.publisher.github_client import (
     DEFAULT_TIMEOUT_SECONDS,
@@ -27,8 +34,8 @@ from ci.publisher.models import (
 from ci.publisher.redaction import redact_mapping, redact_text
 
 APP_INSTALLATION_TOKEN_ENV = "CDB_GH_APP_INSTALLATION_TOKEN"
-EXPECTED_APP_ID_ENV = "CDB_GH_APP_ID"
-EXPECTED_INSTALLATION_ID_ENV = "CDB_GH_APP_INSTALLATION_ID"
+EXPECTED_APP_ID_ENV = APP_ID_ENV
+EXPECTED_INSTALLATION_ID_ENV = INSTALLATION_ID_ENV
 ALLOWED_BACKENDS = frozenset({"commit-status", "check-run"})
 _DEFAULT_OWNER, _DEFAULT_REPO = EXPECTED_REPOSITORY.split("/", 1)
 
@@ -46,10 +53,18 @@ def parse_positive_int(value: object, *, field_name: str) -> int:
     return parsed
 
 
-def resolve_app_installation_token(*, explicit: str | None = None) -> str:
+def resolve_app_installation_token(
+    *,
+    explicit: str | None = None,
+    transport: Transport | None = None,
+) -> str:
     """Resolve GitHub App installation token — never gh auth / GITHUB_TOKEN / GH_TOKEN.
 
-    Only ``CDB_GH_APP_INSTALLATION_TOKEN`` (or an explicit test inject) is accepted.
+    Priority:
+    1. explicit test inject
+    2. ``CDB_GH_APP_INSTALLATION_TOKEN``
+    3. auto-mint from App ID + Installation ID + private key (path or inline)
+    4. ``AuthenticationError`` (no PAT / ``gh auth`` fallback)
     """
     if explicit is not None:
         token = explicit.strip()
@@ -57,12 +72,22 @@ def resolve_app_installation_token(*, explicit: str | None = None) -> str:
             raise AuthenticationError("Empty GitHub App installation token")
         return token
     token = (os.environ.get(APP_INSTALLATION_TOKEN_ENV) or "").strip()
-    if not token:
+    if token:
+        return token
+    try:
+        return mint_installation_token(transport=transport)
+    except AuthenticationError as exc:
         raise AuthenticationError(
-            f"Missing {APP_INSTALLATION_TOKEN_ENV}; Check Run mode refuses "
-            "GITHUB_TOKEN / GH_TOKEN / gh auth token as App identity proof"
-        )
-    return token
+            f"Missing {APP_INSTALLATION_TOKEN_ENV} and App credential auto-mint "
+            f"failed ({exc}); Check Run mode refuses GITHUB_TOKEN / GH_TOKEN / "
+            "gh auth token as App identity proof"
+        ) from exc
+    except (GitHubApiError, PublisherError) as exc:
+        raise AuthenticationError(
+            f"Missing {APP_INSTALLATION_TOKEN_ENV} and App credential auto-mint "
+            f"failed ({exc}); Check Run mode refuses GITHUB_TOKEN / GH_TOKEN / "
+            "gh auth token as App identity proof"
+        ) from exc
 
 
 def resolve_expected_app_id(
@@ -71,11 +96,14 @@ def resolve_expected_app_id(
     if cli_value is not None:
         return parse_positive_int(cli_value, field_name="expected-app-id")
     env_raw = (os.environ.get(EXPECTED_APP_ID_ENV) or "").strip()
+    if not env_raw:
+        env_raw = (os.environ.get(APP_ID_ALIAS_ENV) or "").strip()
     if env_raw:
         return parse_positive_int(env_raw, field_name=EXPECTED_APP_ID_ENV)
     if require:
         raise PublisherError(
-            f"Check Run mode requires --expected-app-id or {EXPECTED_APP_ID_ENV}"
+            f"Check Run mode requires --expected-app-id or {EXPECTED_APP_ID_ENV} "
+            f"(alias {APP_ID_ALIAS_ENV})"
         )
     return None
 
@@ -86,12 +114,14 @@ def resolve_expected_installation_id(
     if cli_value is not None:
         return parse_positive_int(cli_value, field_name="expected-installation-id")
     env_raw = (os.environ.get(EXPECTED_INSTALLATION_ID_ENV) or "").strip()
+    if not env_raw:
+        env_raw = (os.environ.get(INSTALLATION_ID_ALIAS_ENV) or "").strip()
     if env_raw:
         return parse_positive_int(env_raw, field_name=EXPECTED_INSTALLATION_ID_ENV)
     if require:
         raise PublisherError(
             "Check Run mode requires --expected-installation-id or "
-            f"{EXPECTED_INSTALLATION_ID_ENV}"
+            f"{EXPECTED_INSTALLATION_ID_ENV} (alias {INSTALLATION_ID_ALIAS_ENV})"
         )
     return None
 

--- a/ci/publisher/cli.py
+++ b/ci/publisher/cli.py
@@ -11,6 +11,7 @@ from typing import Any, Sequence
 from ci.lib.evidence import DEFAULT_FRESHNESS_HOURS, utc_now
 from ci.lib.gitinfo import EXPECTED_REPOSITORY, collect_git_info
 from ci.publisher import DEFAULT_STATUS_CONTEXT, PREVIEW_STATUS_CONTEXT
+from ci.publisher.app_auth import credential_summary
 from ci.publisher.backends import (
     ALLOWED_BACKENDS,
     CheckRunBackend,
@@ -39,7 +40,12 @@ from ci.publisher.ledger import (
     find_exact_publication,
     load_ledger,
 )
-from ci.publisher.models import CHECK_RUN_NAME, SHADOW_CHECK_RUN_NAME
+from ci.publisher.models import (
+    CHECK_RUN_NAME,
+    SHADOW_CHECK_RUN_NAME,
+    CheckRunPayload,
+    build_check_run_external_id,
+)
 from ci.publisher.redaction import redact_mapping, redact_text
 from tools.ci.policy_gate_local import evaluate_policy_gate
 
@@ -816,14 +822,167 @@ def cmd_inspect(args: argparse.Namespace) -> int:
     return SUCCESS_EXIT
 
 
+def cmd_app_auth_probe(args: argparse.Namespace) -> int:
+    """Mint App installation token and write SHADOW Check Run only (#4170 Phase C).
+
+    Refuses required name ``cdb-local-ci`` and any Commit Status write. Intended
+    for disposable probe SHAs — bypasses full evidence gates by design.
+    """
+    commit_sha = (args.commit_sha or "").strip().lower()
+    if not commit_sha or len(commit_sha) != 40:
+        print(
+            "REJECT: --commit-sha must be the exact 40-char probe SHA",
+            file=sys.stderr,
+        )
+        _print_json(
+            {
+                "command": "app-auth-probe",
+                "ok": False,
+                "reason": "exact 40-char commit SHA required",
+            }
+        )
+        return USAGE_EXIT
+
+    check_name = str(getattr(args, "check_run_name", None) or SHADOW_CHECK_RUN_NAME)
+    if check_name != SHADOW_CHECK_RUN_NAME:
+        print(
+            f"REJECT: app-auth-probe only allows check-run name "
+            f"{SHADOW_CHECK_RUN_NAME!r} (refused {check_name!r})",
+            file=sys.stderr,
+        )
+        _print_json(
+            {
+                "command": "app-auth-probe",
+                "ok": False,
+                "reason": f"refused non-shadow check-run name {check_name!r}",
+                "allowed_name": SHADOW_CHECK_RUN_NAME,
+            }
+        )
+        return FAILURE_EXIT
+    if check_name == CHECK_RUN_NAME:
+        print(
+            f"REJECT: app-auth-probe refuses required name {CHECK_RUN_NAME!r}",
+            file=sys.stderr,
+        )
+        return FAILURE_EXIT
+
+    repository = str(args.repository or EXPECTED_REPOSITORY)
+    if repository != EXPECTED_REPOSITORY:
+        print(
+            f"REJECT: repository must be {EXPECTED_REPOSITORY}",
+            file=sys.stderr,
+        )
+        return FAILURE_EXIT
+
+    try:
+        owner, repo = repository.split("/", 1)
+        app_id, installation_id = _cli_app_ids(args)
+        expected_app_id = resolve_expected_app_id(cli_value=app_id, require=True)
+        expected_installation_id = resolve_expected_installation_id(
+            cli_value=installation_id, require=True
+        )
+        assert expected_app_id is not None and expected_installation_id is not None
+        token = resolve_app_installation_token()
+        backend = CheckRunBackend(
+            token=token,
+            expected_app_id=expected_app_id,
+            expected_installation_id=expected_installation_id,
+            owner=owner,
+            repo=repo,
+        )
+        now = utc_now()
+        run_id = f"app-auth-probe-{commit_sha[:12]}"
+        payload = CheckRunPayload(
+            name=SHADOW_CHECK_RUN_NAME,
+            head_sha=commit_sha,
+            conclusion="success",
+            started_at=now,
+            completed_at=now,
+            external_id=build_check_run_external_id(
+                run_id=run_id, commit_sha=commit_sha
+            ),
+            output_title="cdb-local-ci App auth probe (shadow)",
+            output_summary=(
+                "Phase-C shadow probe: GitHub App JWT auto-mint + Check Run write. "
+                "Not the required cdb-local-ci context."
+            ),
+        )
+        if args.dry_run:
+            result = backend.publish(check_run_payload=payload, dry_run=True)
+            _print_json(
+                {
+                    "command": "app-auth-probe",
+                    "ok": True,
+                    "dry_run": True,
+                    "sha": commit_sha,
+                    "check_run_name": SHADOW_CHECK_RUN_NAME,
+                    "expected_app_id": expected_app_id,
+                    "expected_installation_id": expected_installation_id,
+                    "credentials": credential_summary(),
+                    "remote_verification_status": result.remote_verification_status,
+                }
+            )
+            return SUCCESS_EXIT
+
+        result = backend.publish(check_run_payload=payload, dry_run=False)
+        _print_json(
+            {
+                "command": "app-auth-probe",
+                "ok": True,
+                "dry_run": False,
+                "sha": commit_sha,
+                "check_run_name": result.check_run_name,
+                "github_check_run_id": result.remote_id,
+                "app_id": result.github_app_id,
+                "installation_id": result.github_installation_id,
+                "external_id": result.external_id,
+                "remote_verification_status": result.remote_verification_status,
+                "idempotent_noop": result.idempotent_noop,
+                "credentials": credential_summary(),
+            }
+        )
+        return SUCCESS_EXIT
+    except AuthenticationError as exc:
+        message = redact_text(str(exc))
+        blocked = (
+            "insufficient app permission" in message.lower()
+            or "checks" in message.lower()
+        )
+        status = "BLOCKED_APP_PERMISSION" if blocked else "AUTH_FAILED"
+        print(f"REJECT: {message}", file=sys.stderr)
+        _print_json(
+            {
+                "command": "app-auth-probe",
+                "ok": False,
+                "status": status,
+                "reason": message,
+                "credentials": credential_summary(),
+            }
+        )
+        return FAILURE_EXIT
+    except (GitHubApiError, PublisherError) as exc:
+        message = redact_text(str(exc))
+        print(f"REJECT: {message}", file=sys.stderr)
+        _print_json(
+            {
+                "command": "app-auth-probe",
+                "ok": False,
+                "reason": message,
+                "credentials": credential_summary(),
+            }
+        )
+        return FAILURE_EXIT
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m ci.publisher",
         description=(
             "Validate local Docker CI evidence and publish a commit-bound "
             "GitHub Commit Status (default) or an explicit App-bound Check Run "
-            "(--publisher-backend check-run). Branch Protection is not changed "
-            "by this tool."
+            "(--publisher-backend check-run). Check Run mode auto-mints an "
+            "installation token when App ID/Installation ID/PEM are set. "
+            "Branch Protection is not changed by this tool."
         ),
     )
     sub = parser.add_subparsers(dest="command", required=True)
@@ -854,6 +1013,48 @@ def build_parser() -> argparse.ArgumentParser:
             action.required = False
             action.default = "."
     inspect.set_defaults(func=cmd_inspect)
+
+    probe = sub.add_parser(
+        "app-auth-probe",
+        help=(
+            f"Mint App installation token and write shadow Check Run "
+            f"{SHADOW_CHECK_RUN_NAME} only (no evidence gates; refuses "
+            f"{CHECK_RUN_NAME})"
+        ),
+    )
+    probe.add_argument(
+        "--commit-sha",
+        required=True,
+        help="Exact 40-char probe commit SHA (not main)",
+    )
+    probe.add_argument(
+        "--repository",
+        default=EXPECTED_REPOSITORY,
+        help="owner/name (must be jannekbuengener/Claire_de_Binare)",
+    )
+    probe.add_argument(
+        "--expected-app-id",
+        type=int,
+        default=0,
+        help="Expected GitHub App ID (or CDB_GH_APP_ID / alias)",
+    )
+    probe.add_argument(
+        "--expected-installation-id",
+        type=int,
+        default=0,
+        help="Expected installation ID (or CDB_GH_APP_INSTALLATION_ID / alias)",
+    )
+    probe.add_argument(
+        "--check-run-name",
+        default=SHADOW_CHECK_RUN_NAME,
+        help=f"Must be {SHADOW_CHECK_RUN_NAME} (default)",
+    )
+    probe.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve credentials path and build payload without GitHub write",
+    )
+    probe.set_defaults(func=cmd_app_auth_probe)
 
     return parser
 

--- a/ci/publisher/redaction.py
+++ b/ci/publisher/redaction.py
@@ -13,14 +13,15 @@ _TOKEN_RE = re.compile(
     r"|ghu_[A-Za-z0-9_]{8,}"
     r"|ghs_[A-Za-z0-9_]{8,}"
     r"|ghr_[A-Za-z0-9_]{8,}"
-    r"|Bearer\s+[A-Za-z0-9\-._~+/]+=*"
+    r"|Bearer\s+\S+"
     r")\b"
 )
+_JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
 _PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN[A-Z ]*PRIVATE KEY-----[\s\S]*?-----END[A-Z ]*PRIVATE KEY-----"
 )
 _AUTH_HEADER_RE = re.compile(
-    r"(?i)(authorization\s*[:=]\s*)(['\"]?)([^'\"\s,;]+)(['\"]?)"
+    r"(?i)(authorization\s*[:=]\s*)(['\"]?)(Bearer\s+\S+|[^'\"\s,;]+)(['\"]?)"
 )
 _QUERY_TOKEN_RE = re.compile(r"(?i)([?&](?:access_token|token|auth)=)([^&\s]+)")
 
@@ -33,6 +34,7 @@ def redact_text(value: str) -> str:
     redacted = _QUERY_TOKEN_RE.sub(r"\1[REDACTED]", redacted)
     redacted = _PRIVATE_KEY_RE.sub("[REDACTED_PRIVATE_KEY]", redacted)
     redacted = _TOKEN_RE.sub("[REDACTED]", redacted)
+    redacted = _JWT_RE.sub("[REDACTED_JWT]", redacted)
     return redacted
 
 
@@ -50,6 +52,8 @@ def redact_mapping(payload: Any) -> Any:
                 "secret",
                 "private_key",
                 "privatekey",
+                "jwt",
+                "app_jwt",
             }:
                 out[key] = "[REDACTED]"
             else:

--- a/docs/ci/local-status-publisher.md
+++ b/docs/ci/local-status-publisher.md
@@ -81,11 +81,41 @@ separate Human-GO cutover (see
 | Surface | Auth needed | Status |
 |---------|-------------|--------|
 | Commit Status | PAT / `gh` with statuses write | **Default / current required path** |
-| Check Run | GitHub App installation token (`CDB_GH_APP_INSTALLATION_TOKEN`) + expected App/Installation IDs | **Code-ready; BP cutover external** |
+| Check Run | App ID + Installation ID + PEM (auto-mint) **or** `CDB_GH_APP_INSTALLATION_TOKEN` override | **Code-ready + auto-mint; BP cutover external (Phase D)** |
 
 `GitHubStatusClient` still has no `create_check_run` method. Check Runs live in
 `ci.publisher.backends.CheckRunBackend`. User/OAuth/`gh auth` tokens are **not**
 accepted as App identity proof for Check Run mode.
+
+### Check Run auth priority
+
+1. Explicit test inject (programmatic only)
+2. `CDB_GH_APP_INSTALLATION_TOKEN` (optional override)
+3. Auto-mint via `ci.publisher.app_auth` from `CDB_GH_APP_ID` +
+   `CDB_GH_APP_INSTALLATION_ID` + (`CDB_GH_APP_PRIVATE_KEY` **or**
+   `CDB_GH_APP_PRIVATE_KEY_PATH`)
+4. Fail closed — **no** `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth` fallback
+
+Documented aliases: `CDB_GITHUB_APP_ID`, `CDB_GITHUB_APP_INSTALLATION_ID`,
+`CDB_GITHUB_APP_PRIVATE_KEY_PATH`.
+
+Normal Check Run operation does **not** require manual JWT / installation-token
+steps when PEM + IDs are configured. For permission smoke without evidence
+gates:
+
+```bash
+python -m ci.publisher app-auth-probe --commit-sha <exact_probe_sha>
+```
+
+Shadow only (`cdb-local-ci-app-preview`). Refuses required name `cdb-local-ci`.
+
+Troubleshooting:
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| 401 on mint / Check Run | Bad PEM, wrong App ID, expired JWT clock skew | Recheck PEM path + IDs; do not print secrets |
+| 403 on Check Run create | Missing App permission `checks:write` | **STOP** `BLOCKED_APP_PERMISSION`; fix App permissions (no Commit Status bypass) |
+| 404 on `/app/installations/.../access_tokens` | Wrong installation ID or App not installed on repo | Fix installation ID / install App on canonical repo |
 
 ### CLI backend switch
 

--- a/docs/runbooks/cdb_local_ci_app_check_run_cutover.md
+++ b/docs/runbooks/cdb_local_ci_app_check_run_cutover.md
@@ -28,7 +28,7 @@ local CI evidence.
 | Backend | CLI | Auth | GitHub object |
 |---|---|---|---|
 | `commit-status` (default) | `--publisher-backend commit-status` | `GITHUB_TOKEN` / `GH_TOKEN` / `gh auth` via existing resolver | Commit Status |
-| `check-run` (explicit) | `--publisher-backend check-run` | **only** `CDB_GH_APP_INSTALLATION_TOKEN` | Check Run |
+| `check-run` (explicit) | `--publisher-backend check-run` | App credentials auto-mint **or** `CDB_GH_APP_INSTALLATION_TOKEN` (never PAT/`gh`) | Check Run |
 
 Shared fail-closed gates (unchanged): evidence validation, exact SHA bind,
 `--pr-number` for required context, local policy-gate mirror, dirty-worktree
@@ -82,15 +82,24 @@ path so Checks R/W + Metadata Read is the minimum for the Check Run writer.
 6. Do **not** reuse the Control-Board / Projects App as the local-ci publisher
    unless explicitly decided; least privilege prefers a dedicated App.
 
-### C_SHADOW_SMOKE (explicit credentials + Human-GO)
+### C_SHADOW_SMOKE (App credentials + Human-GO; publisher auto-mints)
 
 Recommended shadow name: `cdb-local-ci-app-preview` (not required).
 
+Phase C (#4170): the publisher mints a short-lived installation token from
+App ID + Installation ID + private key (path or inline). Manual
+`CDB_GH_APP_INSTALLATION_TOKEN` remains optional override.
+
 ```bash
-export CDB_GH_APP_INSTALLATION_TOKEN="<short-lived installation token>"
 export CDB_GH_APP_ID="<app_id>"
 export CDB_GH_APP_INSTALLATION_ID="<installation_id>"
+export CDB_GH_APP_PRIVATE_KEY_PATH="/path/to/cdb-local-ci-app.pem"
+# optional override: export CDB_GH_APP_INSTALLATION_TOKEN="<short-lived token>"
 
+# Disposable probe SHA (no full evidence gates); refuses required name cdb-local-ci:
+python -m ci.publisher app-auth-probe --commit-sha <exact_probe_sha>
+
+# Full evidence path for shadow Check Run (after dry-run OK + Human-GO):
 python -m ci.publisher dry-run \
   --publisher-backend check-run \
   --expected-app-id "$CDB_GH_APP_ID" \
@@ -100,7 +109,6 @@ python -m ci.publisher dry-run \
   --commit-sha <exact_pr_head_sha> \
   --pr-number <n>
 
-# Only after dry-run OK and Human-GO:
 python -m ci.publisher publish \
   --publisher-backend check-run \
   --expected-app-id "$CDB_GH_APP_ID" \
@@ -119,6 +127,8 @@ python -m ci.publisher inspect \
 ```
 
 Verify remote: `name`, `head_sha`, `conclusion`, `external_id`, **`app.id`**.
+On 403 / missing `checks:write` → **STOP** `BLOCKED_APP_PERMISSION`
+(no Commit Status bypass).
 
 ### D_CUTOVER (separate Human-GO; not this PR)
 
@@ -143,21 +153,24 @@ Verify remote: `name`, `head_sha`, `conclusion`, `external_id`, **`app.id`**.
 
 | Name | Kind | Notes |
 |---|---|---|
-| `CDB_GH_APP_INSTALLATION_TOKEN` | ephemeral secret | Installation token (~1h); mint outside publisher core |
-| `CDB_GH_APP_ID` | non-secret config | Expected App ID for readback |
-| `CDB_GH_APP_INSTALLATION_ID` | non-secret config | Expected installation ID |
-| Private Key | secret, external SSOT only | Never in repo, logs, issues, or PR bodies |
+| `CDB_GH_APP_ID` | non-secret config | Expected App ID for readback (+ JWT `iss`) |
+| `CDB_GH_APP_INSTALLATION_ID` | non-secret config | Installation used for token mint |
+| `CDB_GH_APP_PRIVATE_KEY_PATH` / `CDB_GH_APP_PRIVATE_KEY` | secret | PEM path (preferred) or inline; external SSOT only |
+| `CDB_GH_APP_INSTALLATION_TOKEN` | ephemeral secret | Optional override (~1h); else publisher auto-mints |
+
+Documented read aliases (User-env convenience): `CDB_GITHUB_APP_ID`,
+`CDB_GITHUB_APP_INSTALLATION_ID`, `CDB_GITHUB_APP_PRIVATE_KEY_PATH`.
 
 Rotation:
 
 1. Generate new Private Key in GitHub App settings (or rotate App).
 2. Store in external secrets SSOT; sync to GitHub repo secrets if needed.
 3. Revoke old key.
-4. Mint fresh installation tokens from the new key via a separate ops path.
-5. Re-run shadow smoke.
+4. Re-run shadow smoke / `app-auth-probe` (publisher mints a fresh installation token).
 
-Publisher core **consumes** an installation token; it does not mint from a
-Private Key in this slice.
+Publisher Check Run mode **auto-mints** the installation token when App
+credentials are present (`ci.publisher.app_auth`). Explicit
+`CDB_GH_APP_INSTALLATION_TOKEN` still wins when set.
 
 Collision note: Control-Board workflows already document `CDB_GH_APP_ID` /
 `PRIVATE_KEY` / `INSTALLATION_ID`. Prefer a **dedicated** local-ci App and
@@ -174,7 +187,7 @@ secrets blindly.
 - [ ] Permission matrix matches this runbook (no prohibited grants)
 - [ ] Shadow check name `cdb-local-ci-app-preview` chosen
 - [ ] Test PR number and exact head SHA recorded
-- [ ] Installation token available in env (not argv, not logged)
+- [ ] App PEM path or inline key available (or optional installation token override)
 - [ ] Local evidence validated for that SHA
 
 ---
@@ -237,14 +250,14 @@ secret_names:
   installation_token: CDB_GH_APP_INSTALLATION_TOKEN
   expected_app_id: CDB_GH_APP_ID
   expected_installation_id: CDB_GH_APP_INSTALLATION_ID
+  private_key_path: CDB_GH_APP_PRIVATE_KEY_PATH
+  private_key_inline: CDB_GH_APP_PRIVATE_KEY
 private_key_storage: "External secrets SSOT only (never repository)"
-token_minting_responsibility: "Human/ops outside publisher core"
+token_minting_responsibility: "Publisher auto-mint via ci.publisher.app_auth (Phase C); optional INSTALLATION_TOKEN override"
 shadow_check_name: cdb-local-ci-app-preview
 shadow_smoke_command: >
-  python -m ci.publisher publish --publisher-backend check-run
-  --check-run-name cdb-local-ci-app-preview
-  --expected-app-id <ID> --expected-installation-id <ID>
-  --evidence-dir ci/artifacts/<run_id> --commit-sha <SHA> --pr-number <N>
+  python -m ci.publisher app-auth-probe --commit-sha <PROBE_SHA>
+phase_c_completed_by_code: true
 expected_remote_app_id_verification: "GET check-run → app.id == CDB_GH_APP_ID"
 branch_protection_before:
   required_contexts: ["cdb-local-ci"]
@@ -265,5 +278,5 @@ human_go_points:
 unresolved_risks:
   - "Live BP not writable/readable by cloud integration (403 observed)"
   - "Control-Board CDB_GH_APP_* name collision if shared carelessly"
-  - "Installation token minting ops path not automated in this PR"
+  - "Live App checks:write still required for probe; BP cutover remains Phase D Human-GO"
 ```

--- a/docs/runbooks/cdb_secrets_ssot.md
+++ b/docs/runbooks/cdb_secrets_ssot.md
@@ -55,14 +55,22 @@ powershell -File scripts/secrets/sync_cdb_secrets.ps1
     (non-secret config). Prefer a **dedicated** local-ci App; do not blindly
     overwrite Control-Board values.
 - `CDB_GH_APP_PRIVATE_KEY`:
-  - GitHub App private key (optional, required with app id for minting).
-  - Never commit; store only in external SSOT. Publisher core does not mint
-    tokens from this key (#4170).
+  - GitHub App private key (optional inline PEM; required with app id for minting
+    when path is unset).
+  - Never commit; store only in external SSOT.
+- `CDB_GH_APP_PRIVATE_KEY_PATH` (local operator input, preferred):
+  - Absolute path to PEM in the external SSOT directory (e.g.
+    `...\Documents\.secrets\.cdb\cdb-local-ci-app.pem`).
+  - Prefer path over inline env when both are available locally.
+  - Documented alias: `CDB_GITHUB_APP_PRIVATE_KEY_PATH`.
 - `CDB_GH_APP_INSTALLATION_ID`:
   - Optional explicit installation id for app path / Check Run expected ID.
+  - Documented alias: `CDB_GITHUB_APP_INSTALLATION_ID` (with
+    `CDB_GITHUB_APP_ID` for App ID).
 - `CDB_GH_APP_INSTALLATION_TOKEN` (publisher Check Run mode, ephemeral):
-  - Short-lived installation token consumed by
-    `--publisher-backend check-run`. Not minted by the publisher itself.
+  - Short-lived installation token for `--publisher-backend check-run`.
+  - Optional override; when unset, `ci.publisher.app_auth` auto-mints from
+    App ID + Installation ID + PEM (#4170 Phase C).
   - Never pass as CLI argument; never log. See
     [`cdb_local_ci_app_check_run_cutover.md`](cdb_local_ci_app_check_run_cutover.md).
 

--- a/tests/unit/ci/test_status_publisher_app_auth.py
+++ b/tests/unit/ci/test_status_publisher_app_auth.py
@@ -1,0 +1,367 @@
+"""Unit tests for GitHub App JWT / installation-token auto-mint (#4170 Phase C)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from ci.publisher.app_auth import (
+    APP_ID_ALIAS_ENV,
+    APP_ID_ENV,
+    INSTALLATION_ID_ALIAS_ENV,
+    INSTALLATION_ID_ENV,
+    PRIVATE_KEY_ENV,
+    PRIVATE_KEY_PATH_ALIAS_ENV,
+    PRIVATE_KEY_PATH_ENV,
+    load_private_key_pem,
+    mint_app_jwt,
+    mint_installation_token,
+    request_installation_token,
+    resolve_app_id_from_env,
+    resolve_installation_id_from_env,
+)
+from ci.publisher.backends import (
+    APP_INSTALLATION_TOKEN_ENV,
+    resolve_app_installation_token,
+)
+from ci.publisher.cli import main as publisher_main
+from ci.publisher.exceptions import AuthenticationError, GitHubApiError
+from ci.publisher.github_client import GitHubResponse
+from ci.publisher.models import CHECK_RUN_NAME, SHADOW_CHECK_RUN_NAME
+from ci.publisher.redaction import redact_text
+
+pytestmark = pytest.mark.unit
+
+APP_ID = 2247101
+INSTALLATION_ID = 987654321
+SHA = "dddddddddddddddddddddddddddddddddddddddd"
+
+
+def _make_pem() -> bytes:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+class FakeTransport:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.responses: list[GitHubResponse] = []
+
+    def __call__(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes | None,
+        timeout: float,
+    ) -> GitHubResponse:
+        safe_headers = {
+            k: ("[REDACTED]" if k.lower() == "authorization" else v)
+            for k, v in headers.items()
+        }
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": safe_headers,
+                "body": body.decode("utf-8") if body else None,
+                "timeout": timeout,
+            }
+        )
+        if not self.responses:
+            raise AssertionError("No fake response queued")
+        return self.responses.pop(0)
+
+
+@pytest.fixture()
+def pem_bytes() -> bytes:
+    return _make_pem()
+
+
+@pytest.fixture()
+def clear_app_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        APP_ID_ENV,
+        APP_ID_ALIAS_ENV,
+        INSTALLATION_ID_ENV,
+        INSTALLATION_ID_ALIAS_ENV,
+        PRIVATE_KEY_ENV,
+        PRIVATE_KEY_PATH_ENV,
+        PRIVATE_KEY_PATH_ALIAS_ENV,
+        APP_INSTALLATION_TOKEN_ENV,
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_resolve_app_id_canonical(clear_app_env: None, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(APP_ID_ENV, str(APP_ID))
+    assert resolve_app_id_from_env() == APP_ID
+
+
+def test_resolve_app_id_alias(clear_app_env: None, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(APP_ID_ALIAS_ENV, str(APP_ID))
+    assert resolve_app_id_from_env() == APP_ID
+
+
+def test_resolve_installation_id_alias(
+    clear_app_env: None, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(INSTALLATION_ID_ALIAS_ENV, str(INSTALLATION_ID))
+    assert resolve_installation_id_from_env() == INSTALLATION_ID
+
+
+def test_missing_app_id_fail_closed(clear_app_env: None):
+    with pytest.raises(AuthenticationError, match=APP_ID_ENV):
+        resolve_app_id_from_env()
+
+
+def test_missing_installation_id_fail_closed(clear_app_env: None):
+    with pytest.raises(AuthenticationError, match=INSTALLATION_ID_ENV):
+        resolve_installation_id_from_env()
+
+
+def test_private_key_inline_beats_path(
+    clear_app_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    pem_bytes: bytes,
+    tmp_path: Path,
+):
+    other = _make_pem()
+    path = tmp_path / "other.pem"
+    path.write_bytes(other)
+    monkeypatch.setenv(PRIVATE_KEY_ENV, pem_bytes.decode("utf-8"))
+    monkeypatch.setenv(PRIVATE_KEY_PATH_ENV, str(path))
+    loaded = load_private_key_pem()
+    assert loaded.strip() == pem_bytes.strip()
+    assert b"BEGIN" in loaded
+
+
+def test_private_key_path_canonical(
+    clear_app_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    pem_bytes: bytes,
+    tmp_path: Path,
+):
+    path = tmp_path / "app.pem"
+    path.write_bytes(pem_bytes)
+    monkeypatch.setenv(PRIVATE_KEY_PATH_ENV, str(path))
+    assert load_private_key_pem().strip() == pem_bytes.strip()
+
+
+def test_private_key_path_alias(
+    clear_app_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    pem_bytes: bytes,
+    tmp_path: Path,
+):
+    path = tmp_path / "alias.pem"
+    path.write_bytes(pem_bytes)
+    monkeypatch.setenv(PRIVATE_KEY_PATH_ALIAS_ENV, str(path))
+    assert load_private_key_pem().strip() == pem_bytes.strip()
+
+
+def test_unreadable_pem_path_fail_closed(
+    clear_app_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    missing = tmp_path / "missing.pem"
+    monkeypatch.setenv(PRIVATE_KEY_PATH_ENV, str(missing))
+    with pytest.raises(AuthenticationError, match="Unable to read"):
+        load_private_key_pem()
+
+
+def test_invalid_pem_fail_closed(clear_app_env: None, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(PRIVATE_KEY_ENV, "not-a-pem")
+    with pytest.raises(AuthenticationError, match="not a PEM"):
+        load_private_key_pem()
+
+
+def test_mint_app_jwt_rs256_no_secret_leak(pem_bytes: bytes):
+    jwt = mint_app_jwt(app_id=APP_ID, private_key_pem=pem_bytes, now=1_700_000_000)
+    parts = jwt.split(".")
+    assert len(parts) == 3
+    header = json.loads(base64.urlsafe_b64decode(parts[0] + "=="))
+    payload = json.loads(base64.urlsafe_b64decode(parts[1] + "=="))
+    assert header["alg"] == "RS256"
+    assert payload["iss"] == str(APP_ID)
+    assert "BEGIN" not in jwt
+    assert pem_bytes.decode("utf-8") not in jwt
+    redacted = redact_text(f"Authorization: Bearer {jwt}")
+    assert "[REDACTED]" in redacted
+    assert jwt not in redacted
+
+
+def test_request_installation_token_success(pem_bytes: bytes):
+    transport = FakeTransport()
+    transport.responses.append(
+        GitHubResponse(201, {"token": "ghs_installation_token_testvalue"}, {})
+    )
+    jwt = mint_app_jwt(app_id=APP_ID, private_key_pem=pem_bytes, now=1_700_000_000)
+    token = request_installation_token(
+        app_jwt=jwt, installation_id=INSTALLATION_ID, transport=transport
+    )
+    assert token.startswith("ghs_")
+    assert transport.calls[0]["method"] == "POST"
+    assert (
+        f"/app/installations/{INSTALLATION_ID}/access_tokens"
+        in transport.calls[0]["url"]
+    )
+    assert transport.calls[0]["headers"]["Authorization"] == "[REDACTED]"
+
+
+@pytest.mark.parametrize("status", [401, 403, 404])
+def test_request_installation_token_auth_errors(status: int, pem_bytes: bytes):
+    transport = FakeTransport()
+    transport.responses.append(
+        GitHubResponse(status, {"message": "nope ghs_should_redact_abcdefgh"}, {})
+    )
+    jwt = mint_app_jwt(app_id=APP_ID, private_key_pem=pem_bytes, now=1_700_000_000)
+    with pytest.raises(AuthenticationError):
+        request_installation_token(
+            app_jwt=jwt, installation_id=INSTALLATION_ID, transport=transport
+        )
+
+
+def test_request_installation_token_missing_token_field(pem_bytes: bytes):
+    transport = FakeTransport()
+    transport.responses.append(GitHubResponse(201, {"expires_at": "soon"}, {}))
+    jwt = mint_app_jwt(app_id=APP_ID, private_key_pem=pem_bytes, now=1_700_000_000)
+    with pytest.raises(AuthenticationError, match="missing token"):
+        request_installation_token(
+            app_jwt=jwt, installation_id=INSTALLATION_ID, transport=transport
+        )
+
+
+def test_mint_installation_token_end_to_end(
+    clear_app_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    pem_bytes: bytes,
+    tmp_path: Path,
+):
+    path = tmp_path / "key.pem"
+    path.write_bytes(pem_bytes)
+    monkeypatch.setenv(APP_ID_ENV, str(APP_ID))
+    monkeypatch.setenv(INSTALLATION_ID_ENV, str(INSTALLATION_ID))
+    monkeypatch.setenv(PRIVATE_KEY_PATH_ENV, str(path))
+    transport = FakeTransport()
+    transport.responses.append(
+        GitHubResponse(201, {"token": "ghs_minted_installation_abcdefgh"}, {})
+    )
+    token = mint_installation_token(transport=transport, now=1_700_000_000)
+    assert token.startswith("ghs_minted_")
+
+
+def test_resolve_priority_explicit_token_env_beats_mint(
+    clear_app_env: None, monkeypatch: pytest.MonkeyPatch, pem_bytes: bytes
+):
+    monkeypatch.setenv(APP_INSTALLATION_TOKEN_ENV, "ghs_explicit_env_token_value")
+    monkeypatch.setenv(APP_ID_ENV, str(APP_ID))
+    monkeypatch.setenv(INSTALLATION_ID_ENV, str(INSTALLATION_ID))
+    monkeypatch.setenv(PRIVATE_KEY_ENV, pem_bytes.decode("utf-8"))
+    transport = FakeTransport()
+    token = resolve_app_installation_token(transport=transport)
+    assert token == "ghs_explicit_env_token_value"
+    assert transport.calls == []
+
+
+def test_resolve_auto_mint_when_token_env_missing(
+    clear_app_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    pem_bytes: bytes,
+    tmp_path: Path,
+):
+    path = tmp_path / "key.pem"
+    path.write_bytes(pem_bytes)
+    monkeypatch.setenv(APP_ID_ALIAS_ENV, str(APP_ID))
+    monkeypatch.setenv(INSTALLATION_ID_ALIAS_ENV, str(INSTALLATION_ID))
+    monkeypatch.setenv(PRIVATE_KEY_PATH_ALIAS_ENV, str(path))
+    transport = FakeTransport()
+    transport.responses.append(
+        GitHubResponse(201, {"token": "ghs_auto_minted_token_valuexx"}, {})
+    )
+    token = resolve_app_installation_token(transport=transport)
+    assert token.startswith("ghs_auto_minted_")
+
+
+def test_resolve_no_pat_fallback_when_mint_fails(
+    clear_app_env: None, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_should_not_be_used_abcdefgh")
+    monkeypatch.setenv("GH_TOKEN", "ghs_also_not_used_abcdefghijkl")
+    with pytest.raises(AuthenticationError, match="refuses"):
+        resolve_app_installation_token()
+
+
+def test_resolve_explicit_inject(clear_app_env: None):
+    assert (
+        resolve_app_installation_token(explicit="ghs_explicit_inject_token_xx")
+        == "ghs_explicit_inject_token_xx"
+    )
+
+
+def test_app_auth_probe_refuses_required_name(capsys: pytest.CaptureFixture[str]):
+    code = publisher_main(
+        [
+            "app-auth-probe",
+            "--commit-sha",
+            SHA,
+            "--check-run-name",
+            CHECK_RUN_NAME,
+        ]
+    )
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "refused" in err.lower() or "rejects" in err.lower() or "REJECT" in err
+    assert CHECK_RUN_NAME in err or "non-shadow" in err.lower() or "only allows" in err
+
+
+def test_app_auth_probe_requires_sha():
+    code = publisher_main(["app-auth-probe", "--commit-sha", "short"])
+    assert code == 2
+
+
+def test_app_auth_probe_dry_run_with_mint(
+    clear_app_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    pem_bytes: bytes,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    path = tmp_path / "key.pem"
+    path.write_bytes(pem_bytes)
+    monkeypatch.setenv(APP_ID_ENV, str(APP_ID))
+    monkeypatch.setenv(INSTALLATION_ID_ENV, str(INSTALLATION_ID))
+    monkeypatch.setenv(PRIVATE_KEY_PATH_ENV, str(path))
+    monkeypatch.setenv(APP_INSTALLATION_TOKEN_ENV, "ghs_probe_dry_run_token_value")
+
+    code = publisher_main(
+        [
+            "app-auth-probe",
+            "--commit-sha",
+            SHA,
+            "--dry-run",
+            "--check-run-name",
+            SHADOW_CHECK_RUN_NAME,
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert payload["dry_run"] is True
+    assert payload["check_run_name"] == SHADOW_CHECK_RUN_NAME
+    assert payload["sha"] == SHA
+    assert "ghs_" not in out
+    assert "BEGIN" not in out

--- a/tests/unit/ci/test_status_publisher_check_run.py
+++ b/tests/unit/ci/test_status_publisher_check_run.py
@@ -197,7 +197,14 @@ def test_gh_auth_token_not_auto_used(monkeypatch: pytest.MonkeyPatch):
         resolve_app_installation_token()
 
 
-def test_missing_expected_app_id_rejected():
+def test_missing_expected_app_id_rejected(monkeypatch: pytest.MonkeyPatch):
+    for key in (
+        "CDB_GH_APP_ID",
+        "CDB_GITHUB_APP_ID",
+        "CDB_GH_APP_INSTALLATION_ID",
+        "CDB_GITHUB_APP_INSTALLATION_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
     with pytest.raises(PublisherError, match="expected-app-id"):
         build_publisher_backend(
             backend="check-run",

--- a/tests/unit/ci/test_status_publisher_check_run.py
+++ b/tests/unit/ci/test_status_publisher_check_run.py
@@ -144,15 +144,38 @@ def test_unknown_conclusion_rejected():
 
 def test_missing_installation_token_rejected(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv(APP_INSTALLATION_TOKEN_ENV, raising=False)
+    for key in (
+        "CDB_GH_APP_ID",
+        "CDB_GITHUB_APP_ID",
+        "CDB_GH_APP_INSTALLATION_ID",
+        "CDB_GITHUB_APP_INSTALLATION_ID",
+        "CDB_GH_APP_PRIVATE_KEY",
+        "CDB_GH_APP_PRIVATE_KEY_PATH",
+        "CDB_GITHUB_APP_PRIVATE_KEY_PATH",
+    ):
+        monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("GITHUB_TOKEN", "ghs_should_not_be_used_abcdefgh")
     monkeypatch.setenv("GH_TOKEN", "ghs_also_not_used_abcdefghijkl")
-    with pytest.raises(AuthenticationError, match=APP_INSTALLATION_TOKEN_ENV):
+    with pytest.raises(AuthenticationError, match="refuses"):
         resolve_app_installation_token()
 
 
-def test_empty_installation_token_rejected(monkeypatch: pytest.MonkeyPatch):
+def test_empty_installation_token_falls_through_to_mint_or_reject(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Whitespace-only INSTALLATION_TOKEN is treated as unset → mint path / reject.
     monkeypatch.setenv(APP_INSTALLATION_TOKEN_ENV, "   ")
-    with pytest.raises(AuthenticationError, match=APP_INSTALLATION_TOKEN_ENV):
+    for key in (
+        "CDB_GH_APP_ID",
+        "CDB_GITHUB_APP_ID",
+        "CDB_GH_APP_INSTALLATION_ID",
+        "CDB_GITHUB_APP_INSTALLATION_ID",
+        "CDB_GH_APP_PRIVATE_KEY",
+        "CDB_GH_APP_PRIVATE_KEY_PATH",
+        "CDB_GITHUB_APP_PRIVATE_KEY_PATH",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    with pytest.raises(AuthenticationError, match="refuses"):
         resolve_app_installation_token()
 
 
@@ -160,6 +183,16 @@ def test_gh_auth_token_not_auto_used(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv(APP_INSTALLATION_TOKEN_ENV, raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
+    for key in (
+        "CDB_GH_APP_ID",
+        "CDB_GITHUB_APP_ID",
+        "CDB_GH_APP_INSTALLATION_ID",
+        "CDB_GITHUB_APP_INSTALLATION_ID",
+        "CDB_GH_APP_PRIVATE_KEY",
+        "CDB_GH_APP_PRIVATE_KEY_PATH",
+        "CDB_GITHUB_APP_PRIVATE_KEY_PATH",
+    ):
+        monkeypatch.delenv(key, raising=False)
     with pytest.raises(AuthenticationError, match="refuses"):
         resolve_app_installation_token()
 


### PR DESCRIPTION
## Summary
- Phase C for #4170: auto-mint short-lived GitHub App JWTs / installation tokens from App ID + Installation ID + PEM (path or inline).
- Wire mint into `resolve_app_installation_token` (priority: inject → INSTALLATION_TOKEN → auto-mint → fail-closed; never PAT/gh).
- Add shadow-only `python -m ci.publisher app-auth-probe` for `cdb-local-ci-app-preview` (refuses required `cdb-local-ci`).
- Docs: cutover runbook, secrets SSOT, local-status-publisher auth priority + troubleshooting.

## Refs
Refs #4170 (Phase C). Issue stays **OPEN** for Phase D BP cutover (separate Human-GO).

## Test plan
- [x] `pytest -q tests/unit/ci/test_status_publisher_app_auth.py tests/unit/ci/test_status_publisher_check_run.py tests/unit/ci/test_status_publisher_redaction.py` (60 passed)
- [x] `ruff check` on touched publisher modules
- [x] `black --check` on touched Python
- [x] Live shadow probe attempted on disposable SHA `5bd364cd…` → `BLOCKED_APP_PERMISSION` (App lacks checks list/write); no Commit Status bypass; probe branch deleted

## Non-goals
- Branch Protection cutover / required Check Run on main (Phase D)
- Trading / LR / runtime / secrets in git
- Closing #4170

## Remaining uncertainty
- Live App `checks:write` still unproven (probe blocked). Code path covered by mocked HTTP unit tests.