### PR TITLE
[DOCS][GUARD] Area Entry Link Rule enforcement in validate_readme_links (#4298)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,9 @@ make readme-links-guard      # active README.md + explicit canon entry points (#
 make onboarding-docs-guard   # onboarding front-door surfaces (#3233)
 ```
 
-The link-existence guard does **not** yet enforce Area Entry Link preference;
-Canon defines the contract, automatic enforcement follows later (Slice S7).
+The README link guard enforces both link existence and the Area Entry Link
+Rule (bare folder / dual-link / established `index.md` hubs) via
+`python -m tools.validate_readme_links` / `make readme-links-guard` (#4298).
 
 See also [`docs/meta/REPOSITORY_CANON.md`](docs/meta/REPOSITORY_CANON.md)
 (README vs. `index.md` navigation rule; Area Entry Link Rule).

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -12,18 +12,18 @@
 
 ## Repo / Engineering Status (2026-08-02)
 
-<!-- cdb:live-claim type=main_sha value=365f50b9 -->
-- **Confirmed main state**: `origin/main` @ `365f50b9` — same snapshot as the [`README.md`](README.md) Current-main section. Tip after Area Entry Link Canon squash-merge [#4295](https://github.com/jannekbuengener/Claire_de_Binare/pull/4295) (supersedes Hermes tip `fca8ad09`).
+<!-- cdb:live-claim type=main_sha value=d4704025 -->
+- **Confirmed main state**: `origin/main` @ `d4704025` — same snapshot as the [`README.md`](README.md) Current-main section. Tip after ACP dispatcher residuals squash-merge [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297) (supersedes Area Entry Canon tip `365f50b9`).
 
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
 <!-- cdb:live-claim type=issue_state issue=3995 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4005 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4204 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4228 state=closed -->
+<!-- cdb:live-claim type=issue_state issue=4293 state=closed -->
 - **#4289 Hermes Hetzner Bootstrap**: Repo-Slice **MERGED** via PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290) (`infrastructure/hermes/`, `config/hermes/`, `tools/hermes_ops/`, runbook, threat model, unit tests). Issue remains open for Live Hetzner/Windows/GitHub drills (`HOLD_SCOPE_BLOCKER`). Auth lineage reuses #4170/#4195. `#4257` remains HOLD. LR **NO-GO** unchanged.  <!-- pragma: allowlist secret -->
 
-<!-- cdb:live-claim type=issue_state issue=4293 state=open -->
-- **#4293 ACP dispatcher post-merge residuals**: open follow-up via PR [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297) (`batch/agent-skills-issue-4293`; R1–R4). Sequencing hold for Approval Agent stays until this issue closes. LR **NO-GO** unchanged.
+- **#4293 ACP dispatcher post-merge residuals**: **DONE_MERGED_CLOSED** via PR [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297) @ `d4704025`. LR **NO-GO** unchanged.
 
 - **PR #4286 Agent Control Plane batch**: **DONE_MERGED_CLOSED** — squash-merged; issues #4250–#4256 closed. Prior ledger tip `2d4651a7` superseded by consolidation tip `fce4c754`, then Hermes tip `fca8ad09`. LR **NO-GO** unchanged.
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 ## Current-main Snapshot
 
 <!-- cdb:status-freshness header-date=2026-08-02 -->
-<!-- cdb:live-claim type=main_sha value=365f50b9 -->
+<!-- cdb:live-claim type=main_sha value=d4704025 -->
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
-Auf `origin/main` (`365f50b9`, Stand 2026-08-02) sind die juengsten relevanten Merge-Cluster u. a.:
+<!-- cdb:live-claim type=issue_state issue=4293 state=closed -->
+Auf `origin/main` (`d4704025`, Stand 2026-08-02) sind die juengsten relevanten Merge-Cluster u. a.:
 
+- **ACP dispatcher residuals ([#4293](https://github.com/jannekbuengener/Claire_de_Binare/issues/4293) / PR [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297)):** **MERGED** @ `d4704025`.
 - **Area Entry Link Canon ([#4294](https://github.com/jannekbuengener/Claire_de_Binare/issues/4294)/[#4296](https://github.com/jannekbuengener/Claire_de_Binare/issues/4296) / PR [#4295](https://github.com/jannekbuengener/Claire_de_Binare/pull/4295)):** **MERGED** — README Area Entry Link Rule + active README reconcile @ `365f50b9`.
 - **Hermes Hetzner Bootstrap ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290)):** Repo-Slice **MERGED** auf tip `fca8ad09` (Infrastructure/Profiles/Ops/Token-Broker). Issue `#4289` bleibt offen fuer Live-VM/Windows/GitHub-Drills (`HOLD_SCOPE_BLOCKER`).  <!-- pragma: allowlist secret -->
 - **Repository consolidation wave:** [#4286](https://github.com/jannekbuengener/Claire_de_Binare/pull/4286) ACP batch, [#4162](https://github.com/jannekbuengener/Claire_de_Binare/pull/4162) Grafana 13.1.1, [#4245](https://github.com/jannekbuengener/Claire_de_Binare/pull/4245) CVE HOLD, [#4246](https://github.com/jannekbuengener/Claire_de_Binare/pull/4246) PG15 preflight, [#4244](https://github.com/jannekbuengener/Claire_de_Binare/pull/4244) Dependabot facts, [#4243](https://github.com/jannekbuengener/Claire_de_Binare/pull/4243) dataset fingerprints — squash-merged (prior tip `fce4c754`, superseded by Hermes tip).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ LR bleibt **NO-GO** — SSOT: [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.m
 - [`infrastructure/compose/`](infrastructure/compose/README.md) — Compose-Canon (`compose.blue.yml` + `compose.red.yml`)
 - [`config/`](config/README.md) — versionierte Repo-Konfiguration
 - [`config/arvp/`](config/arvp/README.md) — ARVP-Kampagnen und Compose-Overrides
-- [`.github/governance/`](.github/governance/) — direkt von GitHub Actions gelesene Governance-Gates (kein Area-README; Action-Inputs)
+- [`.github/governance/`](.github/governance/README.md) — Governance-Gates und Action-Inputs (Area-README)
 - [`docs/runbooks/`](docs/runbooks/README.md) — operative Runbooks inkl. Control Register
 - [`docs/live-readiness/`](docs/live-readiness/README.md) — LR-Audit- und Gate-Artefakte
 - [`docs/evidence/`](docs/evidence/README.md) — geprüfte, versionierte Nachweise; neue Ausgaben entstehen unter `artifacts/`

--- a/agents/HV/README.md
+++ b/agents/HV/README.md
@@ -20,7 +20,7 @@ Dokumentation zur **High-Voltage Multi-Agent Engine** — experimenteller/isolie
 | BLUE+RED Trading-Stack | [`infrastructure/compose/README.md`](../../infrastructure/compose/README.md) |
 | Live-Readiness | [`docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`](../../docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md) (**NO-GO**) |
 
-HV-Docs beschreiben keinen LR-Go und ersetzen keine operativen Runbooks unter [`docs/runbooks/`](../../docs/runbooks/).
+HV-Docs beschreiben keinen LR-Go und ersetzen keine operativen Runbooks unter [`docs/runbooks/`](../../docs/runbooks/README.md).
 
 ## Related
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ sondern ein Pointer auf die bestehenden Docs, Runbooks und Source Trees.
 | Ein Issue-to-PR-Beispiel als Referenz sehen willst | [`first_issue_to_pr_flow.md`](onboarding/examples/first_issue_to_pr_flow.md) | Kleinster Issue-to-PR-Workflow als Example/Referenz |
 | Den Repo-Brain-Erstkontakt brauchst | [`repo_brain_first_use.md`](onboarding/examples/repo_brain_first_use.md) | Context Intelligence / Repo Brain als read-only Orientation |
 | Das vollständige Repo-Brain-Onboarding brauchst | [`repo_brain_context_intelligence.md`](onboarding/repo_brain_context_intelligence.md) | Brain Evidence Block, Safety Boundaries, First-Use-Flow |
-| Prompt-, Evidence- oder PR-Body-Vorlagen brauchst | [`onboarding/templates/`](onboarding/templates/) | Agent-Prompt-, Evidence-Doc- und PR-Body-Vorlagen |
+| Prompt-, Evidence- oder PR-Body-Vorlagen brauchst | [`onboarding/templates/`](onboarding/templates/README.md) | Agent-Prompt-, Evidence-Doc- und PR-Body-Vorlagen |
 
 ## Repo Brain / Context Intelligence
 

--- a/docs/meta/REPOSITORY_CANON.md
+++ b/docs/meta/REPOSITORY_CANON.md
@@ -241,10 +241,10 @@ ist.
 
 ### Enforcement-Hinweis
 
-Diese Regel ist der Navigationsvertrag. Der bestehende README-Link-Guard
-(`python -m tools.validate_readme_links`) prüft Link-Existenz, noch nicht die
-Area-Entry-Präferenz. Automatischer Enforcement-Guard folgt in einem späteren
-Slice (S7).
+Diese Regel ist der Navigationsvertrag. Der README-Link-Guard
+(`python -m tools.validate_readme_links`, Policy
+`tests/fixtures/readme_link_policy.yaml` → `area_entry_link_rule`) prüft
+Link-Existenz und die Area Entry Link Rule fail-closed (Issue #4298 / S7).
 
 ## Archive
 

--- a/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
+++ b/docs/onboarding/DEVELOPER_VISUAL_START_HERE.md
@@ -32,7 +32,7 @@ before touching implementation work.
    `python -m tools.onboarding_doctor` or `make onboarding-doctor`.
 7. Use the examples in [`examples/README.md`](examples/README.md) before drafting
    your first issue-to-PR workflow.
-8. Use the templates in [`templates/`](templates/) for prompts, evidence docs,
+8. Use the templates in [`templates/`](templates/README.md) for prompts, evidence docs,
    and docs/onboarding PR bodies.
 
 ## Start Path For Agents

--- a/infrastructure/scripts/README.md
+++ b/infrastructure/scripts/README.md
@@ -35,7 +35,7 @@ Operator scripts for stack lifecycle, backup/DR, smoke, and evidence — prefer 
 | [`stack_up.ps1`](stack_up.ps1) | Superseded by `setup_blue_red.ps1` |
 
 Repo-root helpers such as `smart_health_check.py`, project PowerShell automation,
-`check_core_duplicates.py`, and `dimensionality_audit/` own under [`scripts/`](../../scripts/).
+`check_core_duplicates.py`, and `dimensionality_audit/` own under [`scripts/`](../../scripts/README.md).
 Do not reintroduce identical copies here; Rule 3 in `scripts/check_core_duplicates.py`
 guards against new exact clones.
 

--- a/tests/fixtures/readme_link_policy.yaml
+++ b/tests/fixtures/readme_link_policy.yaml
@@ -1,12 +1,13 @@
-# README link validation policy (#3994, extended #4037 and #4124)
+# README link validation policy (#3994, extended #4037, #4124, #4298)
 #
 # Discovery: git ls-files '**/README.md' (automatic, fail-closed for new files)
-# This fixture holds only classification rules, explicit active non-README
-# surfaces, and documented exceptions.
+# This fixture holds classification rules, explicit active non-README surfaces,
+# documented exceptions, and the Area Entry Link Rule machine contract.
+# Canon SSOT: docs/meta/REPOSITORY_CANON.md § Area Entry Link Rule.
 
 version: 1
 issue: 3994
-follow_up_issue: 4124
+follow_up_issue: 4298
 
 # Unmatched README paths use this class and are validated (fail-closed).
 default_classification: active
@@ -47,3 +48,20 @@ explicit_active_surfaces:
 
 # Explicit per-path overrides (use sparingly).
 documented_exceptions: []
+
+# Executable mirror of REPOSITORY_CANON.md § Area Entry Link Rule / index hubs.
+# Invalid entries fail closed at policy load (missing fields, duplicates,
+# missing entrypoints, entrypoints outside directory, absolute/external paths).
+area_entry_link_rule:
+  enabled: true
+  established_index_hubs:
+    - directory: docs
+      entrypoint: docs/index.md
+    - directory: docs/ci
+      entrypoint: docs/ci/index.md
+    - directory: docs/db
+      entrypoint: docs/db/index.md
+    - directory: docs/env
+      entrypoint: docs/env/index.md
+    - directory: docs/external-docs
+      entrypoint: docs/external-docs/index.md

--- a/tests/unit/tools/test_validate_readme_links.py
+++ b/tests/unit/tools/test_validate_readme_links.py
@@ -330,7 +330,7 @@ def test_area_entry_direct_yaml_ok(tmp_path: Path) -> None:
 
 
 def test_area_entry_established_index_hub_ok(tmp_path: Path) -> None:
-    _make_file(tmp_path, "docs/index.md", "# docs hub")
+    _make_file(tmp_path, "docs/index.md", "# docs landing")
     errors = _validate_content(
         tmp_path,
         "README.md",

--- a/tests/unit/tools/test_validate_readme_links.py
+++ b/tests/unit/tools/test_validate_readme_links.py
@@ -1,4 +1,4 @@
-"""Unit tests for README link validator (#3994)."""
+"""Unit tests for README link validator (#3994, Area Entry Link Rule #4298)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,12 @@ import pytest
 import yaml
 
 from tools import validate_readme_links as readme_validator
-from tools.markdown_link_utils import check_markdown_links, extract_relative_links
+from tools.markdown_link_utils import (
+    MarkdownLink,
+    check_markdown_links,
+    extract_markdown_links,
+    extract_relative_links,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -18,6 +23,67 @@ def _make_file(root: Path, rel: str, content: str = "") -> Path:
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(content, encoding="utf-8")
     return target
+
+
+def _policy(
+    tmp_path: Path,
+    *,
+    hubs: list[dict[str, str]] | None = None,
+    enabled: bool = True,
+    extra: dict | None = None,
+) -> Path:
+    resolved_hubs = (
+        hubs
+        if hubs is not None
+        else [
+            {"directory": "docs", "entrypoint": "docs/index.md"},
+            {"directory": "docs/ci", "entrypoint": "docs/ci/index.md"},
+        ]
+    )
+    for hub in resolved_hubs:
+        _make_file(tmp_path, hub["entrypoint"], f"# {hub['directory']}\n")
+    data: dict = {
+        "default_classification": "active",
+        "classification_rules": {
+            "archive_snapshot": {
+                "path_prefixes": ["docs/archive/", "knowledge/archive/"]
+            },
+            "fixture_testdata": {"path_prefixes": ["tests/fixtures/", "artifacts/"]},
+        },
+        "documented_exceptions": [],
+        "area_entry_link_rule": {
+            "enabled": enabled,
+            "established_index_hubs": resolved_hubs,
+        },
+    }
+    if extra:
+        data.update(extra)
+    path = tmp_path / "policy.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def _validate_content(
+    tmp_path: Path,
+    rel_path: str,
+    content: str,
+    *,
+    hubs: list[dict[str, str]] | None = None,
+    enabled: bool = True,
+) -> list[str]:
+    policy_path = _policy(tmp_path, hubs=hubs, enabled=enabled)
+    _make_file(tmp_path, rel_path, content)
+    # Ensure common area trees exist for resolution fixtures.
+    return readme_validator.validate_surface_file(
+        tmp_path,
+        rel_path,
+        policy_path=policy_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Existing classification / inventory tests (#3994)
+# ---------------------------------------------------------------------------
 
 
 def test_classify_readme_active_by_default() -> None:
@@ -40,9 +106,7 @@ def test_classify_readme_archive_prefix() -> None:
         "documented_exceptions": [],
     }
     assert (
-        readme_validator.classify_readme(
-            "docs/archive/README.md", policy
-        )
+        readme_validator.classify_readme("docs/archive/README.md", policy)
         == "archive_snapshot"
     )
 
@@ -64,8 +128,14 @@ def test_classify_readme_documented_exception() -> None:
     )
 
 
-def test_validate_all_skips_non_active(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    policy_path = tmp_path / "policy.yaml"
+def test_validate_all_skips_non_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    policy_path = _policy(tmp_path)
+    _make_file(tmp_path, "active/README.md", "[ok](target.md)")
+    _make_file(tmp_path, "active/target.md")
+    _make_file(tmp_path, "archive/README.md", "[broken](missing.md)")
+    # Remap archive classification for this fixture tree.
     policy_path.write_text(
         yaml.safe_dump(
             {
@@ -74,13 +144,11 @@ def test_validate_all_skips_non_active(tmp_path: Path, monkeypatch: pytest.Monke
                     "archive_snapshot": {"path_prefixes": ["archive/"]},
                 },
                 "documented_exceptions": [],
+                "area_entry_link_rule": {"enabled": True, "established_index_hubs": []},
             }
         ),
         encoding="utf-8",
     )
-    _make_file(tmp_path, "active/README.md", "[ok](target.md)")
-    _make_file(tmp_path, "active/target.md")
-    _make_file(tmp_path, "archive/README.md", "[broken](missing.md)")
 
     monkeypatch.setattr(
         readme_validator,
@@ -95,11 +163,7 @@ def test_validate_all_skips_non_active(tmp_path: Path, monkeypatch: pytest.Monke
 def test_validate_all_fails_on_broken_active_link(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    policy_path = tmp_path / "policy.yaml"
-    policy_path.write_text(
-        yaml.safe_dump({"default_classification": "active"}),
-        encoding="utf-8",
-    )
+    policy_path = _policy(tmp_path, hubs=[])
     _make_file(tmp_path, "services/README.md", "[bad](missing.md)")
 
     monkeypatch.setattr(
@@ -113,7 +177,9 @@ def test_validate_all_fails_on_broken_active_link(
     assert "broken relative link" in errors[0]
 
 
-def test_build_inventory_counts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_inventory_counts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     policy_path = tmp_path / "policy.yaml"
     policy_path.write_text(
         yaml.safe_dump(
@@ -125,6 +191,7 @@ def test_build_inventory_counts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
                 "explicit_active_surfaces": {
                     "paths": ["CURRENT_STATUS.md"],
                 },
+                "area_entry_link_rule": {"enabled": True, "established_index_hubs": []},
             }
         ),
         encoding="utf-8",
@@ -146,16 +213,11 @@ def test_build_inventory_counts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 def test_validate_all_checks_explicit_active_surfaces(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    policy_path = tmp_path / "policy.yaml"
-    policy_path.write_text(
-        yaml.safe_dump(
-            {
-                "default_classification": "active",
-                "explicit_active_surfaces": {"paths": ["CURRENT_STATUS.md"]},
-            }
-        ),
-        encoding="utf-8",
-    )
+    policy_path = _policy(tmp_path, hubs=[])
+    # Ensure area_entry policy loads; explicit surface still checked for broken links.
+    data = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    data["explicit_active_surfaces"] = {"paths": ["CURRENT_STATUS.md"]}
+    policy_path.write_text(yaml.safe_dump(data), encoding="utf-8")
     _make_file(tmp_path, "CURRENT_STATUS.md", "[broken](missing.md)")
     monkeypatch.setattr(
         readme_validator,
@@ -215,3 +277,384 @@ def test_check_markdown_links_with_fragment(tmp_path: Path) -> None:
         False,
     )
     assert errors == []
+
+
+def test_extract_markdown_links_includes_label() -> None:
+    links = extract_markdown_links("[Services](services/README.md)")
+    assert links == [MarkdownLink(label="Services", target="services/README.md")]
+
+
+# ---------------------------------------------------------------------------
+# Area Entry Link Rule — positive cases (#4298)
+# ---------------------------------------------------------------------------
+
+
+def test_area_entry_readme_target_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# services")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[Services](services/README.md)",
+    )
+    assert errors == []
+
+
+def test_area_entry_visible_folder_text_readme_target_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# services")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[`services/`](services/README.md)",
+    )
+    assert errors == []
+
+
+def test_area_entry_direct_canon_file_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "docs/meta/REPOSITORY_CANON.md", "# canon")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[Canon](docs/meta/REPOSITORY_CANON.md)",
+    )
+    assert errors == []
+
+
+def test_area_entry_direct_yaml_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "docs/navigation/mcp-navpack/ENTRYPOINTS.yaml", "x: 1\n")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[Entrypoints](docs/navigation/mcp-navpack/ENTRYPOINTS.yaml)",
+    )
+    assert errors == []
+
+
+def test_area_entry_established_index_hub_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "docs/index.md", "# docs hub")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[Docs](docs/index.md)",
+    )
+    assert errors == []
+
+
+def test_area_entry_external_link_ok(tmp_path: Path) -> None:
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[GitHub](https://github.com/jannekbuengener/Claire_de_Binare)",
+    )
+    assert errors == []
+
+
+def test_area_entry_pure_anchor_ok(tmp_path: Path) -> None:
+    errors = _validate_content(tmp_path, "README.md", "[top](#top)")
+    assert errors == []
+
+
+def test_area_entry_fenced_code_block_example_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# s")
+    content = """
+# Nav
+
+```markdown
+[Beispiel](services/)
+```
+"""
+    errors = _validate_content(tmp_path, "README.md", content)
+    assert errors == []
+
+
+def test_area_entry_unlinked_folder_text_with_readme_link_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk")
+    content = """
+| Ordner | Dokumentation |
+| --- | --- |
+| `risk/` | [`README`](services/risk/README.md) |
+"""
+    errors = _validate_content(tmp_path, "README.md", content)
+    assert errors == []
+
+
+def test_area_entry_deep_relative_readme_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk")
+    _make_file(tmp_path, "core/README.md", "# core")
+    errors = _validate_content(
+        tmp_path,
+        "services/risk/README.md",
+        "[Core](../../core/README.md)",
+    )
+    assert errors == []
+
+
+def test_area_entry_readme_with_anchor_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# services\n## usage\n")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[Services](services/README.md#usage)",
+    )
+    assert errors == []
+
+
+def test_area_entry_excluded_archive_surface_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    policy_path = _policy(tmp_path, hubs=[])
+    _make_file(tmp_path, "docs/archive/README.md", "[bare](legacy/)")
+    _make_file(tmp_path, "docs/archive/legacy/README.md", "# legacy")
+    monkeypatch.setattr(
+        readme_validator,
+        "discover_tracked_readmes",
+        lambda _root: ["docs/archive/README.md"],
+    )
+    errors = readme_validator.validate_all(tmp_path, policy_path)
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Area Entry Link Rule — negative cases (#4298)
+# ---------------------------------------------------------------------------
+
+
+def test_area_entry_bare_folder_with_readme_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# services")
+    errors = _validate_content(tmp_path, "README.md", "[Services](services/)")
+    assert len(errors) == 1
+    assert "bare area link 'services/'" in errors[0]
+    assert "services/README.md" in errors[0]
+
+
+def test_area_entry_bare_folder_no_slash_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# services")
+    errors = _validate_content(tmp_path, "README.md", "[Services](services)")
+    assert any("bare area link 'services'" in e for e in errors)
+
+
+def test_area_entry_dot_slash_folder_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# services")
+    errors = _validate_content(tmp_path, "README.md", "[Services](./services/)")
+    assert any("bare area link './services/'" in e for e in errors)
+
+
+def test_area_entry_parent_relative_folder_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# services")
+    _make_file(tmp_path, "docs/guide/README.md", "[Services](../../services/)")
+    errors = _validate_content(
+        tmp_path,
+        "docs/guide/README.md",
+        "[Services](../../services/)",
+    )
+    assert any("bare area link '../../services/'" in e for e in errors)
+
+
+def test_area_entry_dual_link_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk")
+    content = "[folder](services/risk/) and [readme](services/risk/README.md)"
+    errors = _validate_content(tmp_path, "README.md", content)
+    assert any("dual area links" in e for e in errors)
+    assert any("services/risk" in e for e in errors)
+
+
+def test_area_entry_dual_link_in_table_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk")
+    errors = _validate_content(
+        tmp_path,
+        "services/README.md",
+        """
+| Bereich | Dokumentation |
+| --- | --- |
+| [`risk/`](risk/) | [`README`](risk/README.md) |
+""",
+    )
+    assert any("dual area links" in e for e in errors)
+
+
+def test_area_entry_bare_index_hub_folder_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "docs/index.md", "# docs")
+    _make_file(tmp_path, "docs/ci/index.md", "# ci")
+    errors = _validate_content(tmp_path, "README.md", "[CI](docs/ci/)")
+    assert any("established index hub" in e for e in errors)
+    assert any("docs/ci/index.md" in e for e in errors)
+
+
+def test_area_entry_invalid_policy_entry_fails_closed(tmp_path: Path) -> None:
+    policy_path = tmp_path / "bad.yaml"
+    policy_path.write_text(
+        yaml.safe_dump(
+            {
+                "default_classification": "active",
+                "area_entry_link_rule": {
+                    "enabled": True,
+                    "established_index_hubs": [{"directory": "docs"}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="entrypoint"):
+        readme_validator.load_policy(policy_path, root=tmp_path)
+
+
+def test_area_entry_missing_policy_entrypoint_fails_closed(tmp_path: Path) -> None:
+    policy_path = tmp_path / "bad.yaml"
+    policy_path.write_text(
+        yaml.safe_dump(
+            {
+                "default_classification": "active",
+                "area_entry_link_rule": {
+                    "enabled": True,
+                    "established_index_hubs": [
+                        {"directory": "docs", "entrypoint": "docs/index.md"},
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="does not exist"):
+        readme_validator.load_policy(policy_path, root=tmp_path)
+
+
+def test_area_entry_broken_link_still_reported(tmp_path: Path) -> None:
+    errors = _validate_content(tmp_path, "README.md", "[x](missing.md)")
+    assert any("broken relative link" in e for e in errors)
+
+
+def test_area_entry_normalized_spellings_same_area(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk")
+    content = "[a](services/risk) [b](./services/risk/) [c](services/../services/risk/)"
+    errors = _validate_content(tmp_path, "README.md", content)
+    bare = [e for e in errors if "bare area link" in e]
+    # Multiple spellings normalize to one area; report once with original target.
+    assert len(bare) == 1
+    assert "services/risk" in bare[0]
+    keys = {
+        readme_validator.normalize_area_key(tmp_path, "README.md", t)
+        for t in ("services/risk", "./services/risk/", "services/../services/risk/")
+    }
+    assert keys == {"services/risk"}
+
+
+def test_area_entry_dual_link_with_readme_anchor_fails(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk\n## usage\n")
+    content = "[folder](services/risk/) [readme](services/risk/README.md#usage)"
+    errors = _validate_content(tmp_path, "README.md", content)
+    assert any("dual area links" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Area Entry Link Rule — boundary cases (#4298)
+# ---------------------------------------------------------------------------
+
+
+def test_area_entry_folder_without_readme_or_index_not_hard_error(
+    tmp_path: Path,
+) -> None:
+    _make_file(tmp_path, "orphan/note.txt", "x")
+    errors = _validate_content(tmp_path, "README.md", "[Orphan](orphan/)")
+    assert errors == []
+
+
+def test_area_entry_inline_code_folder_not_a_link(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "See `services/risk/` and [`README`](services/risk/README.md).",
+    )
+    assert errors == []
+
+
+def test_area_entry_direct_file_same_folder_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/config.py", "x = 1\n")
+    errors = _validate_content(
+        tmp_path,
+        "services/README.md",
+        "[config](config.py)",
+    )
+    assert errors == []
+
+
+def test_area_entry_two_distinct_areas_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/risk/README.md", "# risk")
+    _make_file(tmp_path, "services/signal/README.md", "# signal")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[R](services/risk/README.md) [S](services/signal/README.md)",
+    )
+    assert errors == []
+
+
+def test_area_entry_query_and_anchor_on_readme_ok(tmp_path: Path) -> None:
+    _make_file(tmp_path, "services/README.md", "# s")
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[S](services/README.md?x=1#usage)",
+    )
+    assert errors == []
+
+
+def test_area_entry_image_link_to_file_ok(tmp_path: Path) -> None:
+    # Existing parser matches the [alt](path) portion of image syntax.
+    _make_file(tmp_path, "docs/img.png", "png")
+    errors = _validate_content(tmp_path, "README.md", "![diagram](docs/img.png)")
+    assert errors == []
+
+
+def test_area_entry_archive_target_from_active_docs_skipped_for_existence(
+    tmp_path: Path,
+) -> None:
+    # Archive targets are skipped by existence check; no area-entry hard error either.
+    errors = _validate_content(
+        tmp_path,
+        "README.md",
+        "[hist](docs/archive/old/README.md)",
+    )
+    assert errors == []
+
+
+def test_area_entry_duplicate_hub_directory_fails_closed(tmp_path: Path) -> None:
+    _make_file(tmp_path, "docs/index.md", "# docs")
+    policy_path = tmp_path / "bad.yaml"
+    policy_path.write_text(
+        yaml.safe_dump(
+            {
+                "default_classification": "active",
+                "area_entry_link_rule": {
+                    "enabled": True,
+                    "established_index_hubs": [
+                        {"directory": "docs", "entrypoint": "docs/index.md"},
+                        {"directory": "docs", "entrypoint": "docs/index.md"},
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        readme_validator.load_policy(policy_path, root=tmp_path)
+
+
+def test_area_entry_hub_outside_directory_fails_closed(tmp_path: Path) -> None:
+    _make_file(tmp_path, "other/index.md", "# other")
+    policy_path = tmp_path / "bad.yaml"
+    policy_path.write_text(
+        yaml.safe_dump(
+            {
+                "default_classification": "active",
+                "area_entry_link_rule": {
+                    "enabled": True,
+                    "established_index_hubs": [
+                        {"directory": "docs", "entrypoint": "other/index.md"},
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="outside"):
+        readme_validator.load_policy(policy_path, root=tmp_path)

--- a/tools/markdown_link_utils.py
+++ b/tools/markdown_link_utils.py
@@ -2,19 +2,28 @@
 
 Used by:
 - tools.validate_onboarding_docs (#3233)
-- tools.validate_readme_links (#3994, #4037)
+- tools.validate_readme_links (#3994, #4037, #4298)
 
-Issues: #3994, #4037
+Issues: #3994, #4037, #4298
 """
 
 from __future__ import annotations
 
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class MarkdownLink:
+    """One Markdown link outside fenced code blocks."""
+
+    label: str
+    target: str
 
 
 def strip_fenced_code_blocks(content: str) -> str:
@@ -35,20 +44,48 @@ def is_archive_link_target(link: str) -> bool:
     return link.startswith(("docs/archive/", "knowledge/archive/"))
 
 
+def strip_link_fragments(link: str) -> str:
+    """Remove query/anchor portions used only for path resolution."""
+    return link.split("#", 1)[0].split("?", 1)[0]
+
+
 def resolve_relative_link(source_file: Path, link: str) -> Path:
-    link_clean = link.split("#")[0].split("?")[0]
+    link_clean = strip_link_fragments(link)
     if not link_clean:
         return source_file
     return (source_file.parent / link_clean).resolve()
 
 
-def extract_relative_links(content: str) -> list[str]:
-    links: list[str] = []
+def extract_markdown_links(content: str) -> list[MarkdownLink]:
+    """Extract relative and absolute Markdown links (label + target).
+
+    External URLs and pure anchors are included; callers filter as needed.
+    Fenced code blocks are ignored.
+    """
+    links: list[MarkdownLink] = []
     for match in MARKDOWN_LINK_RE.finditer(strip_fenced_code_blocks(content)):
-        link = match.group(2).strip()
-        if not is_external_url(link) and not is_pure_anchor(link):
-            links.append(link)
+        label = match.group(1)
+        target = match.group(2).strip()
+        if target:
+            links.append(MarkdownLink(label=label, target=target))
     return links
+
+
+def extract_relative_links(content: str) -> list[str]:
+    """Backward-compatible target-only extraction for relative links."""
+    return [
+        link.target
+        for link in extract_markdown_links(content)
+        if not is_external_url(link.target) and not is_pure_anchor(link.target)
+    ]
+
+
+def repo_relative_posix(root: Path, path: Path) -> str | None:
+    """Return POSIX path relative to root, or None if outside the repository."""
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return None
 
 
 def check_markdown_links(

--- a/tools/validate_readme_links.py
+++ b/tools/validate_readme_links.py
@@ -5,6 +5,9 @@ policy, and fail-closed validates all `active` README surfaces offline.
 Also validates explicit non-README canon entry points listed in policy
 (`explicit_active_surfaces`, #3995) with the same link engine.
 
+Area Entry Link Rule (#4298): fail-closed on bare folder area links when a
+local README or established index hub exists, and on dual folder+README links.
+
 Usage:
     python -m tools.validate_readme_links
     python -m tools.validate_readme_links --verbose
@@ -14,7 +17,7 @@ Exit codes:
     0 - all active surface link checks PASS
     1 - one or more validation failures
 
-Issues: #3994 (README discovery), #3995 (explicit canon entry points), #4037 (glossary + active markdown)
+Issues: #3994, #3995, #4037, #4298
 """
 
 from __future__ import annotations
@@ -27,10 +30,23 @@ from typing import Any
 
 import yaml
 
-from tools.markdown_link_utils import check_markdown_links
+from tools.markdown_link_utils import (
+    MarkdownLink,
+    check_markdown_links,
+    extract_markdown_links,
+    is_archive_link_target,
+    is_external_url,
+    is_pure_anchor,
+    repo_relative_posix,
+    resolve_relative_link,
+    strip_link_fragments,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_POLICY_PATH = REPO_ROOT / "tests/fixtures/readme_link_policy.yaml"
+
+README_NAME = "README.md"
+INDEX_NAME = "index.md"
 
 
 def discover_tracked_readmes(root: Path) -> list[str]:
@@ -42,10 +58,83 @@ def discover_tracked_readmes(root: Path) -> list[str]:
     return sorted(set(line.strip() for line in output.splitlines() if line.strip()))
 
 
-def load_policy(policy_path: Path) -> dict[str, Any]:
+def _normalize_policy_path(value: str) -> str:
+    return value.strip().replace("\\", "/").strip("/")
+
+
+def _validate_area_entry_policy(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    """Validate and normalize area_entry_link_rule; fail closed on bad config."""
+    block = policy.get("area_entry_link_rule")
+    if block is None:
+        return {"enabled": False, "hubs": {}}
+    if not isinstance(block, dict):
+        raise ValueError("area_entry_link_rule must be a mapping")
+
+    enabled = block.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ValueError("area_entry_link_rule.enabled must be a boolean")
+
+    hubs_raw = block.get("established_index_hubs") or []
+    if not isinstance(hubs_raw, list):
+        raise ValueError("area_entry_link_rule.established_index_hubs must be a list")
+
+    hubs: dict[str, str] = {}
+    for idx, entry in enumerate(hubs_raw):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"area_entry_link_rule.established_index_hubs[{idx}] must be a mapping"
+            )
+        directory = entry.get("directory")
+        entrypoint = entry.get("entrypoint")
+        if not directory or not isinstance(directory, str):
+            raise ValueError(
+                f"area_entry_link_rule.established_index_hubs[{idx}] missing directory"
+            )
+        if not entrypoint or not isinstance(entrypoint, str):
+            raise ValueError(
+                f"area_entry_link_rule.established_index_hubs[{idx}] missing entrypoint"
+            )
+        if "://" in directory or "://" in entrypoint:
+            raise ValueError(
+                f"area_entry_link_rule hub paths must be repository-relative "
+                f"(got directory={directory!r}, entrypoint={entrypoint!r})"
+            )
+        if Path(directory).is_absolute() or Path(entrypoint).is_absolute():
+            raise ValueError(
+                "area_entry_link_rule hub paths must not be absolute filesystem paths"
+            )
+
+        dir_key = _normalize_policy_path(directory)
+        entry_key = _normalize_policy_path(entrypoint)
+        if dir_key in hubs:
+            raise ValueError(
+                f"area_entry_link_rule duplicate directory entry: {dir_key}"
+            )
+        if not (
+            entry_key == f"{dir_key}/{INDEX_NAME}"
+            or entry_key.startswith(f"{dir_key}/")
+        ):
+            raise ValueError(
+                f"area_entry_link_rule entrypoint '{entry_key}' is outside "
+                f"directory '{dir_key}'"
+            )
+
+        entry_path = root / entry_key
+        if not entry_path.is_file():
+            raise ValueError(
+                f"area_entry_link_rule entrypoint '{entry_key}' does not exist"
+            )
+        hubs[dir_key] = entry_key
+
+    return {"enabled": enabled, "hubs": hubs}
+
+
+def load_policy(policy_path: Path, root: Path | None = None) -> dict[str, Any]:
     data = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"Invalid policy YAML: {policy_path}")
+    scan_root = root if root is not None else REPO_ROOT
+    data["_area_entry"] = _validate_area_entry_policy(scan_root, data)
     return data
 
 
@@ -74,12 +163,166 @@ def explicit_active_surfaces(policy: dict[str, Any]) -> list[str]:
     return sorted({str(p).strip() for p in paths if str(p).strip()})
 
 
+def normalize_area_key(root: Path, source_rel: str, link_target: str) -> str | None:
+    """Normalize a relative link target to a repository-relative area directory key."""
+    if is_external_url(link_target) or is_pure_anchor(link_target):
+        return None
+    if is_archive_link_target(link_target):
+        return None
+
+    source_path = (root / source_rel).resolve()
+    resolved = resolve_relative_link(source_path, link_target)
+    rel = repo_relative_posix(root, resolved)
+    if rel is None:
+        return None
+
+    clean = strip_link_fragments(link_target)
+    # If the link path (before resolve) ends with README.md / index.md, area is parent.
+    path_part = clean.replace("\\", "/")
+    base_name = Path(path_part).name.lower()
+    if base_name in {README_NAME.lower(), INDEX_NAME.lower()}:
+        parent = Path(rel).parent
+        if str(parent) == ".":
+            return ""
+        return parent.as_posix()
+
+    if resolved.is_dir():
+        return rel
+    if resolved.is_file():
+        # Direct non-entry file link — not an area key for dual-link grouping,
+        # unless it is README/index (handled above via path name).
+        return None
+
+    # Target missing: still classify by path shape for dual-link / bare checks.
+    if path_part.endswith("/") or "." not in Path(path_part).name:
+        return rel
+    return None
+
+
+def _preferred_area_entrypoint(
+    root: Path,
+    area_key: str,
+    hubs: dict[str, str],
+) -> str | None:
+    if area_key in hubs:
+        return hubs[area_key]
+    readme = f"{area_key}/{README_NAME}" if area_key else README_NAME
+    if (root / readme).is_file():
+        return readme
+    return None
+
+
+def _classify_area_link(
+    root: Path,
+    source_rel: str,
+    link: MarkdownLink,
+    hubs: dict[str, str],
+) -> tuple[str | None, str | None]:
+    """Return (area_key, kind) where kind is bare|readme|index|None."""
+    target = link.target
+    if (
+        is_external_url(target)
+        or is_pure_anchor(target)
+        or is_archive_link_target(target)
+    ):
+        return None, None
+
+    source_path = (root / source_rel).resolve()
+    resolved = resolve_relative_link(source_path, target)
+    rel = repo_relative_posix(root, resolved)
+    if rel is None:
+        return None, None
+
+    path_part = strip_link_fragments(target).replace("\\", "/")
+    base_name = Path(path_part).name.lower()
+
+    if base_name == README_NAME.lower():
+        area = normalize_area_key(root, source_rel, target)
+        return area, "readme"
+    if base_name == INDEX_NAME.lower():
+        area = normalize_area_key(root, source_rel, target)
+        if area is not None and area in hubs and hubs[area] == rel:
+            return area, "index"
+        # Non-hub index.md is a direct file link, not area dual-link fodder.
+        return None, None
+
+    looks_like_dir = path_part.endswith("/") or "." not in Path(path_part).name
+    if resolved.is_dir() or (not resolved.exists() and looks_like_dir):
+        return rel, "bare"
+
+    return None, None
+
+
+def check_area_entry_links(
+    root: Path,
+    source_rel: str,
+    content: str,
+    policy: dict[str, Any],
+) -> list[str]:
+    area_cfg = policy.get("_area_entry") or {"enabled": False, "hubs": {}}
+    if not area_cfg.get("enabled"):
+        return []
+
+    hubs: dict[str, str] = area_cfg.get("hubs") or {}
+    errors: list[str] = []
+    relative_links = [
+        link
+        for link in extract_markdown_links(content)
+        if not is_external_url(link.target) and not is_pure_anchor(link.target)
+    ]
+
+    # Dual-link aggregation: bare vs readme/index for same area.
+    by_area: dict[str, dict[str, list[str]]] = {}
+    bare_reported: set[str] = set()
+
+    for link in relative_links:
+        if is_archive_link_target(link.target):
+            continue
+
+        area_key, kind = _classify_area_link(root, source_rel, link, hubs)
+        if area_key is None or kind is None:
+            continue
+
+        bucket = by_area.setdefault(area_key, {"bare": [], "entry": []})
+        if kind == "bare":
+            bucket["bare"].append(link.target)
+            preferred = _preferred_area_entrypoint(root, area_key, hubs)
+            if preferred and area_key not in bare_reported:
+                bare_reported.add(area_key)
+                if area_key in hubs:
+                    errors.append(
+                        f"{source_rel}: bare area link '{link.target}' targets an "
+                        f"established index hub; use '{preferred}'"
+                    )
+                else:
+                    errors.append(
+                        f"{source_rel}: bare area link '{link.target}' targets "
+                        f"directory '{area_key}'; use '{preferred}'"
+                    )
+        else:
+            bucket["entry"].append(link.target)
+
+    for area_key, groups in sorted(by_area.items()):
+        bare_targets = groups["bare"]
+        entry_targets = groups["entry"]
+        if bare_targets and entry_targets:
+            errors.append(
+                f"{source_rel}: dual area links for '{area_key}': "
+                f"'{bare_targets[0]}' and '{entry_targets[0]}'; "
+                f"keep only the README or index target"
+            )
+
+    return errors
+
+
 def validate_surface_file(
     root: Path,
     rel_path: str,
     *,
     verbose: bool = False,
     surface_kind: str = "active",
+    policy_path: Path | None = None,
+    policy: dict[str, Any] | None = None,
 ) -> list[str]:
     full_path = root / rel_path
     if not full_path.is_file():
@@ -89,11 +332,19 @@ def validate_surface_file(
         print(f"Validating ({surface_kind}): {rel_path}", file=sys.stderr)
 
     content = full_path.read_text(encoding="utf-8", errors="replace")
-    return check_markdown_links(root, rel_path, content, verbose)
+    errors = check_markdown_links(root, rel_path, content, verbose)
+
+    active_policy = policy
+    if active_policy is None and policy_path is not None:
+        active_policy = load_policy(policy_path, root=root)
+    if active_policy is not None:
+        errors.extend(check_area_entry_links(root, rel_path, content, active_policy))
+
+    return errors
 
 
 def build_inventory(root: Path, policy_path: Path | None = None) -> dict[str, Any]:
-    policy = load_policy(policy_path or DEFAULT_POLICY_PATH)
+    policy = load_policy(policy_path or DEFAULT_POLICY_PATH, root=root)
     readmes = discover_tracked_readmes(root)
     by_class: dict[str, list[str]] = {}
     for rel in readmes:
@@ -101,6 +352,7 @@ def build_inventory(root: Path, policy_path: Path | None = None) -> dict[str, An
         by_class.setdefault(cls, []).append(rel)
 
     explicit = explicit_active_surfaces(policy)
+    area_cfg = policy.get("_area_entry") or {}
 
     return {
         "total_readmes": len(readmes),
@@ -109,6 +361,13 @@ def build_inventory(root: Path, policy_path: Path | None = None) -> dict[str, An
         "by_classification": {k: len(v) for k, v in sorted(by_class.items())},
         "paths_by_classification": by_class,
         "policy_path": str((policy_path or DEFAULT_POLICY_PATH).relative_to(root)),
+        "area_entry_link_rule": {
+            "enabled": bool(area_cfg.get("enabled")),
+            "established_index_hubs": [
+                {"directory": d, "entrypoint": e}
+                for d, e in sorted((area_cfg.get("hubs") or {}).items())
+            ],
+        },
     }
 
 
@@ -118,7 +377,7 @@ def validate_all(
     verbose: bool = False,
 ) -> list[str]:
     r = root or REPO_ROOT
-    policy = load_policy(policy_path or DEFAULT_POLICY_PATH)
+    policy = load_policy(policy_path or DEFAULT_POLICY_PATH, root=r)
     all_errors: list[str] = []
 
     for rel_path in discover_tracked_readmes(r):
@@ -132,7 +391,13 @@ def validate_all(
             continue
 
         all_errors.extend(
-            validate_surface_file(r, rel_path, verbose=verbose, surface_kind="active")
+            validate_surface_file(
+                r,
+                rel_path,
+                verbose=verbose,
+                surface_kind="active",
+                policy=policy,
+            )
         )
 
     for rel_path in explicit_active_surfaces(policy):
@@ -142,6 +407,7 @@ def validate_all(
                 rel_path,
                 verbose=verbose,
                 surface_kind="canon_entry_point",
+                policy=policy,
             )
         )
 
@@ -150,7 +416,10 @@ def validate_all(
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Validate relative links in active tracked README.md files (#3994)."
+        description=(
+            "Validate relative links and Area Entry Link Rule on active "
+            "README/canon surfaces (#3994/#4298)."
+        )
     )
     parser.add_argument(
         "--verbose",
@@ -184,7 +453,10 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  FAIL: {err}", file=sys.stderr)
         return 1
 
-    print("OK: all active README and explicit canon entry surfaces pass link validation")
+    print(
+        "OK: all active README and explicit canon entry surfaces pass "
+        "link and area-entry validation"
+    )
     return 0
 
 


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: docs-governance
lane: docs-governance
base_branch: main
validation_profile: docs-governance-v1
merge_mode: batch
steward_state: frozen
objective_key: issue-4298
planned_issues: #4298
contract_keys: none
risk_flags: none
-->

## Kurzbefund

Fail-closed Area Entry Link Rule enforcement inside the existing README link validator (S7 / #4298), with minimal active-surface fixes and no second parallel guard.

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4298 | SLICE_DELIVERED | d795720af900c328b7f91dd0a0e95d6a27c1e5c6 | Fast-CI PASS + unit/docs/guard | docs-guard | none material |

## Delivered
- Extended `tools/validate_readme_links` with Area Entry Link Rule enforcement (bare folder with README, dual-link, established index hubs).
- Backward-compatible `MarkdownLink` extraction in `tools/markdown_link_utils`.
- Machine-readable `area_entry_link_rule` in `tests/fixtures/readme_link_policy.yaml` (fail-closed load validation).
- Unit test matrix for positive / negative / boundary cases.
- Minimal fixes for five active-surface guard findings.
- Status freshness reconcile for closed #4293 / main tip `d4704025`.
- Canon/CONTRIBUTING enforcement notes updated for S7 landed.

## Guard Contract
Fail-closed on active README + explicit canon surfaces when a relative Markdown link targets a directory that has a local `README.md` or an established `index.md` hub, or when the same source dual-links bare folder + README/index for one area.

## Area Entry Detection
Bare targets such as `services/`, `services`, `./services/`, `../services/` resolve to a repo-relative area key; if `README.md` exists, suggest that entrypoint.

## Dual-Link Detection
Same source file linking both bare folder and `README.md` (including README anchors) for one area fails with a dual-link message.

## Index Hub Policy
Policy hubs (Canon mirror): `docs`, `docs/ci`, `docs/db`, `docs/env`, `docs/external-docs`. Bare folder links to those hubs must use the concrete `index.md`.

## Direct File Links Preserved
Concrete file targets remain allowed and are not redirected to area READMEs.

## Policy Validation
Invalid hubs fail at load: missing fields, duplicates, missing entrypoints, entrypoint outside directory, absolute/external paths.

## Test-first Evidence
- negative_tests_before_implementation: RED (32 failed / 15 passed)
- positive_tests_after_implementation: GREEN (47 passed)

## Repository-wide Scan
- Violations found: 6 / 5 files; all fixed; remaining: none

## Guard Findings Fixed
Yes — five active navigation surfaces + status freshness reconcile.

## CI Integration
Existing path: `python -m tools.validate_readme_links` / `make readme-links-guard` / `ci/stages/docs.py`

## Validation
- Full Fast-CI PASS (`run_id=20260802T215509Z_4c1dd620`, `merge_evidence=true`)
- `cdb-local-ci` App Check Run SUCCESS `app_id=4410232` on exact head `d795720a…` (check-run id `91553384557`, remote_verification_status=verified)
- Hosted advisory checks SUCCESS on head

## Completeness Review
MERGE_CANDIDATE after MUST_FIX for retired terminology in tests was closed; dimensions PASS / justified N/A; LR NO-GO unchanged.

## Non-goals
No runtime/trading/DB/MCP/secrets; no bulk README modernization; no new parallel CI workflow.

## Brain Evidence
repo-only / not-used / insufficient_evidence / context tools available with no records

## Final-Head-Evidence

- Final Head SHA: `d795720af900c328b7f91dd0a0e95d6a27c1e5c6`
- Integrated Base SHA: `d47040259267d7ec7dc88a415e806131c876e566`
- Full Fast-CI: PASS (`20260802T215509Z_4c1dd620`)
- Policy-Gate mirror: PASS
- `cdb-local-ci` exact SHA: SUCCESS app_id=4410232 check-run 91553384557
- Blocking reviews: none

## Guardrails

- Merge-Trigger ist keine Merge-Autorisierung.
- Kein Zwischenstands-Publish.
- Kein Admin-Merge.
- LR bleibt `NO-GO`.

## Merge Evidence
Capability gate satisfied for regular squash merge on exact validated head.

Closes #4298
