### PR TITLE
feat(agent-control): Human-GO Cursor cloud live pilot path (Refs #4258)

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -12,20 +12,24 @@
 
 ## Repo / Engineering Status (2026-08-03)
 
-<!-- cdb:live-claim type=main_sha value=a4cfb8a8 -->
-- **Confirmed main state**: `origin/main` @ `a4cfb8a8` — tip after PR approval context squash-merge [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300) (supersedes dispatcher-residuals tip `d4704025`).
+<!-- cdb:live-claim type=main_sha value=abf997d5 -->
+- **Confirmed main state**: `origin/main` @ `abf997d5` — tip after mock-first ACP E2E pilot foundation squash-merge [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301) (supersedes approval-context tip `a4cfb8a8`).
 
 <!-- cdb:live-claim type=issue_state issue=4258 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4257 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
+- **#4258 Live Cursor Pilot wiring (delivery)**: Dedicated branch `dedicated/agent-skills-issue-4258` — Human-GO `cursor-cloud-api` pilot path, credential presence gate, delivery verify, `AWAITING_APPROVAL` handoff, offline recorded tests. Controlled live attempt: `CURSOR_API_KEY` absent → `PRECONDITION_BLOCKED` / zero network. **Refs #4258** only (not Closes until real cloud evidence). LR **NO-GO** unchanged.
+
 - **#4257 PR Approval Context**: **DONE_MERGED_CLOSED** via PR [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300) @ `a4cfb8a8`. LR **NO-GO** unchanged.
 
-- **#4258 ACP E2E Pilot Foundation (mock-first)**: Delivery slice on `batch/agent-skills-issue-4258` — CLI `pilot run|verify`, report contract, fixtures P1/N1–N8. **Refs #4258** only (not Closes); Live-Cursor rest keeps issue OPEN. LR **NO-GO** unchanged.
+- **#4258 ACP E2E Pilot Foundation (mock-first)**: **DONE_MERGED_CLOSED** via PR [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301) @ `abf997d5`. Live-Cursor rest remains OPEN. LR **NO-GO** unchanged.
 
 <!-- cdb:historical-as-of date=2026-08-02 -->
 > Historical as of 2026-08-02 — append-only ledger. Entries below record the
 > state at their own date and are intentionally not rewritten when reality
 > moves on. They are exempt from live freshness verification.
+
+> Note: older 2026-08-03 lines that claimed tip `a4cfb8a8` or foundation still in-flight are superseded by the live tip claim above.
 
 ## Repo / Engineering Status (2026-08-02)
 

--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -12,13 +12,18 @@
 
 ## Repo / Engineering Status (2026-08-03)
 
-<!-- cdb:live-claim type=main_sha value=abf997d5 -->
-- **Confirmed main state**: `origin/main` @ `abf997d5` — tip after mock-first ACP E2E pilot foundation squash-merge [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301) (supersedes approval-context tip `a4cfb8a8`).
+<!-- cdb:live-claim type=main_sha value=312d12e0 -->
+- **Confirmed main state**: `origin/main` @ `312d12e0` — tip after Security Backlog Reconciliation squash-merge [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303) (supersedes ACP foundation tip `abf997d5`).
 
 <!-- cdb:live-claim type=issue_state issue=4258 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4257 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
-- **#4258 Live Cursor Pilot wiring (delivery)**: Dedicated branch `dedicated/agent-skills-issue-4258` — Human-GO `cursor-cloud-api` pilot path, credential presence gate, delivery verify, `AWAITING_APPROVAL` handoff, offline recorded tests. Controlled live attempt: `CURSOR_API_KEY` absent → `PRECONDITION_BLOCKED` / zero network. **Refs #4258** only (not Closes until real cloud evidence). LR **NO-GO** unchanged.
+<!-- cdb:live-claim type=issue_state issue=2513 state=open -->
+- **#2513 Security backlog reconciliation**: **DONE_MERGED_CLOSED** via PR [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303) @ `312d12e0` (meta issue stays open as canonical tracker). Remaining open `type:security` issues are **Upstream HOLDs** — parked until suite-native `FixedVersion` evidence; no remediation slice without live FixedVersion. Duplicate/pip trackers closed post-merge. LR **NO-GO** unchanged.
+
+- **#4258 Live Cursor Pilot (delivery PR #4302)**: Dedicated PR [#4302](https://github.com/jannekbuengener/Claire_de_Binare/pull/4302) reintegrated onto `312d12e0`. CDB hardening + claimed-vs-verified delivery + operator bootstrap preflight delivered; controlled live Cursor run ended `ERROR`/`FAILED` with phantom branch. **No second Cursor create** without new Human-GO after Dashboard OK. Issue stays OPEN until Acceptance (real cloud delivery) is met. LR **NO-GO** unchanged.
+
+- **#4289 Hermes Live drills**: Repo-slice already merged; Live Hetzner/Windows/GitHub drills remain `HOLD_SCOPE_BLOCKER` (parked). LR **NO-GO** unchanged.
 
 - **#4257 PR Approval Context**: **DONE_MERGED_CLOSED** via PR [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300) @ `a4cfb8a8`. LR **NO-GO** unchanged.
 
@@ -29,7 +34,7 @@
 > state at their own date and are intentionally not rewritten when reality
 > moves on. They are exempt from live freshness verification.
 
-> Note: older 2026-08-03 lines that claimed tip `a4cfb8a8` or foundation still in-flight are superseded by the live tip claim above.
+> Note: older 2026-08-03 lines that claimed tip `abf997d5` / `a4cfb8a8` or foundation still in-flight are superseded by the live tip claim above (`312d12e0`).
 
 ## Repo / Engineering Status (2026-08-02)
 

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 <!-- cdb:status-freshness header-date=2026-08-03 -->
 **Stand 2026-08-03.**
-<!-- cdb:live-claim type=main_sha value=a4cfb8a8 -->
+<!-- cdb:live-claim type=main_sha value=abf997d5 -->
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4257 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4258 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4293 state=closed -->
-Auf `origin/main` (`a4cfb8a8`) sind die juengsten relevanten Merge-Cluster u. a.:
+Auf `origin/main` (`abf997d5`) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **PR Approval Context ([#4257](https://github.com/jannekbuengener/Claire_de_Binare/issues/4257) / PR [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300)):** **MERGED** @ `a4cfb8a8`.
-- **ACP E2E Pilot Foundation ([#4258](https://github.com/jannekbuengener/Claire_de_Binare/issues/4258)):** mock-first delivery in flight (`Refs` only; Live-Cursor rest keeps issue open).
+- **ACP E2E Pilot Foundation ([#4258](https://github.com/jannekbuengener/Claire_de_Binare/issues/4258) / PR [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301)):** **MERGED** @ `abf997d5` (mock-first). Live Cursor Human-GO path in dedicated delivery (`Refs` only; issue remains open until real cloud evidence).
+- **PR Approval Context ([#4257](https://github.com/jannekbuengener/Claire_de_Binare/issues/4257) / PR [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300)):** **MERGED** @ `a4cfb8a8` (ancestor of tip).
 - **ACP dispatcher residuals ([#4293](https://github.com/jannekbuengener/Claire_de_Binare/issues/4293) / PR [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297)):** **MERGED** @ `d4704025` (ancestor of tip).
 - **Area Entry Link Canon ([#4294](https://github.com/jannekbuengener/Claire_de_Binare/issues/4294)/[#4296](https://github.com/jannekbuengener/Claire_de_Binare/issues/4296) / PR [#4295](https://github.com/jannekbuengener/Claire_de_Binare/pull/4295)):** **MERGED** — README Area Entry Link Rule + active README reconcile @ `365f50b9`.
 - **Hermes Hetzner Bootstrap ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290)):** Repo-Slice **MERGED** auf tip `fca8ad09` (Infrastructure/Profiles/Ops/Token-Broker). Issue `#4289` bleibt offen fuer Live-VM/Windows/GitHub-Drills (`HOLD_SCOPE_BLOCKER`).  <!-- pragma: allowlist secret -->

--- a/README.md
+++ b/README.md
@@ -70,18 +70,20 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 <!-- cdb:status-freshness header-date=2026-08-03 -->
 **Stand 2026-08-03.**
-<!-- cdb:live-claim type=main_sha value=abf997d5 -->
+<!-- cdb:live-claim type=main_sha value=312d12e0 -->
 <!-- cdb:live-claim type=issue_state issue=4289 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4257 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4258 state=open -->
+<!-- cdb:live-claim type=issue_state issue=2513 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4293 state=closed -->
-Auf `origin/main` (`abf997d5`) sind die juengsten relevanten Merge-Cluster u. a.:
+Auf `origin/main` (`312d12e0`) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **ACP E2E Pilot Foundation ([#4258](https://github.com/jannekbuengener/Claire_de_Binare/issues/4258) / PR [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301)):** **MERGED** @ `abf997d5` (mock-first). Live Cursor Human-GO path in dedicated delivery (`Refs` only; issue remains open until real cloud evidence).
+- **Security Backlog Reconciliation ([#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513) / PR [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303)):** **MERGED** @ `312d12e0`. Offene Security-Issues bleiben Upstream-HOLDs (geparkt bis FixedVersion). Meta `#2513` bleibt Tracker.
+- **ACP E2E Pilot Foundation ([#4258](https://github.com/jannekbuengener/Claire_de_Binare/issues/4258) / PR [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301)):** **MERGED** @ `abf997d5` (mock-first). Live Cursor Human-GO path in dedicated PR [#4302](https://github.com/jannekbuengener/Claire_de_Binare/pull/4302) (`Refs` only; issue remains open until real cloud evidence; kein zweiter Create ohne neues Human-GO).
 - **PR Approval Context ([#4257](https://github.com/jannekbuengener/Claire_de_Binare/issues/4257) / PR [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300)):** **MERGED** @ `a4cfb8a8` (ancestor of tip).
 - **ACP dispatcher residuals ([#4293](https://github.com/jannekbuengener/Claire_de_Binare/issues/4293) / PR [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297)):** **MERGED** @ `d4704025` (ancestor of tip).
 - **Area Entry Link Canon ([#4294](https://github.com/jannekbuengener/Claire_de_Binare/issues/4294)/[#4296](https://github.com/jannekbuengener/Claire_de_Binare/issues/4296) / PR [#4295](https://github.com/jannekbuengener/Claire_de_Binare/pull/4295)):** **MERGED** — README Area Entry Link Rule + active README reconcile @ `365f50b9`.
-- **Hermes Hetzner Bootstrap ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290)):** Repo-Slice **MERGED** auf tip `fca8ad09` (Infrastructure/Profiles/Ops/Token-Broker). Issue `#4289` bleibt offen fuer Live-VM/Windows/GitHub-Drills (`HOLD_SCOPE_BLOCKER`).  <!-- pragma: allowlist secret -->
+- **Hermes Hetzner Bootstrap ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290)):** Repo-Slice **MERGED**. Issue `#4289` bleibt offen fuer Live-VM/Windows/GitHub-Drills (`HOLD_SCOPE_BLOCKER`, geparkt).  <!-- pragma: allowlist secret -->
 - **Repository consolidation wave:** [#4286](https://github.com/jannekbuengener/Claire_de_Binare/pull/4286) ACP batch, [#4162](https://github.com/jannekbuengener/Claire_de_Binare/pull/4162) Grafana 13.1.1, [#4245](https://github.com/jannekbuengener/Claire_de_Binare/pull/4245) CVE HOLD, [#4246](https://github.com/jannekbuengener/Claire_de_Binare/pull/4246) PG15 preflight, [#4244](https://github.com/jannekbuengener/Claire_de_Binare/pull/4244) Dependabot facts, [#4243](https://github.com/jannekbuengener/Claire_de_Binare/pull/4243) dataset fingerprints — squash-merged (prior tip `fce4c754`, superseded by Hermes tip).
 - **Validation Pilot Spec ([#4272](https://github.com/jannekbuengener/Claire_de_Binare/issues/4272) / PR [#4292](https://github.com/jannekbuengener/Claire_de_Binare/pull/4292)):** **MERGED** — prior tip cluster (historical relative to consolidation tip).
 - **Fast-CI Slice Gates ([#4204](https://github.com/jannekbuengener/Claire_de_Binare/issues/4204) / PR [#4236](https://github.com/jannekbuengener/Claire_de_Binare/pull/4236)):** **CLOSED/MERGED** — Versionierte Slice-Policy, fail-closed unbekannte Pfade, Timing-Evidence.

--- a/config/agent-control/README.md
+++ b/config/agent-control/README.md
@@ -57,16 +57,18 @@ and live Cursor dispatch are forbidden. Mock execute is test-only
 (`--execute --allow-mock-dispatch`). Cursor adapters are constructible offline /
 with injected fake transports only. Registry agents:
 `acp-mock-dispatcher` (`#4253`), `acp-e2e-pilot` (`#4258` foundation,
-`mock` + `mock-pilot.v1`), `acp-cursor-sdk-adapter` (`#4254`/`#4255`,
-`live_dispatch: false`, environment `cdb-agent-skills.v1`).
+`mock` + `mock-pilot.v1`), `acp-live-cursor-pilot` (`#4258` Human-GO live,
+`cursor-cloud-api.v1` + `cursor-live-pilot.v1`), `acp-cursor-sdk-adapter`
+(`#4254`/`#4255`, `live_dispatch: false`, environment `cdb-agent-skills.v1`).
 
 Governed environment profiles (`#4255`):
 `cdb-docs-readonly.v1`, `cdb-agent-skills.v1`, `cdb-python-fast.v1`,
 `cdb-ci-debug.v1`, `cdb-validation-research.v1`,
-`cdb-runtime-risk-restricted.v1`, plus `mock-pilot.v1` for the `#4258`
-foundation pilot. Cursor config: `.cursor/environment.json`.
-Evidence bundle remains `#4256`; approval `#4257`; mock-first foundation pilot
-CLI is `#4258` (`Refs` only — Live Cursor rest keeps the issue open).
+`cdb-runtime-risk-restricted.v1`, plus `mock-pilot.v1` and
+`cursor-live-pilot.v1` for `#4258`. Cursor config: `.cursor/environment.json`.
+Evidence bundle remains `#4256`; approval `#4257`; pilot CLI is `#4258`
+(`Refs` only — Live Cursor requires `--human-go-live-cursor`; see
+[`docs/runbooks/agent_control_live_cursor_pilot.md`](../../docs/runbooks/agent_control_live_cursor_pilot.md)).
 
 ## Schema
 

--- a/config/agent-control/agents/registry.v1.yaml
+++ b/config/agent-control/agents/registry.v1.yaml
@@ -151,3 +151,34 @@ agents:
       runtime_mutation: false
       database_mutation: false
       mcp_live_mutation: false
+
+  - agent_id: acp-live-cursor-pilot
+    version: "1.0.0"
+    enabled: true
+    description: >
+      Human-GO live Cursor cloud pilot agent for #4258. Provider cursor-cloud-api.v1
+      with environment cursor-live-pilot.v1 (runtime_class mock for CI doctor).
+      Live execute requires explicit Human-GO flags; never merges or closes #4258.
+    execution_contract_profile: delivery_safe.v1
+    provider_profile: cursor-cloud-api.v1
+    environment_profile: cursor-live-pilot.v1
+    skills:
+      - session_core.v1
+    mcp_profiles:
+      - none.v1
+    subagents: []
+    labels_or_routing_selectors:
+      lane: agent-skills
+      batch_key: agent-skills
+      role: live-cursor-pilot
+      objective: issue-4258
+    depends_on:
+      - acp-e2e-pilot
+    permission_overrides:
+      merge: false
+      publish_cdb_local_ci: false
+      close_issue: false
+      open_pr: false
+      runtime_mutation: false
+      database_mutation: false
+      mcp_live_mutation: false

--- a/config/agent-control/profiles/environments/cursor-live-pilot.v1.yaml
+++ b/config/agent-control/profiles/environments/cursor-live-pilot.v1.yaml
@@ -1,0 +1,37 @@
+profile_id: cursor-live-pilot.v1
+profile_version: "1.0.0"
+description: >
+  Human-GO live Cursor cloud pilot environment for #4258. runtime_class remains
+  mock so CI doctor stays friendly; real live dispatch is enabled only via
+  explicit Human-GO CLI flags (allow_live_cursor + human_go_live_cursor), never
+  by flipping this profile. inject_cursor_api_key is a class-ref policy flag
+  only — secrets are never embedded here. No merge / cdb-local-ci / issue close.
+runtime_class: mock
+allowed_provider_ids:
+  - cursor-cloud-api
+  - mock
+execution_limits:
+  setup_timeout_seconds: 120
+  run_timeout_seconds: 3600
+  cancel_confirmation_required: true
+network_policy:
+  mode: allowlist
+  allowed_classes:
+    - github_api_write_via_gh_cli
+    - docs_fetch_readonly
+  allowed_domains:
+    - api.github.com
+    - github.com
+    - api.cursor.com
+    - cursor.com
+secret_policy:
+  allowed_classes:
+    - cursor_api_key
+    - github_token
+  workload_secrets: class_refs_only
+  inject_cursor_api_key: true
+cost_limit:
+  max_live_cost_usd: 2
+  unknown_cost_blocks_live: true
+  enforcement_required: true
+live_dispatch_allowed: false

--- a/docs/contracts/agent_pilot/CDB_AGENT_CONTROL_PILOT_REPORT_V1.md
+++ b/docs/contracts/agent_pilot/CDB_AGENT_CONTROL_PILOT_REPORT_V1.md
@@ -13,10 +13,14 @@ create a second Run-Evidence truth.
 
 ## Scope boundary
 
-- This foundation slice proves Contract → Registry → Dispatch → Environment →
+- Foundation slice proves Contract → Registry → Dispatch → Environment →
   MockProvider → Run Evidence → Approval Context wiring.
-- It does **not** close Issue `#4258` (use `Refs #4258`, never `Closes #4258`).
-- Live Cursor Cloud/SDK delivery remains the rest of `#4258`.
+- Live Cursor path (Human-GO `--provider cursor-cloud-api --human-go-live-cursor`)
+  extends the same report envelope; default remains mock.
+- It does **not** close Issue `#4258` until a real cloud delivery + CDB approval
+  handoff is evidenced (use `Refs #4258`, never premature `Closes #4258`).
+- Cursor Dashboard Approval Agents remain `MANUAL_BOOTSTRAP_ONLY` (no API handoff).
+- Operator runbook: [`docs/runbooks/agent_control_live_cursor_pilot.md`](../../runbooks/agent_control_live_cursor_pilot.md).
 
 ## Head-SHA binding
 

--- a/docs/contracts/cdb_cursor_live_preflight.v1.schema.json
+++ b/docs/contracts/cdb_cursor_live_preflight.v1.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare.local/contracts/cdb_cursor_live_preflight.v1.schema.json",
+  "title": "cdb.cursor_live_preflight.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_id",
+    "schema_version",
+    "repository",
+    "cursor_account",
+    "credential_present",
+    "environment_requested",
+    "environment_resolved",
+    "environment_version",
+    "environment_selection_status",
+    "repo_config_status",
+    "github_app_status",
+    "github_permissions",
+    "existing_run_status",
+    "public_api_gaps",
+    "manual_consent_boundaries",
+    "ready_for_live_run",
+    "limitations",
+    "checks"
+  ],
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "const": "cdb.cursor_live_preflight.v1"
+    },
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "repository": { "type": "string", "minLength": 3 },
+    "cursor_account": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "credential_present": { "type": "boolean" },
+    "environment_requested": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "environment_resolved": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "environment_version": {
+      "type": ["string", "null"]
+    },
+    "environment_selection_status": {
+      "type": "string",
+      "enum": ["PASS", "PARTIAL", "BLOCKED", "UNKNOWN"]
+    },
+    "repo_config_status": {
+      "type": "string",
+      "enum": ["PASS", "PARTIAL", "BLOCKED", "UNKNOWN"]
+    },
+    "github_app_status": {
+      "type": "string",
+      "enum": ["PASS", "PARTIAL", "BLOCKED", "UNKNOWN"]
+    },
+    "github_permissions": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "existing_run_status": {
+      "type": "string",
+      "enum": ["PASS", "PARTIAL", "BLOCKED", "UNKNOWN"]
+    },
+    "public_api_gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "surface", "impact"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "surface": { "type": "string" },
+          "impact": { "type": "string" },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "manual_consent_boundaries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "boundary"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "boundary": { "type": "string" },
+          "why_not_automatable": { "type": "string" }
+        }
+      }
+    },
+    "ready_for_live_run": { "type": "boolean" },
+    "limitations": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "status"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["PASS", "PARTIAL", "BLOCKED", "UNKNOWN"]
+          },
+          "detail": { "type": "object", "additionalProperties": true }
+        }
+      }
+    },
+    "binding_mode": {
+      "type": "string",
+      "enum": ["named_cloud_env", "repos_plus_repo_config", "unknown"]
+    },
+    "cursor_http_gets": { "type": "integer", "minimum": 0 },
+    "cursor_http_posts": { "type": "integer", "minimum": 0 },
+    "github_writes": { "type": "integer", "minimum": 0 },
+    "dashboard_observations": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    }
+  }
+}

--- a/docs/runbooks/agent_control_live_cursor_pilot.md
+++ b/docs/runbooks/agent_control_live_cursor_pilot.md
@@ -1,0 +1,92 @@
+# Agent Control — Live Cursor Pilot (Zero-Click)
+
+Status: Operator runbook  
+Scope: Issue `#4258` live Cursor cloud pilot (Human-GO)  
+Refs: `#4258` only — never Closes, never merge, never `cdb-local-ci` publish
+
+## Boundaries
+
+- Default pilot remains **mock** (`--provider mock`).
+- Live path requires **explicit Human-GO**: `--provider cursor-cloud-api --human-go-live-cursor`.
+- Credential bootstrap is **MANUAL_BOOTSTRAP_ONLY**: operator places `CURSOR_API_KEY` in the
+  local secrets directory or environment. Agents must not invent or print secret values.
+- Cursor Approval Agents remain **MANUAL_BOOTSTRAP_ONLY** — pilot pauses at
+  `AWAITING_APPROVAL` and does not auto-merge.
+- LR stays NO-GO. No live trading, no productive DB/MCP mutation, no BLUE/RED runtime change.
+
+## Registry surfaces
+
+| Item | Id |
+| --- | --- |
+| Agent | `acp-live-cursor-pilot` |
+| Provider profile | `cursor-cloud-api.v1` (`live_dispatch: false`) |
+| Environment profile | `cursor-live-pilot.v1` (`runtime_class: mock` for CI doctor; live only via Human-GO flags) |
+
+## Credential bootstrap (MANUAL_BOOTSTRAP_ONLY)
+
+1. Obtain a Cursor API key outside the agent session.
+2. Export `CURSOR_API_KEY` in the operator shell **or** place a non-empty file
+   `CURSOR_API_KEY` / `CURSOR_API_KEY.txt` under the operator secrets directory.
+3. Never paste the key into issues, PRs, chat, or pilot reports.
+4. Presence is checked fail-closed (`PRECONDITION_BLOCKED`) before any network call.
+
+## Zero-Click operator flow
+
+```bash
+# 1) Validate registry (includes live-pilot env + agent)
+python -m tools.agent_control registry validate --config config/agent-control
+
+# 2) Optional doctor on the live-pilot env (offline / mock runtime_class)
+python -m tools.agent_control environment doctor \
+  --profile cursor-live-pilot.v1 \
+  --config config/agent-control \
+  --offline
+
+# 3) Human-GO live pilot (operator shell with CURSOR_API_KEY present)
+python -m tools.agent_control pilot run \
+  --manifest <LIVE_MANIFEST.json> \
+  --provider cursor-cloud-api \
+  --human-go-live-cursor \
+  --state artifacts/agent_control/live-pilot-runstore.json \
+  --out artifacts/agent_control/live-pilot-report.json
+
+# Optional: request Cursor autoCreatePR (still Human-GO gated; no merge)
+#   --auto-create-pr
+
+# 4) Resume after process restart (same state file; reuses provider_run_id)
+python -m tools.agent_control pilot run \
+  --manifest <LIVE_MANIFEST.json> \
+  --provider cursor-cloud-api \
+  --human-go-live-cursor \
+  --state artifacts/agent_control/live-pilot-runstore.json \
+  --resume <RUN_ID> \
+  --out artifacts/agent_control/live-pilot-report.json
+```
+
+Fail-closed without Human-GO:
+
+```bash
+python -m tools.agent_control pilot run \
+  --manifest <LIVE_MANIFEST.json> \
+  --provider cursor-cloud-api
+# → PILOT_HUMAN_GO_REQUIRED
+```
+
+## Expected terminal shape
+
+1. Credential presence → PASS (or `PRECONDITION_BLOCKED` with zero network).
+2. Dispatch via `cursor-cloud-api` with injected/live HTTP under Human-GO.
+3. GitHub delivery verify (`gh`) binds head SHA + changed-file allowlist.
+4. Watch with `auto_advance_success=False` → **`AWAITING_APPROVAL`**.
+5. Run evidence may be HOLD (non-terminal) — acceptable.
+6. Approval context recommendation is advisory only; authority limits stay all-false.
+7. Report limitations include `live_cursor_pilot`,
+   `awaiting_approval_operator_handoff`,
+   `cursor_approval_agents_manual_bootstrap_only`.
+
+## Non-goals
+
+- No squash merge, no `--admin`, no branch-protection mutation.
+- No `cdb-local-ci` publish from this pilot.
+- No issue close for `#4258` (Refs only).
+- No real Cursor agents from unit tests (fake HTTP / fake `gh` only).

--- a/docs/runbooks/agent_control_live_cursor_pilot.md
+++ b/docs/runbooks/agent_control_live_cursor_pilot.md
@@ -22,6 +22,50 @@ Refs: `#4258` only — never Closes, never merge, never `cdb-local-ci` publish
 | Provider profile | `cursor-cloud-api.v1` (`live_dispatch: false`) |
 | Environment profile | `cursor-live-pilot.v1` (`runtime_class: mock` for CI doctor; live only via Human-GO flags) |
 
+## Operator Bootstrap Preflight (before second Live-GO)
+
+Do **not** start a second Cursor create until this checklist is green.
+Read-only API checks alone are **not** sufficient after a terminal `ERROR`
+with claimed-but-missing GitHub delivery.
+
+### A) API-readable (agent may verify; no Create/Follow-up)
+
+| Check | How | Pass criterion |
+| --- | --- | --- |
+| Credential presence | `CURSOR_API.txt` / `CURSOR_API_KEY` present | `credential_present=true` (never print value) |
+| Auth identity | `GET /v1/me` | HTTP 200 |
+| Models catalog | `GET /v1/models` | HTTP 200, ≥1 model |
+| GitHub App repo scope | `GET /v1/repositories` (strict rate limit) | `https://github.com/jannekbuengener/Claire_de_Binare` listed |
+| Prior run immutable | `GET /v1/agents/{id}` + `.../runs/{runId}` | Existing ERROR run readable; **no** new create |
+
+### B) Dashboard-only (Jannek / operator; agent cannot complete)
+
+Open [Cloud Agents → Environments](https://cursor.com/dashboard/cloud-agents#environments)
+and the GitHub App installation for the Cursor account that owns the API key.
+
+| Check | Pass criterion |
+| --- | --- |
+| GitHub connection | Cursor GitHub App installed for `jannekbuengener`; not only read-clone |
+| Repository freigabe | `Claire_de_Binare` explicitly allowed for Cloud Agents |
+| Push / PR permission | App can push branches **and** open PRs on this repo |
+| Cloud Environment health | Environment for this repo shows last successful setup/snapshot (not failed install) |
+| Resolution path | Confirm whether run uses repo `.cursor/environment.json` and/or a named saved environment |
+| Expected delivery path | Decide: `autoCreatePR=true` + `startingRef=main` **or** work on an existing PR URL; document the expected branch/PR shape |
+| Secrets / install | Any required install secrets present in dashboard (not in repo); install script expected to succeed |
+
+### C) Repo-backed environment hint (evidence, not a green light)
+
+- Repo has `.cursor/environment.json` (on `main`) with Dockerfile `../ci/Dockerfile` + pip install.
+- Official resolution order: repo `environment.json` → personal saved env → team saved env.
+- A broken Cloud Environment bootstrap can produce an opaque API `ERROR` with claimed `git.branches` and **no** GitHub object — treat dashboard Environment health as mandatory before the next Human-GO.
+
+### D) Gate for exactly one second live create
+
+Only after A+B are green, issue a **new** explicit Human-GO for **one** create.
+Use a **new** state file / run id; keep the failed run
+`run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b` as immutable evidence.
+Still: no merge, no `cdb-local-ci`, Refs `#4258` only, issue stays open.
+
 ## Credential bootstrap (MANUAL_BOOTSTRAP_ONLY)
 
 1. Obtain a Cursor API key outside the agent session.

--- a/docs/runbooks/agent_control_live_cursor_pilot.md
+++ b/docs/runbooks/agent_control_live_cursor_pilot.md
@@ -22,49 +22,49 @@ Refs: `#4258` only — never Closes, never merge, never `cdb-local-ci` publish
 | Provider profile | `cursor-cloud-api.v1` (`live_dispatch: false`) |
 | Environment profile | `cursor-live-pilot.v1` (`runtime_class: mock` for CI doctor; live only via Human-GO flags) |
 
-## Operator Bootstrap Preflight (before second Live-GO)
+## Operator Bootstrap Preflight (dashboardless)
 
-Do **not** start a second Cursor create until this checklist is green.
-Read-only API checks alone are **not** sufficient after a terminal `ERROR`
-with claimed-but-missing GitHub delivery.
+Manuelle Cursor-Dashboard-Klickpfade sind **kein** normaler Operator-Schritt.
+Voraussetzungen werden programmgesteuert geprüft:
 
-### A) API-readable (agent may verify; no Create/Follow-up)
+```bash
+# Optional: load CURSOR_API_KEY from secrets file into the shell env first
+python -m tools.agent_control pilot cursor-preflight \
+  --repository jannekbuengener/Claire_de_Binare \
+  --environment jannekbuengener/Claire_de_Binare \
+  --binding-mode repos_plus_repo_config \
+  --state artifacts/agent_control/live-pilot-runstore.json \
+  --out artifacts/agent_control/cursor-live-preflight.json
+```
 
-| Check | How | Pass criterion |
-| --- | --- | --- |
-| Credential presence | `CURSOR_API.txt` / `CURSOR_API_KEY` present | `credential_present=true` (never print value) |
-| Auth identity | `GET /v1/me` | HTTP 200 |
-| Models catalog | `GET /v1/models` | HTTP 200, ≥1 model |
-| GitHub App repo scope | `GET /v1/repositories` (strict rate limit) | `https://github.com/jannekbuengener/Claire_de_Binare` listed |
-| Prior run immutable | `GET /v1/agents/{id}` + `.../runs/{runId}` | Existing ERROR run readable; **no** new create |
+Canonical create binding for CDB: **`repos` + versioned `.cursor/environment.json`**
+(`--binding-mode repos_plus_repo_config`). Official API treats named `env` and
+`repos` as mutually exclusive. Named dashboard environments cannot be listed or
+ID-bound via public OpenAPI (`PUBLIC_API_GAP_*`).
 
-### B) Dashboard-only (Jannek / operator; agent cannot complete)
+The preflight report schema is `cdb.cursor_live_preflight.v1`.
+`ready_for_live_run=true` only when all fail-closed gates pass (including a
+**readable** GitHub App installation with `contents=write` and
+`pull_requests=write`). User `gh` tokens often cannot read another App's
+installation — that is recorded as `PUBLIC_API_GAP_GITHUB_INSTALLATION_READ`,
+not as a fake PASS.
 
-Open [Cloud Agents → Environments](https://cursor.com/dashboard/cloud-agents#environments)
-and the GitHub App installation for the Cursor account that owns the API key.
+### Public surfaces used
 
-| Check | Pass criterion |
+| Surface | Role |
 | --- | --- |
-| GitHub connection | Cursor GitHub App installed for `jannekbuengener`; not only read-clone |
-| Repository freigabe | `Claire_de_Binare` explicitly allowed for Cloud Agents |
-| Push / PR permission | App can push branches **and** open PRs on this repo |
-| Cloud Environment health | Environment for this repo shows last successful setup/snapshot (not failed install) |
-| Resolution path | Confirm whether run uses repo `.cursor/environment.json` and/or a named saved environment |
-| Expected delivery path | Decide: `autoCreatePR=true` + `startingRef=main` **or** work on an existing PR URL; document the expected branch/PR shape |
-| Secrets / install | Any required install secrets present in dashboard (not in repo); install script expected to succeed |
+| `GET /v1/me`, `/v1/models`, `/v1/repositories` | Cursor account + repo visibility |
+| `GET /v1/agents/{id}` (+ run) | Immutable prior-run evidence; resolved `env` if present |
+| `.cursor/environment.json` + `ci/Dockerfile` | Repo configuration as code |
+| `gh api repos/...`, branch protection, `apps/cursor` | GitHub metadata (read-only) |
+| `GET /repos/.../installation` | Installation permissions when token allows |
 
-### C) Repo-backed environment hint (evidence, not a green light)
+### Explicit non-goals
 
-- Repo has `.cursor/environment.json` (on `main`) with Dockerfile `../ci/Dockerfile` + pip install.
-- Official resolution order: repo `environment.json` → personal saved env → team saved env.
-- A broken Cloud Environment bootstrap can produce an opaque API `ERROR` with claimed `git.branches` and **no** GitHub object — treat dashboard Environment health as mandatory before the next Human-GO.
-
-### D) Gate for exactly one second live create
-
-Only after A+B are green, issue a **new** explicit Human-GO for **one** create.
-Use a **new** state file / run id; keep the failed run
-`run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b` as immutable evidence.
-Still: no merge, no `cdb-local-ci`, Refs `#4258` only, issue stays open.
+- No private `cursor.com` dashboard API
+- No browser automation
+- No new Cursor agent/run from preflight
+- No merge / `cdb-local-ci` / issue close
 
 ## Credential bootstrap (MANUAL_BOOTSTRAP_ONLY)
 

--- a/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
+++ b/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
@@ -2,47 +2,58 @@
 
 Date: 2026-08-03  
 Branch: `dedicated/agent-skills-issue-4258`  
-Base: `origin/main` @ `abf997d5` (PR #4301 foundation)  
-Mode: Delivery (Plan-GO) — no merge, no `cdb-local-ci` publish
+PR: #4302 @ `2163e1ac`  
+Mode: Controlled live pilot (Plan-GO) — no merge, no `cdb-local-ci` publish
 
 ## Brain Evidence
 
 - brain_source: repo-only / not-used (Context tools available, no enrichment records)
 - repo_fallback_reason: insufficient_evidence
+- context_tool_status: available
 
-## Delivered
+## Official API Audit
 
-- Human-GO live gates on dispatch/preflight (`allow_live_cursor` + `human_go_live_cursor`)
-- `CursorCloudApiDriver`: agentId idempotency, optional autoCreatePR under GO, live urllib transport, watch rehydrate
-- Pilot/CLI: `--provider cursor-cloud-api --human-go-live-cursor --state --resume --auto-create-pr`
-- Credential presence check (no secret values)
-- GitHub delivery verify + scope allowlist
-- Lifecycle pause at `AWAITING_APPROVAL` (no auto merge)
-- Registry agent `acp-live-cursor-pilot` + env `cursor-live-pilot.v1`
-- Runbook `docs/runbooks/agent_control_live_cursor_pilot.md`
-- Offline unit tests (live pilot + mock regression + cursor providers)
+- Source: https://cursor.com/docs/cloud-agent/api/endpoints (Cloud Agents API v1 public beta)
+- Auth: Basic `base64(api_key:)` — ALIGNED
+- Create: POST `/v1/agents` returns `{agent, run}` — ALIGNED
+- agentId must be `bc-<uuid>` or `bc-<string>-<uuid>` — FIXED (uuid5)
+- No `branchName`; use `repos[].startingRef` / auto branch — ALIGNED
+- Follow-up response `{run:{id,status}}` — FIXED
+- Poll before delivery verify — FIXED
+- Skip delivery verify on provider FAILED — FIXED
 
-## Controlled live attempt
+## Controlled live run (exactly one successful create)
 
-- Human-GO: yes (Plan-GO)
-- `CURSOR_API_KEY` present: **false**
-- Result: `final_status=BLOCKED`, `provider_call_count=0`, no network
-- Evidence: `artifacts/agent-control/pilot/live-20260803-precondition/` (local; redacted)
+| Field | Value |
+| --- | --- |
+| CDB run_id | `adr-ee0a9384bc9940a9` |
+| Cursor agent_id | `bc-d1ba82b5-db1a-5040-b50a-2007040a65c7` |
+| Cursor run_id | `run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b` |
+| Cursor terminal | `ERROR` / normalized `FAILED` |
+| Claimed branch | `cloud-cursor/cursor-cloud-pilot-marker-3c10` (not on GitHub; 404) |
+| PR from Cursor | none |
+| provider_call_count (create) | 1 |
+| Resume provider_call_count | 0 |
+| credential_present | true (env; value never logged) |
+| Approval | SKIP (no delivery head) |
+| Authority limits | all false |
+
+Prior HTTP 400 attempt (`Invalid bcId format`) created **zero** Cursor resources; corrected create is the sole live agent/run.
 
 ## Validation
 
-- `pytest` live+mock+cursor provider suites: 47 passed (Windows pytest tmp cleanup noise ignored)
-- `ruff check` on touched Python: pass
-- `black --check` after format: pass
-- `python -m tools.agent_control registry validate`: VALID
+- Offline unit suites PASS after API alignment fixes
+- Live: create+poll verified; delivery not on GitHub
+- No second Cursor create; resume-only after ERROR
 
 ## Boundaries
 
 - LR NO-GO unchanged
 - Refs #4258 only (not Closes)
-- No merge / no cdb-local-ci publish / no branch protection change
-- Cursor Approval Agents: MANUAL_BOOTSTRAP_ONLY
+- No merge / no cdb-local-ci / no branch protection
+- Approval Agents: MANUAL_BOOTSTRAP_ONLY / unproven
+- Zero-Click: NOT fully proven (Cursor ERROR, no delivery PR)
 
-## Follow-up for Issue closure
+## Status
 
-Operator must bootstrap `CURSOR_API_KEY`, re-run Human-GO live pilot once, capture provider_run_id + GitHub head + AWAITING_APPROVAL evidence, then allow `Closes #4258` in a later merge session.
+`HOLD_SCOPE_BLOCKER` — live Cursor run evidenced, but GitHub delivery missing (phantom branch / provider ERROR).

--- a/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
+++ b/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
@@ -82,3 +82,27 @@ Date: 2026-08-03 (same day continuation)
 
 ### Status
 `DONE_CDB_FIX_PUSHED_AWAITING_NEW_LIVE_GO` — next Cursor create needs new explicit Human-GO.
+
+---
+
+## Main reintegration + park (Execute Plan-GO)
+
+Date: 2026-08-03
+Head after merge(main): `b3b4f9fc` (integrated `origin/main` @ `312d12e0` / #4303)
+PR: #4302
+Mode: Finish CDB slice; no second Cursor create; Completeness/Fast-CI/merge intended for CDB delivery only
+
+### Router
+- Labels repaired: `objective:issue-4258`, `contract:agent-skills-v1`, `risk:none`
+- Existing Dedicated PR #4302 retained (plan override vs CREATE_NEW_BATCH_PR metadata noise / Dependabot peers)
+
+### Parked (out of scope)
+- All open `type:security` Upstream HOLDs (#2513 meta + residuals/#4080/#4106/#4114) until FixedVersion
+- #4289 Hermes Live drills (`HOLD_SCOPE_BLOCKER`)
+
+### #4258 Closure
+- Not closing: Acceptance still needs proven cloud delivery / new Human-GO after Dashboard OK
+- Status remains `DONE_CDB_FIX_PUSHED_AWAITING_NEW_LIVE_GO` for the live leg; CDB code path mergeable separately
+
+### Boundaries
+- LR NO-GO; no alert dismissals; no Dependabot PRs #4304–#4306 touched

--- a/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
+++ b/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
@@ -57,3 +57,28 @@ Prior HTTP 400 attempt (`Invalid bcId format`) created **zero** Cursor resources
 ## Status
 
 `HOLD_SCOPE_BLOCKER` — live Cursor run evidenced, but GitHub delivery missing (phantom branch / provider ERROR).
+
+---
+
+## Follow-up diagnosis (existing run only — no second create)
+
+Date: 2026-08-03 (same day continuation)
+
+### Official diagnostic surfaces used
+- GET agent / GET run / list runs / artifacts / usage / stream (read-only)
+- Conversation/messages paths: not in public v1 (404)
+- Repo listed in `GET /v1/repositories` (GitHub integration connected)
+
+### Classification
+- primary: `CURSOR_PLATFORM_INTERNAL` / `CURSOR_MODEL_OR_RUNTIME`
+- secondary: claimed `git.branches` without GitHub object; Run schema lacks structured `error`
+- last successful phase: create accepted
+- first failed phase: terminal `ERROR` without proven push; branch still GitHub 404
+
+### CDB MUST_FIX delivered
+- Head: `cfdb04dd` on PR #4302
+- claimed vs verified delivery; ERROR diagnostics preserved; recorded phantom-branch regressions
+- Offline validation: targeted tests + ruff + black + registry validate + secret scan
+
+### Status
+`DONE_CDB_FIX_PUSHED_AWAITING_NEW_LIVE_GO` — next Cursor create needs new explicit Human-GO.

--- a/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
+++ b/knowledge/logs/sessions/2026-08-03-issue-4258-live-cursor-pilot.md
@@ -1,0 +1,48 @@
+# Session: #4258 Live Cursor Delivery and Approval Pilot v1
+
+Date: 2026-08-03  
+Branch: `dedicated/agent-skills-issue-4258`  
+Base: `origin/main` @ `abf997d5` (PR #4301 foundation)  
+Mode: Delivery (Plan-GO) — no merge, no `cdb-local-ci` publish
+
+## Brain Evidence
+
+- brain_source: repo-only / not-used (Context tools available, no enrichment records)
+- repo_fallback_reason: insufficient_evidence
+
+## Delivered
+
+- Human-GO live gates on dispatch/preflight (`allow_live_cursor` + `human_go_live_cursor`)
+- `CursorCloudApiDriver`: agentId idempotency, optional autoCreatePR under GO, live urllib transport, watch rehydrate
+- Pilot/CLI: `--provider cursor-cloud-api --human-go-live-cursor --state --resume --auto-create-pr`
+- Credential presence check (no secret values)
+- GitHub delivery verify + scope allowlist
+- Lifecycle pause at `AWAITING_APPROVAL` (no auto merge)
+- Registry agent `acp-live-cursor-pilot` + env `cursor-live-pilot.v1`
+- Runbook `docs/runbooks/agent_control_live_cursor_pilot.md`
+- Offline unit tests (live pilot + mock regression + cursor providers)
+
+## Controlled live attempt
+
+- Human-GO: yes (Plan-GO)
+- `CURSOR_API_KEY` present: **false**
+- Result: `final_status=BLOCKED`, `provider_call_count=0`, no network
+- Evidence: `artifacts/agent-control/pilot/live-20260803-precondition/` (local; redacted)
+
+## Validation
+
+- `pytest` live+mock+cursor provider suites: 47 passed (Windows pytest tmp cleanup noise ignored)
+- `ruff check` on touched Python: pass
+- `black --check` after format: pass
+- `python -m tools.agent_control registry validate`: VALID
+
+## Boundaries
+
+- LR NO-GO unchanged
+- Refs #4258 only (not Closes)
+- No merge / no cdb-local-ci publish / no branch protection change
+- Cursor Approval Agents: MANUAL_BOOTSTRAP_ONLY
+
+## Follow-up for Issue closure
+
+Operator must bootstrap `CURSOR_API_KEY`, re-run Human-GO live pilot once, capture provider_run_id + GitHub head + AWAITING_APPROVAL evidence, then allow `Closes #4258` in a later merge session.

--- a/tests/fixtures/agent_control/cursor/dashboard_observations_4258.json
+++ b/tests/fixtures/agent_control/cursor/dashboard_observations_4258.json
@@ -1,0 +1,19 @@
+{
+  "create_prs": "Always",
+  "routing_rule_repository": "jannekbuengener/Claire_de_Binare",
+  "network_access": "Allow All Network Access",
+  "ambiguity": "two active environments with the same visible name",
+  "environments": [
+    {
+      "repository": "jannekbuengener/Claire_de_Binare",
+      "status": "Active",
+      "age_observed": "recent"
+    },
+    {
+      "repository": "jannekbuengener/Claire_de_Binare",
+      "status": "Active",
+      "age_observed": "older"
+    }
+  ],
+  "note": "Supporting operator observations only — not machine truth for preflight PASS"
+}

--- a/tests/fixtures/agent_control/cursor/prompt_live_4258.txt
+++ b/tests/fixtures/agent_control/cursor/prompt_live_4258.txt
@@ -1,0 +1,16 @@
+Controlled Cursor Cloud live pilot for Claire_de_Binare issue #4258.
+
+Create exactly one new markdown file at:
+knowledge/logs/sessions/2026-08-03-cursor-live-pilot-delivery-marker.md
+
+File content must be a short non-secret marker that this controlled Cursor Cloud
+pilot delivery for issue #4258 produced a real branch/commit/PR. Include the
+ISO date 2026-08-03 and the phrase "pilot delivery marker" only.
+
+Hard constraints:
+- Do not modify any other files.
+- Do not merge any pull request.
+- Do not change branch protection, rulesets, or CI required checks.
+- Do not touch secrets, credentials, trading, risk, execution, or BLUE/RED runtime.
+- Do not implement issues #4259 or #4260.
+- Keep the change docs-only and reversible.

--- a/tests/fixtures/agent_control/cursor/run_error_phantom_branch.json
+++ b/tests/fixtures/agent_control/cursor/run_error_phantom_branch.json
@@ -1,0 +1,55 @@
+{
+  "schema_note": "Redacted recorded shape from Cursor Cloud Agents API v1 for #4258 diagnosis. No auth headers, no tokens, no full prompt.",
+  "agent_id": "bc-d1ba82b5-db1a-5040-b50a-2007040a65c7",
+  "run_id": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+  "get_run": {
+    "id": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+    "status": "ERROR",
+    "createdAt": "2026-08-02T00:00:00.000Z",
+    "updatedAt": "2026-08-02T00:00:10.000Z",
+    "git": {
+      "branches": [
+        {
+          "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+          "branch": "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+        }
+      ]
+    }
+  },
+  "stream_events": [
+    {
+      "id": "1",
+      "event": "status",
+      "data": { "status": "ERROR" }
+    },
+    {
+      "id": "2",
+      "event": "result",
+      "data": {
+        "status": "ERROR",
+        "git": {
+          "branches": [
+            {
+              "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+              "branch": "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "3",
+      "event": "done",
+      "data": {}
+    }
+  ],
+  "github_branch_lookup": {
+    "status": 404,
+    "message": "Not Found"
+  },
+  "notes": [
+    "OpenAPI Run schema has no structured error field; this recorded body likewise has none.",
+    "claimed git.branches present without commit SHA or prUrl.",
+    "GitHub branch 404 confirms claimed delivery is not verified."
+  ]
+}

--- a/tests/fixtures/agent_control/pilot/contract_live_cursor.json
+++ b/tests/fixtures/agent_control/pilot/contract_live_cursor.json
@@ -113,7 +113,7 @@
   },
   "integrity": {
     "canonicalization": "RFC8785",
-    "digest": "sha256:800159427aa91b9b331ae71353072b2f7c41e34e38f4bd08667cb7f497d9dd25",
+    "digest": "sha256:84e7fb6cbdadc0817fd94524e539b77b0669792b6c0b677e55854a08c358590e",
     "digest_algorithm": "sha256",
     "digest_encoding": "sha256:<lowercase-hex>"
   },
@@ -145,8 +145,8 @@
     "policy_id": "cdb-pr-routing-v1"
   },
   "provider_work_order": {
-    "prompt_digest": "sha256:850bc9495f0de2f3d72ec9f3e308308e070bd4656e6999770ffb38b96e74fb56",
-    "prompt_ref": "tests/fixtures/agent_control/cursor/prompt_ok.txt",
+    "prompt_digest": "sha256:74738b4af1f0bc0d8bd34c38bea43c651ffe87bc4f580616f44c8334b67e2da4",
+    "prompt_ref": "tests/fixtures/agent_control/cursor/prompt_live_4258.txt",
     "source_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   },
   "route": {

--- a/tests/fixtures/agent_control/pilot/contract_live_cursor.json
+++ b/tests/fixtures/agent_control/pilot/contract_live_cursor.json
@@ -1,0 +1,196 @@
+{
+  "budget": {
+    "max_iterations": 200,
+    "max_tool_calls": 5000,
+    "network_policy": {
+      "allowed_classes": [
+        "github_api_write_via_gh_cli",
+        "docs_fetch_readonly"
+      ],
+      "allowed_domains": [
+        "api.github.com",
+        "github.com",
+        "json-schema.org",
+        "www.rfc-editor.org",
+        "cursor.com"
+      ],
+      "mode": "allowlist"
+    },
+    "wall_time_seconds": 14400
+  },
+  "contract_id": "aec-issue-4258-live-cursor-pilot",
+  "created_at": "2026-08-03T00:00:00Z",
+  "environment": {
+    "environment_profile": "mock",
+    "mcp_profiles": [],
+    "provider_profile": {
+      "extensions": {
+        "api_surface": "cloud-agents-v1-public-beta"
+      },
+      "profile_name": "cursor-cloud-api",
+      "provider_id": "cursor-cloud-api"
+    },
+    "secret_references": [
+      {
+        "class": "provider_api_key",
+        "ref": "env:CURSOR_API_KEY"
+      },
+      {
+        "class": "github_token",
+        "ref": "env:GH_TOKEN"
+      }
+    ],
+    "skills": [
+      "cdb-session-start",
+      "cdb-pr-router",
+      "cdb-session-close"
+    ],
+    "subagents": []
+  },
+  "execution_scope": {
+    "allowed_commands_or_command_classes": [
+      "git_read",
+      "git_commit_push",
+      "pytest_unit",
+      "ruff_check",
+      "gh_issue_comment",
+      "gh_pr_edit",
+      "python_module_tools"
+    ],
+    "allowed_paths": [
+      "docs/contracts",
+      "docs/contracts/*",
+      "tools/agent_control",
+      "tools/agent_control/*",
+      "tools/agent_execution_contract",
+      "tools/agent_execution_contract/*",
+      "tests/unit/governance",
+      "tests/unit/governance/*",
+      "tests/fixtures/agent_control",
+      "tests/fixtures/agent_control/*",
+      "config/agent-control",
+      "config/agent-control/*",
+      "knowledge/governance",
+      "knowledge/governance/*",
+      "knowledge/logs/sessions",
+      "knowledge/logs/sessions/*",
+      "agents",
+      "agents/*",
+      "AGENTS.md",
+      "tests/fixtures/agent_control/cursor",
+      "tests/fixtures/agent_control/cursor/*"
+    ],
+    "delivery_target": {
+      "expected_status": "DONE_SLICE_ADDED_TO_BATCH_PR",
+      "mode": "batch_pr",
+      "target_branch": "batch/agent-skills-issue-4258",
+      "target_pr": 9999
+    },
+    "forbidden_paths": [
+      "services",
+      "services/*",
+      "core",
+      "core/*",
+      "infrastructure/compose",
+      "infrastructure/compose/*",
+      ".github/workflows",
+      ".github/workflows/*"
+    ],
+    "issue_scope": {
+      "delivery_issue": 4258,
+      "forbidden_follow_on_issues": [
+        4259,
+        4260
+      ],
+      "topic": "AGENTS Control Plane Pilot Foundation"
+    },
+    "stop_conditions": [
+      "HOLD_NO_SAFE_ROUTE",
+      "HOLD_DEPENDENCY_NOT_READY",
+      "HOLD_SCOPE_DRIFT",
+      "HOLD_CONTRACT_INTEGRITY_NOT_PROVEN"
+    ]
+  },
+  "integrity": {
+    "canonicalization": "RFC8785",
+    "digest": "sha256:800159427aa91b9b331ae71353072b2f7c41e34e38f4bd08667cb7f497d9dd25",
+    "digest_algorithm": "sha256",
+    "digest_encoding": "sha256:<lowercase-hex>"
+  },
+  "issue": {
+    "number": 4258,
+    "parent_issue": 4249,
+    "predecessor_issue": 4257,
+    "title": "[AGENTS][PILOT] Prove one end-to-end Cursor delivery and approval flow"
+  },
+  "permissions": {
+    "close_issue": false,
+    "comment_issue": true,
+    "commit": true,
+    "database_mutation": false,
+    "mcp_live_mutation": false,
+    "merge": false,
+    "open_pr": false,
+    "publish_cdb_local_ci": false,
+    "push": true,
+    "read_repo": true,
+    "runtime_mutation": false,
+    "update_pr": true,
+    "write_code": true,
+    "write_docs": true
+  },
+  "producer": {
+    "agent": "cursor-cloud",
+    "component": "pr_router_handoff",
+    "policy_id": "cdb-pr-routing-v1"
+  },
+  "provider_work_order": {
+    "prompt_digest": "sha256:850bc9495f0de2f3d72ec9f3e308308e070bd4656e6999770ffb38b96e74fb56",
+    "prompt_ref": "tests/fixtures/agent_control/cursor/prompt_ok.txt",
+    "source_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "route": {
+    "batch_key": "agent-skills",
+    "lane": "agent-skills",
+    "lock_state": "UNLOCKED",
+    "merge_mode": "batch",
+    "policy_id": "cdb-pr-routing-v1",
+    "reason_codes": [
+      "CREATE_NEW_BATCH_WITH_DEFAULT_METADATA"
+    ],
+    "router_observed_at": "2026-08-02T23:02:36Z",
+    "routing_decision": "OPERATIONAL_BATCH_CONTINUATION",
+    "target_branch": "batch/agent-skills-issue-4258",
+    "target_pr": 9999,
+    "validation_profile": "agent-skills-v1"
+  },
+  "schema_id": "cdb.agent_execution.v1",
+  "schema_version": "1.1.0",
+  "validation_and_delivery": {
+    "allowed_delivery_statuses": [
+      "DONE_SLICE_ADDED_TO_BATCH_PR",
+      "HOLD_DEPENDENCY_NOT_READY",
+      "HOLD_PR_LOCK_CONFLICT",
+      "HOLD_NO_SAFE_ROUTE",
+      "HOLD_SCOPE_DRIFT",
+      "HOLD_CONTRACT_INTEGRITY_NOT_PROVEN"
+    ],
+    "evidence_requirements": [
+      "targeted_slice_validation",
+      "brain_evidence_block",
+      "router_decision_record",
+      "contract_hash_record",
+      "issue_comment_handoff"
+    ],
+    "merge_authority": {
+      "granted": false,
+      "role": "none"
+    },
+    "required_validations": [
+      "pytest tests/unit/governance/test_agent_execution_contract_v1.py",
+      "pytest tests/unit/governance/test_pr_routing_contract.py",
+      "git diff --check",
+      "python -m tools.validate_readme_links"
+    ]
+  }
+}

--- a/tests/unit/governance/test_agent_control_live_pilot_v1.py
+++ b/tests/unit/governance/test_agent_control_live_pilot_v1.py
@@ -1,0 +1,290 @@
+"""
+test_id: tc_agent_control_live_pilot_v1_001
+test_name: agent_control_live_cursor_pilot_v1
+test_type: Bauteil-Test
+cdb_area: governance
+rule_ref: docs/runbooks/agent_control_live_cursor_pilot.md
+decision_ref: cdb.agent_control_live_cursor_pilot
+issue_ref: 4258
+security_relevant: true
+live_relevant: false
+profitability_relevant: false
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.agent_control.cli import main as cli_main
+from tools.agent_control.errors import AgentControlError
+from tools.agent_control.pilot import PilotError, run_pilot
+from tools.agent_control.paths import REPO_ROOT
+from tools.agent_control.pilot_report import verify_report
+
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "agent_control" / "pilot"
+HEAD = "a" * 40
+FAKE_KEY = "crsr_test_live_pilot_secret_value_DO_NOT_LEAK"
+
+
+def _live_manifest(**overrides: object) -> dict:
+    data: dict = {
+        "schema_id": "cdb.agent_control_pilot_manifest.v1",
+        "schema_version": "1.0.0",
+        "pilot_id": "acp-live-cursor-4258",
+        "scenario_id": "LIVE_P1",
+        "agent_id": "acp-live-cursor-pilot",
+        "contract_path": "tests/fixtures/agent_control/pilot/contract_live_cursor.json",
+        "registry_root": "config/agent-control",
+        "head_sha": HEAD,
+        "base_sha": "b" * 40,
+        "approval_snapshot_path": "tests/fixtures/agent_control/pilot/approval_clean.json",
+        "force_approval_head_from_manifest": True,
+        "delivery_path_allowlist": [
+            "docs/contracts",
+            "tools/agent_control",
+            "config/agent-control",
+            "tests/unit/governance",
+            "tests/fixtures/agent_control",
+        ],
+        "subject": {"repo": "jannekbuengener/Claire_de_Binare", "pr_number": 9999},
+    }
+    data.update(overrides)
+    return data
+
+
+def _fake_http_finished(*, method, url, json=None, headers=None):
+    del headers
+    if method == "POST" and str(url).endswith("/v1/agents"):
+        assert json is not None
+        assert "agentId" in json
+        # Without human_go on profile+driver, autoCreatePR stays false.
+        return {
+            "status": 200,
+            "json": {
+                "agent": {"id": json["agentId"]},
+                "run": {
+                    "id": "run-live-1",
+                    "status": "FINISHED",
+                    "git": {
+                        "branches": [
+                            {
+                                "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+                                "branch": "batch/agent-skills-issue-4258",
+                                "prUrl": (
+                                    "https://github.com/jannekbuengener/"
+                                    "Claire_de_Binare/pull/9999"
+                                ),
+                            }
+                        ]
+                    },
+                },
+            },
+        }
+    if method == "GET" and "/runs/" in str(url):
+        return {
+            "status": 200,
+            "json": {
+                "status": "FINISHED",
+                "git": {
+                    "branches": [
+                        {
+                            "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+                            "branch": "batch/agent-skills-issue-4258",
+                            "prUrl": (
+                                "https://github.com/jannekbuengener/"
+                                "Claire_de_Binare/pull/9999"
+                            ),
+                        }
+                    ]
+                },
+            },
+        }
+    if method == "GET" and "/v1/agents/" in str(url):
+        return {
+            "status": 200,
+            "json": {"id": "bc-existing", "latestRunId": "run-live-1"},
+        }
+    raise AssertionError(f"unexpected http call {method} {url}")
+
+
+def _gh_ok(argv: list[str]) -> dict:
+    del argv
+    return {
+        "number": 9999,
+        "state": "OPEN",
+        "headRefOid": HEAD,
+        "baseRefOid": "b" * 40,
+        "headRefName": "batch/agent-skills-issue-4258",
+        "files": [
+            {"path": "docs/contracts/agent_pilot/note.md"},
+            {"path": "tools/agent_control/pilot.py"},
+        ],
+        "url": "https://github.com/jannekbuengener/Claire_de_Binare/pull/9999",
+        "headRepository": {"nameWithOwner": "jannekbuengener/Claire_de_Binare"},
+    }
+
+
+def _gh_empty(argv: list[str]) -> dict:
+    data = _gh_ok(argv)
+    data["files"] = []
+    return data
+
+
+@pytest.mark.unit
+def test_n1_no_credential_precondition_blocked_no_dispatch() -> None:
+    report = run_pilot(
+        _live_manifest(scenario_id="N1"),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        http_transport=_fake_http_finished,
+        gh_runner=_gh_ok,
+        credential_env={},  # no CURSOR_API_KEY
+    )
+    assert report["final_status"] == "BLOCKED"
+    assert report["provider_call_count"] == 0
+    codes = [
+        (s.get("detail") or {}).get("code")
+        for s in report["step_results"]
+        if s["step"] == "credential_precondition"
+    ]
+    assert "PRECONDITION_BLOCKED" in codes
+    assert "live_cursor_pilot" in report["limitations"]
+    assert "mock_provider_only" not in report["limitations"]
+    blob = json.dumps(report)
+    assert FAKE_KEY not in blob
+
+
+@pytest.mark.unit
+def test_no_human_go_raises_pilot_error() -> None:
+    with pytest.raises(PilotError) as exc:
+        run_pilot(
+            _live_manifest(),
+            repo_root=REPO_ROOT,
+            provider_id="cursor-cloud-api",
+            human_go_live_cursor=False,
+            credential_env={"CURSOR_API_KEY": FAKE_KEY},
+        )
+    assert exc.value.code == "PILOT_HUMAN_GO_REQUIRED"
+
+
+@pytest.mark.unit
+def test_cli_no_human_go_fail_closed() -> None:
+    code = cli_main(
+        [
+            "pilot",
+            "run",
+            "--manifest",
+            str(FIXTURES / "p1_pass.manifest.json"),
+            "--provider",
+            "cursor-cloud-api",
+        ]
+    )
+    assert code != 0
+
+
+@pytest.mark.unit
+def test_positive_recorded_awaiting_approval_no_network(tmp_path: Path) -> None:
+    state = tmp_path / "runstore.json"
+    report = run_pilot(
+        _live_manifest(),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=state,
+        http_transport=_fake_http_finished,
+        gh_runner=_gh_ok,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    verify_report(report)
+    assert report["final_status"] in {"PASS", "HOLD"}
+    assert report["provider_call_count"] == 1
+    watch = [s for s in report["step_results"] if s["step"] == "provider_watch"]
+    assert watch and watch[0]["detail"]["state"] == "AWAITING_APPROVAL"
+    assert "awaiting_approval_operator_handoff" in report["limitations"]
+    assert "live_cursor_pilot" in report["limitations"]
+    assert "not_live_cursor" not in report["limitations"]
+    assert "mock_provider_only" not in report["limitations"]
+    blob = json.dumps(report)
+    assert FAKE_KEY not in blob
+
+
+@pytest.mark.unit
+def test_idempotent_resume_reuses_provider_run_id(tmp_path: Path) -> None:
+    state = tmp_path / "runstore.json"
+    first = run_pilot(
+        _live_manifest(),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=state,
+        http_transport=_fake_http_finished,
+        gh_runner=_gh_ok,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    run_id = first["run_id"]
+    assert run_id
+    first_watch = [s for s in first["step_results"] if s["step"] == "provider_watch"][0]
+    provider_run_id = first_watch["detail"]["provider_run_id"]
+
+    second = run_pilot(
+        _live_manifest(scenario_id="LIVE_RESUME"),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=state,
+        resume_run_id=run_id,
+        http_transport=_fake_http_finished,
+        gh_runner=_gh_ok,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    assert second["run_id"] == run_id
+    # Resume skips dispatch → zero new provider dispatch calls on fresh driver.
+    assert second["provider_call_count"] == 0
+    second_watch = [s for s in second["step_results"] if s["step"] == "provider_watch"]
+    assert second_watch
+    assert second_watch[0]["detail"]["provider_run_id"] == provider_run_id
+
+
+@pytest.mark.unit
+def test_delivery_empty_blocks_approval_pass(tmp_path: Path) -> None:
+    report = run_pilot(
+        _live_manifest(scenario_id="N_DELIVERY_EMPTY"),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=tmp_path / "state.json",
+        http_transport=_fake_http_finished,
+        gh_runner=_gh_empty,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    assert report["final_status"] == "BLOCKED"
+    assert report.get("approval_recommendation") != "APPROVE_RECOMMENDED"
+    codes = [
+        (s.get("detail") or {}).get("code")
+        for s in report["step_results"]
+        if s["step"] == "delivery_verify"
+    ]
+    assert "DELIVERY_EMPTY" in codes
+    blob = json.dumps(report)
+    assert FAKE_KEY not in blob
+
+
+@pytest.mark.unit
+def test_secret_redaction_in_report_json(tmp_path: Path) -> None:
+    report = run_pilot(
+        _live_manifest(),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=tmp_path / "state.json",
+        http_transport=_fake_http_finished,
+        gh_runner=_gh_ok,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    assert FAKE_KEY not in serialized
+    assert "CURSOR_API_KEY" not in serialized or FAKE_KEY not in serialized

--- a/tests/unit/governance/test_agent_control_live_pilot_v1.py
+++ b/tests/unit/governance/test_agent_control_live_pilot_v1.py
@@ -48,8 +48,11 @@ def _live_manifest(**overrides: object) -> dict:
             "config/agent-control",
             "tests/unit/governance",
             "tests/fixtures/agent_control",
+            "knowledge/logs/sessions",
         ],
         "subject": {"repo": "jannekbuengener/Claire_de_Binare", "pr_number": 9999},
+        # Offline recorded path: no wall-clock sleep between provider polls.
+        "poll_interval_seconds": 0,
     }
     data.update(overrides)
     return data
@@ -269,6 +272,65 @@ def test_delivery_empty_blocks_approval_pass(tmp_path: Path) -> None:
         if s["step"] == "delivery_verify"
     ]
     assert "DELIVERY_EMPTY" in codes
+    blob = json.dumps(report)
+    assert FAKE_KEY not in blob
+
+
+@pytest.mark.unit
+def test_poll_before_delivery_handles_creating_then_finished(tmp_path: Path) -> None:
+    """Official API: create returns CREATING without git; poll until FINISHED."""
+    calls = {"n": 0}
+
+    def http(*, method, url, json=None, headers=None):
+        del headers
+        if method == "POST" and str(url).endswith("/v1/agents"):
+            return {
+                "status": 200,
+                "json": {
+                    "agent": {"id": json["agentId"]},
+                    "run": {"id": "run-live-poll", "status": "CREATING"},
+                },
+            }
+        if method == "GET" and "/runs/" in str(url):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return {"status": 200, "json": {"status": "RUNNING"}}
+            return {
+                "status": 200,
+                "json": {
+                    "status": "FINISHED",
+                    "git": {
+                        "branches": [
+                            {
+                                "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+                                "branch": "batch/agent-skills-issue-4258",
+                                "prUrl": (
+                                    "https://github.com/jannekbuengener/"
+                                    "Claire_de_Binare/pull/9999"
+                                ),
+                            }
+                        ]
+                    },
+                },
+            }
+        raise AssertionError(f"unexpected http call {method} {url}")
+
+    report = run_pilot(
+        _live_manifest(scenario_id="LIVE_POLL"),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=tmp_path / "state.json",
+        http_transport=http,
+        gh_runner=_gh_ok,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    assert report["final_status"] in {"PASS", "HOLD"}
+    poll = [s for s in report["step_results"] if s["step"] == "provider_poll"]
+    assert poll and poll[0]["status"] == "PASS"
+    assert calls["n"] >= 3
+    delivery = [s for s in report["step_results"] if s["step"] == "delivery_verify"]
+    assert delivery and delivery[0]["status"] == "PASS"
     blob = json.dumps(report)
     assert FAKE_KEY not in blob
 

--- a/tests/unit/governance/test_cursor_error_phantom_branch_v1.py
+++ b/tests/unit/governance/test_cursor_error_phantom_branch_v1.py
@@ -1,0 +1,331 @@
+"""
+test_id: tc_cursor_error_phantom_branch_v1_001
+test_name: cursor_terminal_error_claimed_vs_verified_delivery
+test_type: Bauteil-Test
+cdb_area: governance
+rule_ref: docs/runbooks/agent_control_live_cursor_pilot.md
+issue_ref: 4258
+pr_ref: 4302
+security_relevant: true
+live_relevant: false
+profitability_relevant: false
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.agent_control.delivery_verify import (
+    claimed_delivery_from_git,
+    normalize_cursor_git_branches,
+    verify_github_delivery,
+)
+from tools.agent_control.errors import DispatchError
+from tools.agent_control.evidence.redact import sanitize_result_refs
+from tools.agent_control.paths import REPO_ROOT
+from tools.agent_control.pilot import run_pilot
+from tools.agent_control.provider import ProviderRequest
+from tools.agent_control.providers.cursor_cloud_api import CursorCloudApiDriver
+from tools.agent_control.providers.cursor_common import normalize_cursor_status
+
+FIXTURES = REPO_ROOT / "tests" / "fixtures" / "agent_control" / "cursor"
+RECORDED = json.loads(
+    (FIXTURES / "run_error_phantom_branch.json").read_text(encoding="utf-8")
+)
+FAKE_KEY = "crsr_test_error_phantom_secret_value_DO_NOT_LEAK"
+HEAD = "a" * 40
+
+
+def _live_manifest(**overrides: object) -> dict:
+    data: dict = {
+        "schema_id": "cdb.agent_control_pilot_manifest.v1",
+        "schema_version": "1.0.0",
+        "pilot_id": "acp-live-cursor-4258",
+        "scenario_id": "LIVE_ERROR_PHANTOM",
+        "agent_id": "acp-live-cursor-pilot",
+        "contract_path": "tests/fixtures/agent_control/pilot/contract_live_cursor.json",
+        "registry_root": "config/agent-control",
+        "head_sha": HEAD,
+        "base_sha": "b" * 40,
+        "approval_snapshot_path": "tests/fixtures/agent_control/pilot/approval_clean.json",
+        "force_approval_head_from_manifest": True,
+        "delivery_path_allowlist": [
+            "docs/contracts",
+            "tools/agent_control",
+            "config/agent-control",
+            "tests/unit/governance",
+            "tests/fixtures/agent_control",
+            "knowledge/logs/sessions",
+        ],
+        "subject": {"repo": "jannekbuengener/Claire_de_Binare", "pr_number": 9999},
+        "poll_interval_seconds": 0,
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.unit
+def test_recorded_error_normalizes_to_failed() -> None:
+    status, code = normalize_cursor_status(RECORDED["get_run"]["status"])
+    assert status == "FAILED"
+    assert code is None or isinstance(code, str)
+
+
+@pytest.mark.unit
+def test_watch_preserves_error_claimed_delivery_never_verified() -> None:
+    get_run = RECORDED["get_run"]
+    stream_events = list(RECORDED["stream_events"])
+    posts: list[str] = []
+
+    def http(*, method, url, json=None, headers=None):
+        del headers
+        posts.append(f"{method}:{url}")
+        if method == "POST" and str(url).endswith("/v1/agents"):
+            return {
+                "status": 200,
+                "json": {
+                    "agent": {"id": json["agentId"]},
+                    "run": {"id": get_run["id"], "status": "CREATING"},
+                },
+            }
+        if method == "GET" and f"/runs/{get_run['id']}" in str(url):
+            return {"status": 200, "json": dict(get_run)}
+        raise AssertionError((method, url))
+
+    def sse(*, url, last_event_id=None):
+        del url, last_event_id
+        return stream_events
+
+    driver = CursorCloudApiDriver(http=http, sse=sse)
+    req = ProviderRequest(
+        run_id="adr-err",
+        contract_id="aec-x",
+        contract_digest="sha256:" + "9" * 64,
+        agent_id="a",
+        prompt_text="recorded error fixture",
+        route={
+            "repo_url": "https://github.com/jannekbuengener/Claire_de_Binare",
+            "starting_ref": "main",
+        },
+        provider_profile={
+            "autoCreatePR": True,
+            "workOnCurrentBranch": False,
+            "human_go_live": True,
+        },
+    )
+    created = driver.dispatch(req)
+    assert created.provider_run_id == get_run["id"]
+    assert driver.mutating_posts == 1
+
+    watched = driver.watch(created.provider_run_id)
+    assert watched.normalized_status == "FAILED"
+    assert watched.error_code == "PROVIDER_RUN_ERROR"
+    refs = watched.result_refs or {}
+    assert refs.get("delivery_verified") is False
+    claimed = refs.get("claimed_delivery") or {}
+    assert claimed.get("branch") == "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+    assert claimed.get("delivery_verified") is False
+    assert refs.get("raw_status") == "ERROR"
+    git = normalize_cursor_git_branches(refs)
+    assert git.get("branch") == claimed.get("branch")
+
+    diag = driver.read_stream_diagnostics(created.provider_run_id)
+    assert any(e.get("event") == "status" for e in diag["events"])
+    assert any(e.get("event") == "result" for e in diag["events"])
+    assert diag.get("stream_error") is None  # recorded run had no SSE error event
+
+    # Resume/watch again must not create.
+    before = driver.mutating_posts
+    again = driver.watch(created.provider_run_id)
+    assert again.normalized_status == "FAILED"
+    assert driver.mutating_posts == before
+
+
+@pytest.mark.unit
+def test_claimed_branch_without_github_object_unverified() -> None:
+    claimed = claimed_delivery_from_git(RECORDED["get_run"]["git"])
+    assert claimed["branch"] == "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+    assert claimed["delivery_verified"] is False
+
+    def gh_404(argv: list[str]) -> dict:
+        raise DispatchError("DELIVERY_GITHUB_QUERY_FAILED", "Not Found (HTTP 404)")
+
+    with pytest.raises(DispatchError) as exc:
+        verify_github_delivery(
+            expected_repo="jannekbuengener/Claire_de_Binare",
+            branch=claimed["branch"],
+            runner=gh_404,
+        )
+    assert exc.value.code == "DELIVERY_GITHUB_QUERY_FAILED"
+
+
+@pytest.mark.unit
+def test_missing_commit_sha_blocks_delivery() -> None:
+    def gh_no_sha(argv: list[str]) -> dict:
+        return {"name": "cloud-cursor/x", "commit": {"sha": None}}
+
+    result = verify_github_delivery(
+        expected_repo="jannekbuengener/Claire_de_Binare",
+        branch="cloud-cursor/x",
+        runner=gh_no_sha,
+    )
+    assert result.ok is False
+    assert result.code == "DELIVERY_HEAD_INVALID"
+
+
+@pytest.mark.unit
+def test_redaction_strips_auth_token_fields() -> None:
+    dirty = {
+        "agent_id": RECORDED["agent_id"],
+        "Authorization": "Bearer crsr_should_never_persist",
+        "api_key": FAKE_KEY,
+        "claimed_delivery": {
+            "branch": "cloud-cursor/cursor-cloud-pilot-marker-3c10",
+            "delivery_verified": False,
+        },
+        "delivery_verified": False,
+    }
+    clean = sanitize_result_refs(dirty)
+    assert "Authorization" not in clean
+    assert "api_key" not in clean
+    assert clean["claimed_delivery"]["branch"].startswith("cloud-cursor/")
+    blob = json.dumps(clean)
+    assert FAKE_KEY not in blob
+    assert "crsr_should_never_persist" not in blob
+
+
+@pytest.mark.unit
+def test_pilot_terminal_error_never_awaits_approval(tmp_path: Path) -> None:
+    get_run = RECORDED["get_run"]
+    posts: list[str] = []
+
+    def http(*, method, url, json=None, headers=None):
+        del headers
+        posts.append(f"{method}:{url}")
+        if method == "POST" and str(url).endswith("/v1/agents"):
+            return {
+                "status": 200,
+                "json": {
+                    "agent": {"id": json["agentId"]},
+                    "run": {"id": get_run["id"], "status": "CREATING"},
+                },
+            }
+        if method == "GET" and "/runs/" in str(url):
+            return {"status": 200, "json": dict(get_run)}
+        raise AssertionError((method, url))
+
+    def sse(*, url, last_event_id=None):
+        del url, last_event_id
+        return list(RECORDED["stream_events"])
+
+    def gh_boom(argv: list[str]) -> dict:
+        raise AssertionError(f"delivery verify must not run on ERROR: {argv}")
+
+    report = run_pilot(
+        _live_manifest(),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=tmp_path / "state.json",
+        http_transport=http,
+        sse_transport=sse,
+        gh_runner=gh_boom,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    assert report["final_status"] in {"FAILED", "BLOCKED", "HOLD"}
+    assert report.get("approval_recommendation") != "APPROVE_RECOMMENDED"
+    terminal = [s for s in report["step_results"] if s["step"] == "provider_terminal"]
+    assert terminal
+    detail = terminal[0]["detail"]
+    assert detail.get("delivery_verified") is False
+    assert detail.get("normalized_status") == "FAILED"
+    claimed = detail.get("claimed_delivery") or {}
+    assert claimed.get("branch") == "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+    delivery_steps = [
+        s for s in report["step_results"] if s["step"] == "delivery_verify"
+    ]
+    assert not delivery_steps
+    await_steps = [
+        s
+        for s in report["step_results"]
+        if s["step"] == "provider_watch"
+        and (s.get("detail") or {}).get("state") == "AWAITING_APPROVAL"
+    ]
+    assert not await_steps
+    create_posts = [
+        p for p in posts if p.startswith("POST:") and p.endswith("/v1/agents")
+    ]
+    assert len(create_posts) == 1
+    blob = json.dumps(report)
+    assert FAKE_KEY not in blob
+
+
+@pytest.mark.unit
+def test_resume_terminal_error_zero_creates(tmp_path: Path) -> None:
+    get_run = RECORDED["get_run"]
+    creates = {"n": 0}
+
+    def http(*, method, url, json=None, headers=None):
+        del headers
+        if method == "POST" and str(url).endswith("/v1/agents"):
+            creates["n"] += 1
+            return {
+                "status": 200,
+                "json": {
+                    "agent": {"id": json["agentId"]},
+                    "run": {
+                        "id": get_run["id"],
+                        "status": "ERROR",
+                        "git": get_run["git"],
+                    },
+                },
+            }
+        if method == "GET" and "/runs/" in str(url):
+            return {"status": 200, "json": dict(get_run)}
+        raise AssertionError((method, url))
+
+    def sse(*, url, last_event_id=None):
+        del url, last_event_id
+        return list(RECORDED["stream_events"])
+
+    state = tmp_path / "state.json"
+    first = run_pilot(
+        _live_manifest(scenario_id="LIVE_ERROR_CREATE"),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=state,
+        http_transport=http,
+        sse_transport=sse,
+        gh_runner=lambda argv: (_ for _ in ()).throw(AssertionError(argv)),
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    assert creates["n"] == 1
+    # Prefer report run_id; fall back to dispatch step detail for older shapes.
+    run_id = first.get("run_id")
+    if not run_id:
+        for step in first["step_results"]:
+            if step["step"] == "preflight_dispatch":
+                run_id = (step.get("detail") or {}).get("run_id")
+    assert run_id
+    assert first["final_status"] in {"FAILED", "BLOCKED", "HOLD"}
+
+    second = run_pilot(
+        _live_manifest(scenario_id="LIVE_ERROR_RESUME"),
+        repo_root=REPO_ROOT,
+        provider_id="cursor-cloud-api",
+        human_go_live_cursor=True,
+        state_path=state,
+        resume_run_id=run_id,
+        http_transport=http,
+        sse_transport=sse,
+        gh_runner=lambda argv: (_ for _ in ()).throw(AssertionError(argv)),
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+    )
+    assert creates["n"] == 1
+    assert second["provider_call_count"] == 0
+    blob = json.dumps(second)
+    assert FAKE_KEY not in blob

--- a/tests/unit/governance/test_cursor_live_preflight_v1.py
+++ b/tests/unit/governance/test_cursor_live_preflight_v1.py
@@ -1,0 +1,428 @@
+"""
+test_id: tc_cursor_live_preflight_v1_001
+test_name: dashboardless_cursor_live_preflight
+test_type: Bauteil-Test
+cdb_area: governance
+issue_ref: 4258
+pr_ref: 4302
+security_relevant: true
+live_relevant: false
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.agent_control.cursor_preflight import (
+    evaluate_named_environment_selection,
+    extract_environment_identity,
+    run_cursor_live_preflight,
+    validate_preflight_report,
+)
+from tools.agent_control.errors import DispatchError
+from tools.agent_control.paths import REPO_ROOT
+from tools.agent_control.provider import ProviderRequest
+from tools.agent_control.providers.cursor_cloud_api import CursorCloudApiDriver
+
+FAKE_KEY = "crsr_test_preflight_secret_value_DO_NOT_LEAK"
+REPO = "jannekbuengener/Claire_de_Binare"
+
+
+def _http_router(routes: dict[str, tuple[int, dict]]):
+    calls = {"GET": 0, "POST": 0}
+
+    def http_get(path: str):
+        calls["GET"] += 1
+        if path in routes:
+            return routes[path]
+        if path.startswith("/v1/agents/") and "/runs/" in path:
+            return routes.get("run", (200, {"id": "run-x", "status": "ERROR"}))
+        if path.startswith("/v1/agents/"):
+            return routes.get(
+                "agent",
+                (
+                    200,
+                    {
+                        "id": "bc-1",
+                        "status": "ACTIVE",
+                        "env": {"type": "cloud"},
+                        "autoCreatePR": True,
+                        "repos": [{"url": f"https://github.com/{REPO}"}],
+                    },
+                ),
+            )
+        return 404, {"error": "not_found"}
+
+    return http_get, calls
+
+
+def _gh_ok(argv: list[str]):
+    path = argv[0] if argv else ""
+    if path.startswith("repos/") and path.endswith("/installation"):
+        return 1, {"message": "A JSON web token could not be decoded", "status": "401"}
+    if path.startswith("apps/cursor"):
+        return 0, {
+            "id": 1210556,
+            "slug": "cursor",
+            "permissions": {"contents": "write", "pull_requests": "write"},
+        }
+    if path.startswith("repos/") and "/branches/main/protection" in path:
+        return 0, {"block_creations": {"enabled": False}}
+    if path.startswith("repos/"):
+        return 0, {"full_name": REPO, "default_branch": "main"}
+    return 1, {"message": "unexpected"}
+
+
+@pytest.mark.unit
+def test_duplicate_environment_names_without_id_blocks() -> None:
+    status, gaps, limits = evaluate_named_environment_selection(
+        requested_name=REPO,
+        resolved={"type": "cloud", "name": REPO, "environment_public_id": None},
+        list_environments_http=404,
+        dashboard_duplicate_names=True,
+    )
+    assert status == "BLOCKED"
+    assert any(g["id"] == "PUBLIC_API_GAP_ENVIRONMENT_LIST" for g in gaps)
+    assert "dashboard_duplicate_environment_names_observed" in limits
+
+
+@pytest.mark.unit
+def test_requested_resolved_environment_match_and_mismatch() -> None:
+    ok, _, _ = evaluate_named_environment_selection(
+        requested_name="Release workspace",
+        resolved={
+            "type": "cloud",
+            "name": "Release workspace",
+            "environment_public_id": None,
+        },
+        list_environments_http=404,
+        dashboard_duplicate_names=False,
+    )
+    assert ok == "PASS"
+    bad, _, limits = evaluate_named_environment_selection(
+        requested_name="A",
+        resolved={"type": "cloud", "name": "B", "environment_public_id": None},
+        list_environments_http=404,
+        dashboard_duplicate_names=False,
+    )
+    assert bad == "BLOCKED"
+    assert "requested_resolved_environment_mismatch" in limits
+
+
+@pytest.mark.unit
+def test_missing_environment_metadata_unknown() -> None:
+    status, _, _ = evaluate_named_environment_selection(
+        requested_name=REPO,
+        resolved={"type": "cloud", "name": None, "environment_public_id": None},
+        list_environments_http=404,
+        dashboard_duplicate_names=False,
+    )
+    assert status == "UNKNOWN"
+
+
+@pytest.mark.unit
+def test_github_contents_readonly_blocks(tmp_path: Path) -> None:
+    http_get, calls = _http_router(
+        {
+            "/v1/me": (200, {"apiKeyName": "t", "userId": 1}),
+            "/v1/models": (200, {"items": [{"id": "default"}]}),
+            "/v1/repositories": (
+                200,
+                {"items": [{"url": f"https://github.com/{REPO}"}]},
+            ),
+            "/v1/environments": (404, {"error": "missing"}),
+        }
+    )
+
+    def gh(argv: list[str]):
+        path = argv[0]
+        if path.endswith("/installation"):
+            return 0, {
+                "id": 99,
+                "suspended_at": None,
+                "repository_selection": "selected",
+                "permissions": {"contents": "read", "pull_requests": "write"},
+            }
+        if path.startswith("apps/"):
+            return 0, {
+                "permissions": {"contents": "write", "pull_requests": "write"},
+                "slug": "cursor",
+            }
+        if "protection" in path:
+            return 0, {"block_creations": {"enabled": False}}
+        return 0, {"default_branch": "main", "full_name": REPO}
+
+    report = run_cursor_live_preflight(
+        repository=REPO,
+        binding_mode="repos_plus_repo_config",
+        repo_root=REPO_ROOT,
+        secrets_dir=tmp_path,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+        http_get=http_get,
+        gh_api=gh,
+        dashboard_observations=None,
+        existing_agent_id=None,
+        existing_run_id=None,
+    )
+    assert report["github_app_status"] == "BLOCKED"
+    assert report["ready_for_live_run"] is False
+    assert calls["POST"] == 0
+    assert report["cursor_http_posts"] == 0
+    assert report["github_writes"] == 0
+    assert FAKE_KEY not in json.dumps(report)
+
+
+@pytest.mark.unit
+def test_suspended_installation_blocks(tmp_path: Path) -> None:
+    http_get, _ = _http_router(
+        {
+            "/v1/me": (200, {"apiKeyName": "t", "userId": 1}),
+            "/v1/models": (200, {"items": [{"id": "default"}]}),
+            "/v1/repositories": (
+                200,
+                {"items": [{"url": f"https://github.com/{REPO}"}]},
+            ),
+            "/v1/environments": (404, {}),
+        }
+    )
+
+    def gh(argv: list[str]):
+        path = argv[0]
+        if path.endswith("/installation"):
+            return 0, {
+                "id": 99,
+                "suspended_at": "2026-01-01T00:00:00Z",
+                "permissions": {"contents": "write", "pull_requests": "write"},
+            }
+        if path.startswith("apps/"):
+            return 0, {
+                "permissions": {"contents": "write", "pull_requests": "write"},
+                "slug": "cursor",
+            }
+        if "protection" in path:
+            return 0, {"block_creations": {"enabled": False}}
+        return 0, {"default_branch": "main"}
+
+    report = run_cursor_live_preflight(
+        repository=REPO,
+        repo_root=REPO_ROOT,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+        http_get=http_get,
+        gh_api=gh,
+        existing_agent_id=None,
+        existing_run_id=None,
+    )
+    assert report["github_app_status"] == "BLOCKED"
+    assert report["ready_for_live_run"] is False
+
+
+@pytest.mark.unit
+def test_preflight_zero_creates_and_schema(tmp_path: Path) -> None:
+    http_get, calls = _http_router(
+        {
+            "/v1/me": (200, {"apiKeyName": "api.CDB", "userId": 1}),
+            "/v1/models": (200, {"items": [{"id": "default"}]}),
+            "/v1/repositories": (
+                200,
+                {"items": [{"url": f"https://github.com/{REPO}"}]},
+            ),
+            "/v1/environments": (404, {"error": "not_found"}),
+        }
+    )
+    report = run_cursor_live_preflight(
+        repository=REPO,
+        environment_name=REPO,
+        binding_mode="repos_plus_repo_config",
+        repo_root=REPO_ROOT,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+        http_get=http_get,
+        gh_api=_gh_ok,
+        dashboard_observations={
+            "ambiguity": "two active environments with the same visible name",
+            "environments": [
+                {"repository": REPO, "status": "Active"},
+                {"repository": REPO, "status": "Active"},
+            ],
+            "create_prs": "Always",
+        },
+        existing_agent_id=None,
+        existing_run_id=None,
+    )
+    validate_preflight_report(report, repo_root=REPO_ROOT)
+    assert report["cursor_http_posts"] == 0
+    assert report["github_writes"] == 0
+    assert calls["GET"] >= 3
+    assert report["repo_config_status"] == "PASS"
+    assert report["ready_for_live_run"] is False  # installation UNKNOWN
+    assert any(
+        g["id"] == "PUBLIC_API_GAP_GITHUB_INSTALLATION_READ"
+        for g in report["public_api_gaps"]
+    )
+    assert FAKE_KEY not in json.dumps(report)
+
+
+@pytest.mark.unit
+def test_named_mode_duplicate_blocks_ready(tmp_path: Path) -> None:
+    http_get, _ = _http_router(
+        {
+            "/v1/me": (200, {"apiKeyName": "t", "userId": 1}),
+            "/v1/models": (200, {"items": [{"id": "default"}]}),
+            "/v1/repositories": (
+                200,
+                {"items": [{"url": f"https://github.com/{REPO}"}]},
+            ),
+            "/v1/environments": (404, {}),
+            "agent": (
+                200,
+                {
+                    "id": "bc-1",
+                    "status": "ACTIVE",
+                    "env": {"type": "cloud", "name": REPO},
+                },
+            ),
+        }
+    )
+
+    def gh_pass_install(argv: list[str]):
+        path = argv[0]
+        if path.endswith("/installation"):
+            return 0, {
+                "id": 42,
+                "suspended_at": None,
+                "repository_selection": "all",
+                "permissions": {"contents": "write", "pull_requests": "write"},
+            }
+        if path.startswith("apps/"):
+            return 0, {
+                "slug": "cursor",
+                "permissions": {"contents": "write", "pull_requests": "write"},
+            }
+        if "protection" in path:
+            return 0, {"block_creations": {"enabled": False}}
+        return 0, {"default_branch": "main"}
+
+    report = run_cursor_live_preflight(
+        repository=REPO,
+        environment_name=REPO,
+        binding_mode="named_cloud_env",
+        repo_root=REPO_ROOT,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+        http_get=http_get,
+        gh_api=gh_pass_install,
+        dashboard_observations={
+            "ambiguity": "two active environments with the same visible name"
+        },
+        existing_agent_id="bc-1",
+        existing_run_id=None,
+    )
+    assert report["environment_selection_status"] == "BLOCKED"
+    assert report["ready_for_live_run"] is False
+
+
+@pytest.mark.unit
+def test_adapter_environment_mismatch_blocks() -> None:
+    def http(*, method, url, json=None, headers=None):
+        del headers
+        if method == "POST" and str(url).endswith("/v1/agents"):
+            assert "env" in json
+            assert "repos" not in json
+            return {
+                "status": 200,
+                "json": {
+                    "agent": {
+                        "id": json["agentId"],
+                        "env": {"type": "cloud", "name": "Other Env"},
+                    },
+                    "run": {"id": "run-1", "status": "CREATING"},
+                },
+            }
+        raise AssertionError((method, url))
+
+    driver = CursorCloudApiDriver(http=http, human_go_live=True)
+    with pytest.raises(DispatchError) as exc:
+        driver.dispatch(
+            ProviderRequest(
+                run_id="adr-env",
+                contract_id="aec-x",
+                contract_digest="sha256:" + "1" * 64,
+                agent_id="a",
+                prompt_text="x",
+                route={"repo_url": f"https://github.com/{REPO}"},
+                provider_profile={
+                    "autoCreatePR": True,
+                    "human_go_live_cursor": True,
+                    "env": {"type": "cloud", "name": REPO},
+                },
+            )
+        )
+    assert exc.value.code == "PROVIDER_ENVIRONMENT_MISMATCH"
+
+
+@pytest.mark.unit
+def test_adapter_persists_requested_and_resolved_env() -> None:
+    def http(*, method, url, json=None, headers=None):
+        del headers
+        if method == "POST" and str(url).endswith("/v1/agents"):
+            assert json["repos"][0]["startingRef"] == "main"
+            return {
+                "status": 200,
+                "json": {
+                    "agent": {
+                        "id": json["agentId"],
+                        "env": {"type": "cloud"},
+                        "repos": json["repos"],
+                    },
+                    "run": {"id": "run-1", "status": "FINISHED"},
+                },
+            }
+        if method == "GET":
+            return {"status": 200, "json": {"status": "FINISHED"}}
+        raise AssertionError((method, url))
+
+    driver = CursorCloudApiDriver(http=http, human_go_live=True)
+    result = driver.dispatch(
+        ProviderRequest(
+            run_id="adr-repos",
+            contract_id="aec-x",
+            contract_digest="sha256:" + "2" * 64,
+            agent_id="a",
+            prompt_text="x",
+            route={"repo_url": f"https://github.com/{REPO}"},
+            provider_profile={"autoCreatePR": True, "human_go_live_cursor": True},
+        )
+    )
+    refs = result.result_refs or {}
+    assert refs["environment_requested"]["binding_mode"] == "repos_plus_repo_config"
+    assert extract_environment_identity(refs["environment_resolved"])["type"] == "cloud"
+    assert driver.mutating_posts == 1
+
+
+@pytest.mark.unit
+def test_public_api_gap_reported_honestly(tmp_path: Path) -> None:
+    http_get, _ = _http_router(
+        {
+            "/v1/me": (200, {"apiKeyName": "t", "userId": 1}),
+            "/v1/models": (200, {"items": [{"id": "default"}]}),
+            "/v1/repositories": (
+                200,
+                {"items": [{"url": f"https://github.com/{REPO}"}]},
+            ),
+            "/v1/environments": (404, {}),
+        }
+    )
+    report = run_cursor_live_preflight(
+        repository=REPO,
+        repo_root=REPO_ROOT,
+        credential_env={"CURSOR_API_KEY": FAKE_KEY},
+        http_get=http_get,
+        gh_api=_gh_ok,
+        existing_agent_id=None,
+        existing_run_id=None,
+    )
+    ids = {g["id"] for g in report["public_api_gaps"]}
+    assert "PUBLIC_API_GAP_ENVIRONMENT_LIST" in ids
+    assert "PUBLIC_API_GAP_NETWORK_POLICY" in ids
+    assert "PUBLIC_API_GAP_ROUTING_RULES" in ids

--- a/tests/unit/governance/test_cursor_providers_v1.py
+++ b/tests/unit/governance/test_cursor_providers_v1.py
@@ -231,6 +231,26 @@ def test_cli_force_and_write_blocked() -> None:
 
 
 @pytest.mark.unit
+def test_stable_agent_id_is_bc_uuid() -> None:
+    from tools.agent_control.providers.cursor_cloud_api import (
+        _BC_ID,
+        _stable_agent_id,
+    )
+
+    req = ProviderRequest(
+        run_id="adr-agentid",
+        contract_id="aec-x",
+        contract_digest="sha256:" + "4" * 64,
+        agent_id="a",
+        prompt_text=_prompt_text(),
+    )
+    aid = _stable_agent_id(req)
+    assert aid.startswith("bc-")
+    assert _BC_ID.match(aid)
+    assert _stable_agent_id(req) == aid
+
+
+@pytest.mark.unit
 def test_cloud_fake_http_sse_and_guards() -> None:
     posts: list[str] = []
 

--- a/tests/unit/governance/test_cursor_providers_v1.py
+++ b/tests/unit/governance/test_cursor_providers_v1.py
@@ -254,7 +254,11 @@ def test_cloud_fake_http_sse_and_guards() -> None:
         if method == "POST" and url.endswith("/unarchive"):
             return {"status": 200, "json": {}}
         if method == "POST" and url.endswith("/runs"):
-            return {"status": 200, "json": {"id": "run-2", "status": "FINISHED"}}
+            # Official Cloud Agents API v1 follow-up shape.
+            return {
+                "status": 200,
+                "json": {"run": {"id": "run-2", "status": "FINISHED"}},
+            }
         raise AssertionError((method, url))
 
     def sse(*, url, last_event_id=None):
@@ -286,6 +290,18 @@ def test_cloud_fake_http_sse_and_guards() -> None:
     result = driver.dispatch(req)
     assert result.normalized_status == "SUCCEEDED"
     assert driver.mutating_posts == 1
+    fu = driver.follow_up(
+        result.provider_run_id,
+        ProviderRequest(
+            run_id="adr-cloud",
+            contract_id="aec-x",
+            contract_digest="sha256:" + "3" * 64,
+            agent_id="a",
+            prompt_text="follow up",
+        ),
+    )
+    assert fu.provider_run_id == "run-2"
+    assert fu.result_refs.get("follow_up") is True
     events = driver.stream(result.provider_run_id, last_event_id="1")
     assert len(events) == 1
     events2 = driver.stream(result.provider_run_id, last_event_id="expired")

--- a/tools/agent_control/cli.py
+++ b/tools/agent_control/cli.py
@@ -18,6 +18,7 @@ Examples:
   python -m tools.agent_control approval drift --baseline <PATH>
   python -m tools.agent_control pilot run --manifest <PATH> [--out <REPORT>]
   python -m tools.agent_control pilot verify --report <PATH>
+  python -m tools.agent_control pilot cursor-preflight --repository owner/name
 """
 
 from __future__ import annotations
@@ -609,6 +610,47 @@ def cmd_pilot_verify(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def cmd_pilot_cursor_preflight(args: argparse.Namespace) -> int:
+    """Dashboardless Cursor live preflight — zero creates, zero GitHub writes."""
+    from tools.agent_control.cursor_preflight import (
+        CursorPreflightError,
+        run_cursor_live_preflight,
+    )
+    from tools.agent_control.paths import REPO_ROOT
+
+    root = Path(args.repo_root) if args.repo_root else REPO_ROOT
+    secrets = Path(args.secrets_dir) if args.secrets_dir else None
+    state = Path(args.state) if args.state else None
+    dash = None
+    if args.dashboard_observations:
+        try:
+            dash = _load_json(Path(args.dashboard_observations))
+        except (OSError, json.JSONDecodeError, AgentControlError) as exc:
+            print(f"INVALID dashboard_observations: {exc}", file=sys.stderr)
+            return EXIT_ERROR
+    try:
+        report = run_cursor_live_preflight(
+            repository=str(args.repository),
+            environment_name=str(args.environment) if args.environment else None,
+            binding_mode=str(args.binding_mode),
+            repo_root=root,
+            secrets_dir=secrets,
+            state_path=state,
+            existing_agent_id=args.existing_agent_id or None,
+            existing_run_id=args.existing_run_id or None,
+            dashboard_observations=dash if isinstance(dash, dict) else None,
+        )
+    except CursorPreflightError as exc:
+        print(f"INVALID {exc.code}: {exc.message}", file=sys.stderr)
+        return EXIT_ERROR
+    _print_json(report)
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    return EXIT_OK if report.get("ready_for_live_run") is True else EXIT_HOLD
+
+
 def _approval_exit_code(recommendation: str) -> int:
     if recommendation == "APPROVE_RECOMMENDED":
         return EXIT_OK
@@ -1066,6 +1108,50 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_pilot_verify.add_argument("--report", required=True)
     p_pilot_verify.set_defaults(func=cmd_pilot_verify)
+
+    p_pilot_pf = pilot_sub.add_parser(
+        "cursor-preflight",
+        help=(
+            "Dashboardless Cursor live preflight (official API+gh+environment.json; "
+            "zero creates; Refs #4258)"
+        ),
+    )
+    p_pilot_pf.add_argument(
+        "--repository",
+        default="jannekbuengener/Claire_de_Binare",
+        help="owner/name repository",
+    )
+    p_pilot_pf.add_argument(
+        "--environment",
+        default="jannekbuengener/Claire_de_Binare",
+        help="Requested cloud environment name (supporting; see --binding-mode)",
+    )
+    p_pilot_pf.add_argument(
+        "--binding-mode",
+        choices=("repos_plus_repo_config", "named_cloud_env"),
+        default="repos_plus_repo_config",
+        help="Official create binding: repos+environment.json (default) or named env",
+    )
+    p_pilot_pf.add_argument(
+        "--state", default=None, help="Optional local runstore path"
+    )
+    p_pilot_pf.add_argument("--out", default=None, help="Optional JSON report path")
+    p_pilot_pf.add_argument("--repo-root", default=None)
+    p_pilot_pf.add_argument("--secrets-dir", default=None)
+    p_pilot_pf.add_argument(
+        "--dashboard-observations",
+        default=None,
+        help="Optional JSON file with supporting (non-authoritative) dashboard notes",
+    )
+    p_pilot_pf.add_argument(
+        "--existing-agent-id",
+        default="bc-d1ba82b5-db1a-5040-b50a-2007040a65c7",
+    )
+    p_pilot_pf.add_argument(
+        "--existing-run-id",
+        default="run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+    )
+    p_pilot_pf.set_defaults(func=cmd_pilot_cursor_preflight)
 
     return parser
 

--- a/tools/agent_control/cli.py
+++ b/tools/agent_control/cli.py
@@ -532,15 +532,44 @@ def cmd_provider_archive(args: argparse.Namespace) -> int:
 
 
 def cmd_pilot_run(args: argparse.Namespace) -> int:
-    """Run mock-first ACP foundation pilot; never closes issues or live-dispatches."""
+    """Run ACP pilot (mock default; live Cursor only with Human-GO flags)."""
     from tools.agent_control.paths import REPO_ROOT
     from tools.agent_control.pilot import PilotError, run_pilot_from_path
     from tools.agent_control.pilot_report import PilotReportError
 
+    provider_id = str(getattr(args, "provider", "mock") or "mock")
+    human_go = bool(getattr(args, "human_go_live_cursor", False))
+    auto_create_pr = bool(getattr(args, "auto_create_pr", False))
+    if provider_id != "mock" and not human_go:
+        print(
+            "INVALID PILOT_HUMAN_GO_REQUIRED: "
+            "provider!=mock requires --human-go-live-cursor",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+    if auto_create_pr and not human_go:
+        print(
+            "INVALID PILOT_HUMAN_GO_REQUIRED: "
+            "--auto-create-pr requires --human-go-live-cursor",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
     try:
         root = Path(args.repo_root) if args.repo_root else REPO_ROOT
         out = Path(args.out) if args.out else None
-        report = run_pilot_from_path(Path(args.manifest), repo_root=root, out_path=out)
+        state = Path(args.state) if getattr(args, "state", None) else None
+        resume = getattr(args, "resume", None)
+        report = run_pilot_from_path(
+            Path(args.manifest),
+            repo_root=root,
+            out_path=out,
+            provider_id=provider_id,
+            human_go_live_cursor=human_go,
+            resume_run_id=resume,
+            state_path=state,
+            auto_create_pr=auto_create_pr,
+        )
     except (PilotError, PilotReportError, AgentControlError) as exc:
         print(f"INVALID {exc.code}: {exc.message}", file=sys.stderr)
         return EXIT_ERROR
@@ -988,13 +1017,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     pilot = sub.add_parser(
         "pilot",
-        help="Mock-first ACP E2E foundation pilot (#4258; Refs only, not Closes)",
+        help="ACP E2E pilot (#4258; mock default; live Cursor needs Human-GO; Refs only)",
     )
     pilot_sub = pilot.add_subparsers(dest="pilot_command", required=True)
 
     p_pilot_run = pilot_sub.add_parser(
         "run",
-        help="Run fixture/mock-first ACP chain and emit pilot report",
+        help="Run ACP pilot chain and emit pilot report (mock default)",
     )
     p_pilot_run.add_argument("--manifest", required=True)
     p_pilot_run.add_argument("--out", help="Optional report output path")
@@ -1002,6 +1031,32 @@ def build_parser() -> argparse.ArgumentParser:
         "--repo-root",
         default=None,
         help="Optional repo root (defaults to package REPO_ROOT)",
+    )
+    p_pilot_run.add_argument(
+        "--provider",
+        choices=("mock", "cursor-cloud-api"),
+        default="mock",
+        help="Provider adapter (default mock; cursor-cloud-api needs Human-GO)",
+    )
+    p_pilot_run.add_argument(
+        "--human-go-live-cursor",
+        action="store_true",
+        help="Explicit Human-GO for live Cursor cloud pilot (required when provider!=mock)",
+    )
+    p_pilot_run.add_argument(
+        "--resume",
+        default=None,
+        help="Resume an existing run_id from --state (skip dispatch)",
+    )
+    p_pilot_run.add_argument(
+        "--state",
+        default=None,
+        help="JsonFileRunStore path for live/resume persistence",
+    )
+    p_pilot_run.add_argument(
+        "--auto-create-pr",
+        action="store_true",
+        help="Optional Cursor autoCreatePR (requires --human-go-live-cursor)",
     )
     p_pilot_run.set_defaults(func=cmd_pilot_run)
 

--- a/tools/agent_control/credentials.py
+++ b/tools/agent_control/credentials.py
@@ -33,6 +33,8 @@ def cursor_api_key_present(
         for candidate in (
             secrets_dir / "CURSOR_API_KEY",
             secrets_dir / "CURSOR_API_KEY.txt",
+            # Operator alias used on Windows secret store (load into env before live).
+            secrets_dir / "CURSOR_API.txt",
         ):
             if candidate.is_file() and candidate.stat().st_size > 0:
                 return CredentialPresence(

--- a/tools/agent_control/credentials.py
+++ b/tools/agent_control/credentials.py
@@ -1,0 +1,41 @@
+"""Credential presence checks without reading secret values into logs."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CredentialPresence:
+    """Bool-only presence result; never carries secret material."""
+
+    name: str
+    present: bool
+    source: str  # env | file | missing
+
+
+def cursor_api_key_present(
+    *,
+    env: dict[str, str] | None = None,
+    secrets_dir: Path | None = None,
+) -> CredentialPresence:
+    """Return whether CURSOR_API_KEY exists as env or secrets file.
+
+    Does not return or log the secret value. File presence checks only the
+    basename ``CURSOR_API_KEY`` (or ``CURSOR_API_KEY.txt``) under secrets_dir.
+    """
+    environ = env if env is not None else os.environ
+    if "CURSOR_API_KEY" in environ and str(environ.get("CURSOR_API_KEY", "")).strip():
+        return CredentialPresence(name="CURSOR_API_KEY", present=True, source="env")
+    if secrets_dir is not None:
+        for candidate in (
+            secrets_dir / "CURSOR_API_KEY",
+            secrets_dir / "CURSOR_API_KEY.txt",
+        ):
+            if candidate.is_file() and candidate.stat().st_size > 0:
+                return CredentialPresence(
+                    name="CURSOR_API_KEY", present=True, source="file"
+                )
+    return CredentialPresence(name="CURSOR_API_KEY", present=False, source="missing")

--- a/tools/agent_control/cursor_preflight.py
+++ b/tools/agent_control/cursor_preflight.py
@@ -1,0 +1,838 @@
+"""Dashboardless Cursor live preflight (#4258).
+
+Uses only officially documented Cursor Cloud Agents API v1 surfaces,
+GitHub REST via ``gh``, and versioned ``.cursor/environment.json``.
+Never creates agents/runs and never calls private dashboard endpoints.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+from jsonschema import Draft202012Validator
+
+from tools.agent_control.credentials import cursor_api_key_present
+from tools.agent_control.environment.cursor_config import (
+    validate_cursor_environment_config,
+)
+from tools.agent_control.errors import DispatchError
+from tools.agent_control.evidence.redact import assert_no_secrets, sanitize_result_refs
+from tools.agent_control.paths import REPO_ROOT
+
+SCHEMA_ID = "cdb.cursor_live_preflight.v1"
+SCHEMA_VERSION = "1.0.0"
+SCHEMA_RELPATH = "docs/contracts/cdb_cursor_live_preflight.v1.schema.json"
+API_BASE = "https://api.cursor.com"
+CURSOR_GITHUB_APP_SLUG = "cursor"
+DEFAULT_REPO = "jannekbuengener/Claire_de_Binare"
+
+HttpGet = Callable[[str], tuple[int, Any]]
+GhApi = Callable[[list[str]], tuple[int, Any]]
+
+
+class CursorPreflightError(DispatchError):
+    """Fail-closed preflight error."""
+
+
+def _load_schema(repo_root: Path) -> dict[str, Any]:
+    return json.loads((repo_root / SCHEMA_RELPATH).read_text(encoding="utf-8"))
+
+
+def validate_preflight_report(
+    report: dict[str, Any], *, repo_root: Path | None = None
+) -> None:
+    root = repo_root or REPO_ROOT
+    validator = Draft202012Validator(_load_schema(root))
+    errors = sorted(validator.iter_errors(report), key=lambda e: list(e.path))
+    if errors:
+        err = errors[0]
+        loc = ".".join(str(p) for p in err.path) or "$"
+        raise CursorPreflightError(
+            "PREFLIGHT_SCHEMA_INVALID",
+            f"{loc}: {err.message}",
+        )
+    assert_no_secrets(report)
+
+
+def _check(
+    checks: list[dict[str, Any]],
+    check_id: str,
+    status: str,
+    **detail: Any,
+) -> None:
+    checks.append({"id": check_id, "status": status, "detail": detail})
+
+
+def _repo_https(owner_repo: str) -> str:
+    return f"https://github.com/{owner_repo}"
+
+
+def _normalize_repo_url(url: str | None) -> str | None:
+    if not url or not isinstance(url, str):
+        return None
+    text = url.strip().rstrip("/")
+    if text.startswith("github.com/"):
+        text = "https://" + text
+    parsed = urlparse(text)
+    path = (parsed.path or "").strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    if not path or "/" not in path:
+        return None
+    owner, name = path.split("/", 1)
+    return f"{owner}/{name}"
+
+
+def load_cursor_api_key_into_env(
+    *,
+    env: dict[str, str] | None = None,
+    secrets_dir: Path | None = None,
+) -> tuple[bool, dict[str, str]]:
+    """Load key into a copy of env for process-local use; never returns the value."""
+    environ = dict(env if env is not None else os.environ)
+    presence = cursor_api_key_present(env=environ, secrets_dir=secrets_dir)
+    if presence.present and environ.get("CURSOR_API_KEY", "").strip():
+        return True, environ
+    if secrets_dir is None:
+        return False, environ
+    for candidate in (
+        secrets_dir / "CURSOR_API_KEY",
+        secrets_dir / "CURSOR_API_KEY.txt",
+        secrets_dir / "CURSOR_API.txt",
+    ):
+        if candidate.is_file() and candidate.stat().st_size > 0:
+            # Presence already proven; load only into local environ copy.
+            environ["CURSOR_API_KEY"] = candidate.read_text(encoding="utf-8").strip()
+            return bool(environ["CURSOR_API_KEY"]), environ
+    return False, environ
+
+
+def _basic_auth_header(api_key: str) -> str:
+    token = base64.b64encode(f"{api_key}:".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def default_cursor_http_get(
+    path: str, *, api_key: str, timeout: float = 90.0
+) -> tuple[int, Any]:
+    req = urllib.request.Request(
+        f"{API_BASE}{path}",
+        headers={
+            "Authorization": _basic_auth_header(api_key),
+            "Accept": "application/json",
+            "User-Agent": "cdb-cursor-live-preflight/1",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            return int(resp.status), (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            body: Any = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            body = {"message": "non_json_error_body"}
+        return int(exc.code), body
+
+
+def default_gh_api(argv: list[str]) -> tuple[int, Any]:
+    completed = subprocess.run(
+        ["gh", "api", *argv],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    text = completed.stdout or completed.stderr or ""
+    try:
+        payload: Any = (
+            json.loads(text)
+            if text.strip().startswith(("{", "["))
+            else {"message": text.strip()[:500]}
+        )
+    except json.JSONDecodeError:
+        payload = {"message": text.strip()[:500]}
+    return int(completed.returncode), payload
+
+
+def extract_environment_identity(agent_or_env: dict[str, Any] | None) -> dict[str, Any]:
+    """Extract publicly documented env fields only (type/name)."""
+    src = agent_or_env or {}
+    env = src.get("env") if isinstance(src.get("env"), dict) else src
+    if not isinstance(env, dict):
+        return {
+            "type": None,
+            "name": None,
+            "environment_public_id": None,
+            "environment_version_public_id": None,
+        }
+    return {
+        "type": env.get("type"),
+        "name": env.get("name"),
+        # Official OpenAPI AgentEnv has no ID fields — always null.
+        "environment_public_id": env.get("environmentPublicId")
+        or env.get("environment_public_id"),
+        "environment_version_public_id": env.get("environmentVersionPublicId")
+        or env.get("environment_version_public_id"),
+    }
+
+
+def evaluate_named_environment_selection(
+    *,
+    requested_name: str | None,
+    resolved: dict[str, Any] | None,
+    list_environments_http: int | None,
+    dashboard_duplicate_names: bool,
+) -> tuple[str, list[dict[str, Any]], list[str]]:
+    """Return selection status, public_api_gaps, limitations."""
+    gaps: list[dict[str, Any]] = []
+    limitations: list[str] = []
+    if list_environments_http in {404, 405} or list_environments_http is None:
+        gaps.append(
+            {
+                "id": "PUBLIC_API_GAP_ENVIRONMENT_LIST",
+                "surface": "GET /v1/environments (not in OpenAPI)",
+                "impact": "Cannot enumerate cloud environments or detect duplicate names via public API",
+                "evidence": f"probe_http={list_environments_http}",
+            }
+        )
+    gaps.append(
+        {
+            "id": "PUBLIC_API_GAP_ENVIRONMENT_IMMUTABLE_ID",
+            "surface": "AgentEnv / CreateAgentRequest.env",
+            "impact": "Official schema supports only env.type + env.name; no environmentPublicId/version binding",
+            "evidence": "openapi_AgentEnv_type_name_only",
+        }
+    )
+    if not requested_name:
+        return "UNKNOWN", gaps, limitations + ["no_environment_name_requested"]
+    resolved = resolved or {}
+    resolved_name = resolved.get("name")
+    resolved_id = resolved.get("environment_public_id")
+    if dashboard_duplicate_names and not resolved_id:
+        limitations.append("dashboard_duplicate_environment_names_observed")
+        return "BLOCKED", gaps, limitations
+    if resolved_name is None and resolved_id is None:
+        limitations.append("resolved_environment_identity_missing_from_agent_response")
+        return "UNKNOWN", gaps, limitations
+    if resolved_name is not None and resolved_name != requested_name:
+        return (
+            "BLOCKED",
+            gaps,
+            limitations + ["requested_resolved_environment_mismatch"],
+        )
+    if resolved_name == requested_name and not dashboard_duplicate_names:
+        return "PASS", gaps, limitations
+    # Name matched but duplicates or no ID → not deterministic.
+    return "BLOCKED", gaps, limitations + ["environment_name_not_unique_without_id"]
+
+
+def run_cursor_live_preflight(
+    *,
+    repository: str = DEFAULT_REPO,
+    environment_name: str | None = "jannekbuengener/Claire_de_Binare",
+    binding_mode: str = "repos_plus_repo_config",
+    repo_root: Path | None = None,
+    secrets_dir: Path | None = None,
+    state_path: Path | None = None,
+    existing_agent_id: str | None = "bc-d1ba82b5-db1a-5040-b50a-2007040a65c7",
+    existing_run_id: str | None = "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+    dashboard_observations: dict[str, Any] | None = None,
+    credential_env: dict[str, str] | None = None,
+    http_get: HttpGet | None = None,
+    gh_api: GhApi | None = None,
+) -> dict[str, Any]:
+    """Execute read-only preflight; never POST to Cursor or write to GitHub."""
+    root = (repo_root or REPO_ROOT).resolve()
+    checks: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    consent: list[dict[str, Any]] = []
+    limitations: list[str] = [
+        "dashboardless_preflight_only",
+        "no_cursor_create",
+        "no_github_writes",
+        "refs_4258_not_closes",
+    ]
+    cursor_gets = 0
+    cursor_posts = 0
+    github_writes = 0
+
+    secrets = secrets_dir or Path.home() / "Documents" / ".secrets" / ".cdb"
+    present, environ = load_cursor_api_key_into_env(
+        env=credential_env, secrets_dir=secrets
+    )
+    _check(
+        checks,
+        "credential_presence",
+        "PASS" if present else "BLOCKED",
+        credential_present=present,
+    )
+    if not present:
+        report = _finalize_report(
+            repository=repository,
+            cursor_account={"api_reachable": False},
+            credential_present=False,
+            environment_requested={
+                "binding_mode": binding_mode,
+                "name": environment_name,
+            },
+            environment_resolved=None,
+            environment_version=None,
+            environment_selection_status="UNKNOWN",
+            repo_config_status="UNKNOWN",
+            github_app_status="UNKNOWN",
+            github_permissions={},
+            existing_run_status="UNKNOWN",
+            public_api_gaps=gaps,
+            manual_consent_boundaries=consent,
+            ready_for_live_run=False,
+            limitations=limitations + ["credential_missing"],
+            checks=checks,
+            binding_mode=binding_mode,
+            cursor_http_gets=0,
+            cursor_http_posts=0,
+            github_writes=0,
+            dashboard_observations=dashboard_observations,
+            repo_root=root,
+        )
+        return report
+
+    api_key = environ["CURSOR_API_KEY"]
+
+    def do_get(path: str) -> tuple[int, Any]:
+        nonlocal cursor_gets
+        cursor_gets += 1
+        if http_get is not None:
+            return http_get(path)
+        return default_cursor_http_get(path, api_key=api_key)
+
+    def do_gh(argv: list[str]) -> tuple[int, Any]:
+        if gh_api is not None:
+            return gh_api(argv)
+        return default_gh_api(argv)
+
+    # --- Cursor /v1/me ---
+    me_status, me_body = do_get("/v1/me")
+    cursor_account: dict[str, Any] = {"http": me_status}
+    if isinstance(me_body, dict):
+        cursor_account["api_key_name"] = me_body.get("apiKeyName")
+        cursor_account["user_id"] = me_body.get("userId")
+        cursor_account["created_at"] = me_body.get("createdAt")
+    _check(
+        checks,
+        "cursor_me",
+        "PASS" if me_status == 200 else "BLOCKED",
+        http=me_status,
+    )
+
+    # --- models ---
+    models_status, models_body = do_get("/v1/models")
+    model_items = []
+    if isinstance(models_body, dict):
+        raw_items = models_body.get("items") or models_body.get("models") or []
+        if isinstance(raw_items, list):
+            model_items = raw_items
+    _check(
+        checks,
+        "cursor_models",
+        "PASS" if models_status == 200 and model_items else "BLOCKED",
+        http=models_status,
+        count=len(model_items),
+    )
+
+    # --- repositories (rate limited) ---
+    repos_status, repos_body = do_get("/v1/repositories")
+    listed: list[str] = []
+    if isinstance(repos_body, dict):
+        items = repos_body.get("items") or repos_body.get("repositories") or []
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict):
+                    norm = _normalize_repo_url(
+                        item.get("url") or item.get("repository") or item.get("name")
+                    )
+                elif isinstance(item, str):
+                    norm = _normalize_repo_url(item)
+                else:
+                    norm = None
+                if norm:
+                    listed.append(norm)
+    target_listed = repository.lower() in {x.lower() for x in listed}
+    _check(
+        checks,
+        "cursor_repositories",
+        "PASS" if repos_status == 200 and target_listed else "BLOCKED",
+        http=repos_status,
+        count=len(listed),
+        target_listed=target_listed,
+    )
+
+    # --- probe environment list (expected PUBLIC_API_GAP) ---
+    env_list_status, _env_list_body = do_get("/v1/environments")
+    _check(
+        checks,
+        "cursor_environment_list",
+        "UNKNOWN" if env_list_status == 404 else "PARTIAL",
+        http=env_list_status,
+        note="not_in_official_openapi",
+    )
+
+    # --- existing agent/run (immutable evidence; read-only) ---
+    existing_run_status = "PASS"
+    environment_resolved: dict[str, Any] | None = None
+    if existing_agent_id:
+        ag_status, ag_body = do_get(f"/v1/agents/{existing_agent_id}")
+        if ag_status == 200 and isinstance(ag_body, dict):
+            environment_resolved = extract_environment_identity(ag_body)
+            run_state = None
+            if existing_run_id:
+                run_http, run_body = do_get(
+                    f"/v1/agents/{existing_agent_id}/runs/{existing_run_id}"
+                )
+                if run_http == 200 and isinstance(run_body, dict):
+                    run_state = run_body.get("status")
+            active = str(ag_body.get("status") or "").upper() == "ACTIVE"
+            terminal = str(run_state or "").upper() in {
+                "ERROR",
+                "FINISHED",
+                "CANCELLED",
+                "EXPIRED",
+            }
+            if active and run_state and not terminal:
+                existing_run_status = "BLOCKED"
+                limitations.append("existing_non_terminal_run")
+            elif str(run_state or "").upper() == "ERROR":
+                existing_run_status = "PARTIAL"
+                limitations.append("prior_run_error_immutable_evidence")
+            _check(
+                checks,
+                "existing_agent_run",
+                existing_run_status,
+                agent_http=ag_status,
+                agent_status=ag_body.get("status"),
+                run_status=run_state,
+                autoCreatePR=ag_body.get("autoCreatePR"),
+                repos=ag_body.get("repos"),
+                env=environment_resolved,
+            )
+        else:
+            existing_run_status = "UNKNOWN"
+            _check(
+                checks,
+                "existing_agent_run",
+                "UNKNOWN",
+                agent_http=ag_status,
+            )
+    else:
+        _check(checks, "existing_agent_run", "PASS", note="no_existing_ids")
+
+    dash = dashboard_observations or {}
+    dash_envs = (
+        dash.get("environments") if isinstance(dash.get("environments"), list) else []
+    )
+    duplicate_names = False
+    if environment_name and isinstance(dash_envs, list):
+        names = [
+            (e.get("repository") or e.get("name") or "")
+            for e in dash_envs
+            if isinstance(e, dict)
+        ]
+        duplicate_names = (
+            names.count(environment_name) >= 2 or names.count(repository) >= 2
+        )
+    if dash.get("ambiguity") == "two active environments with the same visible name":
+        duplicate_names = True
+
+    env_requested = {
+        "binding_mode": binding_mode,
+        "type": "cloud",
+        "name": environment_name,
+        "repository": repository,
+        "starting_ref": "main",
+    }
+
+    if binding_mode == "named_cloud_env":
+        selection_status, env_gaps, env_limits = evaluate_named_environment_selection(
+            requested_name=environment_name,
+            resolved=environment_resolved,
+            list_environments_http=env_list_status,
+            dashboard_duplicate_names=duplicate_names,
+        )
+        gaps.extend(env_gaps)
+        limitations.extend(env_limits)
+    else:
+        # Official path: repos XOR named env. Prefer repos + .cursor/environment.json.
+        gaps.append(
+            {
+                "id": "PUBLIC_API_GAP_ENVIRONMENT_LIST",
+                "surface": "GET /v1/environments (not in OpenAPI)",
+                "impact": "Named dashboard environments cannot be listed or disambiguated via public API",
+                "evidence": f"probe_http={env_list_status}",
+            }
+        )
+        gaps.append(
+            {
+                "id": "PUBLIC_API_GAP_ENVIRONMENT_IMMUTABLE_ID",
+                "surface": "AgentEnv",
+                "impact": "Cannot bind environmentPublicId/version; create uses repos + repo environment.json resolution",
+                "evidence": "openapi_AgentEnv_type_name_only_mutual_exclusive_with_repos",
+            }
+        )
+        if duplicate_names:
+            limitations.append(
+                "dashboard_duplicate_named_environments_ignored_for_repos_binding"
+            )
+        # Selection for repos mode is PASS when we will send explicit repos URL
+        # (deterministic request). Resolved identity may still be UNKNOWN.
+        selection_status = "PASS"
+        if environment_resolved and not environment_resolved.get("name"):
+            selection_status = "PARTIAL"
+            limitations.append(
+                "agent_response_env_lacks_name_public_api_cannot_verify_named_resolution"
+            )
+
+    _check(
+        checks,
+        "environment_selection",
+        selection_status,
+        binding_mode=binding_mode,
+        requested=env_requested,
+        resolved=environment_resolved,
+        duplicate_names_observed=duplicate_names,
+    )
+
+    # --- repo config as code ---
+    repo_config_status = "UNKNOWN"
+    environment_version: str | None = None
+    try:
+        cfg = validate_cursor_environment_config(root)
+        environment_version = str(cfg.get("digest") or cfg.get("config_digest") or "")
+        dockerfile = (cfg.get("payload") or {}).get("build", {}).get("dockerfile")
+        install = (cfg.get("payload") or {}).get("install")
+        # Ensure dockerfile exists relative to .cursor/
+        env_json = root / ".cursor" / "environment.json"
+        df_ok = False
+        if isinstance(dockerfile, str):
+            df_path = (env_json.parent / dockerfile).resolve()
+            df_ok = df_path.is_file() and str(df_path).startswith(str(root))
+        repo_config_status = "PASS" if df_ok and install else "BLOCKED"
+        _check(
+            checks,
+            "repo_environment_config",
+            repo_config_status,
+            digest=environment_version,
+            dockerfile=dockerfile,
+            dockerfile_exists=df_ok,
+            install_present=bool(install),
+            agentCanUpdateSnapshot=(cfg.get("payload") or {}).get(
+                "agentCanUpdateSnapshot"
+            ),
+        )
+    except DispatchError as exc:
+        repo_config_status = "BLOCKED"
+        _check(
+            checks,
+            "repo_environment_config",
+            "BLOCKED",
+            code=exc.code,
+            message=exc.message,
+        )
+
+    # --- GitHub repo + branch protection (read-only) ---
+    gh_repo_rc, gh_repo = do_gh([f"repos/{repository}"])
+    default_branch = None
+    if gh_repo_rc == 0 and isinstance(gh_repo, dict):
+        default_branch = gh_repo.get("default_branch")
+    _check(
+        checks,
+        "github_repository",
+        "PASS" if gh_repo_rc == 0 and default_branch == "main" else "BLOCKED",
+        returncode=gh_repo_rc,
+        default_branch=default_branch,
+    )
+
+    prot_rc, prot = do_gh([f"repos/{repository}/branches/main/protection"])
+    block_creations = None
+    if isinstance(prot, dict):
+        block_creations = (prot.get("block_creations") or {}).get("enabled")
+    # 403 may mean protection readable only to admins — still try
+    _check(
+        checks,
+        "github_branch_creation_gate",
+        (
+            "PASS"
+            if block_creations is False
+            else ("PARTIAL" if prot_rc != 0 else "BLOCKED")
+        ),
+        block_creations=block_creations,
+        returncode=prot_rc,
+    )
+
+    # --- GitHub App: public app manifest + installation (often unreadable) ---
+    app_rc, app_body = do_gh([f"apps/{CURSOR_GITHUB_APP_SLUG}"])
+    app_perms: dict[str, Any] = {}
+    if app_rc == 0 and isinstance(app_body, dict):
+        app_perms = app_body.get("permissions") or {}
+    contents_level = app_perms.get("contents")
+    pr_level = app_perms.get("pull_requests")
+    _check(
+        checks,
+        "github_app_manifest_permissions",
+        (
+            "PASS"
+            if contents_level == "write" and pr_level == "write"
+            else ("BLOCKED" if app_rc == 0 else "UNKNOWN")
+        ),
+        app_slug=CURSOR_GITHUB_APP_SLUG,
+        contents=contents_level,
+        pull_requests=pr_level,
+        note="manifest_requested_permissions_not_installation_grant",
+    )
+
+    inst_rc, inst_body = do_gh([f"repos/{repository}/installation"])
+    github_app_status = "UNKNOWN"
+    installation_id = None
+    installation_suspended = None
+    installation_repo_selection = None
+    if inst_rc == 0 and isinstance(inst_body, dict) and inst_body.get("id"):
+        installation_id = inst_body.get("id")
+        installation_suspended = inst_body.get("suspended_at")
+        installation_repo_selection = inst_body.get("repository_selection")
+        perms = inst_body.get("permissions") or {}
+        c = perms.get("contents")
+        p = perms.get("pull_requests")
+        if installation_suspended:
+            github_app_status = "BLOCKED"
+        elif c == "write" and p == "write":
+            github_app_status = "PASS"
+        elif c == "read" or p == "read":
+            github_app_status = "BLOCKED"
+        else:
+            github_app_status = "UNKNOWN"
+        _check(
+            checks,
+            "github_app_installation",
+            github_app_status,
+            installation_id=installation_id,
+            suspended=bool(installation_suspended),
+            repository_selection=installation_repo_selection,
+            contents=c,
+            pull_requests=p,
+        )
+    else:
+        gaps.append(
+            {
+                "id": "PUBLIC_API_GAP_GITHUB_INSTALLATION_READ",
+                "surface": "GET /repos/{owner}/{repo}/installation",
+                "impact": "User gh token cannot read Cursor GitHub App installation permissions; requires GitHub App JWT or user-to-server token for that App",
+                "evidence": f"returncode={inst_rc} message={(inst_body or {}).get('message') if isinstance(inst_body, dict) else None}",
+            }
+        )
+        consent.append(
+            {
+                "id": "GITHUB_APP_INSTALLATION_PERMISSION_READ",
+                "boundary": "GitHub does not allow arbitrary OAuth user tokens to introspect another App's installation permission grant",
+                "why_not_automatable": "Reading installation permissions requires credentials belonging to the Cursor GitHub App (JWT) or a user-to-server token authorized for that App",
+            }
+        )
+        github_app_status = "UNKNOWN"
+        _check(
+            checks,
+            "github_app_installation",
+            "UNKNOWN",
+            returncode=inst_rc,
+            message=(
+                (inst_body or {}).get("message")
+                if isinstance(inst_body, dict)
+                else None
+            ),
+        )
+
+    # Supporting (not sufficient): Cursor repositories list includes target.
+    if target_listed:
+        limitations.append(
+            "cursor_repositories_lists_target_supporting_not_permission_proof"
+        )
+
+    # Dashboard observations are supporting only.
+    if dash:
+        limitations.append("dashboard_observations_supporting_not_machine_truth")
+        if dash.get("create_prs"):
+            limitations.append(
+                "dashboard_create_prs_ignored_api_autoCreatePR_is_source_of_truth"
+            )
+
+    # Network / routing policy — no public management API
+    gaps.append(
+        {
+            "id": "PUBLIC_API_GAP_NETWORK_POLICY",
+            "surface": "Cloud Agents API v1",
+            "impact": "No public endpoint to read or set network access policy",
+            "evidence": "openapi_no_network_policy_paths",
+        }
+    )
+    gaps.append(
+        {
+            "id": "PUBLIC_API_GAP_ROUTING_RULES",
+            "surface": "Cloud Agents API v1",
+            "impact": "No public endpoint to manage dashboard routing rules; API create uses explicit repos/env",
+            "evidence": "openapi_create_uses_repos_or_env",
+        }
+    )
+    gaps.append(
+        {
+            "id": "PUBLIC_API_GAP_PR_POLICY_ACCOUNT",
+            "surface": "Cloud Agents API v1",
+            "impact": "Account-level Create PR dashboard setting not readable; use request field autoCreatePR",
+            "evidence": "CreateAgentRequest.autoCreatePR",
+        }
+    )
+
+    # State / idempotency
+    state_status = "PASS"
+    if state_path is not None and Path(state_path).is_file():
+        try:
+            state_obj = json.loads(Path(state_path).read_text(encoding="utf-8"))
+            # JsonFileRunStore may be dict of runs
+            if isinstance(state_obj, dict):
+                for run in (
+                    state_obj.values() if not state_obj.get("run_id") else [state_obj]
+                ):
+                    if not isinstance(run, dict):
+                        continue
+                    st = str(run.get("state") or run.get("last_provider_status") or "")
+                    if st in {"RUNNING", "DISPATCHED", "CREATING"}:
+                        state_status = "BLOCKED"
+                        limitations.append("unresolved_active_local_state")
+        except (OSError, json.JSONDecodeError):
+            state_status = "PARTIAL"
+    _check(
+        checks,
+        "local_state_idempotency",
+        state_status,
+        state_path=str(state_path) if state_path else None,
+    )
+
+    # ready_for_live_run — UNKNOWN/BLOCKED never PASS; github UNKNOWN fails closed
+    blocking = [
+        c
+        for c in checks
+        if c["id"]
+        in {
+            "credential_presence",
+            "cursor_me",
+            "cursor_models",
+            "cursor_repositories",
+            "repo_environment_config",
+            "github_repository",
+        }
+        and c["status"] == "BLOCKED"
+    ]
+    if selection_status == "BLOCKED":
+        blocking.append({"id": "environment_selection", "status": "BLOCKED"})
+    if github_app_status in {"BLOCKED", "UNKNOWN"}:
+        blocking.append({"id": "github_app_installation", "status": github_app_status})
+    if existing_run_status == "BLOCKED" or state_status == "BLOCKED":
+        blocking.append({"id": "active_run_or_state", "status": "BLOCKED"})
+
+    ready = me_status == 200 and present and target_listed and not blocking
+    # Explicit: unknown github install never ready
+    if github_app_status != "PASS":
+        ready = False
+        limitations.append("ready_blocked_github_installation_not_proven")
+    if selection_status in {"BLOCKED", "UNKNOWN"} and binding_mode == "named_cloud_env":
+        ready = False
+        limitations.append("ready_blocked_named_environment_not_deterministic")
+    if binding_mode == "repos_plus_repo_config" and repo_config_status != "PASS":
+        ready = False
+    if cursor_posts != 0 or github_writes != 0:
+        ready = False
+
+    # Deduplicate gaps by id
+    seen = set()
+    uniq_gaps = []
+    for g in gaps:
+        if g["id"] in seen:
+            continue
+        seen.add(g["id"])
+        uniq_gaps.append(g)
+
+    report = _finalize_report(
+        repository=repository,
+        cursor_account=cursor_account,
+        credential_present=True,
+        environment_requested=env_requested,
+        environment_resolved=environment_resolved,
+        environment_version=environment_version or None,
+        environment_selection_status=selection_status,
+        repo_config_status=repo_config_status,
+        github_app_status=github_app_status,
+        github_permissions={
+            "app_slug": CURSOR_GITHUB_APP_SLUG,
+            "manifest_contents": contents_level,
+            "manifest_pull_requests": pr_level,
+            "installation_id": installation_id,
+            "installation_readable": inst_rc == 0 and bool(installation_id),
+            "installation_suspended": installation_suspended,
+            "repository_selection": installation_repo_selection,
+            "default_branch": default_branch,
+            "block_creations": block_creations,
+        },
+        existing_run_status=existing_run_status,
+        public_api_gaps=uniq_gaps,
+        manual_consent_boundaries=consent,
+        ready_for_live_run=ready,
+        limitations=sorted(set(limitations)),
+        checks=checks,
+        binding_mode=binding_mode,
+        cursor_http_gets=cursor_gets,
+        cursor_http_posts=cursor_posts,
+        github_writes=github_writes,
+        dashboard_observations=dashboard_observations,
+        repo_root=root,
+    )
+    # Clear key from local environ copy reference (caller env untouched if copy).
+    environ.pop("CURSOR_API_KEY", None)
+    return report
+
+
+def _finalize_report(**kwargs: Any) -> dict[str, Any]:
+    repo_root: Path = kwargs.pop("repo_root")
+    report = {
+        "schema_id": SCHEMA_ID,
+        "schema_version": SCHEMA_VERSION,
+        "repository": kwargs["repository"],
+        "cursor_account": kwargs["cursor_account"],
+        "credential_present": kwargs["credential_present"],
+        "environment_requested": kwargs["environment_requested"],
+        "environment_resolved": kwargs["environment_resolved"],
+        "environment_version": kwargs["environment_version"],
+        "environment_selection_status": kwargs["environment_selection_status"],
+        "repo_config_status": kwargs["repo_config_status"],
+        "github_app_status": kwargs["github_app_status"],
+        "github_permissions": kwargs["github_permissions"],
+        "existing_run_status": kwargs["existing_run_status"],
+        "public_api_gaps": kwargs["public_api_gaps"],
+        "manual_consent_boundaries": kwargs["manual_consent_boundaries"],
+        "ready_for_live_run": kwargs["ready_for_live_run"],
+        "limitations": kwargs["limitations"],
+        "checks": kwargs["checks"],
+        "binding_mode": kwargs["binding_mode"],
+        "cursor_http_gets": kwargs["cursor_http_gets"],
+        "cursor_http_posts": kwargs["cursor_http_posts"],
+        "github_writes": kwargs["github_writes"],
+        "dashboard_observations": kwargs.get("dashboard_observations"),
+    }
+    # Strip any accidental secrets
+    report = sanitize_result_refs(report)
+    validate_preflight_report(report, repo_root=repo_root)
+    return report

--- a/tools/agent_control/delivery_verify.py
+++ b/tools/agent_control/delivery_verify.py
@@ -1,0 +1,234 @@
+"""GitHub-backed delivery target verification for live Cursor pilots."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from tools.agent_control.errors import DispatchError
+
+SHA40 = re.compile(r"^[a-f0-9]{40}$")
+GhRunner = Callable[[list[str]], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class DeliveryVerification:
+    ok: bool
+    head_sha: str | None
+    base_sha: str | None
+    pr_number: int | None
+    branch: str | None
+    repo: str | None
+    changed_files: list[str]
+    code: str | None = None
+    message: str | None = None
+
+
+def _default_gh_runner(argv: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(
+        argv,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise DispatchError(
+            "DELIVERY_GITHUB_QUERY_FAILED",
+            (completed.stderr or completed.stdout or "gh failed")[:500],
+        )
+    return json.loads(completed.stdout)
+
+
+def verify_github_delivery(
+    *,
+    expected_repo: str,
+    pr_number: int | None = None,
+    branch: str | None = None,
+    expected_paths_prefix: list[str] | None = None,
+    allow_empty: bool = False,
+    runner: GhRunner | None = None,
+) -> DeliveryVerification:
+    """Verify PR/branch exists on expected repo and bind head/base SHAs.
+
+    ``expected_repo`` is ``owner/name``. Never accepts a foreign repo.
+    """
+    run = runner or _default_gh_runner
+    if not expected_repo or "/" not in expected_repo:
+        return DeliveryVerification(
+            ok=False,
+            head_sha=None,
+            base_sha=None,
+            pr_number=pr_number,
+            branch=branch,
+            repo=expected_repo,
+            changed_files=[],
+            code="DELIVERY_REPO_INVALID",
+            message="expected_repo must be owner/name",
+        )
+
+    if pr_number is None and not branch:
+        return DeliveryVerification(
+            ok=False,
+            head_sha=None,
+            base_sha=None,
+            pr_number=None,
+            branch=None,
+            repo=expected_repo,
+            changed_files=[],
+            code="DELIVERY_TARGET_MISSING",
+            message="pr_number or branch required",
+        )
+
+    if pr_number is not None:
+        data = run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                expected_repo,
+                "--json",
+                "number,state,headRefOid,baseRefOid,headRefName,files,url,headRepository",
+            ]
+        )
+        head = data.get("headRefOid")
+        base = data.get("baseRefOid")
+        br = data.get("headRefName")
+        files_raw = data.get("files") or []
+        files = [
+            f.get("path")
+            for f in files_raw
+            if isinstance(f, dict) and isinstance(f.get("path"), str)
+        ]
+        if not isinstance(head, str) or not SHA40.match(head):
+            return DeliveryVerification(
+                ok=False,
+                head_sha=None,
+                base_sha=base if isinstance(base, str) else None,
+                pr_number=int(data.get("number") or pr_number),
+                branch=br if isinstance(br, str) else branch,
+                repo=expected_repo,
+                changed_files=files,
+                code="DELIVERY_HEAD_INVALID",
+                message="PR head SHA missing or not 40-hex",
+            )
+        if not files and not allow_empty:
+            return DeliveryVerification(
+                ok=False,
+                head_sha=head,
+                base_sha=base if isinstance(base, str) else None,
+                pr_number=int(data.get("number") or pr_number),
+                branch=br if isinstance(br, str) else branch,
+                repo=expected_repo,
+                changed_files=[],
+                code="DELIVERY_EMPTY",
+                message="PR has no changed files",
+            )
+        if expected_paths_prefix:
+            bad = [
+                p
+                for p in files
+                if not any(
+                    p == pref or p.startswith(pref.rstrip("*"))
+                    for pref in expected_paths_prefix
+                )
+                and not any(_globish_match(p, pref) for pref in expected_paths_prefix)
+            ]
+            # Soft prefix: allow if every file starts with at least one allowlist root
+            allow_roots = [p.rstrip("/*") for p in expected_paths_prefix]
+            bad = [
+                p
+                for p in files
+                if not any(p == r or p.startswith(r + "/") for r in allow_roots)
+            ]
+            if bad:
+                return DeliveryVerification(
+                    ok=False,
+                    head_sha=head,
+                    base_sha=base if isinstance(base, str) else None,
+                    pr_number=int(data.get("number") or pr_number),
+                    branch=br if isinstance(br, str) else branch,
+                    repo=expected_repo,
+                    changed_files=files,
+                    code="DELIVERY_SCOPE_DRIFT",
+                    message=f"files outside allowlist: {bad[:5]}",
+                )
+        return DeliveryVerification(
+            ok=True,
+            head_sha=head,
+            base_sha=base if isinstance(base, str) else None,
+            pr_number=int(data.get("number") or pr_number),
+            branch=br if isinstance(br, str) else branch,
+            repo=expected_repo,
+            changed_files=files,
+        )
+
+    # Branch-only verification via gh api
+    data = run(
+        [
+            "gh",
+            "api",
+            f"repos/{expected_repo}/branches/{branch}",
+        ]
+    )
+    commit = (data.get("commit") or {}).get("sha")
+    if not isinstance(commit, str) or not SHA40.match(commit):
+        return DeliveryVerification(
+            ok=False,
+            head_sha=None,
+            base_sha=None,
+            pr_number=None,
+            branch=branch,
+            repo=expected_repo,
+            changed_files=[],
+            code="DELIVERY_HEAD_INVALID",
+            message="branch tip SHA missing or not 40-hex",
+        )
+    return DeliveryVerification(
+        ok=True,
+        head_sha=commit,
+        base_sha=None,
+        pr_number=None,
+        branch=branch,
+        repo=expected_repo,
+        changed_files=[],
+    )
+
+
+def _globish_match(path: str, pattern: str) -> bool:
+    if pattern.endswith("/*"):
+        root = pattern[:-2]
+        return path == root or path.startswith(root + "/")
+    return path == pattern
+
+
+def normalize_cursor_git_branches(
+    result_refs: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Extract branch/prUrl from Cursor result_refs without inventing commits."""
+    refs = result_refs or {}
+    git = refs.get("git") if isinstance(refs.get("git"), dict) else {}
+    branches = git.get("branches") if isinstance(git.get("branches"), list) else []
+    out: dict[str, Any] = {"branch": None, "pr_url": None, "repo_url": None}
+    if not branches:
+        return out
+    first = branches[0]
+    if not isinstance(first, dict):
+        return out
+    out["branch"] = first.get("branch")
+    out["pr_url"] = first.get("prUrl") or first.get("pr_url")
+    out["repo_url"] = first.get("repoUrl") or first.get("repo_url")
+    return out
+
+
+def pr_number_from_url(pr_url: str | None) -> int | None:
+    if not pr_url or not isinstance(pr_url, str):
+        return None
+    m = re.search(r"/pull/(\d+)", pr_url)
+    if not m:
+        return None
+    return int(m.group(1))

--- a/tools/agent_control/delivery_verify.py
+++ b/tools/agent_control/delivery_verify.py
@@ -211,6 +211,15 @@ def normalize_cursor_git_branches(
 ) -> dict[str, Any]:
     """Extract branch/prUrl from Cursor result_refs without inventing commits."""
     refs = result_refs or {}
+    claimed = refs.get("claimed_delivery")
+    if isinstance(claimed, dict) and (
+        claimed.get("branch") or claimed.get("pr_url") or claimed.get("repo_url")
+    ):
+        return {
+            "branch": claimed.get("branch"),
+            "pr_url": claimed.get("pr_url"),
+            "repo_url": claimed.get("repo_url"),
+        }
     git = refs.get("git") if isinstance(refs.get("git"), dict) else {}
     branches = git.get("branches") if isinstance(git.get("branches"), list) else []
     out: dict[str, Any] = {"branch": None, "pr_url": None, "repo_url": None}
@@ -223,6 +232,35 @@ def normalize_cursor_git_branches(
     out["pr_url"] = first.get("prUrl") or first.get("pr_url")
     out["repo_url"] = first.get("repoUrl") or first.get("repo_url")
     return out
+
+
+def claimed_delivery_from_git(git: dict[str, Any] | None) -> dict[str, Any]:
+    """Cursor-claimed git snapshot only — never implies GitHub verification."""
+    git = git if isinstance(git, dict) else {}
+    branches = git.get("branches") if isinstance(git.get("branches"), list) else []
+    out: dict[str, Any] = {
+        "branch": None,
+        "pr_url": None,
+        "repo_url": None,
+        "source": "run.git",
+        "delivery_verified": False,
+    }
+    if not branches or not isinstance(branches[0], dict):
+        return out
+    first = branches[0]
+    out["branch"] = first.get("branch")
+    out["pr_url"] = first.get("prUrl") or first.get("pr_url")
+    out["repo_url"] = first.get("repoUrl") or first.get("repo_url")
+    return out
+
+
+def truncate_run_result_text(value: Any, *, limit: int = 2000) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "...[truncated]"
 
 
 def pr_number_from_url(pr_url: str | None) -> int | None:

--- a/tools/agent_control/dispatch.py
+++ b/tools/agent_control/dispatch.py
@@ -398,6 +398,9 @@ def dispatch_run(
     dry_run: bool = True,
     allow_mock_dispatch: bool = False,
     allow_recorded_cursor: bool = False,
+    allow_live_cursor: bool = False,
+    human_go_live_cursor: bool = False,
+    auto_create_pr: bool = False,
     scenario: str = "success",
     clock: Clock | None = None,
     provider: Provider | None = None,
@@ -423,10 +426,12 @@ def dispatch_run(
             "execute requires a RunStore",
         )
 
-    if not allow_mock_dispatch and not allow_recorded_cursor:
+    live_ok = bool(allow_live_cursor and human_go_live_cursor)
+    if not allow_mock_dispatch and not allow_recorded_cursor and not live_ok:
         raise DispatchError(
             "PROVIDER_LIVE_DISPATCH_FORBIDDEN",
-            "execute requires --allow-mock-dispatch or recorded/fake Cursor transport",
+            "execute requires --allow-mock-dispatch, recorded/fake Cursor "
+            "transport, or Human-GO live cursor flags",
         )
 
     pf = preflight(
@@ -435,6 +440,8 @@ def dispatch_run(
         agent_id,
         execute=True,
         allow_recorded_cursor=allow_recorded_cursor,
+        allow_live_cursor=allow_live_cursor,
+        human_go_live_cursor=human_go_live_cursor,
         prompt_text_override=prompt_text_override,
         environment_attestation_path=environment_attestation_path,
     )
@@ -511,10 +518,11 @@ def dispatch_run(
         not isinstance(active_provider, MockProvider)
         and pf.provider_id != "mock"
         and not allow_recorded_cursor
+        and not live_ok
     ):
         raise DispatchError(
             "PROVIDER_LIVE_DISPATCH_FORBIDDEN",
-            "Cursor providers require recorded/fake transport in #4254",
+            "Cursor providers require recorded/fake transport or Human-GO live flags",
         )
 
     at = _iso(clock)
@@ -589,6 +597,14 @@ def dispatch_run(
     store.update_cas(rid, 1, record)
 
     scope = pf.contract.get("execution_scope") or {}
+    provider_profile = deepcopy(pf.provider_profile or {})
+    if live_ok:
+        provider_profile["human_go_live_cursor"] = True
+        if auto_create_pr:
+            provider_profile["autoCreatePR"] = True
+        else:
+            # Default live pilot binds an existing PR (no autoCreatePR).
+            provider_profile["workOnCurrentBranch"] = True
     request = ProviderRequest(
         run_id=rid,
         contract_id=pf.contract["contract_id"],
@@ -599,7 +615,7 @@ def dispatch_run(
         delivery_expectations=deepcopy(expected_delivery),
         idempotency_key=idem,
         provider_id=pf.provider_id,
-        provider_profile=deepcopy(pf.provider_profile or {}),
+        provider_profile=provider_profile,
         route=_normalize_route_bindings(pf.route or {}),
         effective_permissions=deepcopy(pf.agent.get("effective_permissions") or {}),
         allowed_paths=list(
@@ -713,6 +729,9 @@ def watch_run(
         raise DispatchError("DISPATCH_RUN_NOT_FOUND", f"unknown run_id: {run_id}")
     if record["state"] in TERMINAL_STATES:
         return record
+    # Live pilot pause state — treat as watch complete without further provider polls.
+    if record["state"] == "AWAITING_APPROVAL":
+        return record
 
     if record["state"] not in {"DISPATCHED", "RUNNING"}:
         raise DispatchError(
@@ -733,6 +752,24 @@ def watch_run(
         )
 
     active = provider or get_provider("mock")
+    # Rehydrate Cursor cloud driver from persisted result_refs after restart.
+    if (
+        provider is not None
+        and hasattr(provider, "rehydrate")
+        and record.get("provider_id") == "cursor-cloud-api"
+        and record.get("provider_run_id")
+    ):
+        refs = record.get("result_refs") or {}
+        agent_ref = refs.get("agent_id")
+        if agent_ref:
+            try:
+                provider.rehydrate(  # type: ignore[attr-defined]
+                    provider_run_id=str(record["provider_run_id"]),
+                    agent_id=str(agent_ref),
+                    status="RUNNING",
+                )
+            except DispatchError:
+                pass
     # Reuse same mock instance if caller did not inject — for JsonFile CLI,
     # MockProvider is ephemeral; store scenario on record and rebuild.
     if provider is None and isinstance(active, MockProvider):
@@ -967,6 +1004,18 @@ def watch_run(
             )
             record["revision"] = rev + 1
             return store.update_cas(run_id, rev, record)
+        # Live/Human-GO path: pause at AWAITING_APPROVAL (no auto merge path).
+        _apply_state(
+            record,
+            "AWAITING_APPROVAL",
+            event_name="awaiting_approval",
+            clock=clock,
+            detail={
+                "receipt_commit": receipt.get("commit"),
+                "not_merge_authority": True,
+                "cursor_approval_agents": "MANUAL_BOOTSTRAP_ONLY",
+            },
+        )
         record["revision"] = rev + 1
         return store.update_cas(run_id, rev, record)
 

--- a/tools/agent_control/environment/preflight.py
+++ b/tools/agent_control/environment/preflight.py
@@ -31,6 +31,7 @@ def run_environment_preflight(
     repo_root: Path | None = None,
     execute: bool = False,
     allow_recorded: bool = False,
+    allow_live: bool = False,
 ) -> EnvironmentPreflightResult:
     """Shared environment preflight for dry-run and execute paths.
 
@@ -67,6 +68,14 @@ def run_environment_preflight(
         result.execute_ready = False
         result.reason_codes = list(result.reason_codes) + [
             "ENVIRONMENT_EXECUTE_NOT_READY"
+        ]
+        return result
+
+    # Human-GO live cursor: mock/offline-class pilot envs may execute under flags.
+    if allow_live and result.verdict == VERDICT_READY_OFFLINE_ONLY:
+        result.execute_ready = True
+        result.limitations = list(result.limitations) + [
+            "human_go_live_cursor_offline_env"
         ]
         return result
 

--- a/tools/agent_control/pilot.py
+++ b/tools/agent_control/pilot.py
@@ -36,6 +36,7 @@ from tools.agent_control.approval.context import (
 from tools.agent_control.clock import FrozenClock, SystemClock
 from tools.agent_control.credentials import cursor_api_key_present
 from tools.agent_control.delivery_verify import (
+    claimed_delivery_from_git,
     normalize_cursor_git_branches,
     pr_number_from_url,
     verify_github_delivery,
@@ -91,9 +92,8 @@ LIVE_LIMITATIONS = [
 
 GhRunner = Callable[[list[str]], dict[str, Any]]
 HttpTransport = Callable[..., Any]
+SseTransport = Callable[..., Any]
 
-# Debug-mode NDJSON sink (session 0f4913); never logs secrets.
-_DEBUG_LOG_PATH = Path(__file__).resolve().parents[2] / "debug-0f4913.log"
 _PROVIDER_TERMINAL = frozenset({"SUCCEEDED", "FAILED", "CANCELLED"})
 
 
@@ -101,30 +101,45 @@ class PilotError(AgentControlError):
     """Pilot harness fail-closed error."""
 
 
-def _agent_debug_log(
+def _enrich_terminal_diagnostics(
+    provider: Any,
+    run_store: Any,
+    run_id: str,
     *,
-    hypothesis_id: str,
-    location: str,
-    message: str,
-    data: dict[str, Any],
-    run_id: str = "pre-live",
+    provider_run_id: str,
 ) -> None:
-    # #region agent log
+    """Read-only stream snapshot for FAILED runs; never creates or follows up."""
+    if not hasattr(provider, "read_stream_diagnostics"):
+        return
+    record = run_store.get(run_id)
+    if record is None:
+        return
     try:
-        payload = {
-            "sessionId": "0f4913",
-            "runId": run_id,
-            "hypothesisId": hypothesis_id,
-            "location": location,
-            "message": message,
-            "data": data,
-            "timestamp": int(time.time() * 1000),
+        diag = provider.read_stream_diagnostics(str(provider_run_id))
+    except DispatchError:
+        return
+    except Exception:  # noqa: BLE001 — diagnostics must never abort pilot
+        return
+    refs = dict(record.get("result_refs") or {})
+    if isinstance(diag.get("result_text"), str) and not refs.get("run_result_text"):
+        refs["run_result_text"] = diag["result_text"]
+    if isinstance(diag.get("stream_error"), dict):
+        refs["stream_error"] = {
+            "code": diag["stream_error"].get("code"),
+            "message": diag["stream_error"].get("message"),
         }
-        with _DEBUG_LOG_PATH.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
-    except OSError:
-        pass
-    # #endregion
+    events = diag.get("events")
+    if isinstance(events, list) and events:
+        refs["stream_event_summary"] = events[:20]
+    if isinstance(diag.get("git"), dict) and not refs.get("git"):
+        refs["git"] = diag["git"]
+        refs["claimed_delivery"] = claimed_delivery_from_git(diag["git"])
+    refs["delivery_verified"] = False
+    rev = int(record.get("revision") or 0)
+    record["result_refs"] = sanitize_result_refs(refs)
+    record["updated_at"] = SystemClock().now().isoformat().replace("+00:00", "Z")
+    record["revision"] = rev + 1
+    run_store.update_cas(run_id, rev, record)
 
 
 def _poll_provider_until_terminal(
@@ -171,27 +186,19 @@ def _poll_provider_until_terminal(
         record["updated_at"] = SystemClock().now().isoformat().replace("+00:00", "Z")
         record["revision"] = rev + 1
         run_store.update_cas(run_id, rev, record)
-        git_info = normalize_cursor_git_branches(record.get("result_refs"))
-        _agent_debug_log(
-            hypothesis_id="H1",
-            location="pilot.py:_poll_provider_until_terminal",
-            message="provider_poll_tick",
-            data={
-                "poll_index": i,
-                "normalized_status": last_status,
-                "has_branch": bool(git_info.get("branch")),
-                "has_pr_url": bool(git_info.get("pr_url")),
-                "provider_run_id": str(provider_run_id),
-                "agent_id": str(agent_ref) if agent_ref else None,
-            },
-            run_id=str(run_id),
-        )
         if last_status in _PROVIDER_TERMINAL:
             record = run_store.get(run_id) or record
             rev = int(record.get("revision") or 0)
             record["last_provider_status"] = last_status
             record["revision"] = rev + 1
             run_store.update_cas(run_id, rev, record)
+            if last_status == "FAILED":
+                _enrich_terminal_diagnostics(
+                    provider,
+                    run_store,
+                    run_id,
+                    provider_run_id=str(provider_run_id),
+                )
             return run_store.get(run_id) or record
         if last_status == "UNKNOWN":
             raise PilotError(
@@ -333,6 +340,7 @@ def run_pilot(
     resume_run_id: str | None = None,
     state_path: Path | None = None,
     http_transport: HttpTransport | None = None,
+    sse_transport: SseTransport | None = None,
     gh_runner: GhRunner | None = None,
     auto_create_pr: bool = False,
     environment_attestation_path: Path | None = None,
@@ -353,6 +361,7 @@ def run_pilot(
             resume_run_id=resume_run_id,
             state_path=state_path,
             http_transport=http_transport,
+            sse_transport=sse_transport,
             gh_runner=gh_runner,
             auto_create_pr=auto_create_pr,
             environment_attestation_path=environment_attestation_path,
@@ -983,6 +992,7 @@ def _run_live_cursor_pilot(
     resume_run_id: str | None = None,
     state_path: Path | None = None,
     http_transport: HttpTransport | None = None,
+    sse_transport: SseTransport | None = None,
     gh_runner: GhRunner | None = None,
     auto_create_pr: bool = False,
     environment_attestation_path: Path | None = None,
@@ -1109,6 +1119,8 @@ def _run_live_cursor_pilot(
     transports: dict[str, Any] = {"human_go_live": True}
     if http_transport is not None:
         transports["http"] = http_transport
+    if sse_transport is not None:
+        transports["sse"] = sse_transport
     provider = build_provider(
         "cursor-cloud-api",
         allow_live=True,
@@ -1273,6 +1285,47 @@ def _run_live_cursor_pilot(
                     )
                 )
 
+        # Create may already be terminal ERROR/FAILED (no CREATING poll window).
+        if (
+            run_id
+            and run
+            and run.get("state") == "FAILED"
+            and not any(s["step"] == "provider_terminal" for s in steps)
+        ):
+            refs_now = run.get("result_refs") or {}
+            git_info = normalize_cursor_git_branches(refs_now)
+            claimed = (
+                refs_now.get("claimed_delivery")
+                if isinstance(refs_now.get("claimed_delivery"), dict)
+                else {
+                    "branch": git_info.get("branch"),
+                    "pr_url": git_info.get("pr_url"),
+                    "repo_url": git_info.get("repo_url"),
+                    "delivery_verified": False,
+                    "source": "run.git",
+                }
+            )
+            blocked = True
+            hold = True
+            fail = True
+            skip_approval = True
+            steps.append(
+                _step(
+                    "provider_terminal",
+                    "FAIL",
+                    detail={
+                        "normalized_status": "FAILED",
+                        "provider_run_id": run.get("provider_run_id"),
+                        "agent_id": refs_now.get("agent_id"),
+                        "claimed_delivery": claimed,
+                        "delivery_verified": False,
+                        "run_result_text": refs_now.get("run_result_text"),
+                        "run_error": refs_now.get("run_error"),
+                        "note": "terminal_on_create_no_delivery_verify",
+                    },
+                )
+            )
+
         if run_id and run and run.get("state") not in {"BLOCKED", "HOLD", "FAILED"}:
             # Official API returns CREATING without git; poll until terminal first.
             try:
@@ -1338,25 +1391,24 @@ def _run_live_cursor_pilot(
                     if not isinstance(branch, str):
                         branch = None
 
-            _agent_debug_log(
-                hypothesis_id="H1",
-                location="pilot.py:delivery_verify_pre",
-                message="delivery_targets_from_git",
-                data={
-                    "auto_create_pr": bool(auto_create_pr),
-                    "pr_num": pr_num,
-                    "branch": branch,
-                    "has_git_pr_url": bool(git_info.get("pr_url")),
-                },
-                run_id=str(run_id),
-            )
-
             if run_id and run and run.get("state") not in {"BLOCKED", "HOLD", "FAILED"}:
                 provider_norm = str(run.get("last_provider_status") or "")
                 if provider_norm in {"FAILED", "CANCELLED"}:
                     blocked = provider_norm == "FAILED"
                     hold = True
                     fail = provider_norm == "FAILED"
+                    refs_now = (run.get("result_refs") or {}) if run else {}
+                    claimed = (
+                        refs_now.get("claimed_delivery")
+                        if isinstance(refs_now.get("claimed_delivery"), dict)
+                        else {
+                            "branch": git_info.get("branch"),
+                            "pr_url": git_info.get("pr_url"),
+                            "repo_url": git_info.get("repo_url"),
+                            "delivery_verified": False,
+                            "source": "run.git",
+                        }
+                    )
                     steps.append(
                         _step(
                             "provider_terminal",
@@ -1364,10 +1416,14 @@ def _run_live_cursor_pilot(
                             detail={
                                 "normalized_status": provider_norm,
                                 "provider_run_id": run.get("provider_run_id"),
-                                "agent_id": (run.get("result_refs") or {}).get(
-                                    "agent_id"
-                                ),
-                                "git": git_info,
+                                "agent_id": refs_now.get("agent_id"),
+                                "claimed_delivery": claimed,
+                                "delivery_verified": False,
+                                "run_result_text": refs_now.get("run_result_text"),
+                                "run_error": refs_now.get("run_error"),
+                                "stream_error": refs_now.get("stream_error"),
+                                "duration_ms": refs_now.get("duration_ms"),
+                                "raw_status": refs_now.get("raw_status"),
                                 "note": "no_delivery_verify_on_provider_failure",
                             },
                         )
@@ -1434,6 +1490,21 @@ def _run_live_cursor_pilot(
                             commit=str(delivery.head_sha),
                             expected_status=str(expected_status),
                         )
+                        # Mark verified only after live GitHub evidence + head SHA.
+                        run_after = run_store.get(str(run_id)) or run
+                        refs_ok = dict(run_after.get("result_refs") or {})
+                        refs_ok["delivery_verified"] = True
+                        refs_ok["verified_delivery"] = {
+                            "branch": delivery.branch,
+                            "pr_number": delivery.pr_number,
+                            "head_sha": delivery.head_sha,
+                            "repo": delivery.repo,
+                        }
+                        rev_ok = int(run_after.get("revision") or 0)
+                        run_after["result_refs"] = sanitize_result_refs(refs_ok)
+                        run_after["revision"] = rev_ok + 1
+                        run_store.update_cas(str(run_id), rev_ok, run_after)
+                        run = run_store.get(str(run_id)) or run_after
                         steps.append(
                             _step(
                                 "delivery_verify",
@@ -1443,6 +1514,7 @@ def _run_live_cursor_pilot(
                                     "pr_number": delivery.pr_number,
                                     "branch": delivery.branch,
                                     "changed_files": delivery.changed_files,
+                                    "delivery_verified": True,
                                 },
                             )
                         )
@@ -1835,6 +1907,7 @@ def run_pilot_from_path(
     resume_run_id: str | None = None,
     state_path: Path | None = None,
     http_transport: HttpTransport | None = None,
+    sse_transport: SseTransport | None = None,
     gh_runner: GhRunner | None = None,
     auto_create_pr: bool = False,
     environment_attestation_path: Path | None = None,
@@ -1856,6 +1929,7 @@ def run_pilot_from_path(
         resume_run_id=resume_run_id,
         state_path=state_path,
         http_transport=http_transport,
+        sse_transport=sse_transport,
         gh_runner=gh_runner,
         auto_create_pr=auto_create_pr,
         environment_attestation_path=environment_attestation_path,

--- a/tools/agent_control/pilot.py
+++ b/tools/agent_control/pilot.py
@@ -187,6 +187,11 @@ def _poll_provider_until_terminal(
             run_id=str(run_id),
         )
         if last_status in _PROVIDER_TERMINAL:
+            record = run_store.get(run_id) or record
+            rev = int(record.get("revision") or 0)
+            record["last_provider_status"] = last_status
+            record["revision"] = rev + 1
+            run_store.update_cas(run_id, rev, record)
             return run_store.get(run_id) or record
         if last_status == "UNKNOWN":
             raise PilotError(
@@ -1347,132 +1352,175 @@ def _run_live_cursor_pilot(
             )
 
             if run_id and run and run.get("state") not in {"BLOCKED", "HOLD", "FAILED"}:
-                delivery = verify_github_delivery(
-                    expected_repo=expected_repo,
-                    pr_number=pr_num,
-                    branch=branch if isinstance(branch, str) else None,
-                    expected_paths_prefix=allowlist or None,
-                    allow_empty=bool(manifest.get("delivery_allow_empty")),
-                    runner=gh_runner,
-                )
-                if not delivery.ok:
-                    blocked = True
-                    steps.append(
-                        _step(
-                            "delivery_verify",
-                            "BLOCKED",
-                            detail={
-                                "code": delivery.code,
-                                "message": delivery.message,
-                                "changed_files": delivery.changed_files,
-                            },
-                        )
-                    )
-                    # N3/N5-style: do not allow approval PASS after delivery failure.
-                    skip_approval = True
+                provider_norm = str(run.get("last_provider_status") or "")
+                if provider_norm in {"FAILED", "CANCELLED"}:
+                    blocked = provider_norm == "FAILED"
                     hold = True
-                else:
-                    if delivery.head_sha:
-                        head_sha = delivery.head_sha
-                    if delivery.base_sha:
-                        base_sha = delivery.base_sha
-                    expected_status = (run.get("expected_delivery") or {}).get(
-                        "expected_status"
-                    ) or "DONE_SLICE_ADDED_TO_BATCH_PR"
-                    _inject_delivery_receipt(
-                        run_store,
-                        str(run_id),
-                        target_pr=delivery.pr_number or pr_num,
-                        target_branch=(
-                            delivery.branch
-                            if isinstance(delivery.branch, str)
-                            else branch
-                        ),
-                        commit=str(delivery.head_sha),
-                        expected_status=str(expected_status),
-                    )
+                    fail = provider_norm == "FAILED"
                     steps.append(
                         _step(
-                            "delivery_verify",
-                            "PASS",
+                            "provider_terminal",
+                            "FAIL" if provider_norm == "FAILED" else "HOLD",
                             detail={
-                                "head_sha": delivery.head_sha,
-                                "pr_number": delivery.pr_number,
-                                "branch": delivery.branch,
-                                "changed_files": delivery.changed_files,
+                                "normalized_status": provider_norm,
+                                "provider_run_id": run.get("provider_run_id"),
+                                "agent_id": (run.get("result_refs") or {}).get(
+                                    "agent_id"
+                                ),
+                                "git": git_info,
+                                "note": "no_delivery_verify_on_provider_failure",
                             },
                         )
                     )
-
-                    for _ in range(8):
-                        run = watch_run(
-                            str(run_id),
-                            run_store,
-                            provider=provider,
-                            clock=clock,
-                            auto_advance_success=False,
+                    skip_approval = True
+                else:
+                    try:
+                        delivery = verify_github_delivery(
+                            expected_repo=expected_repo,
+                            pr_number=pr_num,
+                            branch=branch if isinstance(branch, str) else None,
+                            expected_paths_prefix=allowlist or None,
+                            allow_empty=bool(manifest.get("delivery_allow_empty")),
+                            runner=gh_runner,
                         )
-                        if run.get("state") in {
-                            "AWAITING_APPROVAL",
-                            "PASS",
-                            "HOLD",
-                            "BLOCKED",
-                            "FAILED",
-                            "CANCELLED",
-                        }:
-                            break
-                    terminal = run.get("state")
-                    if terminal == "AWAITING_APPROVAL":
-                        hold = True
+                    except DispatchError as exc:
+                        from tools.agent_control.delivery_verify import (
+                            DeliveryVerification,
+                        )
+
+                        delivery = DeliveryVerification(
+                            ok=False,
+                            head_sha=None,
+                            base_sha=None,
+                            pr_number=pr_num,
+                            branch=branch if isinstance(branch, str) else None,
+                            repo=expected_repo,
+                            changed_files=[],
+                            code=exc.code,
+                            message=exc.message,
+                        )
+                    if not delivery.ok:
+                        blocked = True
                         steps.append(
                             _step(
-                                "provider_watch",
-                                "HOLD",
+                                "delivery_verify",
+                                "BLOCKED",
                                 detail={
-                                    "state": terminal,
-                                    "provider_run_id": run.get("provider_run_id"),
-                                    "note": "awaiting_approval_operator_handoff",
+                                    "code": delivery.code,
+                                    "message": delivery.message,
+                                    "changed_files": delivery.changed_files,
                                 },
                             )
                         )
-                    elif terminal == "PASS":
+                        skip_approval = True
+                        hold = True
+                    else:
+                        if delivery.head_sha:
+                            head_sha = delivery.head_sha
+                        if delivery.base_sha:
+                            base_sha = delivery.base_sha
+                        expected_status = (run.get("expected_delivery") or {}).get(
+                            "expected_status"
+                        ) or "DONE_SLICE_ADDED_TO_BATCH_PR"
+                        _inject_delivery_receipt(
+                            run_store,
+                            str(run_id),
+                            target_pr=delivery.pr_number or pr_num,
+                            target_branch=(
+                                delivery.branch
+                                if isinstance(delivery.branch, str)
+                                else branch
+                            ),
+                            commit=str(delivery.head_sha),
+                            expected_status=str(expected_status),
+                        )
                         steps.append(
                             _step(
-                                "provider_watch",
+                                "delivery_verify",
                                 "PASS",
                                 detail={
-                                    "state": terminal,
-                                    "provider_run_id": run.get("provider_run_id"),
+                                    "head_sha": delivery.head_sha,
+                                    "pr_number": delivery.pr_number,
+                                    "branch": delivery.branch,
+                                    "changed_files": delivery.changed_files,
                                 },
                             )
                         )
-                    elif terminal in {"HOLD", "BLOCKED"}:
-                        hold = terminal == "HOLD"
-                        blocked = terminal == "BLOCKED"
-                        steps.append(
-                            _step(
-                                "provider_watch",
-                                terminal,
-                                detail={
-                                    "state": terminal,
-                                    "terminal_code": run.get("terminal_code"),
-                                },
+
+                        for _ in range(8):
+                            run = watch_run(
+                                str(run_id),
+                                run_store,
+                                provider=provider,
+                                clock=clock,
+                                auto_advance_success=False,
                             )
-                        )
-                    elif terminal == "FAILED":
-                        fail = True
-                        steps.append(
-                            _step("provider_watch", "FAIL", detail={"state": terminal})
-                        )
-                    else:
-                        unknown = True
-                        steps.append(
-                            _step(
-                                "provider_watch",
-                                "UNKNOWN",
-                                detail={"state": terminal},
+                            if run.get("state") in {
+                                "AWAITING_APPROVAL",
+                                "PASS",
+                                "HOLD",
+                                "BLOCKED",
+                                "FAILED",
+                                "CANCELLED",
+                            }:
+                                break
+                        terminal = run.get("state")
+                        if terminal == "AWAITING_APPROVAL":
+                            hold = True
+                            steps.append(
+                                _step(
+                                    "provider_watch",
+                                    "HOLD",
+                                    detail={
+                                        "state": terminal,
+                                        "provider_run_id": run.get("provider_run_id"),
+                                        "note": "awaiting_approval_operator_handoff",
+                                    },
+                                )
                             )
-                        )
+                        elif terminal == "PASS":
+                            steps.append(
+                                _step(
+                                    "provider_watch",
+                                    "PASS",
+                                    detail={
+                                        "state": terminal,
+                                        "provider_run_id": run.get("provider_run_id"),
+                                    },
+                                )
+                            )
+                        elif terminal in {"HOLD", "BLOCKED"}:
+                            hold = terminal == "HOLD"
+                            blocked = terminal == "BLOCKED"
+                            steps.append(
+                                _step(
+                                    "provider_watch",
+                                    terminal,
+                                    detail={
+                                        "state": terminal,
+                                        "terminal_code": run.get("terminal_code"),
+                                    },
+                                )
+                            )
+                        elif terminal == "FAILED":
+                            fail = True
+                            steps.append(
+                                _step(
+                                    "provider_watch",
+                                    "FAIL",
+                                    detail={"state": terminal},
+                                )
+                            )
+                        else:
+                            unknown = True
+                            steps.append(
+                                _step(
+                                    "provider_watch",
+                                    "UNKNOWN",
+                                    detail={"state": terminal},
+                                )
+                            )
+
     except DispatchError as exc:
         if exc.code in {
             "DISPATCH_PROVIDER_MALFORMED",

--- a/tools/agent_control/pilot.py
+++ b/tools/agent_control/pilot.py
@@ -1,14 +1,18 @@
-"""ACP mock-first E2E pilot harness (#4258 foundation slice).
+"""ACP E2E pilot harness (#4258) — mock default + Human-GO live Cursor path.
 
 Wires real ACP components:
   Execution Contract → Registry → Preflight → Environment attenuation →
-  MockProvider → Run Evidence → PR Approval Context → Pilot Report
+  Provider (MockProvider default | CursorCloudApiDriver under Human-GO) →
+  Run Evidence → PR Approval Context → Pilot Report
 
 Hard boundaries:
-- MockProvider only (no live Cursor)
+- Default remains MockProvider (no network, auto_advance_success=True)
+- Live cursor-cloud-api requires --human-go-live-cursor + credential presence
 - Head-SHA bound in manifest/report/approval — Run Evidence schema unchanged
 - Refs #4258 only; never closes the issue
-- No merge / cdb-local-ci publish / protection mutation / secrets / network
+- No merge / cdb-local-ci publish / protection mutation
+- Live path pauses at AWAITING_APPROVAL (operator handoff; Approval Agents
+  remain MANUAL_BOOTSTRAP_ONLY)
 """
 
 from __future__ import annotations
@@ -18,7 +22,7 @@ import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from jsonschema import Draft202012Validator
 
@@ -29,6 +33,12 @@ from tools.agent_control.approval.context import (
     default_repo_paths,
 )
 from tools.agent_control.clock import FrozenClock
+from tools.agent_control.credentials import cursor_api_key_present
+from tools.agent_control.delivery_verify import (
+    normalize_cursor_git_branches,
+    pr_number_from_url,
+    verify_github_delivery,
+)
 from tools.agent_control.dispatch import dispatch_run, watch_run
 from tools.agent_control.errors import AgentControlError, DispatchError, EvidenceError
 from tools.agent_control.evidence.emit import emit_evidence
@@ -43,7 +53,8 @@ from tools.agent_control.pilot_report import (
     verify_report,
 )
 from tools.agent_control.provider import MockProvider
-from tools.agent_control.run_store import InMemoryRunStore
+from tools.agent_control.providers.factory import build_provider
+from tools.agent_control.run_store import InMemoryRunStore, JsonFileRunStore
 from tools.agent_execution_contract.errors import ContractValidationError
 from tools.agent_execution_contract.validate import validate_contract
 
@@ -53,6 +64,7 @@ MANIFEST_SCHEMA_RELPATH = (
     "docs/contracts/cdb_agent_control_pilot_manifest.v1.schema.json"
 )
 SHA40 = re.compile(r"^[a-f0-9]{40}$")
+DEFAULT_GITHUB_REPO = "jannekbuengener/Claire_de_Binare"
 
 DEFAULT_LIMITATIONS = [
     "foundation_slice_only",
@@ -63,6 +75,20 @@ DEFAULT_LIMITATIONS = [
     "not_merge_authority",
     "refs_4258_not_closes",
 ]
+
+LIVE_LIMITATIONS = [
+    "foundation_slice_only",
+    "live_cursor_pilot",
+    "awaiting_approval_operator_handoff",
+    "cursor_approval_agents_manual_bootstrap_only",
+    "not_issue_closure",
+    "not_final_ci",
+    "not_merge_authority",
+    "refs_4258_not_closes",
+]
+
+GhRunner = Callable[[list[str]], dict[str, Any]]
+HttpTransport = Callable[..., Any]
 
 
 class PilotError(AgentControlError):
@@ -192,8 +218,43 @@ def run_pilot(
     *,
     repo_root: Path | None = None,
     store_path: Path | None = None,
+    provider_id: str = "mock",
+    human_go_live_cursor: bool = False,
+    resume_run_id: str | None = None,
+    state_path: Path | None = None,
+    http_transport: HttpTransport | None = None,
+    gh_runner: GhRunner | None = None,
+    auto_create_pr: bool = False,
+    environment_attestation_path: Path | None = None,
+    secrets_dir: Path | None = None,
+    credential_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Execute one foundation pilot scenario; return pilot report."""
+    """Execute one pilot scenario; return pilot report.
+
+    Default ``provider_id='mock'`` is behavior-identical to the foundation
+    harness (MockProvider, InMemoryRunStore, auto_advance_success=True).
+    """
+    if provider_id == "cursor-cloud-api":
+        return _run_live_cursor_pilot(
+            manifest,
+            repo_root=repo_root,
+            store_path=store_path,
+            human_go_live_cursor=human_go_live_cursor,
+            resume_run_id=resume_run_id,
+            state_path=state_path,
+            http_transport=http_transport,
+            gh_runner=gh_runner,
+            auto_create_pr=auto_create_pr,
+            environment_attestation_path=environment_attestation_path,
+            secrets_dir=secrets_dir,
+            credential_env=credential_env,
+        )
+    if provider_id != "mock":
+        raise PilotError(
+            "PILOT_PROVIDER_UNSUPPORTED",
+            f"unsupported provider_id={provider_id!r}; use mock|cursor-cloud-api",
+        )
+
     root = repo_root or REPO_ROOT
     steps: list[dict[str, Any]] = []
     limitations = list(DEFAULT_LIMITATIONS)
@@ -758,6 +819,673 @@ def run_pilot(
     )
 
 
+def _live_expected_repo(manifest: dict[str, Any]) -> str:
+    subject = (
+        manifest.get("subject") if isinstance(manifest.get("subject"), dict) else {}
+    )
+    repo = subject.get("repo") or manifest.get("expected_repo") or DEFAULT_GITHUB_REPO
+    return str(repo)
+
+
+def _inject_delivery_receipt(
+    run_store: Any,
+    run_id: str,
+    *,
+    target_pr: int | None,
+    target_branch: str | None,
+    commit: str,
+    expected_status: str,
+) -> None:
+    record = run_store.get(run_id)
+    if record is None:
+        return
+    rev = int(record.get("revision") or 0)
+    record["delivery_receipt"] = {
+        "target_pr": target_pr,
+        "target_branch": target_branch,
+        "commit": commit,
+        "delivery_status": expected_status,
+        "observation_source": "github_delivery_verify",
+    }
+    record["revision"] = rev + 1
+    run_store.update_cas(run_id, rev, record)
+
+
+def _run_live_cursor_pilot(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+    store_path: Path | None = None,
+    human_go_live_cursor: bool = False,
+    resume_run_id: str | None = None,
+    state_path: Path | None = None,
+    http_transport: HttpTransport | None = None,
+    gh_runner: GhRunner | None = None,
+    auto_create_pr: bool = False,
+    environment_attestation_path: Path | None = None,
+    secrets_dir: Path | None = None,
+    credential_env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Human-GO live Cursor cloud pilot; pauses at AWAITING_APPROVAL."""
+    if not human_go_live_cursor:
+        raise PilotError(
+            "PILOT_HUMAN_GO_REQUIRED",
+            "provider_id=cursor-cloud-api requires human_go_live_cursor=True",
+        )
+    if auto_create_pr and not human_go_live_cursor:
+        raise PilotError(
+            "PILOT_HUMAN_GO_REQUIRED",
+            "auto_create_pr requires human_go_live_cursor=True",
+        )
+
+    root = repo_root or REPO_ROOT
+    steps: list[dict[str, Any]] = []
+    limitations = list(LIVE_LIMITATIONS)
+    clock = FrozenClock(datetime(2026, 8, 3, 0, 0, tzinfo=timezone.utc))
+    run_id: str | None = resume_run_id
+    attempt: int | None = None
+    contract_digest: str | None = None
+    evidence_refs: list[dict[str, Any]] = []
+    approval_digest: str | None = None
+    approval_rec: str | None = None
+    blocked = False
+    hold = False
+    fail = False
+    unknown = False
+    evidence_ok = False
+    provider_calls = 0
+    head_sha = str(manifest["head_sha"])
+    base_raw = manifest.get("base_sha")
+    base_sha = str(base_raw) if isinstance(base_raw, str) else None
+    agent_id = str(manifest["agent_id"])
+    skip_approval = bool(manifest.get("skip_approval"))
+    skip_evidence = bool(manifest.get("skip_evidence"))
+    registry_root = _resolve(
+        root, manifest.get("registry_root") or str(DEFAULT_CONFIG_ROOT)
+    )
+    expected_repo = _live_expected_repo(manifest)
+    allowlist = list(manifest.get("delivery_path_allowlist") or [])
+    att_path = environment_attestation_path
+    if att_path is None and manifest.get("environment_attestation_path"):
+        att_path = _resolve(root, manifest["environment_attestation_path"])
+
+    # Credential presence before any driver/network construction.
+    presence = cursor_api_key_present(env=credential_env, secrets_dir=secrets_dir)
+    if not presence.present:
+        steps.append(
+            _step(
+                "credential_precondition",
+                "BLOCKED",
+                detail={
+                    "code": "PRECONDITION_BLOCKED",
+                    "credential": presence.name,
+                    "source": presence.source,
+                },
+            )
+        )
+        blocked = True
+        steps.append(
+            _step(
+                "approval_context",
+                "SKIP",
+                detail={"reason": "short_circuit_after_precondition_block"},
+            )
+        )
+        steps.append(
+            _step(
+                "authority_boundary",
+                "PASS",
+                detail={"authority_limits": AUTHORITY_LIMITS, "provider_calls": 0},
+            )
+        )
+        return _finalize(
+            manifest,
+            steps,
+            None,
+            None,
+            head_sha,
+            base_sha,
+            {},
+            0,
+            [],
+            None,
+            None,
+            blocked,
+            hold,
+            fail,
+            unknown,
+            False,
+            limitations,
+            None,
+        )
+
+    steps.append(
+        _step(
+            "credential_precondition",
+            "PASS",
+            detail={"credential": presence.name, "source": presence.source},
+        )
+    )
+
+    if state_path is not None:
+        run_store: Any = JsonFileRunStore(Path(state_path))
+    else:
+        run_store = InMemoryRunStore()
+
+    transports: dict[str, Any] = {"human_go_live": True}
+    if http_transport is not None:
+        transports["http"] = http_transport
+    provider = build_provider(
+        "cursor-cloud-api",
+        allow_live=True,
+        transports=transports,
+    )
+
+    # --- Contract ---
+    try:
+        contract_path = _resolve(root, manifest["contract_path"])
+        contract = _load_verified_contract(_load_json(contract_path))
+        contract_digest = (contract.get("integrity") or {}).get("digest")
+        steps.append(
+            _step(
+                "load_contract",
+                "PASS",
+                detail={
+                    "contract_id": contract.get("contract_id"),
+                    "contract_digest": contract_digest,
+                },
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        steps.append(_step("load_contract", "FAIL", detail={"error": str(exc)}))
+        fail = True
+        return _finalize(
+            manifest,
+            steps,
+            run_id,
+            attempt,
+            head_sha,
+            base_sha,
+            {},
+            0,
+            [],
+            None,
+            None,
+            blocked,
+            hold,
+            fail,
+            unknown,
+            False,
+            limitations,
+            contract_digest,
+        )
+
+    try:
+        registry = load_registry_document(registry_root)
+        steps.append(
+            _step(
+                "resolve_registry",
+                "PASS",
+                detail={"agent_id": agent_id, "registry_root": str(registry_root)},
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        steps.append(_step("resolve_registry", "FAIL", detail={"error": str(exc)}))
+        fail = True
+        return _finalize(
+            manifest,
+            steps,
+            run_id,
+            attempt,
+            head_sha,
+            base_sha,
+            {"contract_digest": contract_digest},
+            0,
+            [],
+            None,
+            None,
+            blocked,
+            hold,
+            fail,
+            unknown,
+            False,
+            limitations,
+            contract_digest,
+        )
+
+    allow_recorded = att_path is not None
+    # Load prompt from working tree for Human-GO / fixture tests so source_commit
+    # history is not required (operator may still bind a real commit in manifests).
+    prompt_override: str | None = None
+    work_order = (
+        contract.get("provider_work_order") if isinstance(contract, dict) else None
+    )
+    if isinstance(work_order, dict) and work_order.get("prompt_ref"):
+        prompt_path = _resolve(root, str(work_order["prompt_ref"]))
+        if prompt_path.is_file():
+            prompt_override = prompt_path.read_text(encoding="utf-8")
+
+    run: dict[str, Any] | None = None
+    try:
+        if resume_run_id:
+            run = run_store.get(resume_run_id)
+            if run is None:
+                raise PilotError(
+                    "PILOT_RESUME_NOT_FOUND",
+                    f"resume_run_id not in store: {resume_run_id}",
+                )
+            run_id = run.get("run_id")
+            attempt = run.get("attempt")
+            steps.append(
+                _step(
+                    "preflight_dispatch",
+                    "PASS",
+                    detail={
+                        "state": run.get("state"),
+                        "run_id": run_id,
+                        "resume": True,
+                        "provider_run_id": run.get("provider_run_id"),
+                    },
+                )
+            )
+        else:
+            result = dispatch_run(
+                contract,
+                registry,
+                agent_id,
+                run_store,
+                dry_run=False,
+                allow_mock_dispatch=False,
+                allow_live_cursor=True,
+                human_go_live_cursor=True,
+                allow_recorded_cursor=allow_recorded,
+                auto_create_pr=auto_create_pr,
+                provider=provider,
+                clock=clock,
+                environment_attestation_path=att_path,
+                prompt_text_override=prompt_override,
+            )
+            run = result["run"]
+            run_id = run.get("run_id")
+            attempt = run.get("attempt")
+            provider_calls = int(getattr(provider, "dispatch_calls", 0) or 0)
+            state = run.get("state")
+            code = run.get("terminal_code")
+            if state in {"BLOCKED", "HOLD"} or code:
+                blocked = state == "BLOCKED"
+                hold = state == "HOLD"
+                steps.append(
+                    _step(
+                        "preflight_dispatch",
+                        "BLOCKED" if blocked else "HOLD",
+                        detail={
+                            "state": state,
+                            "terminal_code": code,
+                            "provider_call_count": provider_calls,
+                        },
+                    )
+                )
+            else:
+                steps.append(
+                    _step(
+                        "preflight_dispatch",
+                        "PASS",
+                        detail={
+                            "state": state,
+                            "run_id": run_id,
+                            "provider_call_count": provider_calls,
+                            "provider_run_id": run.get("provider_run_id"),
+                        },
+                    )
+                )
+
+        if run_id and run and run.get("state") not in {"BLOCKED", "HOLD", "FAILED"}:
+            # Bind GitHub delivery from Cursor git refs before watch advances.
+            git_info = normalize_cursor_git_branches(run.get("result_refs"))
+            pr_num = pr_number_from_url(
+                git_info.get("pr_url")
+                if isinstance(git_info.get("pr_url"), str)
+                else None
+            )
+            if pr_num is None:
+                expected = run.get("expected_delivery") or {}
+                raw_pr = expected.get("target_pr") or (run.get("route") or {}).get(
+                    "target_pr"
+                )
+                if isinstance(raw_pr, int) and not isinstance(raw_pr, bool):
+                    pr_num = raw_pr
+            branch = git_info.get("branch")
+            if not isinstance(branch, str):
+                branch = (run.get("expected_delivery") or {}).get("target_branch") or (
+                    run.get("route") or {}
+                ).get("target_branch")
+
+            delivery = verify_github_delivery(
+                expected_repo=expected_repo,
+                pr_number=pr_num,
+                branch=branch if isinstance(branch, str) else None,
+                expected_paths_prefix=allowlist or None,
+                allow_empty=bool(manifest.get("delivery_allow_empty")),
+                runner=gh_runner,
+            )
+            if not delivery.ok:
+                blocked = True
+                steps.append(
+                    _step(
+                        "delivery_verify",
+                        "BLOCKED",
+                        detail={
+                            "code": delivery.code,
+                            "message": delivery.message,
+                            "changed_files": delivery.changed_files,
+                        },
+                    )
+                )
+                # N3/N5-style: do not allow approval PASS after delivery failure.
+                skip_approval = True
+                hold = True
+            else:
+                if delivery.head_sha:
+                    head_sha = delivery.head_sha
+                if delivery.base_sha:
+                    base_sha = delivery.base_sha
+                expected_status = (run.get("expected_delivery") or {}).get(
+                    "expected_status"
+                ) or "DONE_SLICE_ADDED_TO_BATCH_PR"
+                _inject_delivery_receipt(
+                    run_store,
+                    str(run_id),
+                    target_pr=delivery.pr_number or pr_num,
+                    target_branch=(
+                        delivery.branch if isinstance(delivery.branch, str) else branch
+                    ),
+                    commit=str(delivery.head_sha),
+                    expected_status=str(expected_status),
+                )
+                steps.append(
+                    _step(
+                        "delivery_verify",
+                        "PASS",
+                        detail={
+                            "head_sha": delivery.head_sha,
+                            "pr_number": delivery.pr_number,
+                            "branch": delivery.branch,
+                            "changed_files": delivery.changed_files,
+                        },
+                    )
+                )
+
+                for _ in range(8):
+                    run = watch_run(
+                        str(run_id),
+                        run_store,
+                        provider=provider,
+                        clock=clock,
+                        auto_advance_success=False,
+                    )
+                    if run.get("state") in {
+                        "AWAITING_APPROVAL",
+                        "PASS",
+                        "HOLD",
+                        "BLOCKED",
+                        "FAILED",
+                        "CANCELLED",
+                    }:
+                        break
+                terminal = run.get("state")
+                if terminal == "AWAITING_APPROVAL":
+                    hold = True
+                    steps.append(
+                        _step(
+                            "provider_watch",
+                            "HOLD",
+                            detail={
+                                "state": terminal,
+                                "provider_run_id": run.get("provider_run_id"),
+                                "note": "awaiting_approval_operator_handoff",
+                            },
+                        )
+                    )
+                elif terminal == "PASS":
+                    steps.append(
+                        _step(
+                            "provider_watch",
+                            "PASS",
+                            detail={
+                                "state": terminal,
+                                "provider_run_id": run.get("provider_run_id"),
+                            },
+                        )
+                    )
+                elif terminal in {"HOLD", "BLOCKED"}:
+                    hold = terminal == "HOLD"
+                    blocked = terminal == "BLOCKED"
+                    steps.append(
+                        _step(
+                            "provider_watch",
+                            terminal,
+                            detail={
+                                "state": terminal,
+                                "terminal_code": run.get("terminal_code"),
+                            },
+                        )
+                    )
+                elif terminal == "FAILED":
+                    fail = True
+                    steps.append(
+                        _step("provider_watch", "FAIL", detail={"state": terminal})
+                    )
+                else:
+                    unknown = True
+                    steps.append(
+                        _step("provider_watch", "UNKNOWN", detail={"state": terminal})
+                    )
+    except DispatchError as exc:
+        if exc.code in {
+            "DISPATCH_PROVIDER_MALFORMED",
+            "DISPATCH_DELIVERY_RECEIPT_MISSING",
+            "DISPATCH_DELIVERY_RECEIPT_MISMATCH",
+        }:
+            fail = True
+            steps.append(
+                _step(
+                    "provider_dispatch",
+                    "FAIL",
+                    detail={"code": exc.code, "message": exc.message},
+                )
+            )
+        else:
+            blocked = True
+            steps.append(
+                _step(
+                    "preflight_dispatch",
+                    "BLOCKED",
+                    detail={"code": exc.code, "message": exc.message},
+                )
+            )
+    except PilotError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        fail = True
+        steps.append(_step("preflight_dispatch", "FAIL", detail={"error": str(exc)}))
+
+    provider_calls = int(getattr(provider, "dispatch_calls", 0) or 0)
+
+    # Evidence: HOLD for non-terminal AWAITING_APPROVAL is OK.
+    if not skip_evidence and run_id and run_store.get(run_id) is not None:
+        try:
+            emitted = emit_evidence(run_id, run_store)
+            bundle = emitted["bundle"]
+            verified = verify_bundle(bundle)
+            evidence_ok = bool(verified.get("ok"))
+            ref = {
+                "evidence_id": bundle.get("evidence_id"),
+                "bundle_digest": bundle.get("bundle_digest"),
+                "verdict": emitted.get("verdict"),
+            }
+            evidence_refs.append(ref)
+            if store_path is not None:
+                store = EvidenceJsonlStore(store_path)
+                store.append_idempotent(bundle)
+                verify_store(store_path)
+            verdict = emitted.get("verdict")
+            step_status = "PASS" if evidence_ok and verdict == "PASS" else "HOLD"
+            if verdict == "BLOCKED":
+                step_status = "BLOCKED"
+                blocked = True
+            elif verdict == "HOLD":
+                hold = True
+            elif verdict == "UNKNOWN":
+                unknown = True
+                evidence_ok = False
+            steps.append(_step("run_evidence", step_status, detail=ref))
+        except EvidenceError as exc:
+            hold = True
+            evidence_ok = False
+            steps.append(
+                _step(
+                    "run_evidence",
+                    "HOLD",
+                    detail={"code": exc.code, "message": exc.message},
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            fail = True
+            steps.append(_step("run_evidence", "FAIL", detail={"error": str(exc)}))
+    elif skip_evidence:
+        steps.append(_step("run_evidence", "SKIP", detail={"reason": "skip_evidence"}))
+
+    # Approval — reuse mock path semantics with bound head from delivery verify.
+    if not skip_approval and not blocked:
+        try:
+            snap_path = manifest.get("approval_snapshot_path")
+            if not snap_path:
+                raise PilotError(
+                    "PILOT_APPROVAL_SNAPSHOT_MISSING",
+                    "approval_snapshot_path required unless skip_approval",
+                )
+            snapshot = _load_json(_resolve(root, snap_path))
+            if not isinstance(snapshot, dict):
+                raise PilotError(
+                    "PILOT_APPROVAL_SNAPSHOT_INVALID", "snapshot must be object"
+                )
+            pr = dict(snapshot.get("pr") or {})
+            snap_head = pr.get("head_sha")
+            if manifest.get("force_approval_head_from_manifest", True):
+                pr["head_sha"] = head_sha
+                for check in snapshot.get("checks") or []:
+                    if isinstance(check, dict) and check.get("source_sha") == snap_head:
+                        check["source_sha"] = head_sha
+                snapshot["pr"] = pr
+            paths = default_repo_paths(root)
+            if manifest.get("approval_baseline_path"):
+                paths = RepoPaths(
+                    repo_root=paths.repo_root,
+                    policy_path=paths.policy_path,
+                    prompt_path=paths.prompt_path,
+                    baseline_path=_resolve(root, manifest["approval_baseline_path"]),
+                    schema_path=paths.schema_path,
+                )
+            envelope = build_approval_context(snapshot, paths)
+            approval_digest = envelope.get("context_digest")
+            approval_rec = envelope.get("recommendation")
+            appr_head = (envelope.get("subject") or {}).get("head_sha")
+            reason_codes = list(envelope.get("reason_codes") or [])
+            if approval_rec == "UNKNOWN":
+                unknown = True
+            step_status = "PASS"
+            if approval_rec != "APPROVE_RECOMMENDED":
+                step_status = "HOLD"
+                hold = True
+            steps.append(
+                _step(
+                    "approval_context",
+                    step_status,
+                    detail={
+                        "recommendation": approval_rec,
+                        "context_digest": approval_digest,
+                        "subject_head_sha": appr_head,
+                        "pilot_head_sha": head_sha,
+                        "reason_codes": reason_codes,
+                        "authority_limits": envelope.get("authority_limits"),
+                    },
+                )
+            )
+            limits = envelope.get("authority_limits") or {}
+            for key, val in APPROVAL_AUTHORITY.items():
+                if limits.get(key) is not val:
+                    fail = True
+                    steps.append(
+                        _step(
+                            "authority_boundary",
+                            "FAIL",
+                            detail={"key": key, "value": limits.get(key)},
+                        )
+                    )
+                    break
+            else:
+                steps.append(
+                    _step(
+                        "authority_boundary",
+                        "PASS",
+                        detail={"authority_limits": AUTHORITY_LIMITS},
+                    )
+                )
+        except Exception as exc:  # noqa: BLE001
+            code = getattr(exc, "code", "PILOT_APPROVAL_ERROR")
+            if code in {"APPROVAL_SECRET_DETECTED", "REASON_SECRET_DETECTED"}:
+                blocked = True
+            else:
+                hold = True
+            steps.append(
+                _step(
+                    "approval_context",
+                    "BLOCKED" if blocked else "HOLD",
+                    detail={"code": code, "error": str(exc)},
+                )
+            )
+    elif skip_approval:
+        steps.append(
+            _step("approval_context", "SKIP", detail={"reason": "skip_approval"})
+        )
+        if blocked:
+            steps.append(
+                _step(
+                    "authority_boundary",
+                    "PASS",
+                    detail={
+                        "authority_limits": AUTHORITY_LIMITS,
+                        "provider_calls": provider_calls,
+                    },
+                )
+            )
+
+    input_digests = {
+        "contract_digest": contract_digest,
+        "approval_context_digest": approval_digest,
+    }
+    return _finalize(
+        manifest,
+        steps,
+        run_id,
+        attempt,
+        head_sha,
+        base_sha,
+        input_digests,
+        provider_calls,
+        evidence_refs,
+        approval_digest,
+        approval_rec,
+        blocked,
+        hold,
+        fail,
+        unknown,
+        evidence_ok,
+        limitations,
+        contract_digest,
+    )
+
+
 def _finalize(
     manifest: dict[str, Any],
     steps: list[dict[str, Any]],
@@ -861,6 +1589,16 @@ def run_pilot_from_path(
     *,
     repo_root: Path | None = None,
     out_path: Path | None = None,
+    provider_id: str = "mock",
+    human_go_live_cursor: bool = False,
+    resume_run_id: str | None = None,
+    state_path: Path | None = None,
+    http_transport: HttpTransport | None = None,
+    gh_runner: GhRunner | None = None,
+    auto_create_pr: bool = False,
+    environment_attestation_path: Path | None = None,
+    secrets_dir: Path | None = None,
+    credential_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     root = repo_root or REPO_ROOT
     manifest = load_manifest(manifest_path, repo_root=root)
@@ -868,7 +1606,21 @@ def run_pilot_from_path(
     if manifest.get("evidence_store_path"):
         store_path = _resolve(root, manifest["evidence_store_path"])
         store_path.parent.mkdir(parents=True, exist_ok=True)
-    report = run_pilot(manifest, repo_root=root, store_path=store_path)
+    report = run_pilot(
+        manifest,
+        repo_root=root,
+        store_path=store_path,
+        provider_id=provider_id,
+        human_go_live_cursor=human_go_live_cursor,
+        resume_run_id=resume_run_id,
+        state_path=state_path,
+        http_transport=http_transport,
+        gh_runner=gh_runner,
+        auto_create_pr=auto_create_pr,
+        environment_attestation_path=environment_attestation_path,
+        secrets_dir=secrets_dir,
+        credential_env=credential_env,
+    )
     verify_report(report)
     if out_path is not None:
         out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/agent_control/pilot.py
+++ b/tools/agent_control/pilot.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import copy
 import json
 import re
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -32,7 +33,7 @@ from tools.agent_control.approval.context import (
     build_approval_context,
     default_repo_paths,
 )
-from tools.agent_control.clock import FrozenClock
+from tools.agent_control.clock import FrozenClock, SystemClock
 from tools.agent_control.credentials import cursor_api_key_present
 from tools.agent_control.delivery_verify import (
     normalize_cursor_git_branches,
@@ -42,6 +43,7 @@ from tools.agent_control.delivery_verify import (
 from tools.agent_control.dispatch import dispatch_run, watch_run
 from tools.agent_control.errors import AgentControlError, DispatchError, EvidenceError
 from tools.agent_control.evidence.emit import emit_evidence
+from tools.agent_control.evidence.redact import sanitize_result_refs
 from tools.agent_control.evidence.store import EvidenceJsonlStore
 from tools.agent_control.evidence.verify import verify_bundle, verify_store
 from tools.agent_control.load import load_registry_document
@@ -90,9 +92,112 @@ LIVE_LIMITATIONS = [
 GhRunner = Callable[[list[str]], dict[str, Any]]
 HttpTransport = Callable[..., Any]
 
+# Debug-mode NDJSON sink (session 0f4913); never logs secrets.
+_DEBUG_LOG_PATH = Path(__file__).resolve().parents[2] / "debug-0f4913.log"
+_PROVIDER_TERMINAL = frozenset({"SUCCEEDED", "FAILED", "CANCELLED"})
+
 
 class PilotError(AgentControlError):
     """Pilot harness fail-closed error."""
+
+
+def _agent_debug_log(
+    *,
+    hypothesis_id: str,
+    location: str,
+    message: str,
+    data: dict[str, Any],
+    run_id: str = "pre-live",
+) -> None:
+    # #region agent log
+    try:
+        payload = {
+            "sessionId": "0f4913",
+            "runId": run_id,
+            "hypothesisId": hypothesis_id,
+            "location": location,
+            "message": message,
+            "data": data,
+            "timestamp": int(time.time() * 1000),
+        }
+        with _DEBUG_LOG_PATH.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    except OSError:
+        pass
+    # #endregion
+
+
+def _poll_provider_until_terminal(
+    provider: Any,
+    run_store: Any,
+    run_id: str,
+    *,
+    poll_interval_seconds: float = 15.0,
+    max_polls: int = 240,
+    sleep_fn: Callable[[float], None] | None = None,
+) -> dict[str, Any]:
+    """Poll provider.watch until terminal status; update result_refs only.
+
+    Does not advance lifecycle (receipt must be bound before watch_run).
+    """
+    sleeper = sleep_fn or time.sleep
+    record = run_store.get(run_id)
+    if record is None:
+        raise PilotError("PILOT_RESUME_NOT_FOUND", f"run missing for poll: {run_id}")
+    provider_run_id = record.get("provider_run_id")
+    if not provider_run_id:
+        raise PilotError("PILOT_PROVIDER_RUN_MISSING", "no provider_run_id to poll")
+    refs = record.get("result_refs") or {}
+    agent_ref = refs.get("agent_id")
+    if agent_ref and hasattr(provider, "rehydrate"):
+        try:
+            provider.rehydrate(
+                provider_run_id=str(provider_run_id),
+                agent_id=str(agent_ref),
+                status="RUNNING",
+            )
+        except DispatchError:
+            pass
+
+    last_status = "UNKNOWN"
+    for i in range(max_polls):
+        result = provider.watch(str(provider_run_id))
+        last_status = str(result.normalized_status or "UNKNOWN")
+        record = run_store.get(run_id)
+        assert record is not None
+        rev = int(record.get("revision") or 0)
+        if result.result_refs:
+            record["result_refs"] = sanitize_result_refs(result.result_refs)
+        record["updated_at"] = SystemClock().now().isoformat().replace("+00:00", "Z")
+        record["revision"] = rev + 1
+        run_store.update_cas(run_id, rev, record)
+        git_info = normalize_cursor_git_branches(record.get("result_refs"))
+        _agent_debug_log(
+            hypothesis_id="H1",
+            location="pilot.py:_poll_provider_until_terminal",
+            message="provider_poll_tick",
+            data={
+                "poll_index": i,
+                "normalized_status": last_status,
+                "has_branch": bool(git_info.get("branch")),
+                "has_pr_url": bool(git_info.get("pr_url")),
+                "provider_run_id": str(provider_run_id),
+                "agent_id": str(agent_ref) if agent_ref else None,
+            },
+            run_id=str(run_id),
+        )
+        if last_status in _PROVIDER_TERMINAL:
+            return run_store.get(run_id) or record
+        if last_status == "UNKNOWN":
+            raise PilotError(
+                "PILOT_PROVIDER_STATUS_UNKNOWN",
+                "provider returned UNKNOWN during live poll",
+            )
+        sleeper(poll_interval_seconds)
+    raise PilotError(
+        "PILOT_POLL_TIMEOUT",
+        f"provider still {last_status} after {max_polls} polls",
+    )
 
 
 def _load_json(path: Path) -> Any:
@@ -847,6 +952,19 @@ def _inject_delivery_receipt(
         "delivery_status": expected_status,
         "observation_source": "github_delivery_verify",
     }
+    # Bind observed Cursor/GitHub delivery onto sealed expectations so
+    # autoCreatePR heads are not rejected against fixture placeholders (9999).
+    expected = dict(record.get("expected_delivery") or {})
+    route = dict(record.get("route") or {})
+    if target_pr is not None:
+        expected["target_pr"] = target_pr
+        route["target_pr"] = target_pr
+    if isinstance(target_branch, str) and target_branch:
+        expected["target_branch"] = target_branch
+        route["target_branch"] = target_branch
+    route["target_provenance"] = "cursor_git+github_delivery_verify"
+    record["expected_delivery"] = expected
+    record["route"] = route
     record["revision"] = rev + 1
     run_store.update_cas(run_id, rev, record)
 
@@ -881,7 +999,8 @@ def _run_live_cursor_pilot(
     root = repo_root or REPO_ROOT
     steps: list[dict[str, Any]] = []
     limitations = list(LIVE_LIMITATIONS)
-    clock = FrozenClock(datetime(2026, 8, 3, 0, 0, tzinfo=timezone.utc))
+    # Live polling must observe wall-clock; FrozenClock is for offline digests only.
+    clock = SystemClock()
     run_id: str | None = resume_run_id
     attempt: int | None = None
     contract_digest: str | None = None
@@ -908,6 +1027,16 @@ def _run_live_cursor_pilot(
     att_path = environment_attestation_path
     if att_path is None and manifest.get("environment_attestation_path"):
         att_path = _resolve(root, manifest["environment_attestation_path"])
+    raw_poll = manifest.get("poll_interval_seconds")
+    poll_interval = float(15.0 if raw_poll is None else raw_poll)
+    raw_max = manifest.get("max_polls")
+    max_polls = int(240 if raw_max is None else raw_max)
+    sleep_fn: Callable[[float], None] | None = None
+    if callable(manifest.get("_test_sleep_fn")):
+        sleep_fn = manifest["_test_sleep_fn"]  # type: ignore[assignment]
+    elif poll_interval <= 0:
+        sleep_fn = lambda _s: None  # noqa: E731 — offline recorded tests
+        poll_interval = 0.0
 
     # Credential presence before any driver/network construction.
     presence = cursor_api_key_present(env=credential_env, secrets_dir=secrets_dir)
@@ -1140,146 +1269,210 @@ def _run_live_cursor_pilot(
                 )
 
         if run_id and run and run.get("state") not in {"BLOCKED", "HOLD", "FAILED"}:
-            # Bind GitHub delivery from Cursor git refs before watch advances.
-            git_info = normalize_cursor_git_branches(run.get("result_refs"))
+            # Official API returns CREATING without git; poll until terminal first.
+            try:
+                run = _poll_provider_until_terminal(
+                    provider,
+                    run_store,
+                    str(run_id),
+                    poll_interval_seconds=max(poll_interval, 0.0),
+                    max_polls=max_polls,
+                    sleep_fn=sleep_fn,
+                )
+                steps.append(
+                    _step(
+                        "provider_poll",
+                        "PASS",
+                        detail={
+                            "provider_run_id": run.get("provider_run_id"),
+                            "result_refs_agent_id": (run.get("result_refs") or {}).get(
+                                "agent_id"
+                            ),
+                            "normalized_hint": "terminal_reached",
+                        },
+                    )
+                )
+            except PilotError as exc:
+                blocked = True
+                steps.append(
+                    _step(
+                        "provider_poll",
+                        "BLOCKED",
+                        detail={"code": exc.code, "message": exc.message},
+                    )
+                )
+                skip_approval = True
+                hold = True
+                run = run_store.get(str(run_id)) or run
+
+            # Bind GitHub delivery from Cursor git refs after terminal poll.
+            git_info = normalize_cursor_git_branches(
+                (run or {}).get("result_refs") if run else None
+            )
             pr_num = pr_number_from_url(
                 git_info.get("pr_url")
                 if isinstance(git_info.get("pr_url"), str)
                 else None
             )
-            if pr_num is None:
-                expected = run.get("expected_delivery") or {}
-                raw_pr = expected.get("target_pr") or (run.get("route") or {}).get(
-                    "target_pr"
-                )
-                if isinstance(raw_pr, int) and not isinstance(raw_pr, bool):
-                    pr_num = raw_pr
             branch = git_info.get("branch")
             if not isinstance(branch, str):
-                branch = (run.get("expected_delivery") or {}).get("target_branch") or (
-                    run.get("route") or {}
-                ).get("target_branch")
+                branch = None
+            # autoCreatePR: never fall back to fixture placeholder PR/branch.
+            if not auto_create_pr:
+                if pr_num is None and run:
+                    expected = run.get("expected_delivery") or {}
+                    raw_pr = expected.get("target_pr") or (run.get("route") or {}).get(
+                        "target_pr"
+                    )
+                    if isinstance(raw_pr, int) and not isinstance(raw_pr, bool):
+                        pr_num = raw_pr
+                if branch is None and run:
+                    branch = (run.get("expected_delivery") or {}).get(
+                        "target_branch"
+                    ) or (run.get("route") or {}).get("target_branch")
+                    if not isinstance(branch, str):
+                        branch = None
 
-            delivery = verify_github_delivery(
-                expected_repo=expected_repo,
-                pr_number=pr_num,
-                branch=branch if isinstance(branch, str) else None,
-                expected_paths_prefix=allowlist or None,
-                allow_empty=bool(manifest.get("delivery_allow_empty")),
-                runner=gh_runner,
+            _agent_debug_log(
+                hypothesis_id="H1",
+                location="pilot.py:delivery_verify_pre",
+                message="delivery_targets_from_git",
+                data={
+                    "auto_create_pr": bool(auto_create_pr),
+                    "pr_num": pr_num,
+                    "branch": branch,
+                    "has_git_pr_url": bool(git_info.get("pr_url")),
+                },
+                run_id=str(run_id),
             )
-            if not delivery.ok:
-                blocked = True
-                steps.append(
-                    _step(
-                        "delivery_verify",
-                        "BLOCKED",
-                        detail={
-                            "code": delivery.code,
-                            "message": delivery.message,
-                            "changed_files": delivery.changed_files,
-                        },
-                    )
-                )
-                # N3/N5-style: do not allow approval PASS after delivery failure.
-                skip_approval = True
-                hold = True
-            else:
-                if delivery.head_sha:
-                    head_sha = delivery.head_sha
-                if delivery.base_sha:
-                    base_sha = delivery.base_sha
-                expected_status = (run.get("expected_delivery") or {}).get(
-                    "expected_status"
-                ) or "DONE_SLICE_ADDED_TO_BATCH_PR"
-                _inject_delivery_receipt(
-                    run_store,
-                    str(run_id),
-                    target_pr=delivery.pr_number or pr_num,
-                    target_branch=(
-                        delivery.branch if isinstance(delivery.branch, str) else branch
-                    ),
-                    commit=str(delivery.head_sha),
-                    expected_status=str(expected_status),
-                )
-                steps.append(
-                    _step(
-                        "delivery_verify",
-                        "PASS",
-                        detail={
-                            "head_sha": delivery.head_sha,
-                            "pr_number": delivery.pr_number,
-                            "branch": delivery.branch,
-                            "changed_files": delivery.changed_files,
-                        },
-                    )
-                )
 
-                for _ in range(8):
-                    run = watch_run(
-                        str(run_id),
-                        run_store,
-                        provider=provider,
-                        clock=clock,
-                        auto_advance_success=False,
-                    )
-                    if run.get("state") in {
-                        "AWAITING_APPROVAL",
-                        "PASS",
-                        "HOLD",
-                        "BLOCKED",
-                        "FAILED",
-                        "CANCELLED",
-                    }:
-                        break
-                terminal = run.get("state")
-                if terminal == "AWAITING_APPROVAL":
-                    hold = True
+            if run_id and run and run.get("state") not in {"BLOCKED", "HOLD", "FAILED"}:
+                delivery = verify_github_delivery(
+                    expected_repo=expected_repo,
+                    pr_number=pr_num,
+                    branch=branch if isinstance(branch, str) else None,
+                    expected_paths_prefix=allowlist or None,
+                    allow_empty=bool(manifest.get("delivery_allow_empty")),
+                    runner=gh_runner,
+                )
+                if not delivery.ok:
+                    blocked = True
                     steps.append(
                         _step(
-                            "provider_watch",
-                            "HOLD",
+                            "delivery_verify",
+                            "BLOCKED",
                             detail={
-                                "state": terminal,
-                                "provider_run_id": run.get("provider_run_id"),
-                                "note": "awaiting_approval_operator_handoff",
+                                "code": delivery.code,
+                                "message": delivery.message,
+                                "changed_files": delivery.changed_files,
                             },
                         )
                     )
-                elif terminal == "PASS":
+                    # N3/N5-style: do not allow approval PASS after delivery failure.
+                    skip_approval = True
+                    hold = True
+                else:
+                    if delivery.head_sha:
+                        head_sha = delivery.head_sha
+                    if delivery.base_sha:
+                        base_sha = delivery.base_sha
+                    expected_status = (run.get("expected_delivery") or {}).get(
+                        "expected_status"
+                    ) or "DONE_SLICE_ADDED_TO_BATCH_PR"
+                    _inject_delivery_receipt(
+                        run_store,
+                        str(run_id),
+                        target_pr=delivery.pr_number or pr_num,
+                        target_branch=(
+                            delivery.branch
+                            if isinstance(delivery.branch, str)
+                            else branch
+                        ),
+                        commit=str(delivery.head_sha),
+                        expected_status=str(expected_status),
+                    )
                     steps.append(
                         _step(
-                            "provider_watch",
+                            "delivery_verify",
                             "PASS",
                             detail={
-                                "state": terminal,
-                                "provider_run_id": run.get("provider_run_id"),
+                                "head_sha": delivery.head_sha,
+                                "pr_number": delivery.pr_number,
+                                "branch": delivery.branch,
+                                "changed_files": delivery.changed_files,
                             },
                         )
                     )
-                elif terminal in {"HOLD", "BLOCKED"}:
-                    hold = terminal == "HOLD"
-                    blocked = terminal == "BLOCKED"
-                    steps.append(
-                        _step(
-                            "provider_watch",
-                            terminal,
-                            detail={
-                                "state": terminal,
-                                "terminal_code": run.get("terminal_code"),
-                            },
+
+                    for _ in range(8):
+                        run = watch_run(
+                            str(run_id),
+                            run_store,
+                            provider=provider,
+                            clock=clock,
+                            auto_advance_success=False,
                         )
-                    )
-                elif terminal == "FAILED":
-                    fail = True
-                    steps.append(
-                        _step("provider_watch", "FAIL", detail={"state": terminal})
-                    )
-                else:
-                    unknown = True
-                    steps.append(
-                        _step("provider_watch", "UNKNOWN", detail={"state": terminal})
-                    )
+                        if run.get("state") in {
+                            "AWAITING_APPROVAL",
+                            "PASS",
+                            "HOLD",
+                            "BLOCKED",
+                            "FAILED",
+                            "CANCELLED",
+                        }:
+                            break
+                    terminal = run.get("state")
+                    if terminal == "AWAITING_APPROVAL":
+                        hold = True
+                        steps.append(
+                            _step(
+                                "provider_watch",
+                                "HOLD",
+                                detail={
+                                    "state": terminal,
+                                    "provider_run_id": run.get("provider_run_id"),
+                                    "note": "awaiting_approval_operator_handoff",
+                                },
+                            )
+                        )
+                    elif terminal == "PASS":
+                        steps.append(
+                            _step(
+                                "provider_watch",
+                                "PASS",
+                                detail={
+                                    "state": terminal,
+                                    "provider_run_id": run.get("provider_run_id"),
+                                },
+                            )
+                        )
+                    elif terminal in {"HOLD", "BLOCKED"}:
+                        hold = terminal == "HOLD"
+                        blocked = terminal == "BLOCKED"
+                        steps.append(
+                            _step(
+                                "provider_watch",
+                                terminal,
+                                detail={
+                                    "state": terminal,
+                                    "terminal_code": run.get("terminal_code"),
+                                },
+                            )
+                        )
+                    elif terminal == "FAILED":
+                        fail = True
+                        steps.append(
+                            _step("provider_watch", "FAIL", detail={"state": terminal})
+                        )
+                    else:
+                        unknown = True
+                        steps.append(
+                            _step(
+                                "provider_watch",
+                                "UNKNOWN",
+                                detail={"state": terminal},
+                            )
+                        )
     except DispatchError as exc:
         if exc.code in {
             "DISPATCH_PROVIDER_MALFORMED",

--- a/tools/agent_control/preflight.py
+++ b/tools/agent_control/preflight.py
@@ -161,11 +161,14 @@ def preflight(
     execute: bool,
     repo_root: Path | None = None,
     allow_recorded_cursor: bool = False,
+    allow_live_cursor: bool = False,
+    human_go_live_cursor: bool = False,
     prompt_text_override: str | None = None,
     environment_attestation_path: Path | None = None,
     config_root: Path | None = None,
 ) -> PreflightResult:
     """Validate contract digest + registry + environment. Shared by dry-run/execute."""
+    live_ok = bool(allow_live_cursor and human_go_live_cursor)
     try:
         validated = validate_contract(contract)
     except ContractValidationError as exc:
@@ -343,38 +346,59 @@ def preflight(
         config=config_root or root / "config" / "agent-control",
         repo_root=root,
         execute=execute,
-        allow_recorded=allow_recorded_cursor,
+        allow_recorded=allow_recorded_cursor or live_ok,
+        allow_live=live_ok,
     )
 
     if execute and provider_id != "mock":
         if provider_id in CURSOR_PROVIDER_IDS:
             # Durable gate: environment preflight never enables live dispatch.
+            # Profile live_dispatch=true remains forbidden; Human-GO uses flags.
             if live_dispatch:
                 return _fail(
                     ENVIRONMENT_LIVE_DISPATCH_FORBIDDEN,
                     "provider live_dispatch=true is forbidden; "
-                    "live Cursor dispatch remains blocked pending ratified "
-                    "pilot/approval/evidence path (#4256-#4258)",
+                    "use Human-GO allow_live_cursor flags instead of profile flip",
                     terminal_state="BLOCKED",
                 )
-            if not allow_recorded_cursor:
+            if not allow_recorded_cursor and not live_ok:
                 return _fail(
                     PROVIDER_LIVE_DISPATCH_FORBIDDEN,
-                    f"execute for {provider_id!r} requires recorded/fake transport; "
-                    "live Cursor dispatch remains permanently fail-closed here",
+                    f"execute for {provider_id!r} requires recorded/fake transport "
+                    "or Human-GO live cursor flags",
                     terminal_state="BLOCKED",
                 )
-            if env_result.verdict != VERDICT_READY_FOR_RECORDED_TEST:
-                return _fail(
-                    (
-                        env_result.reason_codes[0]
-                        if env_result.reason_codes
-                        else "ENVIRONMENT_EXECUTE_NOT_READY"
-                    ),
-                    f"environment preflight verdict {env_result.verdict} "
-                    f"blocks recorded execute: {env_result.limitations}",
-                    terminal_state="BLOCKED",
-                )
+            if allow_recorded_cursor and not live_ok:
+                if env_result.verdict != VERDICT_READY_FOR_RECORDED_TEST:
+                    return _fail(
+                        (
+                            env_result.reason_codes[0]
+                            if env_result.reason_codes
+                            else "ENVIRONMENT_EXECUTE_NOT_READY"
+                        ),
+                        f"environment preflight verdict {env_result.verdict} "
+                        f"blocks recorded execute: {env_result.limitations}",
+                        terminal_state="BLOCKED",
+                    )
+            elif live_ok:
+                if env_result.verdict not in {
+                    VERDICT_READY_FOR_RECORDED_TEST,
+                    VERDICT_READY_OFFLINE_ONLY,
+                }:
+                    # Live path still needs a non-blocked environment surface.
+                    from tools.agent_control.environment.codes import VERDICT_BLOCKED
+
+                    if env_result.verdict == VERDICT_BLOCKED:
+                        return _fail(
+                            (
+                                env_result.reason_codes[0]
+                                if env_result.reason_codes
+                                else "ENVIRONMENT_EXECUTE_NOT_READY"
+                            ),
+                            f"environment preflight verdict {env_result.verdict} "
+                            f"blocks live execute: {env_result.limitations}",
+                            terminal_state="BLOCKED",
+                        )
         else:
             return _fail(
                 PROVIDER_LIVE_DISPATCH_FORBIDDEN,

--- a/tools/agent_control/providers/cursor_cloud_api.py
+++ b/tools/agent_control/providers/cursor_cloud_api.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 from urllib.parse import urlparse
 
+from tools.agent_control.cursor_preflight import extract_environment_identity
 from tools.agent_control.delivery_verify import (
     claimed_delivery_from_git,
     truncate_run_result_text,
@@ -225,14 +226,32 @@ class CursorCloudApiDriver:
         if not starting_ref and auto_create:
             # Official API: omit or set startingRef; default to main for autoCreatePR.
             starting_ref = "main"
-        if pr_url and repo_url:
+        # Named cloud environment XOR repos (official CreateAgentRequest).
+        # Prefer explicit repos + versioned .cursor/environment.json for
+        # dashboardless determinism. Optional named env via profile.
+        env_req = profile.get("env") if isinstance(profile.get("env"), dict) else None
+        use_named_env = bool(env_req and env_req.get("type") and env_req.get("name"))
+        if use_named_env:
+            body["env"] = {
+                "type": str(env_req.get("type") or "cloud"),
+                "name": str(env_req["name"]),
+            }
+        elif pr_url and repo_url:
             body["repos"] = [{"url": repo_url, "prUrl": pr_url}]
         elif repo_url:
             entry: dict[str, Any] = {"url": repo_url}
             if starting_ref:
                 entry["startingRef"] = starting_ref
             body["repos"] = [entry]
+        requested_env = {
+            "binding_mode": (
+                "named_cloud_env" if use_named_env else "repos_plus_repo_config"
+            ),
+            "env": body.get("env"),
+            "repos": body.get("repos"),
+        }
         git_meta: dict[str, Any] = {"branches": []}
+        resolved_env: dict[str, Any] | None = None
         if self._http is not None:
             try:
                 created = self._request("POST", "/v1/agents", json_body=body)
@@ -250,7 +269,9 @@ class CursorCloudApiDriver:
                         raise
                     status = "RUNNING"
                     created = {
-                        "agent": {"id": agent_id},
+                        "agent": (
+                            existing if isinstance(existing, dict) else {"id": agent_id}
+                        ),
                         "run": {"id": run_id, "status": status},
                     }
                 else:
@@ -262,17 +283,35 @@ class CursorCloudApiDriver:
             run_body = (
                 created.get("run") if isinstance(created.get("run"), dict) else {}
             )
+            agent_body = (
+                created.get("agent") if isinstance(created.get("agent"), dict) else {}
+            )
+            resolved_env = extract_environment_identity(agent_body)
+            if use_named_env:
+                req_name = str(env_req.get("name"))
+                got_name = resolved_env.get("name")
+                # Fail closed when API returns a conflicting name. Missing name is
+                # a public observability gap (PARTIAL) recorded in result_refs.
+                if got_name is not None and got_name != req_name:
+                    raise DispatchError(
+                        "PROVIDER_ENVIRONMENT_MISMATCH",
+                        f"requested env.name={req_name!r} resolved={got_name!r}",
+                    )
             git_meta = (
                 run_body.get("git") if isinstance(run_body.get("git"), dict) else {}
             )
-            if not git_meta and isinstance(created.get("agent"), dict):
-                agent_git = created["agent"].get("git")
-                if isinstance(agent_git, dict):
-                    git_meta = agent_git
+            if not git_meta and isinstance(agent_body.get("git"), dict):
+                git_meta = agent_body["git"]
         else:
             agent_id = agent_id_client
             run_id = f"run-{request.run_id[-12:]}"
             status = "FINISHED"
+            resolved_env = {
+                "type": "cloud",
+                "name": (env_req or {}).get("name") if use_named_env else None,
+                "environment_public_id": None,
+                "environment_version_public_id": None,
+            }
             if auto_create:
                 git_meta = {
                     "branches": [
@@ -306,6 +345,8 @@ class CursorCloudApiDriver:
                 "claimed_delivery": claimed_delivery_from_git(git_meta),
                 "delivery_verified": False,
                 "raw_status": status,
+                "environment_requested": requested_env,
+                "environment_resolved": resolved_env,
             },
             delivery_receipt=request.delivery_receipt,
             error_code=(

--- a/tools/agent_control/providers/cursor_cloud_api.py
+++ b/tools/agent_control/providers/cursor_cloud_api.py
@@ -34,10 +34,12 @@ class _CloudState:
 
 
 def _stable_agent_id(request: ProviderRequest) -> str:
-    """Client-supplied idempotent agent id from contract digest + attempt key."""
+    """Client-supplied idempotent agent id (official ``bc-<uuid>`` shape)."""
     seed = f"{request.contract_digest}|{request.idempotency_key or request.run_id}"
-    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:20]
-    return f"bc-{digest}"
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    # Official docs show bc- + UUID; derive a stable UUID-shaped id (no randomness).
+    u = digest[:32]
+    return f"bc-{u[:8]}-{u[8:12]}-{u[12:16]}-{u[16:20]}-{u[20:32]}"
 
 
 class CursorCloudApiDriver:
@@ -211,6 +213,9 @@ class CursorCloudApiDriver:
             "agentId": agent_id_client,
         }
         starting_ref = route.get("starting_ref") or route.get("startingRef")
+        if not starting_ref and auto_create:
+            # Official API: omit or set startingRef; default to main for autoCreatePR.
+            starting_ref = "main"
         if pr_url and repo_url:
             body["repos"] = [{"url": repo_url, "prUrl": pr_url}]
         elif repo_url:
@@ -379,8 +384,10 @@ class CursorCloudApiDriver:
                 f"/v1/agents/{agent_id}/runs",
                 json_body={"prompt": {"text": request.prompt_text or ""}},
             )
-            new_run = body["id"]
-            status = body.get("status", "CREATING")
+            # Official v1: {"run": {"id": "...", "status": "..."}}; accept legacy flat id.
+            run_obj = body.get("run") if isinstance(body.get("run"), dict) else body
+            new_run = str(run_obj.get("id") or body.get("id") or new_run)
+            status = str(run_obj.get("status") or body.get("status") or "CREATING")
         else:
             status = "FINISHED"
         state.runs[new_run] = {"status": status, "usage": {"cost": None}}

--- a/tools/agent_control/providers/cursor_cloud_api.py
+++ b/tools/agent_control/providers/cursor_cloud_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable
 from urllib.parse import urlparse
@@ -21,7 +22,11 @@ HttpTransport = Callable[..., Any]
 SseTransport = Callable[..., Any]
 
 API_BASE = "https://api.cursor.com"
-_BC_ID = re.compile(r"^bc-[A-Za-z0-9_-]+$")
+_BC_ID = re.compile(
+    r"^bc-(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{12}|[A-Za-z0-9_-]+-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+)
 
 
 @dataclass
@@ -36,10 +41,8 @@ class _CloudState:
 def _stable_agent_id(request: ProviderRequest) -> str:
     """Client-supplied idempotent agent id (official ``bc-<uuid>`` shape)."""
     seed = f"{request.contract_digest}|{request.idempotency_key or request.run_id}"
-    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
-    # Official docs show bc- + UUID; derive a stable UUID-shaped id (no randomness).
-    u = digest[:32]
-    return f"bc-{u[:8]}-{u[8:12]}-{u[12:16]}-{u[16:20]}-{u[20:32]}"
+    # uuid5 yields a parseable UUID; raw hex slices can fail API UUID validation.
+    return f"bc-{uuid.uuid5(uuid.NAMESPACE_URL, seed)}"
 
 
 class CursorCloudApiDriver:
@@ -94,10 +97,8 @@ class CursorCloudApiDriver:
                 "DISPATCH_PROVIDER_RUN_NOT_FOUND",
                 "rehydrate requires provider_run_id and agent_id",
             )
-        if not _BC_ID.match(agent_id) and not agent_id.startswith("bc-"):
-            # Allow test ids like bc-1
-            if not agent_id.startswith("bc-"):
-                raise DispatchError("PROVIDER_AGENT_ID_INVALID", agent_id)
+        if not (_BC_ID.match(agent_id) or agent_id.startswith("bc-")):
+            raise DispatchError("PROVIDER_AGENT_ID_INVALID", agent_id)
         state = self._agents.get(agent_id) or _CloudState(agent_id=agent_id)
         if provider_run_id not in state.runs:
             state.runs[provider_run_id] = {
@@ -206,6 +207,42 @@ class CursorCloudApiDriver:
             human_go_live=human_go,
         )
         agent_id_client = profile.get("agentId") or _stable_agent_id(request)
+        if not _BC_ID.match(str(agent_id_client)) and not str(
+            agent_id_client
+        ).startswith("bc-"):
+            raise DispatchError("PROVIDER_AGENT_ID_INVALID", str(agent_id_client))
+        # #region agent log
+        try:
+            import json
+            import time
+            from pathlib import Path
+
+            _dbg = Path(__file__).resolve().parents[3] / "debug-0f4913.log"
+            with _dbg.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "sessionId": "0f4913",
+                            "runId": "live-create",
+                            "hypothesisId": "H2",
+                            "location": "cursor_cloud_api.py:dispatch",
+                            "message": "agentId_shape",
+                            "data": {
+                                "agent_id_len": len(str(agent_id_client)),
+                                "agent_id_prefix": str(agent_id_client)[:3],
+                                "has_uuid_dashes": str(agent_id_client).count("-") >= 5,
+                                "regex_ok": bool(_BC_ID.match(str(agent_id_client))),
+                                "auto_create": bool(auto_create),
+                            },
+                            "timestamp": int(time.time() * 1000),
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+        except OSError:
+            pass
+        # #endregion
         body: dict[str, Any] = {
             "prompt": {"text": request.prompt_text},
             "autoCreatePR": bool(auto_create),

--- a/tools/agent_control/providers/cursor_cloud_api.py
+++ b/tools/agent_control/providers/cursor_cloud_api.py
@@ -1,7 +1,9 @@
-"""Cursor Cloud Agents API v1 driver (#4254)."""
+"""Cursor Cloud Agents API v1 driver (#4254 / live pilot #4258)."""
 
 from __future__ import annotations
 
+import hashlib
+import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
 from urllib.parse import urlparse
@@ -19,6 +21,7 @@ HttpTransport = Callable[..., Any]
 SseTransport = Callable[..., Any]
 
 API_BASE = "https://api.cursor.com"
+_BC_ID = re.compile(r"^bc-[A-Za-z0-9_-]+$")
 
 
 @dataclass
@@ -28,6 +31,13 @@ class _CloudState:
     archived: bool = False
     artifacts: list[dict[str, Any]] = field(default_factory=list)
     last_event_ids: dict[str, str] = field(default_factory=dict)
+
+
+def _stable_agent_id(request: ProviderRequest) -> str:
+    """Client-supplied idempotent agent id from contract digest + attempt key."""
+    seed = f"{request.contract_digest}|{request.idempotency_key or request.run_id}"
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:20]
+    return f"bc-{digest}"
 
 
 class CursorCloudApiDriver:
@@ -40,10 +50,12 @@ class CursorCloudApiDriver:
         sse: SseTransport | None = None,
         allow_live: bool = False,
         model_catalog: dict[str, Any] | None = None,
+        human_go_live: bool = False,
     ) -> None:
         self._http = http
         self._sse = sse
         self._allow_live = allow_live
+        self._human_go_live = human_go_live
         self._catalog = model_catalog or {
             "model_ids": ["auto-smart"],
             "optimize_for": ["cost", "balanced", "intelligence"],
@@ -52,6 +64,12 @@ class CursorCloudApiDriver:
         self._run_to_agent: dict[str, str] = {}
         self.dispatch_calls = 0
         self.mutating_posts = 0
+        if self._http is None and self._allow_live:
+            from tools.agent_control.providers.live_http import (
+                build_urllib_http_transport_compat,
+            )
+
+            self._http = build_urllib_http_transport_compat()
 
     def _gate(self) -> None:
         if self._http is None and not self._allow_live:
@@ -60,6 +78,47 @@ class CursorCloudApiDriver:
                 "live cursor-cloud-api dispatch is permanently fail-closed; "
                 "use injected fake/recorded HTTP transport only",
             )
+
+    def rehydrate(
+        self,
+        *,
+        provider_run_id: str,
+        agent_id: str,
+        status: str = "RUNNING",
+    ) -> None:
+        """Restore in-memory maps after process restart (from RunStore refs)."""
+        if not provider_run_id or not agent_id:
+            raise DispatchError(
+                "DISPATCH_PROVIDER_RUN_NOT_FOUND",
+                "rehydrate requires provider_run_id and agent_id",
+            )
+        if not _BC_ID.match(agent_id) and not agent_id.startswith("bc-"):
+            # Allow test ids like bc-1
+            if not agent_id.startswith("bc-"):
+                raise DispatchError("PROVIDER_AGENT_ID_INVALID", agent_id)
+        state = self._agents.get(agent_id) or _CloudState(agent_id=agent_id)
+        if provider_run_id not in state.runs:
+            state.runs[provider_run_id] = {
+                "status": status,
+                "usage": {"cost": None},
+            }
+        self._agents[agent_id] = state
+        self._run_to_agent[provider_run_id] = agent_id
+
+    def _resolve_agent(
+        self, provider_run_id: str, *, result_refs: dict[str, Any] | None = None
+    ) -> tuple[str, _CloudState]:
+        agent_id = self._run_to_agent.get(provider_run_id)
+        if agent_id is None and result_refs and result_refs.get("agent_id"):
+            self.rehydrate(
+                provider_run_id=provider_run_id,
+                agent_id=str(result_refs["agent_id"]),
+            )
+            agent_id = self._run_to_agent.get(provider_run_id)
+        state = self._agents.get(agent_id or "")
+        if state is None or agent_id is None:
+            raise DispatchError("DISPATCH_PROVIDER_RUN_NOT_FOUND", provider_run_id)
+        return agent_id, state
 
     def _request(
         self,
@@ -124,44 +183,97 @@ class CursorCloudApiDriver:
                 "CONTRACT_PROVIDER_WORK_ORDER_MISSING",
                 "cloud API requires verified in-memory prompt",
             )
-        route = request.route or {}
-        auto_create = bool((request.provider_profile or {}).get("autoCreatePR", False))
-        work_on = bool(
-            (request.provider_profile or {}).get("workOnCurrentBranch", False)
-        )
+        route = dict(request.route or {})
+        profile = request.provider_profile or {}
+        human_go = bool(self._human_go_live or profile.get("human_go_live_cursor"))
+        # autoCreatePR only when Human-GO live path explicitly sets it on profile.
+        auto_create = bool(profile.get("autoCreatePR", False)) and human_go
+        work_on = bool(profile.get("workOnCurrentBranch", False))
         pr_url = route.get("pr_url") or route.get("prUrl")
+        repo_url = route.get("repo_url") or route.get("repository_url")
+        if not repo_url:
+            repo_url = "https://github.com/jannekbuengener/Claire_de_Binare"
+        if work_on and not pr_url and route.get("target_pr"):
+            pr_url = f"{str(repo_url).rstrip('/')}/pull/{int(route['target_pr'])}"
         guard_cloud_route_binding(
             auto_create_pr=auto_create,
             work_on_current_branch=work_on,
-            pr_url=pr_url,
+            pr_url=pr_url if isinstance(pr_url, str) else None,
             contract_target_pr=route.get("target_pr"),
             contract_target_branch=route.get("target_branch"),
+            human_go_live=human_go,
         )
-        body = {
+        agent_id_client = profile.get("agentId") or _stable_agent_id(request)
+        body: dict[str, Any] = {
             "prompt": {"text": request.prompt_text},
-            "autoCreatePR": False,
+            "autoCreatePR": bool(auto_create),
             "workOnCurrentBranch": work_on,
+            "agentId": agent_id_client,
         }
-        if pr_url and route.get("repo_url"):
-            body["repos"] = [
-                {
-                    "url": route["repo_url"],
-                    "prUrl": pr_url,
-                }
-            ]
+        starting_ref = route.get("starting_ref") or route.get("startingRef")
+        if pr_url and repo_url:
+            body["repos"] = [{"url": repo_url, "prUrl": pr_url}]
+        elif repo_url:
+            entry: dict[str, Any] = {"url": repo_url}
+            if starting_ref:
+                entry["startingRef"] = starting_ref
+            body["repos"] = [entry]
+        git_meta: dict[str, Any] = {"branches": []}
         if self._http is not None:
-            created = self._request("POST", "/v1/agents", json_body=body)
-            agent_id = created["agent"]["id"]
-            run_id = created["run"]["id"]
-            status = created["run"].get("status", "CREATING")
+            try:
+                created = self._request("POST", "/v1/agents", json_body=body)
+            except DispatchError as exc:
+                if exc.code == "PROVIDER_BUSY" and "agent_id_conflict" in str(
+                    exc.message
+                ):
+                    # Idempotent resume: fetch existing agent + latest run.
+                    existing = self._request("GET", f"/v1/agents/{agent_id_client}")
+                    agent_id = existing.get("id") or agent_id_client
+                    run_id = existing.get("latestRunId") or existing.get(
+                        "latest_run_id"
+                    )
+                    if not run_id:
+                        raise
+                    status = "RUNNING"
+                    created = {
+                        "agent": {"id": agent_id},
+                        "run": {"id": run_id, "status": status},
+                    }
+                else:
+                    raise
+            else:
+                agent_id = created["agent"]["id"]
+                run_id = created["run"]["id"]
+                status = created["run"].get("status", "CREATING")
+            run_body = (
+                created.get("run") if isinstance(created.get("run"), dict) else {}
+            )
+            git_meta = (
+                run_body.get("git") if isinstance(run_body.get("git"), dict) else {}
+            )
+            if not git_meta and isinstance(created.get("agent"), dict):
+                agent_git = created["agent"].get("git")
+                if isinstance(agent_git, dict):
+                    git_meta = agent_git
         else:
-            agent_id = f"bc-{request.run_id[-12:]}"
+            agent_id = agent_id_client
             run_id = f"run-{request.run_id[-12:]}"
             status = "FINISHED"
+            if auto_create:
+                git_meta = {
+                    "branches": [
+                        {
+                            "repoUrl": (repo_url or "").replace("https://", ""),
+                            "branch": f"cursor/pilot-{request.run_id[-8:]}",
+                            "prUrl": "https://github.com/example/repo/pull/1",
+                        }
+                    ]
+                }
         state = _CloudState(agent_id=agent_id)
         state.runs[run_id] = {
             "status": status,
             "usage": {"cost": None, "input_tokens": 2},
+            "git": git_meta,
         }
         state.artifacts = [
             {"path": "artifacts/log.txt", "size": 10, "digest": "sha256:" + "a" * 64}
@@ -173,37 +285,39 @@ class CursorCloudApiDriver:
             provider_run_id=run_id,
             raw_status=status,
             usage=state.runs[run_id]["usage"],
-            result_refs={"agent_id": agent_id, "api": "v1"},
+            result_refs={
+                "agent_id": agent_id,
+                "api": "v1",
+                "git": git_meta,
+            },
             delivery_receipt=request.delivery_receipt,
         )
 
     def watch(self, provider_run_id: str) -> ProviderResult:
-        agent_id = self._run_to_agent.get(provider_run_id)
-        state = self._agents.get(agent_id or "")
-        if state is None:
-            raise DispatchError("DISPATCH_PROVIDER_RUN_NOT_FOUND", provider_run_id)
+        agent_id, state = self._resolve_agent(provider_run_id)
         if self._http is not None:
             body = self._request(
                 "GET",
                 f"/v1/agents/{agent_id}/runs/{provider_run_id}",
             )
             status = body.get("status", "RUNNING")
+            state.runs.setdefault(provider_run_id, {"usage": {"cost": None}})
             state.runs[provider_run_id]["status"] = status
+            if isinstance(body.get("git"), dict):
+                state.runs[provider_run_id]["git"] = body["git"]
         status = state.runs[provider_run_id]["status"]
+        git_meta = state.runs[provider_run_id].get("git") or {}
         return build_provider_result(
             provider_id=self.provider_id,
             provider_run_id=provider_run_id,
             raw_status=status,
             usage=state.runs[provider_run_id].get("usage"),
-            result_refs={"agent_id": agent_id},
+            result_refs={"agent_id": agent_id, "git": git_meta},
         )
 
     def cancel(self, provider_run_id: str, reason: str) -> ProviderResult:
         del reason
-        agent_id = self._run_to_agent.get(provider_run_id)
-        state = self._agents.get(agent_id or "")
-        if state is None:
-            raise DispatchError("DISPATCH_PROVIDER_RUN_NOT_FOUND", provider_run_id)
+        agent_id, state = self._resolve_agent(provider_run_id)
         if self._http is not None:
             self._request(
                 "POST",
@@ -224,10 +338,8 @@ class CursorCloudApiDriver:
         *,
         last_event_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        agent_id = self._run_to_agent.get(provider_run_id)
-        state = self._agents.get(agent_id or "")
-        if state is None:
-            raise DispatchError("DISPATCH_PROVIDER_RUN_NOT_FOUND", provider_run_id)
+        agent_id, state = self._resolve_agent(provider_run_id)
+        del state
         if self._sse is None:
             # Fake stream for offline tests.
             events = [

--- a/tools/agent_control/providers/cursor_cloud_api.py
+++ b/tools/agent_control/providers/cursor_cloud_api.py
@@ -9,6 +9,10 @@ from dataclasses import dataclass, field
 from typing import Any, Callable
 from urllib.parse import urlparse
 
+from tools.agent_control.delivery_verify import (
+    claimed_delivery_from_git,
+    truncate_run_result_text,
+)
 from tools.agent_control.errors import DispatchError
 from tools.agent_control.provider import ProviderRequest, ProviderResult
 from tools.agent_control.providers.cursor_common import (
@@ -211,38 +215,6 @@ class CursorCloudApiDriver:
             agent_id_client
         ).startswith("bc-"):
             raise DispatchError("PROVIDER_AGENT_ID_INVALID", str(agent_id_client))
-        # #region agent log
-        try:
-            import json
-            import time
-            from pathlib import Path
-
-            _dbg = Path(__file__).resolve().parents[3] / "debug-0f4913.log"
-            with _dbg.open("a", encoding="utf-8") as handle:
-                handle.write(
-                    json.dumps(
-                        {
-                            "sessionId": "0f4913",
-                            "runId": "live-create",
-                            "hypothesisId": "H2",
-                            "location": "cursor_cloud_api.py:dispatch",
-                            "message": "agentId_shape",
-                            "data": {
-                                "agent_id_len": len(str(agent_id_client)),
-                                "agent_id_prefix": str(agent_id_client)[:3],
-                                "has_uuid_dashes": str(agent_id_client).count("-") >= 5,
-                                "regex_ok": bool(_BC_ID.match(str(agent_id_client))),
-                                "auto_create": bool(auto_create),
-                            },
-                            "timestamp": int(time.time() * 1000),
-                        },
-                        separators=(",", ":"),
-                    )
-                    + "\n"
-                )
-        except OSError:
-            pass
-        # #endregion
         body: dict[str, Any] = {
             "prompt": {"text": request.prompt_text},
             "autoCreatePR": bool(auto_create),
@@ -331,12 +303,21 @@ class CursorCloudApiDriver:
                 "agent_id": agent_id,
                 "api": "v1",
                 "git": git_meta,
+                "claimed_delivery": claimed_delivery_from_git(git_meta),
+                "delivery_verified": False,
+                "raw_status": status,
             },
             delivery_receipt=request.delivery_receipt,
+            error_code=(
+                "PROVIDER_RUN_ERROR" if str(status).upper() == "ERROR" else None
+            ),
         )
 
     def watch(self, provider_run_id: str) -> ProviderResult:
         agent_id, state = self._resolve_agent(provider_run_id)
+        run_result_text: str | None = None
+        duration_ms: int | None = None
+        stream_error: dict[str, Any] | None = None
         if self._http is not None:
             body = self._request(
                 "GET",
@@ -347,15 +328,104 @@ class CursorCloudApiDriver:
             state.runs[provider_run_id]["status"] = status
             if isinstance(body.get("git"), dict):
                 state.runs[provider_run_id]["git"] = body["git"]
+            if isinstance(body.get("result"), str):
+                run_result_text = body["result"]
+                state.runs[provider_run_id]["result"] = run_result_text
+            if isinstance(body.get("durationMs"), int):
+                duration_ms = body["durationMs"]
+                state.runs[provider_run_id]["duration_ms"] = duration_ms
+            # OpenAPI Run has no structured error field; capture if present anyway.
+            if isinstance(body.get("error"), dict):
+                state.runs[provider_run_id]["error"] = body["error"]
         status = state.runs[provider_run_id]["status"]
         git_meta = state.runs[provider_run_id].get("git") or {}
+        if run_result_text is None and isinstance(
+            state.runs[provider_run_id].get("result"), str
+        ):
+            run_result_text = state.runs[provider_run_id]["result"]
+        if duration_ms is None and isinstance(
+            state.runs[provider_run_id].get("duration_ms"), int
+        ):
+            duration_ms = state.runs[provider_run_id]["duration_ms"]
+        err = state.runs[provider_run_id].get("error")
+        claimed = claimed_delivery_from_git(
+            git_meta if isinstance(git_meta, dict) else None
+        )
+        refs: dict[str, Any] = {
+            "agent_id": agent_id,
+            "api": "v1",
+            "git": git_meta,
+            "claimed_delivery": claimed,
+            "delivery_verified": False,
+            "raw_status": status,
+        }
+        truncated = truncate_run_result_text(run_result_text)
+        if truncated is not None:
+            refs["run_result_text"] = truncated
+        if duration_ms is not None:
+            refs["duration_ms"] = duration_ms
+        if isinstance(err, dict):
+            refs["run_error"] = {
+                "code": err.get("code"),
+                "message": err.get("message"),
+            }
+        if stream_error:
+            refs["stream_error"] = stream_error
+        error_code = None
+        if str(status).upper() == "ERROR":
+            error_code = (
+                isinstance(err, dict) and err.get("code")
+            ) or "PROVIDER_RUN_ERROR"
         return build_provider_result(
             provider_id=self.provider_id,
             provider_run_id=provider_run_id,
             raw_status=status,
             usage=state.runs[provider_run_id].get("usage"),
-            result_refs={"agent_id": agent_id, "git": git_meta},
+            result_refs=refs,
+            error_code=str(error_code) if error_code else None,
         )
+
+    def read_stream_diagnostics(self, provider_run_id: str) -> dict[str, Any]:
+        """Read-only SSE snapshot for an existing run (no follow-up / no create)."""
+        agent_id, state = self._resolve_agent(provider_run_id)
+        events = self.stream(provider_run_id)
+        out: dict[str, Any] = {
+            "agent_id": agent_id,
+            "provider_run_id": provider_run_id,
+            "events": [],
+            "result_text": None,
+            "stream_error": None,
+            "git": None,
+            "terminal_status": None,
+        }
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            name = event.get("event")
+            data = event.get("data") if isinstance(event.get("data"), dict) else {}
+            compact = {"event": name}
+            if name == "error":
+                compact["code"] = data.get("code")
+                compact["message"] = data.get("message")
+                out["stream_error"] = {
+                    "code": data.get("code"),
+                    "message": data.get("message"),
+                }
+            elif name == "result":
+                compact["status"] = data.get("status")
+                out["terminal_status"] = data.get("status")
+                if isinstance(data.get("text"), str):
+                    out["result_text"] = truncate_run_result_text(data.get("text"))
+                if isinstance(data.get("git"), dict):
+                    out["git"] = data.get("git")
+                    state.runs.setdefault(provider_run_id, {})["git"] = data["git"]
+            elif name == "status":
+                compact["status"] = data.get("status")
+                out["terminal_status"] = data.get("status") or out["terminal_status"]
+            out["events"].append(compact)
+            if len(out["events"]) >= 50:
+                break
+        return out
 
     def cancel(self, provider_run_id: str, reason: str) -> ProviderResult:
         del reason

--- a/tools/agent_control/providers/cursor_common.py
+++ b/tools/agent_control/providers/cursor_common.py
@@ -131,12 +131,16 @@ def guard_cloud_route_binding(
     pr_url: str | None,
     contract_target_pr: int | None,
     contract_target_branch: str | None,
+    human_go_live: bool = False,
 ) -> None:
-    if auto_create_pr:
+    if auto_create_pr and not human_go_live:
         raise DispatchError(
             "PROVIDER_ROUTE_AUTOPR_FORBIDDEN",
-            "autoCreatePR must remain false",
+            "autoCreatePR must remain false without Human-GO live cursor",
         )
+    if auto_create_pr and human_go_live:
+        # Human-GO live pilot may request PR creation; no workOnCurrentBranch bind.
+        return
     if work_on_current_branch:
         if not contract_target_pr or not contract_target_branch or not pr_url:
             raise DispatchError(

--- a/tools/agent_control/providers/factory.py
+++ b/tools/agent_control/providers/factory.py
@@ -47,6 +47,7 @@ def build_provider(
             sse=transports.get("sse"),
             allow_live=allow_live,
             model_catalog=transports.get("model_catalog"),
+            human_go_live=bool(transports.get("human_go_live", False)),
         )
     if provider_id == "cursor":
         raise DispatchError(

--- a/tools/agent_control/providers/live_http.py
+++ b/tools/agent_control/providers/live_http.py
@@ -1,0 +1,103 @@
+"""Stdlib HTTP transport for Cursor Cloud Agents API (live path only)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def _auth_header_from_env(environ: dict[str, str] | None = None) -> dict[str, str]:
+    env = environ if environ is not None else os.environ
+    key = env.get("CURSOR_API_KEY", "").strip()
+    if not key:
+        return {}
+    token = base64.b64encode(f"{key}:".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+def build_urllib_http_transport(
+    *,
+    environ: dict[str, str] | None = None,
+    timeout_seconds: float = 60.0,
+):
+    """Return an HttpTransport callable using urllib.
+
+    Auth header is attached per-request from env and never returned in the
+    response body. Callers must not log headers.
+    """
+
+    def _http(
+        *,
+        method: str,
+        url: str,
+        json_body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        # Compat: some call sites use ``json=`` keyword.
+        body = json_body
+        req_headers = {
+            "Accept": "application/json",
+            "User-Agent": "cdb-agent-control/1",
+        }
+        req_headers.update(_auth_header_from_env(environ))
+        if headers:
+            # Never allow caller to override Authorization with a logged value;
+            # only merge non-auth headers.
+            for k, v in headers.items():
+                if k.lower() == "authorization":
+                    continue
+                req_headers[k] = v
+        data = None
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            req_headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(
+            url, data=data, headers=req_headers, method=method.upper()
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_seconds) as resp:
+                raw = resp.read()
+                status = int(getattr(resp, "status", 200) or 200)
+                parsed: Any = {}
+                if raw:
+                    try:
+                        parsed = json.loads(raw.decode("utf-8"))
+                    except json.JSONDecodeError:
+                        parsed = {"raw_text": "[non-json]"}
+                return {
+                    "status": status,
+                    "json": parsed if isinstance(parsed, dict) else {},
+                }
+        except urllib.error.HTTPError as exc:
+            raw = exc.read() if hasattr(exc, "read") else b""
+            parsed = {}
+            if raw:
+                try:
+                    parsed = json.loads(raw.decode("utf-8"))
+                except json.JSONDecodeError:
+                    parsed = {}
+            return {
+                "status": int(exc.code),
+                "json": parsed if isinstance(parsed, dict) else {},
+            }
+        except urllib.error.URLError as exc:
+            raise ConnectionError(
+                str(exc.reason if hasattr(exc, "reason") else exc)
+            ) from exc
+
+    return _http
+
+
+def build_urllib_http_transport_compat():
+    """Wrapper accepting ``json=`` as used by CursorCloudApiDriver._request."""
+
+    inner = build_urllib_http_transport()
+
+    def _http(*, method: str, url: str, json=None, headers=None):  # noqa: A002
+        return inner(method=method, url=url, json_body=json, headers=headers)
+
+    return _http


### PR DESCRIPTION
## Summary
- Human-GO Cursor cloud live pilot (#4258)
- Dashboardless preflight: official Cursor API + `gh` + `.cursor/environment.json` (no dashboard click path)
- Adapter: persist `environment_requested` / `environment_resolved`; fail-closed on name mismatch; default binding `repos` + repo config (named `env` XOR `repos` per OpenAPI)

## Existing Cursor run (immutable)
- agent `bc-d1ba82b5-db1a-5040-b50a-2007040a65c7` / run `run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b` still ERROR
- **No new Cursor agent/run in this session** (`cursor_http_posts=0`)

## Dashboardless preflight (live read-only)
- CLI: `python -m tools.agent_control pilot cursor-preflight …`
- Schema: `cdb.cursor_live_preflight.v1`
- `credential_present=true`
- Repo config PASS (digest `sha256:67728065…`)
- Cursor repos lists `Claire_de_Binare`
- `ready_for_live_run=false` (fail-closed)

## Public API gaps (machine evidence)
- No `GET /v1/environments` (404) → cannot list/disambiguate duplicate dashboard env names
- AgentEnv = `type`+`name` only → no immutable environment ID/version
- Agent response often returns `env={type:cloud}` without name
- `GET /repos/.../installation` unreadable with user `gh` token (needs App JWT) → GitHub installation write grant **UNKNOWN**
- No public network/routing/account-PR-policy management API; use request `autoCreatePR` + explicit `repos`

## Environment resolution
- Canonical CDB path: `--binding-mode repos_plus_repo_config` (ignores duplicate named dashboard envs)
- Named mode remains BLOCKED when duplicates exist without public IDs → `HOLD_ENVIRONMENT_SELECTION_AMBIGUOUS` if forced

## Offline validation
- [x] unit preflight + provider tests
- [x] ruff / black / registry validate / git diff --check
- [x] secret scan
- [x] live preflight: 0 creates, 0 GitHub writes

## Non-goals
- Refs #4258 only — do not close
- No merge / no cdb-local-ci / no private dashboard API / no browser automation

## Next Live-GO
- **Not ready** until GitHub App installation permissions are machine-readable as write, or a documented CDB-approved alternate proof replaces the UNKNOWN fail-closed gate
- New create still needs **new explicit Human-GO** after that

Refs #4258