### PR TITLE
fix(agent-control): address #4286 dispatcher residuals

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -12,19 +12,20 @@
 
 ## Repo / Engineering Status (2026-08-02)
 
-<!-- cdb:live-claim type=main_sha value=fce4c754 -->
-- **Confirmed main state**: `origin/main` @ `fce4c754` — same snapshot as the [`README.md`](README.md) Current-main section. Tip after consolidation squash-merges [#4286](https://github.com/jannekbuengener/Claire_de_Binare/pull/4286), [#4162](https://github.com/jannekbuengener/Claire_de_Binare/pull/4162), [#4245](https://github.com/jannekbuengener/Claire_de_Binare/pull/4245), [#4246](https://github.com/jannekbuengener/Claire_de_Binare/pull/4246), [#4244](https://github.com/jannekbuengener/Claire_de_Binare/pull/4244), [#4243](https://github.com/jannekbuengener/Claire_de_Binare/pull/4243).
+<!-- cdb:live-claim type=main_sha value=fca8ad09 -->
+- **Confirmed main state**: `origin/main` @ `fca8ad09` — same snapshot as the [`README.md`](README.md) Current-main section. Tip after Hermes repo-slice squash-merge [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290) (supersedes consolidation tip `fce4c754`).
 
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
 <!-- cdb:live-claim type=issue_state issue=3995 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4005 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4204 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4228 state=closed -->
-- **#4289 Hermes Hetzner Bootstrap**: **IN_DELIVERY** via PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290) (`infrastructure/hermes/`, `config/hermes/`, `tools/hermes_ops/`, runbook, threat model, unit tests). Live Hetzner/Windows/GitHub drills remain `HOLD_SCOPE_BLOCKER`. Auth lineage reuses #4170/#4195. `#4257` remains HOLD. LR **NO-GO** unchanged.  <!-- pragma: allowlist secret -->
+- **#4289 Hermes Hetzner Bootstrap**: Repo-Slice **MERGED** via PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290) (`infrastructure/hermes/`, `config/hermes/`, `tools/hermes_ops/`, runbook, threat model, unit tests). Issue remains open for Live Hetzner/Windows/GitHub drills (`HOLD_SCOPE_BLOCKER`). Auth lineage reuses #4170/#4195. `#4257` remains HOLD. LR **NO-GO** unchanged.  <!-- pragma: allowlist secret -->
 
-- **#4293 ACP dispatcher post-merge residuals**: **IN_DELIVERY** via `batch/agent-skills-issue-4293` (R1–R4 P2 fixes after #4286). Targeted governance tests PASS; no merge / no `cdb-local-ci` in delivery session. `#4257` remains Implementation-Hold until #4293 merges. LR **NO-GO** unchanged.
+<!-- cdb:live-claim type=issue_state issue=4293 state=open -->
+- **#4293 ACP dispatcher post-merge residuals**: open follow-up via PR [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297) (`batch/agent-skills-issue-4293`; R1–R4). Sequencing hold for Approval Agent stays until this issue closes. LR **NO-GO** unchanged.
 
-- **PR #4286 Agent Control Plane batch**: **DONE_MERGED_CLOSED** — squash-merged; issues #4250–#4256 closed. Prior ledger tip `2d4651a7` superseded by consolidation tip `fce4c754`. LR **NO-GO** unchanged.
+- **PR #4286 Agent Control Plane batch**: **DONE_MERGED_CLOSED** — squash-merged; issues #4250–#4256 closed. Prior ledger tip `2d4651a7` superseded by consolidation tip `fce4c754`, then Hermes tip `fca8ad09`. LR **NO-GO** unchanged.
 
 <!-- cdb:historical-as-of date=2026-07-31 -->
 > Historical as of 2026-07-31 — append-only ledger. Entries below record the

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -22,6 +22,8 @@
 <!-- cdb:live-claim type=issue_state issue=4228 state=closed -->
 - **#4289 Hermes Hetzner Bootstrap**: **IN_DELIVERY** via PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290) (`infrastructure/hermes/`, `config/hermes/`, `tools/hermes_ops/`, runbook, threat model, unit tests). Live Hetzner/Windows/GitHub drills remain `HOLD_SCOPE_BLOCKER`. Auth lineage reuses #4170/#4195. `#4257` remains HOLD. LR **NO-GO** unchanged.  <!-- pragma: allowlist secret -->
 
+- **#4293 ACP dispatcher post-merge residuals**: **IN_DELIVERY** via `batch/agent-skills-issue-4293` (R1–R4 P2 fixes after #4286). Targeted governance tests PASS; no merge / no `cdb-local-ci` in delivery session. `#4257` remains Implementation-Hold until #4293 merges. LR **NO-GO** unchanged.
+
 - **PR #4286 Agent Control Plane batch**: **DONE_MERGED_CLOSED** — squash-merged; issues #4250–#4256 closed. Prior ledger tip `2d4651a7` superseded by consolidation tip `fce4c754`. LR **NO-GO** unchanged.
 
 <!-- cdb:historical-as-of date=2026-07-31 -->

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 ## Current-main Snapshot
 
 <!-- cdb:status-freshness header-date=2026-08-02 -->
-<!-- cdb:live-claim type=main_sha value=fce4c754 -->
+<!-- cdb:live-claim type=main_sha value=fca8ad09 -->
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
-Auf `origin/main` (`fce4c754`, Stand 2026-08-02) sind die juengsten relevanten Merge-Cluster u. a.:
+Auf `origin/main` (`fca8ad09`, Stand 2026-08-02) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **Hermes Hetzner Bootstrap ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290)):** Open issue `#4289` with repo-slice PR `#4290` (Infrastructure/Profiles/Ops/Token-Broker); Live-VM/Windows-Drills bleiben `HOLD_SCOPE_BLOCKER`. Tip `main` @ `fce4c754` vor diesem Merge.  <!-- pragma: allowlist secret -->
-- **Repository consolidation wave:** [#4286](https://github.com/jannekbuengener/Claire_de_Binare/pull/4286) ACP batch, [#4162](https://github.com/jannekbuengener/Claire_de_Binare/pull/4162) Grafana 13.1.1, [#4245](https://github.com/jannekbuengener/Claire_de_Binare/pull/4245) CVE HOLD, [#4246](https://github.com/jannekbuengener/Claire_de_Binare/pull/4246) PG15 preflight, [#4244](https://github.com/jannekbuengener/Claire_de_Binare/pull/4244) Dependabot facts, [#4243](https://github.com/jannekbuengener/Claire_de_Binare/pull/4243) dataset fingerprints — squash-merged onto tip `fce4c754`.
+- **Hermes Hetzner Bootstrap ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290)):** Repo-Slice **MERGED** @ `fca8ad09`; issue `#4289` remains open for Live-VM/Windows/GitHub drills (`HOLD_SCOPE_BLOCKER`).  <!-- pragma: allowlist secret -->
+- **Repository consolidation wave:** [#4286](https://github.com/jannekbuengener/Claire_de_Binare/pull/4286) ACP batch, [#4162](https://github.com/jannekbuengener/Claire_de_Binare/pull/4162) Grafana 13.1.1, [#4245](https://github.com/jannekbuengener/Claire_de_Binare/pull/4245) CVE HOLD, [#4246](https://github.com/jannekbuengener/Claire_de_Binare/pull/4246) PG15 preflight, [#4244](https://github.com/jannekbuengener/Claire_de_Binare/pull/4244) Dependabot facts, [#4243](https://github.com/jannekbuengener/Claire_de_Binare/pull/4243) dataset fingerprints — squash-merged onto prior tip `fce4c754`.
 - **Validation Pilot Spec ([#4272](https://github.com/jannekbuengener/Claire_de_Binare/issues/4272) / PR [#4292](https://github.com/jannekbuengener/Claire_de_Binare/pull/4292)):** **MERGED** — prior tip cluster (historical relative to consolidation tip).
 - **Fast-CI Slice Gates ([#4204](https://github.com/jannekbuengener/Claire_de_Binare/issues/4204) / PR [#4236](https://github.com/jannekbuengener/Claire_de_Binare/pull/4236)):** **CLOSED/MERGED** — Versionierte Slice-Policy, fail-closed unbekannte Pfade, Timing-Evidence.
 - **PR-Router Live-Konventionen ([#4228](https://github.com/jannekbuengener/Claire_de_Binare/issues/4228) / PR [#4231](https://github.com/jannekbuengener/Claire_de_Binare/pull/4231)):** **CLOSED/MERGED** — Policy/Matcher an reale Titel-Token und `scope:*`/`type:*` Labels angeglichen.

--- a/docs/contracts/cdb_agent_dispatch_run.v1.schema.json
+++ b/docs/contracts/cdb_agent_dispatch_run.v1.schema.json
@@ -67,7 +67,11 @@
         "target_pr": { "type": ["integer", "null"] },
         "target_branch": { "type": ["string", "null"] },
         "lane": { "type": ["string", "null"] },
-        "batch_key": { "type": ["string", "null"] }
+        "batch_key": { "type": ["string", "null"] },
+        "target_provenance": {
+          "type": ["string", "null"],
+          "enum": [null, "route+validated_provider_receipt"]
+        }
       }
     },
     "agent_id": { "type": "string", "minLength": 1 },

--- a/knowledge/logs/sessions/2026-08-02-issue-4293-dispatcher-residuals.md
+++ b/knowledge/logs/sessions/2026-08-02-issue-4293-dispatcher-residuals.md
@@ -1,0 +1,35 @@
+# Session 2026-08-02 — Issue #4293 ACP dispatcher residuals
+
+## Goal
+Fix four post-merge P2 residuals from PR #4286 on the Agent Control Plane
+dispatcher before #4257 implementation.
+
+## Live truth
+- `origin/main` @ `fca8ad09`
+- Issue #4293 OPEN; no prior open PR
+- PR #4286 MERGED; four unresolved P2 threads confirmed as R1–R4
+- Router: `CREATE_NEW_BATCH_PR` → `batch/agent-skills-issue-4293`
+- Anti-repush: did not reuse `batch/agent-skills-issue-4250`
+
+## Brain Evidence
+- brain_source: repo-only
+- brain_status: not-used
+- context_tool_status: available
+- context_trust_level: none
+- repo_fallback_reason: insufficient_evidence
+- Plan-GO + implementation_go from operator prompt contract
+
+## Delivered
+- R1: `DISPATCH_DELIVERY_TARGET_CONFLICT` before provider call
+- R2: effective attenuated `wall_time_seconds` on run + ProviderRequest + timeout
+- R3: CREATE observed targets on run.route + evidence provenance
+- R4: verify_store uniqueness `(run_id, attempt, lifecycle.state)`
+
+## Validation
+- pytest 105 targeted governance tests PASS
+- ruff + black --check PASS on scope
+- git diff --check PASS
+- No Full Fast-CI / no cdb-local-ci / no merge / issue left open
+
+## Boundaries
+- LR NO-GO unchanged; no BLUE/RED, secrets, DB/MCP mutation, live dispatch

--- a/tests/unit/governance/test_agent_dispatcher_v1.py
+++ b/tests/unit/governance/test_agent_dispatcher_v1.py
@@ -775,7 +775,19 @@ def test_whitespace_only_delivery_branch_does_not_override_route() -> None:
 
 
 @pytest.mark.unit
-def test_boolean_create_receipt_pr_rejected() -> None:
+def test_whitespace_only_existing_route_branch_rejected_in_preflight() -> None:
+    """Existing routes must not treat whitespace-only target_branch as present."""
+    from tools.agent_control.preflight import preflight
+
+    contract = _contract()
+    contract["route"]["target_branch"] = "   "
+    contract["execution_scope"]["delivery_target"][
+        "target_branch"
+    ] = "batch/agent-skills-issue-4250"
+    contract = attach_digest(contract)
+    result = preflight(contract, _registry(), AGENT_ID, execute=True)
+    assert result.ok is False
+    assert result.code == "DISPATCH_ROUTE_TARGET_MISSING"
     """R3: bool is not a valid observed target_pr (bool subclasses int)."""
     from tools.agent_control.dispatch import _validate_delivery_receipt
 

--- a/tests/unit/governance/test_agent_dispatcher_v1.py
+++ b/tests/unit/governance/test_agent_dispatcher_v1.py
@@ -743,6 +743,38 @@ def test_identical_duplicate_delivery_targets_allowed() -> None:
 
 
 @pytest.mark.unit
+def test_whitespace_only_delivery_branch_does_not_override_route() -> None:
+    """R1: whitespace-only delivery_target branch is absent, not a sealed override."""
+    from tools.agent_control.dispatch import (
+        _delivery_target,
+        assert_delivery_target_consistent,
+    )
+
+    contract = _contract()
+    route_branch = contract["route"]["target_branch"]
+    contract["execution_scope"]["delivery_target"]["target_branch"] = "   \t"
+    contract = attach_digest(contract)
+    assert_delivery_target_consistent(contract)
+    sealed = _delivery_target(contract)
+    assert sealed["target_branch"] == route_branch
+
+    store = InMemoryRunStore()
+    provider = MockProvider()
+    result = dispatch_run(
+        contract,
+        _registry(),
+        AGENT_ID,
+        store,
+        dry_run=False,
+        allow_mock_dispatch=True,
+        provider=provider,
+    )
+    assert result["run"]["state"] != "BLOCKED"
+    assert result["run"]["expected_delivery"]["target_branch"] == route_branch
+    assert provider.dispatch_calls >= 1
+
+
+@pytest.mark.unit
 def test_create_route_empty_targets_allowed() -> None:
     """R1: CREATE routes may leave targets empty until receipt observation."""
     from tools.agent_control.dispatch import assert_delivery_target_consistent

--- a/tests/unit/governance/test_agent_dispatcher_v1.py
+++ b/tests/unit/governance/test_agent_dispatcher_v1.py
@@ -682,3 +682,254 @@ def test_create_route_accepts_observed_new_pr_number() -> None:
             },
         )
     assert exc.value.code == "DISPATCH_DELIVERY_RECEIPT_MISMATCH"
+
+
+# ---------------------------------------------------------------------------
+# #4293 post-merge residuals R1–R3
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_conflicting_delivery_targets_block_before_provider() -> None:
+    """R1: mismatched route vs delivery_target must fail-closed; no provider call."""
+    from tools.agent_control.dispatch import assert_delivery_target_consistent
+
+    contract = _contract()
+    contract["execution_scope"]["delivery_target"]["target_pr"] = 13
+    # route still has 4286
+    contract = attach_digest(contract)
+    with pytest.raises(DispatchError) as exc:
+        assert_delivery_target_consistent(contract)
+    assert exc.value.code == "DISPATCH_DELIVERY_TARGET_CONFLICT"
+
+    store = InMemoryRunStore()
+    provider = MockProvider()
+    result = dispatch_run(
+        contract,
+        _registry(),
+        AGENT_ID,
+        store,
+        dry_run=False,
+        allow_mock_dispatch=True,
+        provider=provider,
+    )
+    assert provider.dispatch_calls == 0
+    assert result["run"]["state"] == "BLOCKED"
+    assert result["run"]["terminal_code"] == "DISPATCH_DELIVERY_TARGET_CONFLICT"
+
+
+@pytest.mark.unit
+def test_conflicting_delivery_branches_block() -> None:
+    """R1: mismatched target_branch also conflicts."""
+    from tools.agent_control.dispatch import assert_delivery_target_consistent
+
+    contract = _contract()
+    contract["execution_scope"]["delivery_target"][
+        "target_branch"
+    ] = "batch/other-branch"
+    contract = attach_digest(contract)
+    with pytest.raises(DispatchError) as exc:
+        assert_delivery_target_consistent(contract)
+    assert exc.value.code == "DISPATCH_DELIVERY_TARGET_CONFLICT"
+
+
+@pytest.mark.unit
+def test_identical_duplicate_delivery_targets_allowed() -> None:
+    """R1: identical route + delivery_target values remain valid."""
+    from tools.agent_control.dispatch import assert_delivery_target_consistent
+
+    contract = _contract()
+    assert_delivery_target_consistent(contract)  # no raise
+
+
+@pytest.mark.unit
+def test_create_route_empty_targets_allowed() -> None:
+    """R1: CREATE routes may leave targets empty until receipt observation."""
+    from tools.agent_control.dispatch import assert_delivery_target_consistent
+
+    contract = {
+        "route": {
+            "routing_decision": "CREATE_NEW_BATCH_PR",
+            "target_pr": None,
+            "target_branch": None,
+        },
+        "execution_scope": {
+            "delivery_target": {
+                "expected_status": "DONE_PR_OPEN",
+                "target_pr": None,
+                "target_branch": None,
+            }
+        },
+    }
+    assert_delivery_target_consistent(contract)
+
+
+@pytest.mark.unit
+def test_attenuated_wall_time_applied_to_run_and_request(monkeypatch) -> None:
+    """R2: lower profile wall ceiling becomes effective run/request budget."""
+    import tools.agent_control.preflight as pf_mod
+    from tools.agent_control.dispatch import effective_dispatch_budget
+    from tools.agent_control.provider import ProviderRequest, ProviderResult
+
+    # Unit: restrictive merge
+    merged = effective_dispatch_budget(
+        {"wall_time_seconds": 14400, "max_iterations": 10},
+        {"wall_time_seconds": 60},
+    )
+    assert merged["wall_time_seconds"] == 60
+    assert merged["max_iterations"] == 10
+    # Higher profile must not expand
+    expanded = effective_dispatch_budget(
+        {"wall_time_seconds": 100},
+        {"wall_time_seconds": 9999},
+    )
+    assert expanded["wall_time_seconds"] == 100
+
+    original_digest = compute_digest(_contract())
+
+    class _Capture:
+        provider_id = "mock"
+
+        def __init__(self) -> None:
+            self.inner = MockProvider()
+            self.last_request = None
+
+        def dispatch(self, request: ProviderRequest) -> ProviderResult:
+            self.last_request = request
+            return self.inner.dispatch(request)
+
+        def watch(self, provider_run_id: str) -> ProviderResult:
+            return self.inner.watch(provider_run_id)
+
+        def cancel(self, provider_run_id: str, reason: str) -> ProviderResult:
+            return self.inner.cancel(provider_run_id, reason)
+
+    real_env = pf_mod.run_environment_preflight
+
+    def _with_wall(**kwargs):
+        result = real_env(**kwargs)
+        result.effective_constraints = {
+            **(result.effective_constraints or {}),
+            "wall_time_seconds": 60,
+        }
+        return result
+
+    monkeypatch.setattr(pf_mod, "run_environment_preflight", _with_wall)
+    contract = _contract()
+    store = InMemoryRunStore()
+    provider = _Capture()
+    clock = FrozenClock(datetime(2026, 8, 1, 21, 0, tzinfo=timezone.utc))
+    result = dispatch_run(
+        contract,
+        _registry(),
+        AGENT_ID,
+        store,
+        dry_run=False,
+        allow_mock_dispatch=True,
+        provider=provider,
+        clock=clock,
+        scenario="success",
+    )
+    run = result["run"]
+    assert run["budget"]["wall_time_seconds"] == 60
+    assert provider.last_request is not None
+    assert provider.last_request.budget["wall_time_seconds"] == 60
+    assert compute_digest(contract) == original_digest
+    # Timeout enforcement uses the same restrictive budget
+    clock.advance(61)
+    timed = watch_run(run["run_id"], store, provider=provider, clock=clock)
+    assert timed["state"] in {"CANCELLED", "BLOCKED"}
+    assert timed["terminal_code"] in {"TIMEOUT", "PROVIDER_CANCEL_UNCONFIRMED"}
+
+
+@pytest.mark.unit
+def test_create_route_records_observed_targets_on_run() -> None:
+    """R3: CREATE routes persist validated receipt targets onto the run route."""
+    from tools.agent_control.dispatch import _merge_observed_create_targets
+    from tools.agent_control.provider import ProviderRequest, ProviderResult
+
+    class _CreateProvider:
+        provider_id = "mock"
+
+        def __init__(self) -> None:
+            self._ticks = 0
+
+        def dispatch(self, request: ProviderRequest) -> ProviderResult:
+            return ProviderResult(
+                provider_id="mock",
+                provider_run_id=f"mock-{request.run_id}",
+                normalized_status="QUEUED",
+                usage={"iterations": 0, "tool_calls": 0},
+            )
+
+        def watch(self, provider_run_id: str) -> ProviderResult:
+            self._ticks += 1
+            if self._ticks == 1:
+                return ProviderResult(
+                    provider_id="mock",
+                    provider_run_id=provider_run_id,
+                    normalized_status="RUNNING",
+                    usage={"iterations": 1, "tool_calls": 1},
+                )
+            return ProviderResult(
+                provider_id="mock",
+                provider_run_id=provider_run_id,
+                normalized_status="SUCCEEDED",
+                usage={"iterations": 2, "tool_calls": 2},
+                delivery_receipt={
+                    "target_pr": 99123,
+                    "target_branch": "batch/agent-skills-issue-4293",
+                    "commit": "c" * 40,
+                    "delivery_status": "DONE_PR_OPEN",
+                },
+            )
+
+        def cancel(self, provider_run_id: str, reason: str) -> ProviderResult:
+            raise AssertionError("cancel not expected")
+
+    contract = _contract()
+    contract["route"] = {
+        **contract["route"],
+        "routing_decision": "CREATE_NEW_BATCH_PR",
+        "target_pr": None,
+        "target_branch": None,
+    }
+    contract["execution_scope"]["delivery_target"] = {
+        **contract["execution_scope"]["delivery_target"],
+        "expected_status": "DONE_PR_OPEN",
+        "target_pr": None,
+        "target_branch": None,
+    }
+    contract = attach_digest(contract)
+    store = InMemoryRunStore()
+    provider = _CreateProvider()
+    clock = FrozenClock(datetime(2026, 8, 1, 21, 0, tzinfo=timezone.utc))
+    result = dispatch_run(
+        contract,
+        _registry(),
+        AGENT_ID,
+        store,
+        dry_run=False,
+        allow_mock_dispatch=True,
+        provider=provider,
+        clock=clock,
+        scenario="success",
+    )
+    run = watch_run(result["run"]["run_id"], store, provider=provider, clock=clock)
+    run = watch_run(run["run_id"], store, provider=provider, clock=clock)
+    assert run["state"] == "PASS"
+    assert run["route"]["target_pr"] == 99123
+    assert run["route"]["target_branch"] == "batch/agent-skills-issue-4293"
+    assert run["route"]["target_provenance"] == "route+validated_provider_receipt"
+
+    # HOLD / missing receipt must not invent targets
+    record = {
+        "route": {
+            "routing_decision": "CREATE_NEW_BATCH_PR",
+            "target_pr": None,
+            "target_branch": None,
+        }
+    }
+    _merge_observed_create_targets(record, {})
+    assert record["route"]["target_pr"] is None
+    assert record["route"].get("target_provenance") is None

--- a/tests/unit/governance/test_agent_run_evidence_v1.py
+++ b/tests/unit/governance/test_agent_run_evidence_v1.py
@@ -515,3 +515,114 @@ def test_evidence_id_versions_across_lifecycle_states() -> None:
     assert hold_id != pass_id
     assert hold_id.startswith("are-")
     assert pass_id.startswith("are-")
+
+
+@pytest.mark.unit
+def test_lifecycle_versioned_store_allows_hold_then_pass(tmp_path: Path) -> None:
+    """R4: HOLD + PASS for same run/attempt verify together in the store."""
+    store, run = _pass_run()
+    jsonl = tmp_path / "lifecycle.jsonl"
+
+    def to_hold(record: dict) -> None:
+        record["state"] = "HOLD"
+        record["terminal_code"] = "HOLD_TEST"
+        record["terminal_reason"] = "pre-pass hold emission"
+
+    _mutate(store, run["run_id"], to_hold)
+    hold_bundle = emit_evidence(run["run_id"], store, jsonl_path=jsonl)["bundle"]
+
+    def to_pass(record: dict) -> None:
+        record["state"] = "PASS"
+        record["terminal_code"] = "PASS"
+        record["terminal_reason"] = "delivery_goals_met"
+
+    _mutate(store, run["run_id"], to_pass)
+    pass_bundle = emit_evidence(run["run_id"], store, jsonl_path=jsonl)["bundle"]
+
+    assert hold_bundle["evidence_id"] != pass_bundle["evidence_id"]
+    assert hold_bundle["lifecycle"]["state"] == "HOLD"
+    assert pass_bundle["lifecycle"]["state"] == "PASS"
+    result = verify_store(jsonl)
+    assert result["ok"] is True
+    assert result["count"] == 2
+
+
+@pytest.mark.unit
+def test_same_lifecycle_conflicting_bundles_still_blocked(tmp_path: Path) -> None:
+    """R4: same run/attempt/lifecycle with conflicting content remains blocked."""
+    store, run = _pass_run()
+    jsonl = tmp_path / "collision.jsonl"
+    bundle = emit_evidence(run["run_id"], store, jsonl_path=jsonl)["bundle"]
+    other = deepcopy(bundle)
+    other["limitations"] = list(bundle["limitations"]) + ["extra-conflict"]
+    from tools.agent_control.evidence.digest import attach_bundle_digest
+
+    other.pop("bundle_digest", None)
+    other.get("integrity", {}).pop("digest", None)
+    other = attach_bundle_digest(other)
+    with pytest.raises(EvidenceError) as exc:
+        EvidenceJsonlStore(jsonl).append_idempotent(other)
+    assert exc.value.code == "EVIDENCE_ID_DIGEST_COLLISION"
+
+
+@pytest.mark.unit
+def test_create_route_evidence_includes_observed_targets() -> None:
+    """R3: evidence delivery_context carries observed create-route targets."""
+    store, run = _pass_run()
+
+    def mutate(record: dict) -> None:
+        record["route"] = {
+            "routing_decision": "CREATE_NEW_BATCH_PR",
+            "target_pr": None,
+            "target_branch": None,
+        }
+        record["delivery_receipt"] = {
+            "target_pr": 77777,
+            "target_branch": "batch/create-77777",
+            "commit": "d" * 40,
+            "delivery_status": "DONE_PR_OPEN",
+        }
+
+    _mutate(store, run["run_id"], mutate)
+    bundle = build_evidence_bundle(store.get(run["run_id"]))
+    ctx = bundle["delivery_context"]
+    assert ctx["target_pr"] == 77777
+    assert ctx["target_branch"] == "batch/create-77777"
+    assert ctx["provenance"]["source"] == "run.route+validated_provider_receipt"
+
+    # After route merge (happy path), provenance must still mark receipt origin.
+    def mutate_merged(record: dict) -> None:
+        record["route"] = {
+            "routing_decision": "CREATE_NEW_BATCH_PR",
+            "target_pr": 77777,
+            "target_branch": "batch/create-77777",
+            "target_provenance": "route+validated_provider_receipt",
+        }
+        record["delivery_receipt"] = {
+            "target_pr": 77777,
+            "target_branch": "batch/create-77777",
+            "commit": "d" * 40,
+            "delivery_status": "DONE_PR_OPEN",
+        }
+
+    _mutate(store, run["run_id"], mutate_merged)
+    merged = build_evidence_bundle(store.get(run["run_id"]))
+    assert merged["delivery_context"]["target_pr"] == 77777
+    assert (
+        merged["delivery_context"]["provenance"]["source"]
+        == "run.route+validated_provider_receipt"
+    )
+
+    # Missing receipt → no invented target
+    def clear_receipt(record: dict) -> None:
+        record["route"] = {
+            "routing_decision": "CREATE_NEW_BATCH_PR",
+            "target_pr": None,
+            "target_branch": None,
+        }
+        record["delivery_receipt"] = None
+
+    _mutate(store, run["run_id"], clear_receipt)
+    bare = build_evidence_bundle(store.get(run["run_id"]))
+    assert bare["delivery_context"]["target_pr"] is None
+    assert bare["delivery_context"]["target_branch"] is None

--- a/tools/agent_control/dispatch.py
+++ b/tools/agent_control/dispatch.py
@@ -181,7 +181,43 @@ def build_dry_run_plan(
     return plan
 
 
+def _field_present(value: Any, *, field: str) -> bool:
+    if value is None:
+        return False
+    if field == "target_branch":
+        return isinstance(value, str) and bool(value.strip())
+    return True
+
+
+def assert_delivery_target_consistent(contract: dict[str, Any]) -> None:
+    """Fail-closed when route and delivery_target disagree on the same field.
+
+    Identical duplicates remain allowed. Create routes may leave targets empty
+    until a validated provider receipt supplies them.
+    """
+    route = contract.get("route") or {}
+    target = (contract.get("execution_scope") or {}).get("delivery_target") or {}
+    conflicts: list[str] = []
+    for field in ("target_pr", "target_branch"):
+        route_val = route.get(field)
+        target_val = target.get(field)
+        if not (
+            _field_present(route_val, field=field)
+            and _field_present(target_val, field=field)
+        ):
+            continue
+        if route_val != target_val:
+            conflicts.append(field)
+    if conflicts:
+        raise DispatchError(
+            "DISPATCH_DELIVERY_TARGET_CONFLICT",
+            "route and execution_scope.delivery_target conflict on: "
+            + ", ".join(conflicts),
+        )
+
+
 def _delivery_target(contract: dict[str, Any]) -> dict[str, Any]:
+    assert_delivery_target_consistent(contract)
     scope = contract.get("execution_scope") or {}
     target = scope.get("delivery_target") or {}
     route = contract.get("route") or {}
@@ -192,6 +228,49 @@ def _delivery_target(contract: dict[str, Any]) -> dict[str, Any]:
         or "DONE_SLICE_ADDED_TO_BATCH_PR",
         "routing_decision": route.get("routing_decision"),
     }
+
+
+def effective_dispatch_budget(
+    contract_budget: dict[str, Any] | None,
+    effective_constraints: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge contract budget with attenuated environment ceilings (restrictive).
+
+    Does not mutate the signed/hashed contract input. Numeric ceilings take the
+    more restrictive value when both sides are present.
+    """
+    budget = deepcopy(contract_budget or {})
+    eff = effective_constraints or {}
+    wall_e = eff.get("wall_time_seconds")
+    if isinstance(wall_e, int) and not isinstance(wall_e, bool):
+        wall_c = budget.get("wall_time_seconds")
+        if isinstance(wall_c, int) and not isinstance(wall_c, bool):
+            budget["wall_time_seconds"] = min(wall_c, wall_e)
+        else:
+            budget["wall_time_seconds"] = wall_e
+    return budget
+
+
+def _merge_observed_create_targets(
+    record: dict[str, Any], receipt: dict[str, Any]
+) -> None:
+    """For CREATE routes, persist validated receipt targets onto the run route."""
+    route = record.get("route") or {}
+    routing = route.get("routing_decision")
+    if routing not in CREATE_ROUTE_DECISIONS:
+        return
+    updated = False
+    receipt_pr = receipt.get("target_pr")
+    receipt_branch = receipt.get("target_branch")
+    if isinstance(receipt_pr, int) and receipt_pr > 0:
+        route["target_pr"] = receipt_pr
+        updated = True
+    if isinstance(receipt_branch, str) and receipt_branch.strip():
+        route["target_branch"] = receipt_branch
+        updated = True
+    if updated:
+        route["target_provenance"] = "route+validated_provider_receipt"
+    record["route"] = route
 
 
 def _expected_delivery_from_contract(contract: dict[str, Any]) -> dict[str, Any]:
@@ -402,6 +481,11 @@ def dispatch_run(
     at = _iso(clock)
     rid = run_id or _new_run_id()
     expected_delivery = _expected_delivery_from_contract(pf.contract)
+    # Effective budget = contract ∩ attenuated environment ceilings.
+    # Contract digest/input remain untouched; only the run/request budget shrinks.
+    run_budget = effective_dispatch_budget(
+        pf.budget, pf.effective_environment_constraints
+    )
     record: dict[str, Any] = {
         "schema_id": "cdb.agent_dispatch_run.v1",
         "schema_version": "1.0.0",
@@ -424,7 +508,7 @@ def dispatch_run(
         "agent_id": agent_id,
         "provider_id": pf.provider_id,
         "provider_run_id": None,
-        "budget": deepcopy(pf.budget or {}),
+        "budget": run_budget,
         "usage": {"iterations": 0, "tool_calls": 0},
         "lifecycle_events": [],
         "terminal_reason": None,
@@ -485,7 +569,7 @@ def dispatch_run(
             or scope.get("allowed_commands_or_command_classes")
             or []
         ),
-        budget=deepcopy(pf.budget or {}),
+        budget=deepcopy(run_budget),
         prompt_ref=pf.prompt_ref,
         prompt_digest=pf.prompt_digest,
         prompt_text=pf.prompt_text,
@@ -799,6 +883,7 @@ def watch_run(
             return store.update_cas(run_id, rev, record)
 
         record["delivery_receipt"] = deepcopy(receipt)
+        _merge_observed_create_targets(record, receipt)
         if auto_advance_success:
             _apply_state(
                 record,

--- a/tools/agent_control/dispatch.py
+++ b/tools/agent_control/dispatch.py
@@ -181,11 +181,19 @@ def build_dry_run_plan(
     return plan
 
 
+def _normalized_branch(value: Any) -> str | None:
+    """Return stripped branch name, or None for missing/whitespace-only."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def _field_present(value: Any, *, field: str) -> bool:
     if value is None:
         return False
     if field == "target_branch":
-        return isinstance(value, str) and bool(value.strip())
+        return _normalized_branch(value) is not None
     return True
 
 
@@ -193,7 +201,8 @@ def assert_delivery_target_consistent(contract: dict[str, Any]) -> None:
     """Fail-closed when route and delivery_target disagree on the same field.
 
     Identical duplicates remain allowed. Create routes may leave targets empty
-    until a validated provider receipt supplies them.
+    until a validated provider receipt supplies them. Whitespace-only branches
+    are treated as absent (same semantics as coalesce in `_delivery_target`).
     """
     route = contract.get("route") or {}
     target = (contract.get("execution_scope") or {}).get("delivery_target") or {}
@@ -201,6 +210,14 @@ def assert_delivery_target_consistent(contract: dict[str, Any]) -> None:
     for field in ("target_pr", "target_branch"):
         route_val = route.get(field)
         target_val = target.get(field)
+        if field == "target_branch":
+            route_cmp = _normalized_branch(route_val)
+            target_cmp = _normalized_branch(target_val)
+            if route_cmp is None or target_cmp is None:
+                continue
+            if route_cmp != target_cmp:
+                conflicts.append(field)
+            continue
         if not (
             _field_present(route_val, field=field)
             and _field_present(target_val, field=field)
@@ -221,9 +238,13 @@ def _delivery_target(contract: dict[str, Any]) -> dict[str, Any]:
     scope = contract.get("execution_scope") or {}
     target = scope.get("delivery_target") or {}
     route = contract.get("route") or {}
+    # Whitespace-only branches must not win over a real route branch via
+    # truthy `or` (R1 / #4293 acceptance residual).
+    delivery_branch = _normalized_branch(target.get("target_branch"))
+    route_branch = _normalized_branch(route.get("target_branch"))
     return {
         "target_pr": target.get("target_pr") or route.get("target_pr"),
-        "target_branch": target.get("target_branch") or route.get("target_branch"),
+        "target_branch": delivery_branch or route_branch,
         "expected_status": target.get("expected_status")
         or "DONE_SLICE_ADDED_TO_BATCH_PR",
         "routing_decision": route.get("routing_decision"),

--- a/tools/agent_control/evidence/emit.py
+++ b/tools/agent_control/evidence/emit.py
@@ -39,6 +39,7 @@ from tools.agent_control.evidence.redact import (
 )
 from tools.agent_control.evidence.store import EvidenceJsonlStore
 from tools.agent_control.evidence.verdict import derive_verdict
+from tools.agent_control.provider import CREATE_ROUTE_DECISIONS
 from tools.agent_control.run_store import RunStore
 from tools.agent_execution_contract.jcs import canonicalize
 
@@ -279,6 +280,25 @@ def build_evidence_bundle(
     route = deepcopy(run.get("route") or {})
     receipt = deepcopy(run.get("delivery_receipt") or {})
 
+    target_pr = route.get("target_pr")
+    target_branch = route.get("target_branch")
+    provenance_source = "run.route+delivery_receipt"
+    routing = route.get("routing_decision")
+    if routing in CREATE_ROUTE_DECISIONS:
+        # Prefer explicit route provenance stamped after validated receipt merge.
+        if route.get("target_provenance") == "route+validated_provider_receipt":
+            provenance_source = "run.route+validated_provider_receipt"
+        # Else fill blanks from validated receipt when route was not yet updated.
+        if target_pr is None and isinstance(receipt.get("target_pr"), int):
+            if int(receipt["target_pr"]) > 0:
+                target_pr = receipt.get("target_pr")
+                provenance_source = "run.route+validated_provider_receipt"
+        receipt_branch = receipt.get("target_branch")
+        if (not target_branch) and isinstance(receipt_branch, str):
+            if receipt_branch.strip():
+                target_branch = receipt_branch
+                provenance_source = "run.route+validated_provider_receipt"
+
     bundle: dict[str, Any] = {
         "schema_id": SCHEMA_ID,
         "schema_version": SCHEMA_VERSION,
@@ -318,15 +338,15 @@ def build_evidence_bundle(
         },
         "delivery_context": {
             "issue": run.get("delivery_issue"),
-            "target_pr": route.get("target_pr"),
-            "target_branch": route.get("target_branch"),
+            "target_pr": target_pr,
+            "target_branch": target_branch,
             "source_commit": run.get("source_commit"),
             "delivery_commit": receipt.get("commit"),
             "delivery_status": receipt.get("delivery_status"),
             "provenance": {
                 "trust_class": "control_plane_observed",
-                "source": "run.route+delivery_receipt",
-                "reference": str(route.get("target_pr")),
+                "source": provenance_source,
+                "reference": str(target_pr),
                 "digest": None,
             },
         },

--- a/tools/agent_control/evidence/verify.py
+++ b/tools/agent_control/evidence/verify.py
@@ -65,7 +65,9 @@ def verify_store(path: Path) -> dict[str, Any]:
     store = EvidenceJsonlStore(path)
     records = store.read_all()
     seen_ids: dict[str, str] = {}
-    seen_run_attempts: set[tuple[str, int]] = set()
+    # Uniqueness is lifecycle-versioned: HOLD then PASS for same run/attempt
+    # must coexist after evidence-id lifecycle binding (#4293 / R4).
+    seen_run_attempts: set[tuple[str, int, str]] = set()
     verified: list[dict[str, Any]] = []
     for record in records:
         result = verify_bundle(record)
@@ -77,11 +79,16 @@ def verify_store(path: Path) -> dict[str, Any]:
                 f"duplicate evidence_id with digest mismatch: {eid}",
             )
         seen_ids[eid] = digest
-        key = (str(record.get("run_id")), int(record.get("attempt") or 0))
+        lifecycle_state = str((record.get("lifecycle") or {}).get("state") or "")
+        key = (
+            str(record.get("run_id")),
+            int(record.get("attempt") or 0),
+            lifecycle_state,
+        )
         if key in seen_run_attempts:
             raise EvidenceError(
                 REASON_DUPLICATE_RUN_ATTEMPT,
-                f"duplicate run/attempt pair: {key}",
+                f"duplicate run/attempt/lifecycle triple: {key}",
             )
         seen_run_attempts.add(key)
         verified.append(result)

--- a/tools/agent_control/preflight.py
+++ b/tools/agent_control/preflight.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,46 @@ SLICE_FORBIDDEN_TRUE = frozenset(
         "mcp_live_mutation",
     }
 )
+
+
+def _delivery_target_conflict_message(contract: dict[str, Any]) -> str | None:
+    """Return conflict message when route and delivery_target disagree."""
+    route = contract.get("route") or {}
+    target = (contract.get("execution_scope") or {}).get("delivery_target") or {}
+    conflicts: list[str] = []
+    for field in ("target_pr", "target_branch"):
+        route_val = route.get(field)
+        target_val = target.get(field)
+        if field == "target_branch":
+            route_present = isinstance(route_val, str) and bool(route_val.strip())
+            target_present = isinstance(target_val, str) and bool(target_val.strip())
+        else:
+            route_present = route_val is not None
+            target_present = target_val is not None
+        if route_present and target_present and route_val != target_val:
+            conflicts.append(field)
+    if not conflicts:
+        return None
+    return "route and execution_scope.delivery_target conflict on: " + ", ".join(
+        conflicts
+    )
+
+
+def _effective_budget_from_constraints(
+    contract_budget: dict[str, Any],
+    effective_constraints: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Restrictive merge of contract budget with attenuated environment ceilings."""
+    budget = deepcopy(contract_budget or {})
+    eff = effective_constraints or {}
+    wall_e = eff.get("wall_time_seconds")
+    if isinstance(wall_e, int) and not isinstance(wall_e, bool):
+        wall_c = budget.get("wall_time_seconds")
+        if isinstance(wall_c, int) and not isinstance(wall_c, bool):
+            budget["wall_time_seconds"] = min(wall_c, wall_e)
+        else:
+            budget["wall_time_seconds"] = wall_e
+    return budget
 
 
 @dataclass(frozen=True)
@@ -153,6 +194,14 @@ def preflight(
                 "safe existing/continuation route requires target_pr and target_branch",
                 terminal_state="BLOCKED",
             )
+
+    conflict_msg = _delivery_target_conflict_message(validated)
+    if conflict_msg:
+        return _fail(
+            "DISPATCH_DELIVERY_TARGET_CONFLICT",
+            conflict_msg,
+            terminal_state="BLOCKED",
+        )
 
     permissions = validated.get("permissions") or {}
     for key in SLICE_FORBIDDEN_TRUE:
@@ -343,6 +392,11 @@ def preflight(
     except ContractValidationError as exc:
         return _fail(exc.code, exc.message, terminal_state="BLOCKED")
 
+    # Effective run budget uses attenuated environment ceilings; contract stays intact.
+    effective_budget = _effective_budget_from_constraints(
+        budget, env_result.effective_constraints
+    )
+
     return PreflightResult(
         ok=True,
         terminal_state=None,
@@ -353,7 +407,7 @@ def preflight(
         agent=agent,
         provider_id=provider_id,
         route=route,
-        budget=budget,
+        budget=effective_budget,
         prompt_ref=prompt_ref,
         prompt_digest=prompt_digest,
         prompt_text=prompt_text,

--- a/tools/agent_control/preflight.py
+++ b/tools/agent_control/preflight.py
@@ -46,8 +46,18 @@ SLICE_FORBIDDEN_TRUE = frozenset(
 )
 
 
+def _normalized_branch(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def _delivery_target_conflict_message(contract: dict[str, Any]) -> str | None:
-    """Return conflict message when route and delivery_target disagree."""
+    """Return conflict message when route and delivery_target disagree.
+
+    Whitespace-only branches are absent (aligned with dispatch coalesce).
+    """
     route = contract.get("route") or {}
     target = (contract.get("execution_scope") or {}).get("delivery_target") or {}
     conflicts: list[str] = []
@@ -55,11 +65,15 @@ def _delivery_target_conflict_message(contract: dict[str, Any]) -> str | None:
         route_val = route.get(field)
         target_val = target.get(field)
         if field == "target_branch":
-            route_present = isinstance(route_val, str) and bool(route_val.strip())
-            target_present = isinstance(target_val, str) and bool(target_val.strip())
-        else:
-            route_present = route_val is not None
-            target_present = target_val is not None
+            route_cmp = _normalized_branch(route_val)
+            target_cmp = _normalized_branch(target_val)
+            if route_cmp is None or target_cmp is None:
+                continue
+            if route_cmp != target_cmp:
+                conflicts.append(field)
+            continue
+        route_present = route_val is not None
+        target_present = target_val is not None
         if route_present and target_present and route_val != target_val:
             conflicts.append(field)
     if not conflicts:

--- a/tools/agent_control/preflight.py
+++ b/tools/agent_control/preflight.py
@@ -202,7 +202,14 @@ def preflight(
         "OPERATIONAL_BATCH_CONTINUATION",
     }
     if needs_target:
-        if not route.get("target_pr") or not route.get("target_branch"):
+        route_pr = route.get("target_pr")
+        route_branch = _normalized_branch(route.get("target_branch"))
+        pr_ok = (
+            isinstance(route_pr, int)
+            and not isinstance(route_pr, bool)
+            and route_pr > 0
+        )
+        if not pr_ok or route_branch is None:
             return _fail(
                 "DISPATCH_ROUTE_TARGET_MISSING",
                 "safe existing/continuation route requires target_pr and target_branch",


### PR DESCRIPTION
## Summary
- Closes #4293
- Refs #4249
- Refs #4257
- Refs #4286

Post-merge P2 residuals from PR #4286 on the ACP dispatcher: delivery-target conflict fail-closed, attenuated wall-time budget enforcement, CREATE-route observed targets in run/evidence, and lifecycle-versioned evidence store uniqueness.

## Router Decision
- `routing_decision`: `CREATE_NEW_BATCH_PR`
- `target_branch`: `batch/agent-skills-issue-4293`
- `lane` / `batch_key`: `agent-skills`
- `lock_state`: `UNLOCKED`
- Anti-repush: did **not** reuse deleted `batch/agent-skills-issue-4250`

## Brain Evidence
- brain_source: `repo-only`
- brain_status: `not-used`
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: `insufficient_evidence`
- context_tool_status: `available`
- context_trust_level: `none`
- records_found: none
- GitHub/repo live evidence authoritative over brain/ledger

## Root Cause
1. **R1** `_delivery_target` silently preferred `execution_scope.delivery_target` over conflicting `route` values.
2. **R2** Environment attenuation computed a lower `wall_time_seconds`, but run/request/timeout kept the original contract budget.
3. **R3** CREATE routes left null route targets in evidence `delivery_context` after a validated receipt supplied real PR/branch.
4. **R4** `verify_store` treated `(run_id, attempt)` as globally unique and rejected valid HOLD+PASS lifecycle pairs.

## Delivered
### R1 Delivery Target Conflict
- Preflight + dispatch assert semantic equality when both sides set `target_pr` / `target_branch`
- Error: `DISPATCH_DELIVERY_TARGET_CONFLICT` before any provider call
- Identical duplicates and empty CREATE targets remain allowed

### R2 Effective Environment Budget
- Effective budget = min(contract wall, attenuated `wall_time_seconds`)
- Same value on run record, `ProviderRequest.budget`, and timeout enforcement
- Contract digest / signed input unchanged

### R3 Observed Create Targets
- After validated CREATE receipt: merge targets onto `run.route` with `target_provenance=route+validated_provider_receipt`
- Evidence `delivery_context` includes observed targets and matching provenance (blank-fill and post-merge happy path)

### R4 Lifecycle Evidence Collisions
- Store uniqueness key: `(run_id, attempt, lifecycle.state)`
- HOLD + PASS for same run/attempt verify together
- Same lifecycle conflicting digests still collide via evidence-id digest check

## Validation
- `pytest -q` on dispatcher / run-evidence / environment-profiles / cursor-providers → **105 passed**
- `ruff check` + `black --check` on touched scope → PASS
- `git diff --check` → PASS
- No Full Fast-CI; no `cdb-local-ci` publish

## Regression Coverage
- New R1–R4 unit cases in `test_agent_dispatcher_v1.py` and `test_agent_run_evidence_v1.py`
- Existing #4286 regression suite in the four targeted files remains green

## Non-goals
- No #4257 / #4258 implementation
- No merge, issue close, Full Fast-CI, or `cdb-local-ci`
- No live Cursor/provider calls, BLUE/RED, secrets, productive DB/MCP writes

## Safety Boundaries
- LR remains **NO-GO**
- Board `trade-capable` ≠ Live-Go
- `PERSIST_ALLOWED=false` / `MUTATION_ALLOWED=false`

## Remaining Uncertainties
- Hosted Actions advisory checks not asserted in this delivery session
- Mock environment profiles still skip attenuation in doctor early-return; effective budget applies when constraints are present (cloud / injected)

## Merge Handoff
Separate merge session required:
1. `cdb-integration-wiring-audit`
2. `cdb-pr-gap-classifier`
3. `cdb-pr-completeness-review` → only on `MERGE_CANDIDATE`
4. `cdb-batch-merge-conductor` (freeze, integrate main, Full Fast-CI, `cdb-local-ci` on exact head, regular squash-merge)
5. Close #4293 after verified merge; then lift Implementation-Hold for #4257

Head: `ed0952eb` on `batch/agent-skills-issue-4293`