### PR TITLE
fix(ci): preserve App installation token through mint transport (#4170)

### DIFF
--- a/ci/publisher/app_auth.py
+++ b/ci/publisher/app_auth.py
@@ -22,7 +22,6 @@ from ci.publisher.github_client import (
     GITHUB_API,
     GitHubResponse,
     Transport,
-    _default_transport,
 )
 from ci.publisher.redaction import redact_mapping, redact_text
 
@@ -172,6 +171,87 @@ def mint_app_jwt(
     return f"{signing_input.decode('ascii')}.{_b64url(signature)}"
 
 
+_REDACTED_SENTINELS = frozenset(
+    {
+        "[REDACTED]",
+        "[REDACTED_JWT]",
+        "[REDACTED_PRIVATE_KEY]",
+    }
+)
+
+
+def _mint_transport(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    body: bytes | None,
+    timeout: float,
+) -> GitHubResponse:
+    """HTTP transport for installation-token minting.
+
+    Unlike ``_default_transport``, successful JSON bodies are returned
+    **unredacted** so the ``token`` field can be extracted in memory.
+    Error bodies remain redacted. Callers must never log the success body.
+    """
+    import urllib.error
+    import urllib.request
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read()
+            parsed: Any
+            if raw:
+                try:
+                    parsed = json.loads(raw.decode("utf-8"))
+                except json.JSONDecodeError:
+                    parsed = {"raw": redact_text(raw.decode("utf-8", errors="replace"))}
+            else:
+                parsed = {}
+            header_map = {k.lower(): v for k, v in response.headers.items()}
+            return GitHubResponse(
+                status_code=getattr(response, "status", 200),
+                body=parsed,
+                headers=header_map,
+            )
+    except urllib.error.HTTPError as exc:
+        raw = exc.read() if hasattr(exc, "read") else b""
+        parsed: Any
+        try:
+            parsed = json.loads(raw.decode("utf-8")) if raw else {"message": str(exc)}
+        except json.JSONDecodeError:
+            parsed = {"message": redact_text(raw.decode("utf-8", errors="replace"))}
+        header_map = {
+            k.lower(): v for k, v in (exc.headers.items() if exc.headers else [])
+        }
+        return GitHubResponse(
+            status_code=exc.code,
+            body=redact_mapping(parsed),
+            headers=header_map,
+        )
+    except urllib.error.URLError as exc:
+        raise GitHubApiError(
+            f"Network failure talking to GitHub API: {redact_text(str(exc.reason))}"
+        ) from exc
+    except TimeoutError as exc:
+        raise GitHubApiError("GitHub App installation token request timed out") from exc
+
+
+def _extract_installation_token(body: Any) -> str:
+    """Pull installation token from mint response; reject redaction sentinels."""
+    if not isinstance(body, dict):
+        raise GitHubApiError("Ambiguous installation token response")
+    token = str(body.get("token") or "").strip()
+    if not token:
+        raise AuthenticationError("Installation token response missing token field")
+    if token in _REDACTED_SENTINELS:
+        raise AuthenticationError(
+            "Installation token response was redacted before extraction; "
+            "mint transport must preserve the token field in memory"
+        )
+    return token
+
+
 def request_installation_token(
     *,
     app_jwt: str,
@@ -179,7 +259,12 @@ def request_installation_token(
     transport: Transport | None = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> str:
-    """POST /app/installations/{id}/access_tokens; return token (memory only)."""
+    """POST /app/installations/{id}/access_tokens; return token (memory only).
+
+    Default transport intentionally does **not** run ``redact_mapping`` on the
+    success body: ``_default_transport`` would replace ``token`` with
+    ``[REDACTED]`` and break live Check Run auth (#4170 Phase D).
+    """
     if not app_jwt.strip():
         raise AuthenticationError("Empty GitHub App JWT")
     installation_id = _parse_positive_int(
@@ -194,7 +279,8 @@ def request_installation_token(
         "User-Agent": "cdb-local-ci-app-auth",
         "Content-Type": "application/json",
     }
-    runner = transport or _default_transport
+    # Never default to _default_transport — it redacts the token field.
+    runner = transport or _mint_transport
     try:
         response: GitHubResponse = runner("POST", url, headers, b"{}", timeout_seconds)
     except TimeoutError as exc:
@@ -220,13 +306,7 @@ def request_installation_token(
             f"Installation token mint failed HTTP {response.status_code}: "
             f"{redact_mapping(response.body)}"
         )
-    body = response.body
-    if not isinstance(body, dict):
-        raise GitHubApiError("Ambiguous installation token response")
-    token = str(body.get("token") or "").strip()
-    if not token:
-        raise AuthenticationError("Installation token response missing token field")
-    return token
+    return _extract_installation_token(response.body)
 
 
 def mint_installation_token(

--- a/docs/runbooks/cdb_local_ci_app_check_run_cutover.md
+++ b/docs/runbooks/cdb_local_ci_app_check_run_cutover.md
@@ -172,6 +172,11 @@ Publisher Check Run mode **auto-mints** the installation token when App
 credentials are present (`ci.publisher.app_auth`). Explicit
 `CDB_GH_APP_INSTALLATION_TOKEN` still wins when set.
 
+Implementation note: mint uses a dedicated transport that keeps the success
+`token` field in memory. The shared publisher `_default_transport` runs
+`redact_mapping` on JSON bodies and must **not** be used for mint extraction
+(would replace `token` with `[REDACTED]` and yield HTTP 401 Bad credentials).
+
 Collision note: Control-Board workflows already document `CDB_GH_APP_ID` /
 `PRIVATE_KEY` / `INSTALLATION_ID`. Prefer a **dedicated** local-ci App and
 document which values the publisher expects. Do not overwrite Control-Board

--- a/tests/unit/ci/test_status_publisher_app_auth.py
+++ b/tests/unit/ci/test_status_publisher_app_auth.py
@@ -244,6 +244,41 @@ def test_request_installation_token_missing_token_field(pem_bytes: bytes):
         )
 
 
+def test_request_installation_token_rejects_redacted_sentinel(pem_bytes: bytes):
+    """Regression: _default_transport redact_mapping replaced token with [REDACTED]."""
+    transport = FakeTransport()
+    transport.responses.append(GitHubResponse(201, {"token": "[REDACTED]"}, {}))
+    jwt = mint_app_jwt(app_id=APP_ID, private_key_pem=pem_bytes, now=1_700_000_000)
+    with pytest.raises(AuthenticationError, match="redacted before extraction"):
+        request_installation_token(
+            app_jwt=jwt, installation_id=INSTALLATION_ID, transport=transport
+        )
+
+
+def test_default_style_redacting_transport_would_break_without_mint_transport(
+    pem_bytes: bytes,
+):
+    """Simulate _default_transport success path (redact_mapping on body)."""
+    from ci.publisher.redaction import redact_mapping
+
+    real_token = "ghs_live_style_installation_token_xx"
+
+    def redacting_transport(method, url, headers, body, timeout):
+        return GitHubResponse(
+            201,
+            redact_mapping({"token": real_token, "permissions": {"checks": "write"}}),
+            {},
+        )
+
+    jwt = mint_app_jwt(app_id=APP_ID, private_key_pem=pem_bytes, now=1_700_000_000)
+    with pytest.raises(AuthenticationError, match="redacted before extraction"):
+        request_installation_token(
+            app_jwt=jwt,
+            installation_id=INSTALLATION_ID,
+            transport=redacting_transport,
+        )
+
+
 def test_mint_installation_token_end_to_end(
     clear_app_env: None,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Root cause: `_default_transport` runs `redact_mapping` on success JSON, so auto-mint returned literal `[REDACTED]` and Check Run calls got HTTP 401 Bad credentials.
- Fix: dedicated `_mint_transport` keeps the token field in memory; reject redaction sentinels; regression tests + cutover note.
- Live evidence (pre-PR): `app-auth-probe` PASS on probe SHA `7a65c66d…` → Check Run id `91365889923`, `app.id=4410232`, name `cdb-local-ci-app-preview`.

## Test plan
- [x] `pytest tests/unit/ci/test_status_publisher_app_auth.py` (+ check_run/redaction)
- [x] Live `app-auth-probe` on disposable probe SHA
- [ ] Local Fast-CI + `cdb-local-ci` on exact PR head

## Non-goals
- Branch Protection cutover (Phase D BP remains separate Human-GO)
- Required `cdb-local-ci` Check Run cutover

Refs #4170