### PR TITLE
fix(agent-control): Cursor dual-run ERROR support bundle (Refs #4258)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,6 +249,8 @@ artifacts/local-dev-hygiene/
 # Generated reports and evidence runs (local/CI artifacts, not repository canon)
 /artifacts/reports/
 /artifacts/evidence-runs/
+/artifacts/agent_control/dual_run_4258_support/
+/artifacts/agent_control/dual_run_4258/
 
 # Local nested repo — mock exchange dependency candidate (github.com/didac-crst/mockexchange)
 # Intentionally kept local; must not be staged as gitlink or committed as submodule (#1645)

--- a/docs/evidence/agent_control/CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md
+++ b/docs/evidence/agent_control/CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md
@@ -1,0 +1,62 @@
+# Cursor Cloud Dual-Run Failure Evidence (#4258)
+
+- Generated: `2026-08-03T02:51:10Z`
+- Bundle digest: `sha256:fa2f925903d2908f0a191f377cfd05e53532a7ae183a18c53767e78060a4cae0`
+- Schema: `cdb.cursor_dual_run_support_bundle.v1` `1.0.0`
+- Issue: #4258 (remains OPEN)
+- Third Cursor run: **not started**
+- `cursor_http_posts`: 0
+
+## Direct evidence
+
+| Field | Run 1 | Run 2 |
+| --- | --- | --- |
+| CDB run | `adr-ee0a9384bc9940a9` | `adr-d97cf406ff9d486d` |
+| Evidence | `are-5ae1839fa8b0c71ad7e8b902` | `are-48dbdce0fbaf7ff5654b23f4` |
+| Agent | `bc-d1ba82b5-db1a-5040-b50a-2007040a65c7` | `bc-767ef75f-c948-5049-9bc2-0534fd6cf46f` |
+| Run | `run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b` | `run-c2c3898b-af9e-4f73-ad91-830f600561b9` |
+| Status | `ERROR` | `ERROR` |
+| Duration ms | 7824 | 7501 |
+| Tokens | 1041 | 1596 |
+| Claimed branch | `['cloud-cursor/cursor-cloud-pilot-marker-3c10']` | `['cloud-cursor/probe-4258-documentation-69b3']` |
+| GitHub ref | 404 | 404 |
+| Structured error | False | False |
+| Artifacts empty | True | True |
+
+## Failure phases
+
+- Last proven successful: `AGENT_REASONING`
+- First failed/missing: `GIT_PUSH`
+- Git push attempt proven: `False`
+
+## Root-cause classification
+
+- Primary: `UNKNOWN_OBSERVABILITY_GAP` (confidence `MEDIUM`)
+- Secondary: CURSOR_PLATFORM_INTERNAL, CURSOR_GITHUB_DELIVERY, CURSOR_MODEL_OR_RUNTIME, CURSOR_ENVIRONMENT_BOOTSTRAP
+- Cursor support required: `True`
+- Operator configuration required: `False`
+- CDB diagnostic fix required: `True`
+
+## Excluded (public evidence)
+
+- AUTH (create + GETs succeeded)
+- MODEL_NOT_AVAILABLE (tokens > 0 on both runs)
+- GITHUB_WRITE_PERMISSION_ROOT_CAUSE as sole cause (#4295 cursoragent commits exist; failed runs never verified push)
+- CDB create mapping failure (agents ACTIVE, runs accepted)
+- Full cold environment bootstrap as proven primary (duration ~8s with tokens; unproven)
+
+## Documented API path note
+
+Usage/artifacts are agent-scoped (`/v1/agents/{id}/usage`, `/v1/agents/{id}/artifacts`).
+A 404 on run-scoped `/runs/{runId}/usage` is **not** evidence that usage is missing.
+
+## Successful reference
+
+PR #4295 / `cloud-cursor/area-entry-link-canon-4a6a` includes `cursoragent` commits.
+This proves GitHub write capability on some path; it does **not** prove the failed
+API runs used the same workspace binding.
+
+## Limitations
+
+Public Cursor API did not return a machine-readable error reason. Exact platform
+root cause remains an observability gap pending Cursor backend investigation.

--- a/docs/evidence/agent_control/CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md
+++ b/docs/evidence/agent_control/CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md
@@ -1,11 +1,12 @@
 # Cursor Cloud Dual-Run Failure Evidence (#4258)
 
-- Generated: `2026-08-03T02:51:10Z`
-- Bundle digest: `sha256:fa2f925903d2908f0a191f377cfd05e53532a7ae183a18c53767e78060a4cae0`
-- Schema: `cdb.cursor_dual_run_support_bundle.v1` `1.0.0`
+- Generated: `2026-08-03T03:32:49Z`
+- Bundle digest: `sha256:c8b4766cc4121e394eb952250a5ccaa0be7468c85cb0aff9f3a7db4e6b9ec871`
+- Schema: `cdb.cursor_dual_run_support_bundle.v1` `1.1.0`
 - Issue: #4258 (remains OPEN)
 - Third Cursor run: **not started**
 - `cursor_http_posts`: 0
+- `external_send_allowed`: false
 
 ## Direct evidence
 
@@ -15,6 +16,8 @@
 | Evidence | `are-5ae1839fa8b0c71ad7e8b902` | `are-48dbdce0fbaf7ff5654b23f4` |
 | Agent | `bc-d1ba82b5-db1a-5040-b50a-2007040a65c7` | `bc-767ef75f-c948-5049-9bc2-0534fd6cf46f` |
 | Run | `run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b` | `run-c2c3898b-af9e-4f73-ad91-830f600561b9` |
+| created_at (UTC) | `2026-08-03T01:29:56.853Z` | `2026-08-03T02:29:44.901Z` |
+| terminal_at (UTC) | `2026-08-03T01:30:04.677Z` | `2026-08-03T02:29:52.402Z` |
 | Status | `ERROR` | `ERROR` |
 | Duration ms | 7824 | 7501 |
 | Tokens | 1041 | 1596 |
@@ -23,11 +26,22 @@
 | Structured error | False | False |
 | Artifacts empty | True | True |
 
+## Create / config
+
+- Binding: `repos_plus_repo_config`
+- `startingRef=main`, `autoCreatePR=true`, `workOnCurrentBranch=false`
+- Named environment: absent
+- `branchName`: absent
+- Repo config: `.cursor/environment.json` digest `sha256:e05855dfea663d49b4f143440677c9962f39117d6fae1af59259922fe039b314`
+- Exactly one accepted Create per documented run; earlier HTTP 400 created no resource
+
 ## Failure phases
 
 - Last proven successful: `AGENT_REASONING`
 - First failed/missing: `GIT_PUSH`
 - Git push attempt proven: `False`
+- Commit attempt proven: `False`
+- PR create attempt proven: `False`
 
 ## Root-cause classification
 
@@ -55,6 +69,12 @@ A 404 on run-scoped `/runs/{runId}/usage` is **not** evidence that usage is miss
 PR #4295 / `cloud-cursor/area-entry-link-canon-4a6a` includes `cursoragent` commits.
 This proves GitHub write capability on some path; it does **not** prove the failed
 API runs used the same workspace binding.
+
+## Privacy
+
+Numeric Cursor account ids, API key display names, unrelated repositories, usage UUIDs,
+cost data, full prompts, and credential presence metadata are omitted from the
+external package.
 
 ## Limitations
 

--- a/docs/runbooks/agent_control_live_cursor_pilot.md
+++ b/docs/runbooks/agent_control_live_cursor_pilot.md
@@ -37,6 +37,26 @@ python -m tools.agent_control pilot cursor-preflight \
   --out artifacts/agent_control/cursor-live-preflight.json
 ```
 
+### Dual-run ERROR support bundle (read-only)
+
+When existing Cursor runs terminate `ERROR` without a structured error object,
+build a redacted dual-run support package from recorded states (zero POSTs,
+no new agents/runs):
+
+```bash
+python -m tools.agent_control pilot cursor-support-bundle \
+  --state-run1 tests/fixtures/agent_control/cursor/dual_run_error_run1.json \
+  --state-run2 tests/fixtures/agent_control/cursor/dual_run_error_run2.json \
+  --shared tests/fixtures/agent_control/cursor/dual_run_shared_meta.json \
+  --output artifacts/agent_control/dual_run_4258_support \
+  --tracked-summary docs/evidence/agent_control/CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md
+```
+
+Documented usage/artifacts paths are agent-scoped (`GET /v1/agents/{id}/usage`,
+`GET /v1/agents/{id}/artifacts`). A 404 on run-scoped `/runs/{runId}/usage` is
+not evidence that usage is missing. Support drafts are ready-to-send but must
+not be mailed without a new explicit operator authorization.
+
 Canonical create binding for CDB: **`repos` + versioned `.cursor/environment.json`**
 (`--binding-mode repos_plus_repo_config`). Official API treats named `env` and
 `repos` as mutually exclusive. Named dashboard environments cannot be listed or

--- a/knowledge/logs/sessions/2026-08-03-issue-4258-cursor-dual-run-debug.md
+++ b/knowledge/logs/sessions/2026-08-03-issue-4258-cursor-dual-run-debug.md
@@ -1,0 +1,32 @@
+# Session 2026-08-03 — #4258 Cursor dual-run root-cause debug
+
+## Scope
+Plan-GO dual-run root-cause for existing Cursor ERROR runs only.
+No third agent/run. No merge. No `cdb-local-ci`. Issue stays OPEN.
+
+## Brain Evidence
+- brain_source: repo-only
+- brain_status: not-used
+- context_tool_status: available
+- context_trust_level: none
+- repo_fallback_reason: insufficient_evidence
+
+## Live facts
+- Issue #4258 OPEN
+- PR #4302 MERGED @ e899ed41
+- Both ERROR runs still readable via Cursor v1 GETs
+- Claimed branches both GitHub 404
+- Usage (documented agent-scoped path): run1=1041 tokens, run2=1596 tokens
+- Artifacts empty; stream status/result/done; no structured error
+- Primary classification: UNKNOWN_OBSERVABILITY_GAP (MEDIUM)
+- Router: CREATE_NEW_BATCH_PR → batch/agent-skills-issue-4258
+
+## Delivered
+- cursor-support-bundle CLI + module
+- recorded fixtures for both ERROR runs
+- provider live usage/artifacts on documented paths
+- tracked evidence + ready-to-send support draft (not sent)
+- regression tests (9 targeted passed)
+
+## Boundaries
+LR NO-GO; cursor_http_posts=0; no third run; no merge.

--- a/tests/fixtures/agent_control/cursor/dual_run_error_run1.json
+++ b/tests/fixtures/agent_control/cursor/dual_run_error_run1.json
@@ -1,0 +1,92 @@
+{
+  "schema_note": "Redacted recorded dual-run state for #4258 Run1. No auth headers, no tokens, no full prompt.",
+  "cdb_run_id": "adr-ee0a9384bc9940a9",
+  "evidence_id": "are-5ae1839fa8b0c71ad7e8b902",
+  "agent_id": "bc-d1ba82b5-db1a-5040-b50a-2007040a65c7",
+  "run_id": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+  "claimed_branch": "cloud-cursor/cursor-cloud-pilot-marker-3c10",
+  "agent": {
+    "id": "bc-d1ba82b5-db1a-5040-b50a-2007040a65c7",
+    "name": "Cursor cloud pilot marker",
+    "status": "ACTIVE",
+    "env": { "type": "cloud" },
+    "repos": [
+      { "url": "https://github.com/jannekbuengener/Claire_de_Binare" }
+    ],
+    "autoCreatePR": true,
+    "workOnCurrentBranch": false,
+    "createdAt": "2026-08-03T01:29:56.853Z",
+    "updatedAt": "2026-08-03T01:30:05.025Z",
+    "latestRunId": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b"
+  },
+  "run": {
+    "id": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+    "agentId": "bc-d1ba82b5-db1a-5040-b50a-2007040a65c7",
+    "status": "ERROR",
+    "createdAt": "2026-08-03T01:29:56.853Z",
+    "updatedAt": "2026-08-03T01:30:04.677Z",
+    "git": {
+      "branches": [
+        {
+          "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+          "branch": "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+        }
+      ]
+    }
+  },
+  "usage": {
+    "totalUsage": {
+      "inputTokens": 587,
+      "outputTokens": 454,
+      "cacheWriteTokens": 0,
+      "cacheReadTokens": 0,
+      "totalTokens": 1041
+    },
+    "cost": { "rawCostCents": 0.13111, "chargedCents": 0.13111 },
+    "runs": [
+      {
+        "id": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+        "usageUuid": "156f951d-a147-534f-9137-7fbe9d14edc1",
+        "usage": {
+          "inputTokens": 587,
+          "outputTokens": 454,
+          "cacheWriteTokens": 0,
+          "cacheReadTokens": 0,
+          "totalTokens": 1041
+        }
+      }
+    ]
+  },
+  "artifacts": { "items": [] },
+  "stream_events": [
+    {
+      "event": "status",
+      "data": {
+        "runId": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+        "status": "ERROR"
+      }
+    },
+    {
+      "event": "result",
+      "data": {
+        "runId": "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+        "status": "ERROR",
+        "git": {
+          "branches": [
+            {
+              "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+              "branch": "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+            }
+          ]
+        }
+      }
+    },
+    { "event": "done", "data": {} }
+  ],
+  "github_branch_lookup": { "status": 404, "message": "Not Found" },
+  "notes": [
+    "OpenAPI Run schema has no structured error field.",
+    "Usage fetched from documented /v1/agents/{id}/usage (not run-scoped).",
+    "Claimed branch remains unverified (GitHub 404)."
+  ]
+}

--- a/tests/fixtures/agent_control/cursor/dual_run_error_run2.json
+++ b/tests/fixtures/agent_control/cursor/dual_run_error_run2.json
@@ -1,0 +1,91 @@
+{
+  "schema_note": "Redacted recorded dual-run state for #4258 Run2. No auth headers, no tokens, no full prompt.",
+  "cdb_run_id": "adr-d97cf406ff9d486d",
+  "evidence_id": "are-48dbdce0fbaf7ff5654b23f4",
+  "agent_id": "bc-767ef75f-c948-5049-9bc2-0534fd6cf46f",
+  "run_id": "run-c2c3898b-af9e-4f73-ad91-830f600561b9",
+  "claimed_branch": "cloud-cursor/probe-4258-documentation-69b3",
+  "agent": {
+    "id": "bc-767ef75f-c948-5049-9bc2-0534fd6cf46f",
+    "name": "Probe 4258 documentation",
+    "status": "ACTIVE",
+    "env": { "type": "cloud" },
+    "repos": [
+      { "url": "https://github.com/jannekbuengener/Claire_de_Binare" }
+    ],
+    "autoCreatePR": true,
+    "workOnCurrentBranch": false,
+    "createdAt": "2026-08-03T02:29:44.901Z",
+    "updatedAt": "2026-08-03T02:29:52.742Z",
+    "latestRunId": "run-c2c3898b-af9e-4f73-ad91-830f600561b9"
+  },
+  "run": {
+    "id": "run-c2c3898b-af9e-4f73-ad91-830f600561b9",
+    "agentId": "bc-767ef75f-c948-5049-9bc2-0534fd6cf46f",
+    "status": "ERROR",
+    "createdAt": "2026-08-03T02:29:44.901Z",
+    "updatedAt": "2026-08-03T02:29:52.402Z",
+    "git": {
+      "branches": [
+        {
+          "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+          "branch": "cloud-cursor/probe-4258-documentation-69b3"
+        }
+      ]
+    }
+  },
+  "usage": {
+    "totalUsage": {
+      "inputTokens": 625,
+      "outputTokens": 971,
+      "cacheWriteTokens": 0,
+      "cacheReadTokens": 0,
+      "totalTokens": 1596
+    },
+    "cost": { "rawCostCents": 0.2615, "chargedCents": 0.2615 },
+    "runs": [
+      {
+        "id": "run-c2c3898b-af9e-4f73-ad91-830f600561b9",
+        "usageUuid": "1f9bc746-2008-520a-8841-4f19fcebfbf8",
+        "usage": {
+          "inputTokens": 625,
+          "outputTokens": 971,
+          "cacheWriteTokens": 0,
+          "cacheReadTokens": 0,
+          "totalTokens": 1596
+        }
+      }
+    ]
+  },
+  "artifacts": { "items": [] },
+  "stream_events": [
+    {
+      "event": "status",
+      "data": {
+        "runId": "run-c2c3898b-af9e-4f73-ad91-830f600561b9",
+        "status": "ERROR"
+      }
+    },
+    {
+      "event": "result",
+      "data": {
+        "runId": "run-c2c3898b-af9e-4f73-ad91-830f600561b9",
+        "status": "ERROR",
+        "git": {
+          "branches": [
+            {
+              "repoUrl": "github.com/jannekbuengener/Claire_de_Binare",
+              "branch": "cloud-cursor/probe-4258-documentation-69b3"
+            }
+          ]
+        }
+      }
+    },
+    { "event": "done", "data": {} }
+  ],
+  "github_branch_lookup": { "status": 404, "message": "Not Found" },
+  "notes": [
+    "Second ERROR run with identical stream signature.",
+    "Evidence digest (external): sha256:9d6854c8040308a56bc379e8890605228cf5dd5f66003217e21b22a103c064da"
+  ]
+}

--- a/tests/fixtures/agent_control/cursor/dual_run_shared_meta.json
+++ b/tests/fixtures/agent_control/cursor/dual_run_shared_meta.json
@@ -1,0 +1,16 @@
+{
+  "me": {
+    "apiKeyName": "api.CDB",
+    "userId": 363812814,
+    "createdAt": "2026-08-03T01:14:23.218Z"
+  },
+  "models_count": 33,
+  "claire_repository_listed": true,
+  "repositories": {
+    "items": [
+      { "url": "https://github.com/jannekbuengener/sample-brain" },
+      { "url": "https://github.com/jannekbuengener/Claire_de_Binare" },
+      { "url": "https://github.com/jannekbuengener/gpt-mcp-server" }
+    ]
+  }
+}

--- a/tests/unit/governance/test_cursor_providers_v1.py
+++ b/tests/unit/governance/test_cursor_providers_v1.py
@@ -267,6 +267,51 @@ def test_cloud_fake_http_sse_and_guards() -> None:
             }
         if method == "POST" and url.endswith("/cancel"):
             return {"status": 200, "json": {"status": "CANCELLED"}}
+        # Documented agent-scoped usage (NOT /runs/{id}/usage).
+        if (
+            method == "GET"
+            and "/agents/" in url
+            and url.rstrip("/").split("?")[0].endswith("/usage")
+        ):
+            path_only = url.split("?")[0]
+            assert "/runs/" not in path_only
+            return {
+                "status": 200,
+                "json": {
+                    "totalUsage": {
+                        "totalTokens": 10,
+                        "inputTokens": 6,
+                        "outputTokens": 4,
+                    },
+                    "cost": {"chargedCents": 0.1},
+                    "runs": [
+                        {
+                            "id": "run-1",
+                            "usageUuid": "u-1",
+                            "usage": {
+                                "totalTokens": 10,
+                                "inputTokens": 6,
+                                "outputTokens": 4,
+                            },
+                            "cost": {"chargedCents": 0.1},
+                        }
+                    ],
+                },
+            }
+        if method == "GET" and url.endswith("/artifacts"):
+            assert "/runs/" not in url
+            return {
+                "status": 200,
+                "json": {
+                    "items": [
+                        {
+                            "path": "artifacts/log.txt",
+                            "sizeBytes": 10,
+                            "digest": "sha256:" + "a" * 64,
+                        }
+                    ]
+                },
+            }
         if method == "GET" and "/runs/" in url:
             return {"status": 200, "json": {"status": "FINISHED"}}
         if method == "POST" and url.endswith("/archive"):
@@ -329,7 +374,9 @@ def test_cloud_fake_http_sse_and_guards() -> None:
     arts = driver.list_artifacts(result.provider_run_id)
     assert arts[0]["path"].startswith("artifacts/")
     usage = driver.get_usage(result.provider_run_id)
-    assert usage.get("cost") is None
+    assert usage.get("total_tokens") == 10
+    assert usage.get("source_path", "").endswith("/usage")
+    assert not any("/runs/" in u and u.endswith("/usage") for u in posts)
     driver.archive(result.provider_run_id)
     driver.unarchive(result.provider_run_id)
     with pytest.raises(DispatchError):

--- a/tests/unit/governance/test_cursor_support_bundle_v1.py
+++ b/tests/unit/governance/test_cursor_support_bundle_v1.py
@@ -31,6 +31,17 @@ SHARED = FIX / "dual_run_shared_meta.json"
 FAKE_KEY = "crsr_test_support_bundle_secret_DO_NOT_LEAK"
 
 
+def _bundle(tmp_path: Path) -> dict:
+    result = run_support_bundle_from_states(
+        state_run1_path=RUN1,
+        state_run2_path=RUN2,
+        shared_path=SHARED,
+        output_dir=tmp_path / "out",
+        repo_root=REPO_ROOT,
+    )
+    return json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
+
+
 @pytest.mark.unit
 def test_dual_error_runs_produce_deterministic_comparison(tmp_path: Path) -> None:
     out1 = tmp_path / "a"
@@ -48,8 +59,6 @@ def test_dual_error_runs_produce_deterministic_comparison(tmp_path: Path) -> Non
         shared_path=SHARED,
         output_dir=out2,
         repo_root=REPO_ROOT,
-        # freeze observed_at via rebuilding from same states — digests of
-        # comparison signature should match even if timestamps differ.
     )
     b1 = json.loads((out1 / "support_bundle_redacted.json").read_text(encoding="utf-8"))
     b2 = json.loads((out2 / "support_bundle_redacted.json").read_text(encoding="utf-8"))
@@ -81,6 +90,10 @@ def test_support_bundle_zero_posts_and_no_secrets(tmp_path: Path) -> None:
     dumped = json.dumps(bundle)
     assert bundle["safety"]["cursor_http_posts"] == 0
     assert result["cursor_http_posts"] == 0
+    assert result["new_agents"] == 0
+    assert result["new_runs"] == 0
+    assert result["third_run_started"] is False
+    assert bundle["external_send_allowed"] is False
     assert FAKE_KEY not in dumped
     assert "Authorization" not in dumped
     assert "Bearer " not in dumped
@@ -88,15 +101,60 @@ def test_support_bundle_zero_posts_and_no_secrets(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_claimed_branch_unverified_and_github_404_preserved(tmp_path: Path) -> None:
-    result = run_support_bundle_from_states(
-        state_run1_path=RUN1,
-        state_run2_path=RUN2,
-        shared_path=SHARED,
-        output_dir=tmp_path / "out",
-        repo_root=REPO_ROOT,
+def test_privacy_minimization_omits_account_and_cost_metadata(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    dumped = json.dumps(bundle)
+    draft = (tmp_path / "out" / "cursor_support_request_draft.md").read_text(
+        encoding="utf-8"
     )
-    bundle = json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
+    combined = dumped + "\n" + draft
+    # JSON/API field names must not appear as keys or raw values.
+    assert '"userId"' not in combined
+    assert "363812814" not in combined
+    assert '"apiKeyName"' not in combined
+    assert "api.CDB" not in combined
+    assert '"usageUuid"' not in combined
+    assert "156f951d-a147-534f-9137-7fbe9d14edc1" not in combined
+    assert "chargedCents" not in combined
+    assert "rawCostCents" not in combined
+    assert "sample-brain" not in combined
+    assert "gpt-mcp-server" not in combined
+    assert "redacted_states" not in dumped
+    assert "credential_present" not in dumped
+    assert "token_length" not in combined
+    assert "token_prefix" not in combined
+    assert "token_suffix" not in combined
+    assert "token_hash" not in combined
+    assert ".secrets/" not in combined
+    assert "C:\\Users\\" not in combined
+    assert "prompt_text" not in combined
+    # Required evidence retained
+    assert bundle["inferences"]["root_cause"]["primary_classification"] == (
+        "UNKNOWN_OBSERVABILITY_GAP"
+    )
+    assert bundle["direct_evidence"]["run1"]["created_at"] == (
+        "2026-08-03T01:29:56.853Z"
+    )
+    assert bundle["direct_evidence"]["run2"]["terminal_at"] == (
+        "2026-08-03T02:29:52.402Z"
+    )
+    assert (
+        bundle["direct_evidence"]["repo_config"]["named_environment_present"] is False
+    )
+    assert bundle["direct_evidence"]["repo_config"]["branchName_present"] is False
+    assert (
+        bundle["direct_evidence"]["successful_reference"]["proves_same_api_workspace"]
+        is False
+    )
+    shared = bundle["direct_evidence"]["shared"]
+    assert shared["numeric_account_id_omitted"] is True
+    assert shared["api_key_display_name_omitted"] is True
+    assert shared["unrelated_repositories_omitted"] is True
+
+
+@pytest.mark.unit
+def test_claimed_branch_unverified_and_github_404_preserved(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
     d = bundle["direct_evidence"]
     assert (
         d["run1"]["github_branch_status"][
@@ -112,6 +170,9 @@ def test_claimed_branch_unverified_and_github_404_preserved(tmp_path: Path) -> N
     )
     assert bundle["inferences"]["delivery_verified"] is False
     assert bundle["inferences"]["approval_context"].startswith("SKIP")
+    assert bundle["inferences"]["failure_phases"]["git_push_attempt_proven"] is False
+    assert bundle["inferences"]["failure_phases"]["commit_attempt_proven"] is False
+    assert bundle["inferences"]["failure_phases"]["pr_create_attempt_proven"] is False
 
 
 @pytest.mark.unit
@@ -124,14 +185,7 @@ def test_workspace_mismatch_unknown_without_identity_evidence() -> None:
 
 @pytest.mark.unit
 def test_reference_pr_does_not_prove_same_api_workspace(tmp_path: Path) -> None:
-    result = run_support_bundle_from_states(
-        state_run1_path=RUN1,
-        state_run2_path=RUN2,
-        shared_path=SHARED,
-        output_dir=tmp_path / "out",
-        repo_root=REPO_ROOT,
-    )
-    bundle = json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
+    bundle = _bundle(tmp_path)
     ref = bundle["direct_evidence"]["successful_reference"]
     assert ref["proves_same_api_workspace"] is False
     assert ref["proves_github_app_can_write_at_some_path"] is True
@@ -141,6 +195,22 @@ def test_reference_pr_does_not_prove_same_api_workspace(tmp_path: Path) -> None:
 def test_missing_error_maps_to_observability_gap_and_usage_not_pass(
     tmp_path: Path,
 ) -> None:
+    bundle = _bundle(tmp_path)
+    rc = bundle["inferences"]["root_cause"]
+    assert rc["primary_classification"] == "UNKNOWN_OBSERVABILITY_GAP"
+    assert bundle["direct_evidence"]["run1"]["usage_total_tokens"] > 0
+    assert bundle["direct_evidence"]["run2"]["usage_total_tokens"] > 0
+    assert bundle["inferences"]["delivery_verified"] is False
+    assert (
+        bundle["comparison"]["repeated_failure_signature"]["no_structured_error_object"]
+        is True
+    )
+
+
+@pytest.mark.unit
+def test_support_draft_contains_backend_questions_and_required_sections(
+    tmp_path: Path,
+) -> None:
     result = run_support_bundle_from_states(
         state_run1_path=RUN1,
         state_run2_path=RUN2,
@@ -148,17 +218,34 @@ def test_missing_error_maps_to_observability_gap_and_usage_not_pass(
         output_dir=tmp_path / "out",
         repo_root=REPO_ROOT,
     )
-    bundle = json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
-    rc = bundle["inferences"]["root_cause"]
-    assert rc["primary_classification"] == "UNKNOWN_OBSERVABILITY_GAP"
-    assert bundle["direct_evidence"]["run1"]["usage_total_tokens"] > 0
-    assert bundle["direct_evidence"]["run2"]["usage_total_tokens"] > 0
-    # usage without delivery never maps to PASS
-    assert bundle["inferences"]["delivery_verified"] is False
-    assert (
-        bundle["comparison"]["repeated_failure_signature"]["no_structured_error_object"]
-        is True
-    )
+    draft = Path(result["draft_path"]).read_text(encoding="utf-8")
+    for section in (
+        "## Summary",
+        "## Expected behavior",
+        "## Actual behavior",
+        "## Run 1 identifiers and timestamps",
+        "## Run 2 identifiers and timestamps",
+        "## Repeated failure signature",
+        "## Create and configuration details",
+        "## Repository visibility",
+        "## Successful reference PR #4295",
+        "## Ruled-out causes and evidence limits",
+        "## Requested backend investigation",
+        "## Security and privacy statement",
+        "## Attachment list",
+    ):
+        assert section in draft
+    assert "Internal backend error for both run IDs" in draft
+    assert "Workspace associated with the API key" in draft
+    assert "Workspace associated with the GitHub App installation" in draft
+    assert "Repository authorization and effective permissions" in draft
+    assert "Environment selection, repo-config resolution" in draft
+    assert "Selected model and model/runtime startup result" in draft
+    assert "Whether file changes, commits or Git pushes were attempted" in draft
+    assert "Whether PR creation was attempted" in draft
+    assert "run.git.branches" in draft
+    assert "known defect in the public Cloud Agents v1 API" in draft
+    assert (tmp_path / "out" / "ATTACHMENT_MANIFEST.md").is_file()
 
 
 @pytest.mark.unit
@@ -193,8 +280,13 @@ def test_cli_cursor_support_bundle(tmp_path: Path) -> None:
     assert code == 0
     assert (out / "support_bundle_redacted.json").is_file()
     assert (out / "cursor_support_request_draft.md").is_file()
+    assert (out / "ATTACHMENT_MANIFEST.md").is_file()
     assert tracked.is_file()
     text = tracked.read_text(encoding="utf-8")
     assert "UNKNOWN_OBSERVABILITY_GAP" in text
     assert "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b" in text
     assert "run-c2c3898b-af9e-4f73-ad91-830f600561b9" in text
+    assert '"userId"' not in text
+    assert '"apiKeyName"' not in text
+    assert "363812814" not in text
+    assert "api.CDB" not in text

--- a/tests/unit/governance/test_cursor_support_bundle_v1.py
+++ b/tests/unit/governance/test_cursor_support_bundle_v1.py
@@ -1,0 +1,200 @@
+"""
+test_id: tc_cursor_support_bundle_v1_001
+test_name: dual_run_cursor_support_bundle
+test_type: Bauteil-Test
+cdb_area: governance
+issue_ref: 4258
+security_relevant: true
+live_relevant: false
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.agent_control.cli import main as cli_main
+from tools.agent_control.cursor_support_bundle import (
+    SupportBundleError,
+    build_support_bundle,
+    classify_workspace_binding,
+    run_support_bundle_from_states,
+)
+from tools.agent_control.paths import REPO_ROOT
+
+FIX = REPO_ROOT / "tests" / "fixtures" / "agent_control" / "cursor"
+RUN1 = FIX / "dual_run_error_run1.json"
+RUN2 = FIX / "dual_run_error_run2.json"
+SHARED = FIX / "dual_run_shared_meta.json"
+FAKE_KEY = "crsr_test_support_bundle_secret_DO_NOT_LEAK"
+
+
+@pytest.mark.unit
+def test_dual_error_runs_produce_deterministic_comparison(tmp_path: Path) -> None:
+    out1 = tmp_path / "a"
+    out2 = tmp_path / "b"
+    r1 = run_support_bundle_from_states(
+        state_run1_path=RUN1,
+        state_run2_path=RUN2,
+        shared_path=SHARED,
+        output_dir=out1,
+        repo_root=REPO_ROOT,
+    )
+    r2 = run_support_bundle_from_states(
+        state_run1_path=RUN1,
+        state_run2_path=RUN2,
+        shared_path=SHARED,
+        output_dir=out2,
+        repo_root=REPO_ROOT,
+        # freeze observed_at via rebuilding from same states — digests of
+        # comparison signature should match even if timestamps differ.
+    )
+    b1 = json.loads((out1 / "support_bundle_redacted.json").read_text(encoding="utf-8"))
+    b2 = json.loads((out2 / "support_bundle_redacted.json").read_text(encoding="utf-8"))
+    assert (
+        b1["comparison"]["repeated_failure_signature"]
+        == b2["comparison"]["repeated_failure_signature"]
+    )
+    assert r1["run_ids"] == r2["run_ids"]
+    assert set(r1["run_ids"]) == {
+        "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
+        "run-c2c3898b-af9e-4f73-ad91-830f600561b9",
+    }
+    assert set(r1["evidence_ids"]) == {
+        "are-5ae1839fa8b0c71ad7e8b902",
+        "are-48dbdce0fbaf7ff5654b23f4",
+    }
+
+
+@pytest.mark.unit
+def test_support_bundle_zero_posts_and_no_secrets(tmp_path: Path) -> None:
+    result = run_support_bundle_from_states(
+        state_run1_path=RUN1,
+        state_run2_path=RUN2,
+        shared_path=SHARED,
+        output_dir=tmp_path / "out",
+        repo_root=REPO_ROOT,
+    )
+    bundle = json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
+    dumped = json.dumps(bundle)
+    assert bundle["safety"]["cursor_http_posts"] == 0
+    assert result["cursor_http_posts"] == 0
+    assert FAKE_KEY not in dumped
+    assert "Authorization" not in dumped
+    assert "Bearer " not in dumped
+    assert "crsr_" not in dumped
+
+
+@pytest.mark.unit
+def test_claimed_branch_unverified_and_github_404_preserved(tmp_path: Path) -> None:
+    result = run_support_bundle_from_states(
+        state_run1_path=RUN1,
+        state_run2_path=RUN2,
+        shared_path=SHARED,
+        output_dir=tmp_path / "out",
+        repo_root=REPO_ROOT,
+    )
+    bundle = json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
+    d = bundle["direct_evidence"]
+    assert (
+        d["run1"]["github_branch_status"][
+            "cloud-cursor/cursor-cloud-pilot-marker-3c10"
+        ]["status"]
+        == 404
+    )
+    assert (
+        d["run2"]["github_branch_status"]["cloud-cursor/probe-4258-documentation-69b3"][
+            "status"
+        ]
+        == 404
+    )
+    assert bundle["inferences"]["delivery_verified"] is False
+    assert bundle["inferences"]["approval_context"].startswith("SKIP")
+
+
+@pytest.mark.unit
+def test_workspace_mismatch_unknown_without_identity_evidence() -> None:
+    assert classify_workspace_binding({"apiKeyName": "api.CDB", "userId": 1}) == (
+        "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
+    )
+    assert classify_workspace_binding({}) == "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
+
+
+@pytest.mark.unit
+def test_reference_pr_does_not_prove_same_api_workspace(tmp_path: Path) -> None:
+    result = run_support_bundle_from_states(
+        state_run1_path=RUN1,
+        state_run2_path=RUN2,
+        shared_path=SHARED,
+        output_dir=tmp_path / "out",
+        repo_root=REPO_ROOT,
+    )
+    bundle = json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
+    ref = bundle["direct_evidence"]["successful_reference"]
+    assert ref["proves_same_api_workspace"] is False
+    assert ref["proves_github_app_can_write_at_some_path"] is True
+
+
+@pytest.mark.unit
+def test_missing_error_maps_to_observability_gap_and_usage_not_pass(
+    tmp_path: Path,
+) -> None:
+    result = run_support_bundle_from_states(
+        state_run1_path=RUN1,
+        state_run2_path=RUN2,
+        shared_path=SHARED,
+        output_dir=tmp_path / "out",
+        repo_root=REPO_ROOT,
+    )
+    bundle = json.loads(Path(result["bundle_path"]).read_text(encoding="utf-8"))
+    rc = bundle["inferences"]["root_cause"]
+    assert rc["primary_classification"] == "UNKNOWN_OBSERVABILITY_GAP"
+    assert bundle["direct_evidence"]["run1"]["usage_total_tokens"] > 0
+    assert bundle["direct_evidence"]["run2"]["usage_total_tokens"] > 0
+    # usage without delivery never maps to PASS
+    assert bundle["inferences"]["delivery_verified"] is False
+    assert (
+        bundle["comparison"]["repeated_failure_signature"]["no_structured_error_object"]
+        is True
+    )
+
+
+@pytest.mark.unit
+def test_post_nonzero_raises() -> None:
+    s1 = json.loads(RUN1.read_text(encoding="utf-8"))
+    s2 = json.loads(RUN2.read_text(encoding="utf-8"))
+    with pytest.raises(SupportBundleError) as exc:
+        build_support_bundle(state_run1=s1, state_run2=s2, cursor_posts=1)
+    assert exc.value.code == "BUNDLE_POST_FORBIDDEN"
+
+
+@pytest.mark.unit
+def test_cli_cursor_support_bundle(tmp_path: Path) -> None:
+    out = tmp_path / "bundle_out"
+    tracked = tmp_path / "CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md"
+    code = cli_main(
+        [
+            "pilot",
+            "cursor-support-bundle",
+            "--state-run1",
+            str(RUN1),
+            "--state-run2",
+            str(RUN2),
+            "--shared",
+            str(SHARED),
+            "--output",
+            str(out),
+            "--tracked-summary",
+            str(tracked),
+        ]
+    )
+    assert code == 0
+    assert (out / "support_bundle_redacted.json").is_file()
+    assert (out / "cursor_support_request_draft.md").is_file()
+    assert tracked.is_file()
+    text = tracked.read_text(encoding="utf-8")
+    assert "UNKNOWN_OBSERVABILITY_GAP" in text
+    assert "run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b" in text
+    assert "run-c2c3898b-af9e-4f73-ad91-830f600561b9" in text

--- a/tools/agent_control/cli.py
+++ b/tools/agent_control/cli.py
@@ -19,6 +19,8 @@ Examples:
   python -m tools.agent_control pilot run --manifest <PATH> [--out <REPORT>]
   python -m tools.agent_control pilot verify --report <PATH>
   python -m tools.agent_control pilot cursor-preflight --repository owner/name
+  python -m tools.agent_control pilot cursor-support-bundle \\
+      --state-run1 <PATH> --state-run2 <PATH> --output <DIR>
 """
 
 from __future__ import annotations
@@ -651,6 +653,36 @@ def cmd_pilot_cursor_preflight(args: argparse.Namespace) -> int:
     return EXIT_OK if report.get("ready_for_live_run") is True else EXIT_HOLD
 
 
+def cmd_pilot_cursor_support_bundle(args: argparse.Namespace) -> int:
+    """Dual-run Cursor ERROR support bundle — recorded states; zero POSTs."""
+    from tools.agent_control.cursor_support_bundle import (
+        SupportBundleError,
+        run_support_bundle_from_states,
+    )
+    from tools.agent_control.paths import REPO_ROOT
+
+    root = Path(args.repo_root) if args.repo_root else REPO_ROOT
+    tracked = Path(args.tracked_summary) if args.tracked_summary else None
+    shared = Path(args.shared) if args.shared else None
+    try:
+        result = run_support_bundle_from_states(
+            state_run1_path=Path(args.state_run1),
+            state_run2_path=Path(args.state_run2),
+            shared_path=shared,
+            output_dir=Path(args.output),
+            repo_root=root,
+            write_tracked_summary=tracked,
+        )
+    except SupportBundleError as exc:
+        print(f"INVALID {exc.code}: {exc.message}", file=sys.stderr)
+        return EXIT_ERROR
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"INVALID BUNDLE_IO: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+    _print_json(result)
+    return EXIT_OK
+
+
 def _approval_exit_code(recommendation: str) -> int:
     if recommendation == "APPROVE_RECOMMENDED":
         return EXIT_OK
@@ -1152,6 +1184,33 @@ def build_parser() -> argparse.ArgumentParser:
         default="run-d4d336e2-f7d5-4ab6-bbd8-1af94f9a094b",
     )
     p_pilot_pf.set_defaults(func=cmd_pilot_cursor_preflight)
+
+    p_pilot_sb = pilot_sub.add_parser(
+        "cursor-support-bundle",
+        help=(
+            "Dual-run Cursor ERROR support bundle (recorded states; zero POSTs; "
+            "Refs #4258)"
+        ),
+    )
+    p_pilot_sb.add_argument("--state-run1", required=True)
+    p_pilot_sb.add_argument("--state-run2", required=True)
+    p_pilot_sb.add_argument(
+        "--shared",
+        default=None,
+        help="Optional shared metadata JSON (/v1/me, repos listing flags)",
+    )
+    p_pilot_sb.add_argument(
+        "--output",
+        required=True,
+        help="Gitignored output directory for redacted bundle + support draft",
+    )
+    p_pilot_sb.add_argument(
+        "--tracked-summary",
+        default=None,
+        help="Optional tracked markdown summary path under docs/evidence/",
+    )
+    p_pilot_sb.add_argument("--repo-root", default=None)
+    p_pilot_sb.set_defaults(func=cmd_pilot_cursor_support_bundle)
 
     return parser
 

--- a/tools/agent_control/cursor_support_bundle.py
+++ b/tools/agent_control/cursor_support_bundle.py
@@ -1,0 +1,897 @@
+"""Dual-run Cursor Cloud support bundle (#4258).
+
+Read-only diagnosis over recorded or live Cursor Cloud Agents API v1 GETs.
+Zero POSTs. Separates direct evidence from inference. Never invents a root cause.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from tools.agent_control.cursor_preflight import (
+    HttpGet,
+    default_cursor_http_get,
+    load_cursor_api_key_into_env,
+)
+from tools.agent_control.errors import DispatchError
+from tools.agent_control.evidence.redact import assert_no_secrets, strip_secrets
+from tools.agent_control.paths import REPO_ROOT
+
+SCHEMA_ID = "cdb.cursor_dual_run_support_bundle.v1"
+SCHEMA_VERSION = "1.0.0"
+API_BASE = "https://api.cursor.com"
+
+# Documented agent-scoped surfaces (NOT run-scoped).
+USAGE_PATH = "/v1/agents/{agent_id}/usage"
+ARTIFACTS_PATH = "/v1/agents/{agent_id}/artifacts"
+
+HttpCounter = dict[str, int]
+GhRefLookup = Callable[[str], tuple[int, Any]]
+
+_PII_KEYS = re.compile(
+    r"(?i)^(useremail|userfirstname|userlastname|email|first_name|last_name)$"
+)
+
+
+class SupportBundleError(DispatchError):
+    """Fail-closed support-bundle error."""
+
+
+def _utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _duration_ms(created: str | None, updated: str | None) -> int | None:
+    if not created or not updated:
+        return None
+    try:
+        c = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        u = datetime.fromisoformat(updated.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0, int((u - c).total_seconds() * 1000))
+
+
+def redact_for_support(value: Any) -> Any:
+    """Structural redaction + PII key drop for support bundles."""
+    cleaned = strip_secrets(deepcopy(value))
+    return _drop_pii(cleaned)
+
+
+def _drop_pii(value: Any) -> Any:
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, item in value.items():
+            if _PII_KEYS.match(str(key)):
+                out[str(key)] = "[REDACTED_PII]"
+                continue
+            out[str(key)] = _drop_pii(item)
+        return out
+    if isinstance(value, list):
+        return [_drop_pii(x) for x in value]
+    return value
+
+
+def claimed_branches(run_body: dict[str, Any] | None) -> list[str]:
+    if not isinstance(run_body, dict):
+        return []
+    git = run_body.get("git") if isinstance(run_body.get("git"), dict) else {}
+    branches = git.get("branches") if isinstance(git.get("branches"), list) else []
+    out: list[str] = []
+    for item in branches:
+        if isinstance(item, dict) and item.get("branch"):
+            out.append(str(item["branch"]))
+    return out
+
+
+def has_structured_error(run_body: dict[str, Any] | None) -> bool:
+    if not isinstance(run_body, dict):
+        return False
+    return any(k in run_body for k in ("error", "errorMessage", "failureReason"))
+
+
+def summarize_stream(events: list[dict[str, Any]]) -> dict[str, Any]:
+    types: list[str | None] = []
+    for event in events:
+        ev = event.get("event")
+        if isinstance(ev, str):
+            types.append(ev)
+        elif isinstance(event.get("data"), dict):
+            types.append(event["data"].get("type"))
+        else:
+            types.append(None)
+    return {
+        "event_count": len(events),
+        "event_types": types,
+        "unique_types": sorted({t for t in types if t}),
+        "has_error_field": any(
+            isinstance(e.get("data"), dict)
+            and any(
+                "error" in str(k).lower() or "fail" in str(k).lower() for k in e["data"]
+            )
+            for e in events
+        ),
+    }
+
+
+def classify_workspace_binding(me: dict[str, Any] | None) -> str:
+    """Account mismatch only when concrete IDs contradict — else UNKNOWN."""
+    if not isinstance(me, dict) or not me:
+        return "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
+    # Public /v1/me has userId/apiKeyName but no workspace/team id to compare
+    # against GitHub App installation workspace. Match cannot be proven.
+    if me.get("userId") or me.get("apiKeyName"):
+        return "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
+    return "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
+
+
+def classify_model_phase(usage: dict[str, Any] | None) -> str:
+    if not isinstance(usage, dict):
+        return "MODEL_CAUSE_UNKNOWN"
+    runs = usage.get("runs") if isinstance(usage.get("runs"), list) else []
+    total = 0
+    if runs:
+        for item in runs:
+            if not isinstance(item, dict):
+                continue
+            u = item.get("usage") if isinstance(item.get("usage"), dict) else {}
+            total += int(u.get("totalTokens") or 0)
+    else:
+        tu = (
+            usage.get("totalUsage") if isinstance(usage.get("totalUsage"), dict) else {}
+        )
+        total = int(tu.get("totalTokens") or 0)
+    if total > 0:
+        return "MODEL_ACCEPTED_RUNTIME_FAILED"
+    if usage.get("statusCode") == 404 or usage.get("error"):
+        return "MODEL_CAUSE_UNKNOWN"
+    return "MODEL_EXECUTION_NOT_REACHED"
+
+
+def failure_phase_model(
+    *,
+    create_accepted: bool,
+    usage_tokens: int,
+    claimed: list[str],
+    github_404: bool,
+    structured_error: bool,
+) -> dict[str, Any]:
+    """Map dual-run evidence onto the failure-phase ladder."""
+    if not create_accepted:
+        last_ok = "AUTH"
+        first_bad = "CREATE_ACCEPTED"
+    elif usage_tokens > 0:
+        last_ok = "AGENT_REASONING"
+        first_bad = "TOOL_EXECUTION" if not structured_error else "TERMINAL_RESULT"
+    else:
+        last_ok = "CREATE_ACCEPTED"
+        first_bad = "ENVIRONMENT_RESOLUTION"
+    if claimed and github_404:
+        # Push not verified; do not claim push was attempted.
+        first_bad = "GIT_PUSH"
+    return {
+        "last_proven_successful_phase": last_ok,
+        "first_proven_failed_or_missing_phase": first_bad,
+        "unobservable_intermediate_phases": [
+            "REPOSITORY_RESOLUTION",
+            "ENVIRONMENT_RESOLUTION",
+            "ENVIRONMENT_BOOTSTRAP",
+            "MODEL_START",
+            "TOOL_EXECUTION",
+            "FILE_CHANGE",
+            "GIT_COMMIT",
+            "PR_CREATE",
+        ],
+        "git_push_attempt_proven": False,
+        "note": (
+            "Phantom git.branches without GitHub object does not prove push was "
+            "attempted; usage tokens prove model execution only."
+        ),
+    }
+
+
+def root_cause_classification(
+    *,
+    both_error: bool,
+    structured_error: bool,
+    usage_tokens_run1: int,
+    usage_tokens_run2: int,
+    phantom_branches: bool,
+    github_404_both: bool,
+    workspace_class: str,
+) -> dict[str, Any]:
+    """Primary classification — fail closed to UNKNOWN_OBSERVABILITY_GAP."""
+    hypotheses = [
+        {
+            "category": "CURSOR_PLATFORM_INTERNAL",
+            "confidence": "MEDIUM",
+            "rationale": (
+                "Both runs terminal ERROR without structured error object; "
+                "stream status/result/done only; phantom branches."
+            ),
+        },
+        {
+            "category": "CURSOR_GITHUB_DELIVERY",
+            "confidence": "MEDIUM",
+            "rationale": (
+                "Claimed branches present while GitHub refs 404; "
+                "delivery_verified must remain false."
+            ),
+        },
+        {
+            "category": "CURSOR_MODEL_OR_RUNTIME",
+            "confidence": "LOW",
+            "rationale": (
+                "Tokens were consumed then ERROR; model id not echoed on agent GET."
+            ),
+        },
+        {
+            "category": "CURSOR_ENVIRONMENT_BOOTSTRAP",
+            "confidence": "LOW",
+            "rationale": (
+                "~8s duration with tokens is weakly compatible with full cold "
+                "Docker+pip bootstrap; cannot prove env failure from public API."
+            ),
+        },
+        {
+            "category": "CURSOR_WORKSPACE_ACCOUNT_MISMATCH",
+            "confidence": "NONE",
+            "rationale": (
+                f"workspace_class={workspace_class}; no contradictory workspace IDs."
+            ),
+        },
+    ]
+    primary = "UNKNOWN_OBSERVABILITY_GAP"
+    confidence = "MEDIUM" if both_error and not structured_error else "LOW"
+    return {
+        "primary_classification": primary,
+        "confidence": confidence,
+        "secondary_factors": [
+            h["category"] for h in hypotheses if h["confidence"] in {"MEDIUM", "LOW"}
+        ],
+        "hypotheses": hypotheses,
+        "cdb_fix_required": True,
+        "operator_configuration_required": False,
+        "cursor_support_required": True,
+        "direct_evidence_summary": {
+            "both_terminal_ERROR": both_error,
+            "structured_error_present": structured_error,
+            "usage_tokens": {
+                "run1": usage_tokens_run1,
+                "run2": usage_tokens_run2,
+            },
+            "phantom_branches": phantom_branches,
+            "github_404_both": github_404_both,
+            "workspace_class": workspace_class,
+        },
+        "rule": (
+            "No single category reaches HIGH with public API fields; "
+            "primary remains UNKNOWN_OBSERVABILITY_GAP."
+        ),
+    }
+
+
+def load_run_state(path: Path) -> dict[str, Any]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise SupportBundleError("BUNDLE_STATE_INVALID", f"not an object: {path}")
+    return raw
+
+
+def _usage_tokens(usage_body: dict[str, Any] | None) -> int:
+    if not isinstance(usage_body, dict):
+        return 0
+    tu = usage_body.get("totalUsage")
+    if isinstance(tu, dict) and tu.get("totalTokens") is not None:
+        return int(tu["totalTokens"])
+    runs = usage_body.get("runs")
+    if isinstance(runs, list):
+        total = 0
+        for item in runs:
+            if isinstance(item, dict) and isinstance(item.get("usage"), dict):
+                total += int(item["usage"].get("totalTokens") or 0)
+        return total
+    return 0
+
+
+def _default_gh_branch_lookup(branch: str) -> tuple[int, Any]:
+    import subprocess
+
+    repo = "jannekbuengener/Claire_de_Binare"
+    proc = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/git/ref/heads/{branch}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return 404, {"message": "Not Found", "status": "404"}
+    try:
+        return 200, json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return 200, {"raw": True}
+
+
+def collect_live_run(
+    *,
+    agent_id: str,
+    run_id: str,
+    http_get: HttpGet,
+    counters: HttpCounter,
+) -> dict[str, Any]:
+    """Official documented GETs only — never POST."""
+
+    def get(path: str) -> tuple[int, Any]:
+        counters["GET"] = counters.get("GET", 0) + 1
+        if counters.get("POST", 0):
+            raise SupportBundleError(
+                "BUNDLE_POST_FORBIDDEN", "support bundle must not POST"
+            )
+        return http_get(path)
+
+    agent_st, agent_body = get(f"/v1/agents/{agent_id}")
+    run_st, run_body = get(f"/v1/agents/{agent_id}/runs/{run_id}")
+    list_st, list_body = get(f"/v1/agents/{agent_id}/runs")
+    usage_st, usage_body = get(USAGE_PATH.format(agent_id=agent_id))
+    # Optional filter query is documented.
+    usage_q_st, usage_q_body = get(
+        f"{USAGE_PATH.format(agent_id=agent_id)}?runId={run_id}"
+    )
+    art_st, art_body = get(ARTIFACTS_PATH.format(agent_id=agent_id))
+    return {
+        "agent_id": agent_id,
+        "run_id": run_id,
+        "http": {
+            "agent": agent_st,
+            "run": run_st,
+            "runs_list": list_st,
+            "usage": usage_st,
+            "usage_filtered": usage_q_st,
+            "artifacts": art_st,
+        },
+        "agent": agent_body if isinstance(agent_body, dict) else {"_non_object": True},
+        "run": run_body if isinstance(run_body, dict) else {"_non_object": True},
+        "runs_list": list_body if isinstance(list_body, dict) else {},
+        "usage": usage_body if isinstance(usage_body, dict) else {},
+        "usage_filtered": usage_q_body if isinstance(usage_q_body, dict) else {},
+        "artifacts": art_body if isinstance(art_body, dict) else {},
+        "stream_events": [],
+        "stream_note": (
+            "stream omitted in live collect helper; supply recorded stream in state"
+        ),
+    }
+
+
+def build_support_bundle(
+    *,
+    state_run1: dict[str, Any],
+    state_run2: dict[str, Any],
+    repo_root: Path | None = None,
+    shared: dict[str, Any] | None = None,
+    reference_pr: dict[str, Any] | None = None,
+    github_lookups: dict[str, tuple[int, Any]] | None = None,
+    env_config_digest: str | None = None,
+    cursor_posts: int = 0,
+    observed_at: str | None = None,
+) -> dict[str, Any]:
+    """Build deterministic redacted dual-run support bundle from state objects."""
+    if cursor_posts != 0:
+        raise SupportBundleError(
+            "BUNDLE_POST_FORBIDDEN",
+            f"cursor_posts must be 0, got {cursor_posts}",
+        )
+    root = repo_root or REPO_ROOT
+    env_path = root / ".cursor" / "environment.json"
+    if env_config_digest is None and env_path.is_file():
+        env_config_digest = _sha256_bytes(env_path.read_bytes())
+
+    r1 = redact_for_support(state_run1)
+    r2 = redact_for_support(state_run2)
+    shared_r = redact_for_support(shared or {})
+
+    run1_body = r1.get("run") or r1.get("get_run") or {}
+    run2_body = r2.get("run") or r2.get("get_run") or {}
+    if not isinstance(run1_body, dict):
+        run1_body = {}
+    if not isinstance(run2_body, dict):
+        run2_body = {}
+
+    claimed1 = claimed_branches(run1_body) or list(
+        filter(None, [r1.get("claimed_branch")])
+    )
+    claimed2 = claimed_branches(run2_body) or list(
+        filter(None, [r2.get("claimed_branch")])
+    )
+
+    lookups = github_lookups or {}
+    gh1 = {
+        b: {"status": lookups.get(b, (404, {"message": "Not Found"}))[0]}
+        for b in claimed1
+    }
+    gh2 = {
+        b: {"status": lookups.get(b, (404, {"message": "Not Found"}))[0]}
+        for b in claimed2
+    }
+    github_404_both = all(v["status"] == 404 for v in {**gh1, **gh2}.values()) and bool(
+        claimed1 and claimed2
+    )
+
+    usage1 = r1.get("usage") if isinstance(r1.get("usage"), dict) else {}
+    usage2 = r2.get("usage") if isinstance(r2.get("usage"), dict) else {}
+    tokens1 = _usage_tokens(usage1)
+    tokens2 = _usage_tokens(usage2)
+
+    stream1 = (
+        r1.get("stream_events") if isinstance(r1.get("stream_events"), list) else []
+    )
+    stream2 = (
+        r2.get("stream_events") if isinstance(r2.get("stream_events"), list) else []
+    )
+    stream_sum1 = summarize_stream(stream1)
+    stream_sum2 = summarize_stream(stream2)
+
+    status1 = run1_body.get("status")
+    status2 = run2_body.get("status")
+    both_error = status1 == "ERROR" and status2 == "ERROR"
+    structured = has_structured_error(run1_body) or has_structured_error(run2_body)
+
+    me = shared_r.get("me") if isinstance(shared_r.get("me"), dict) else {}
+    workspace_class = classify_workspace_binding(me)
+    model_class = classify_model_phase(usage1 if tokens1 else usage2)
+
+    phases = failure_phase_model(
+        create_accepted=True,
+        usage_tokens=max(tokens1, tokens2),
+        claimed=claimed1 + claimed2,
+        github_404=github_404_both,
+        structured_error=structured,
+    )
+    rc = root_cause_classification(
+        both_error=both_error,
+        structured_error=structured,
+        usage_tokens_run1=tokens1,
+        usage_tokens_run2=tokens2,
+        phantom_branches=bool(claimed1 or claimed2) and github_404_both,
+        github_404_both=github_404_both,
+        workspace_class=workspace_class,
+    )
+
+    duration1 = _duration_ms(run1_body.get("createdAt"), run1_body.get("updatedAt"))
+    duration2 = _duration_ms(run2_body.get("createdAt"), run2_body.get("updatedAt"))
+
+    identical = []
+    different = []
+    for field, a, b in [
+        ("run.status", status1, status2),
+        (
+            "stream.unique_types",
+            stream_sum1.get("unique_types"),
+            stream_sum2.get("unique_types"),
+        ),
+        (
+            "stream.event_count",
+            stream_sum1.get("event_count"),
+            stream_sum2.get("event_count"),
+        ),
+        ("artifacts_empty", _artifacts_empty(r1), _artifacts_empty(r2)),
+        (
+            "structured_error",
+            has_structured_error(run1_body),
+            has_structured_error(run2_body),
+        ),
+    ]:
+        entry = {"field": field, "run1": a, "run2": b}
+        if a == b:
+            identical.append(entry)
+        else:
+            different.append(entry)
+    different.append({"field": "claimed_branch", "run1": claimed1, "run2": claimed2})
+    different.append({"field": "usage.totalTokens", "run1": tokens1, "run2": tokens2})
+
+    ref = reference_pr or {
+        "pr": 4295,
+        "branch": "cloud-cursor/area-entry-link-canon-4a6a",
+        "commit_authors_include_cursoragent": True,
+        "pr_author": "jannekbuengener",
+        "proves_same_api_workspace": False,
+        "proves_github_app_can_write_at_some_path": True,
+        "note": (
+            "Successful reference proves GitHub write via cursoragent commit "
+            "authorship on #4295; does not prove the failed API runs used the "
+            "same launch path or workspace binding."
+        ),
+    }
+
+    bundle = {
+        "schema_id": SCHEMA_ID,
+        "schema_version": SCHEMA_VERSION,
+        "issue": 4258,
+        "repository": "jannekbuengener/Claire_de_Binare",
+        "observed_at": observed_at or _utc_now(),
+        "api_version": "cursor-cloud-agents-v1",
+        "credential_present": True,
+        "safety": {
+            "cursor_http_posts": 0,
+            "new_agents": 0,
+            "new_runs": 0,
+            "follow_ups": 0,
+            "third_run_started": False,
+        },
+        "direct_evidence": {
+            "run1": {
+                "cdb_run_id": r1.get("cdb_run_id")
+                or r1.get("meta", {}).get("cdb_run_id"),
+                "evidence_id": r1.get("evidence_id"),
+                "agent_id": r1.get("agent_id"),
+                "run_id": r1.get("run_id"),
+                "status": status1,
+                "duration_ms": duration1,
+                "claimed_branches": claimed1,
+                "github_branch_status": gh1,
+                "usage_total_tokens": tokens1,
+                "artifacts_empty": _artifacts_empty(r1),
+                "structured_error": has_structured_error(run1_body),
+                "stream": stream_sum1,
+                "agent_env": (
+                    (r1.get("agent") or {}).get("env")
+                    if isinstance(r1.get("agent"), dict)
+                    else None
+                ),
+                "autoCreatePR": (
+                    (r1.get("agent") or {}).get("autoCreatePR")
+                    if isinstance(r1.get("agent"), dict)
+                    else None
+                ),
+            },
+            "run2": {
+                "cdb_run_id": r2.get("cdb_run_id")
+                or r2.get("meta", {}).get("cdb_run_id"),
+                "evidence_id": r2.get("evidence_id"),
+                "agent_id": r2.get("agent_id"),
+                "run_id": r2.get("run_id"),
+                "status": status2,
+                "duration_ms": duration2,
+                "claimed_branches": claimed2,
+                "github_branch_status": gh2,
+                "usage_total_tokens": tokens2,
+                "artifacts_empty": _artifacts_empty(r2),
+                "structured_error": has_structured_error(run2_body),
+                "stream": stream_sum2,
+                "agent_env": (
+                    (r2.get("agent") or {}).get("env")
+                    if isinstance(r2.get("agent"), dict)
+                    else None
+                ),
+                "autoCreatePR": (
+                    (r2.get("agent") or {}).get("autoCreatePR")
+                    if isinstance(r2.get("agent"), dict)
+                    else None
+                ),
+            },
+            "shared": {
+                "me_keys": sorted(me.keys()) if me else [],
+                "apiKeyName": me.get("apiKeyName"),
+                "userId_present": me.get("userId") is not None,
+                "repositories_claire_listed": shared_r.get("claire_repository_listed"),
+                "models_count": shared_r.get("models_count"),
+            },
+            "environment_config_digest": env_config_digest,
+            "binding_mode": "repos_plus_repo_config",
+            "startingRef": "main",
+            "autoCreatePR": True,
+            "successful_reference": ref,
+            "usage_path_documented": USAGE_PATH,
+            "artifacts_path_documented": ARTIFACTS_PATH,
+            "wrong_run_scoped_usage_path_is_not_evidence": True,
+        },
+        "inferences": {
+            "workspace_binding": workspace_class,
+            "model_runtime": model_class,
+            "failure_phases": phases,
+            "root_cause": rc,
+            "excluded_causes": [
+                "AUTH (create + GETs succeeded)",
+                "MODEL_NOT_AVAILABLE (tokens > 0 on both runs)",
+                "GITHUB_WRITE_PERMISSION_ROOT_CAUSE as sole cause "
+                "(#4295 cursoragent commits exist; failed runs never verified push)",
+                "CDB create mapping failure (agents ACTIVE, runs accepted)",
+                "Full cold environment bootstrap as proven primary "
+                "(duration ~8s with tokens; unproven)",
+            ],
+            "approval_context": "SKIP — no verified delivery head",
+            "delivery_verified": False,
+        },
+        "comparison": {
+            "identical_fields": identical,
+            "different_fields": different,
+            "repeated_failure_signature": {
+                "both_terminal_ERROR": both_error,
+                "stream_types": ["status", "result", "done"],
+                "phantom_branch_without_github_object": github_404_both,
+                "no_structured_error_object": not structured,
+                "artifacts_empty": True,
+                "usage_tokens_nonzero": tokens1 > 0 and tokens2 > 0,
+            },
+        },
+        "redacted_states": {"run1": r1, "run2": r2, "shared": shared_r},
+        "support_request_ready": True,
+        "external_send_allowed": False,
+    }
+    assert_no_secrets(bundle)
+    # PII placeholders are intentional and not secret-like.
+    return bundle
+
+
+def _artifacts_empty(state: dict[str, Any]) -> bool:
+    arts = state.get("artifacts")
+    if isinstance(arts, dict):
+        items = arts.get("items")
+        if isinstance(items, list):
+            return len(items) == 0
+        if arts.get("statusCode") == 404:
+            # Wrong-path 404 must not be treated as empty inventory proof.
+            return True
+    return True
+
+
+def render_support_request_draft(bundle: dict[str, Any]) -> str:
+    """English, ready-to-send Cursor Support draft — not auto-sent."""
+    d = bundle["direct_evidence"]
+    r1, r2 = d["run1"], d["run2"]
+    rc = bundle["inferences"]["root_cause"]
+    return f"""# Cursor Cloud Agents API — Dual-run ERROR support request
+
+## Summary
+Two consecutive Cloud Agents API v1 creates against `jannekbuengener/Claire_de_Binare`
+ended in terminal `ERROR` (~8s each). Both runs report `git.branches` names, but the
+corresponding GitHub refs return 404. No structured error object is present on the
+Run resource. Public API observability is insufficient to prove a single root cause
+(`primary_classification={rc["primary_classification"]}`, confidence={rc["confidence"]}).
+
+## Account and repository
+- API key name (non-secret): `{d["shared"].get("apiKeyName")}`
+- userId present: {d["shared"].get("userId_present")}
+- Repository: `{bundle["repository"]}`
+- Repo listed by `GET /v1/repositories`: {d["shared"].get("repositories_claire_listed")}
+- Binding: `repos` + repo `.cursor/environment.json` (`repos_plus_repo_config`)
+- `startingRef=main`, `autoCreatePR=true`
+- Environment config digest: `{d.get("environment_config_digest")}`
+
+## Expected behavior
+Agent run finishes with FINISHED (or a structured error), pushes a real GitHub branch
+when `git.branches` is populated, and optionally opens a PR when `autoCreatePR=true`.
+
+## Observed behavior
+- Terminal status: ERROR for both runs
+- Stream events: status → result → done (no error field)
+- `git.branches` populated; GitHub branch refs 404
+- Artifacts list empty
+- Usage shows non-zero tokens (model did execute)
+- No third agent/run was started after these two failures
+
+## Run 1 identifiers
+- CDB run: `{r1.get("cdb_run_id")}`
+- Evidence: `{r1.get("evidence_id")}`
+- Agent: `{r1.get("agent_id")}`
+- Run: `{r1.get("run_id")}`
+- Duration ms: {r1.get("duration_ms")}
+- Claimed branch: {r1.get("claimed_branches")}
+- Usage totalTokens: {r1.get("usage_total_tokens")}
+
+## Run 2 identifiers
+- CDB run: `{r2.get("cdb_run_id")}`
+- Evidence: `{r2.get("evidence_id")}`
+- Agent: `{r2.get("agent_id")}`
+- Run: `{r2.get("run_id")}`
+- Duration ms: {r2.get("duration_ms")}
+- Claimed branch: {r2.get("claimed_branches")}
+- Usage totalTokens: {r2.get("usage_total_tokens")}
+
+## Repeated failure signature
+{json.dumps(bundle["comparison"]["repeated_failure_signature"], indent=2)}
+
+## GitHub verification
+- Claimed branches: 404 on `git/ref/heads/...`
+- Successful reference PR #4295 includes `cursoragent` commits on branch
+  `cloud-cursor/area-entry-link-canon-4a6a` (proves GitHub App write capability
+  at some path; does **not** prove the failed API runs shared that workspace binding)
+
+## Environment configuration
+```json
+{json.dumps({
+  "build": {"dockerfile": "../ci/Dockerfile", "context": ".."},
+  "install": "python -m pip install -r requirements.txt -r requirements-dev.txt -r requirements-mcp.txt",
+  "agentCanUpdateSnapshot": False,
+}, indent=2)}
+```
+
+## API request shape (redacted)
+- `repos[0].url` = https://github.com/jannekbuengener/Claire_de_Binare
+- `repos[0].startingRef` = main
+- `autoCreatePR` = true
+- `workOnCurrentBranch` = false
+- no named `env.name` (repos mode)
+- prompt text omitted from this package
+
+## What has been ruled out
+{chr(10).join("- " + x for x in bundle["inferences"]["excluded_causes"])}
+
+## Requested backend investigation
+1. Backend error reason for both run IDs above
+2. Workspace linked to the API key vs GitHub App installation
+3. Repository authorization at execution time
+4. Environment/bootstrap resolution for repos+repo-config mode
+5. Model/runtime startup details (model id actually used)
+6. Whether Git push or PR creation was attempted
+7. Why `run.git.branches` was populated without a GitHub branch object
+8. Whether this is a known v1 public-beta issue
+
+## Security and privacy note
+No API keys, Authorization headers, or secret values are included. Prompt bodies are
+omitted. Please do not request dashboard-only private endpoints as a prerequisite for
+answering the backend error reason for these two run IDs.
+
+---
+external_send_allowed: false (operator must explicitly authorize any send)
+"""
+
+
+def run_support_bundle_from_states(
+    *,
+    state_run1_path: Path,
+    state_run2_path: Path,
+    output_dir: Path,
+    repo_root: Path | None = None,
+    shared_path: Path | None = None,
+    write_tracked_summary: Path | None = None,
+    github_lookups: dict[str, tuple[int, Any]] | None = None,
+) -> dict[str, Any]:
+    """Offline/recorded entrypoint used by CLI and tests."""
+    s1 = load_run_state(state_run1_path)
+    s2 = load_run_state(state_run2_path)
+    shared = load_run_state(shared_path) if shared_path else {}
+    # Default GitHub 404 for claimed branches when lookups not injected.
+    if github_lookups is None:
+        github_lookups = {}
+        for state in (s1, s2):
+            run_body = state.get("run") or state.get("get_run") or {}
+            for branch in claimed_branches(
+                run_body if isinstance(run_body, dict) else {}
+            ):
+                github_lookups.setdefault(branch, (404, {"message": "Not Found"}))
+            if state.get("claimed_branch"):
+                github_lookups.setdefault(
+                    str(state["claimed_branch"]), (404, {"message": "Not Found"})
+                )
+            gh = state.get("github_branch_lookup")
+            if isinstance(gh, dict) and state.get("claimed_branch"):
+                github_lookups[str(state["claimed_branch"])] = (
+                    int(gh.get("status") or 404),
+                    gh,
+                )
+
+    bundle = build_support_bundle(
+        state_run1=s1,
+        state_run2=s2,
+        repo_root=repo_root,
+        shared=shared,
+        github_lookups=github_lookups,
+        cursor_posts=0,
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = output_dir / "support_bundle_redacted.json"
+    draft_path = output_dir / "cursor_support_request_draft.md"
+    payload = json.dumps(bundle, indent=2, sort_keys=True) + "\n"
+    bundle_path.write_text(payload, encoding="utf-8")
+    draft_path.write_text(render_support_request_draft(bundle), encoding="utf-8")
+    digest = _sha256_bytes(payload.encode("utf-8"))
+    result = {
+        "bundle_path": str(bundle_path),
+        "draft_path": str(draft_path),
+        "bundle_digest": digest,
+        "primary_classification": bundle["inferences"]["root_cause"][
+            "primary_classification"
+        ],
+        "confidence": bundle["inferences"]["root_cause"]["confidence"],
+        "cursor_http_posts": 0,
+        "run_ids": [
+            bundle["direct_evidence"]["run1"]["run_id"],
+            bundle["direct_evidence"]["run2"]["run_id"],
+        ],
+        "evidence_ids": [
+            bundle["direct_evidence"]["run1"]["evidence_id"],
+            bundle["direct_evidence"]["run2"]["evidence_id"],
+        ],
+    }
+    if write_tracked_summary is not None:
+        write_tracked_summary.parent.mkdir(parents=True, exist_ok=True)
+        write_tracked_summary.write_text(
+            _tracked_summary_markdown(bundle, digest),
+            encoding="utf-8",
+        )
+        result["tracked_summary"] = str(write_tracked_summary)
+    return result
+
+
+def _tracked_summary_markdown(bundle: dict[str, Any], digest: str) -> str:
+    d = bundle["direct_evidence"]
+    rc = bundle["inferences"]["root_cause"]
+    ph = bundle["inferences"]["failure_phases"]
+    return f"""# Cursor Cloud Dual-Run Failure Evidence (#4258)
+
+- Generated: `{bundle["observed_at"]}`
+- Bundle digest: `{digest}`
+- Schema: `{bundle["schema_id"]}` `{bundle["schema_version"]}`
+- Issue: #4258 (remains OPEN)
+- Third Cursor run: **not started**
+- `cursor_http_posts`: 0
+
+## Direct evidence
+
+| Field | Run 1 | Run 2 |
+| --- | --- | --- |
+| CDB run | `{d["run1"].get("cdb_run_id")}` | `{d["run2"].get("cdb_run_id")}` |
+| Evidence | `{d["run1"].get("evidence_id")}` | `{d["run2"].get("evidence_id")}` |
+| Agent | `{d["run1"].get("agent_id")}` | `{d["run2"].get("agent_id")}` |
+| Run | `{d["run1"].get("run_id")}` | `{d["run2"].get("run_id")}` |
+| Status | `{d["run1"].get("status")}` | `{d["run2"].get("status")}` |
+| Duration ms | {d["run1"].get("duration_ms")} | {d["run2"].get("duration_ms")} |
+| Tokens | {d["run1"].get("usage_total_tokens")} | {d["run2"].get("usage_total_tokens")} |
+| Claimed branch | `{d["run1"].get("claimed_branches")}` | `{d["run2"].get("claimed_branches")}` |
+| GitHub ref | 404 | 404 |
+| Structured error | {d["run1"].get("structured_error")} | {d["run2"].get("structured_error")} |
+| Artifacts empty | {d["run1"].get("artifacts_empty")} | {d["run2"].get("artifacts_empty")} |
+
+## Failure phases
+
+- Last proven successful: `{ph["last_proven_successful_phase"]}`
+- First failed/missing: `{ph["first_proven_failed_or_missing_phase"]}`
+- Git push attempt proven: `{ph["git_push_attempt_proven"]}`
+
+## Root-cause classification
+
+- Primary: `{rc["primary_classification"]}` (confidence `{rc["confidence"]}`)
+- Secondary: {", ".join(rc["secondary_factors"])}
+- Cursor support required: `{rc["cursor_support_required"]}`
+- Operator configuration required: `{rc["operator_configuration_required"]}`
+- CDB diagnostic fix required: `{rc["cdb_fix_required"]}`
+
+## Excluded (public evidence)
+
+{chr(10).join("- " + x for x in bundle["inferences"]["excluded_causes"])}
+
+## Documented API path note
+
+Usage/artifacts are agent-scoped (`/v1/agents/{{id}}/usage`, `/v1/agents/{{id}}/artifacts`).
+A 404 on run-scoped `/runs/{{runId}}/usage` is **not** evidence that usage is missing.
+
+## Successful reference
+
+PR #4295 / `cloud-cursor/area-entry-link-canon-4a6a` includes `cursoragent` commits.
+This proves GitHub write capability on some path; it does **not** prove the failed
+API runs used the same workspace binding.
+
+## Limitations
+
+Public Cursor API did not return a machine-readable error reason. Exact platform
+root cause remains an observability gap pending Cursor backend investigation.
+"""

--- a/tools/agent_control/cursor_support_bundle.py
+++ b/tools/agent_control/cursor_support_bundle.py
@@ -2,6 +2,7 @@
 
 Read-only diagnosis over recorded or live Cursor Cloud Agents API v1 GETs.
 Zero POSTs. Separates direct evidence from inference. Never invents a root cause.
+External payloads use allowlist projections — never full redacted_states.
 """
 
 from __future__ import annotations
@@ -9,12 +10,13 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import time
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
-from tools.agent_control.clock import SystemClock
+from core.utils.clock import utcnow as cdb_utcnow
 from tools.agent_control.cursor_preflight import (
     HttpGet,
     default_cursor_http_get,
@@ -25,19 +27,67 @@ from tools.agent_control.evidence.redact import assert_no_secrets, strip_secrets
 from tools.agent_control.paths import REPO_ROOT
 
 SCHEMA_ID = "cdb.cursor_dual_run_support_bundle.v1"
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 API_BASE = "https://api.cursor.com"
 
 # Documented agent-scoped surfaces (NOT run-scoped).
 USAGE_PATH = "/v1/agents/{agent_id}/usage"
 ARTIFACTS_PATH = "/v1/agents/{agent_id}/artifacts"
 
+TARGET_REPO_MARKERS = ("Claire_de_Binare",)
+
+# Keys forbidden in external support payloads (values must never appear).
+_FORBIDDEN_SUPPORT_KEYS = frozenset(
+    {
+        "userid",
+        "apikeyname",
+        "usageuuid",
+        "cost",
+        "rawcostcents",
+        "chargedcents",
+        "token_length",
+        "token_prefix",
+        "token_suffix",
+        "token_hash",
+        "prompt_text",
+        "prompt_body",
+        "system_prompt",
+        "raw_prompt",
+    }
+)
+
 HttpCounter = dict[str, int]
 GhRefLookup = Callable[[str], tuple[int, Any]]
 
 _PII_KEYS = re.compile(
-    r"(?i)^(useremail|userfirstname|userlastname|email|first_name|last_name)$"
+    r"(?i)^(useremail|userfirstname|userlastname|email|first_name|last_name|"
+    r"userid|apikeyname)$"
 )
+
+# #region agent log
+_DEBUG_LOG = Path(__file__).resolve().parents[2] / "debug-45fdf8.log"
+
+
+def _agent_dbg(
+    hypothesis_id: str, location: str, message: str, data: dict[str, Any]
+) -> None:
+    try:
+        payload = {
+            "sessionId": "45fdf8",
+            "runId": "support-harden",
+            "hypothesisId": hypothesis_id,
+            "location": location,
+            "message": message,
+            "data": data,
+            "timestamp": int(time.time() * 1000),
+        }
+        with _DEBUG_LOG.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload, sort_keys=True) + "\n")
+    except OSError:
+        pass
+
+
+# #endregion
 
 
 class SupportBundleError(DispatchError):
@@ -45,13 +95,8 @@ class SupportBundleError(DispatchError):
 
 
 def _utc_now() -> str:
-    return (
-        SystemClock()
-        .now()
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z")
-    )
+    """Wall-clock UTC via canonical CDB clock (no datetime.now)."""
+    return cdb_utcnow().replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -80,13 +125,86 @@ def _drop_pii(value: Any) -> Any:
         out: dict[str, Any] = {}
         for key, item in value.items():
             if _PII_KEYS.match(str(key)):
-                out[str(key)] = "[REDACTED_PII]"
+                continue
+            if str(key).lower() in _FORBIDDEN_SUPPORT_KEYS:
                 continue
             out[str(key)] = _drop_pii(item)
         return out
     if isinstance(value, list):
         return [_drop_pii(x) for x in value]
     return value
+
+
+def _is_target_repo_url(url: str) -> bool:
+    return any(marker in url for marker in TARGET_REPO_MARKERS)
+
+
+def project_run_for_support(state: dict[str, Any]) -> dict[str, Any]:
+    """Allowlist projection for one run — no full state / cost / usageUuid."""
+    cleaned = redact_for_support(state)
+    run_body = cleaned.get("run") or cleaned.get("get_run") or {}
+    if not isinstance(run_body, dict):
+        run_body = {}
+    agent = cleaned.get("agent") if isinstance(cleaned.get("agent"), dict) else {}
+    usage = cleaned.get("usage") if isinstance(cleaned.get("usage"), dict) else {}
+    claimed = claimed_branches(run_body) or list(
+        filter(None, [cleaned.get("claimed_branch")])
+    )
+    repos: list[dict[str, str]] = []
+    for repo in agent.get("repos") or []:
+        if isinstance(repo, dict):
+            url = str(repo.get("url") or "")
+            if _is_target_repo_url(url):
+                repos.append({"url": url})
+    stream = (
+        cleaned.get("stream_events")
+        if isinstance(cleaned.get("stream_events"), list)
+        else []
+    )
+    env = agent.get("env") if isinstance(agent.get("env"), dict) else {}
+    return {
+        "cdb_run_id": cleaned.get("cdb_run_id")
+        or (cleaned.get("meta") or {}).get("cdb_run_id"),
+        "evidence_id": cleaned.get("evidence_id"),
+        "agent_id": cleaned.get("agent_id") or agent.get("id"),
+        "run_id": cleaned.get("run_id") or run_body.get("id"),
+        "status": run_body.get("status"),
+        "created_at": run_body.get("createdAt"),
+        "terminal_at": run_body.get("updatedAt"),
+        "duration_ms": _duration_ms(
+            run_body.get("createdAt"), run_body.get("updatedAt")
+        ),
+        "claimed_branches": claimed,
+        "usage_total_tokens": _usage_tokens(usage),
+        "artifacts_empty": _artifacts_empty(cleaned),
+        "structured_error": has_structured_error(run_body),
+        "stream": summarize_stream(stream),
+        "create_config": {
+            "env_type": env.get("type"),
+            "named_environment_present": False,
+            "named_environment": None,
+            "branchName_present": False,
+            "branchName": None,
+            "startingRef": "main",
+            "autoCreatePR": agent.get("autoCreatePR"),
+            "workOnCurrentBranch": agent.get("workOnCurrentBranch"),
+            "repos": repos,
+        },
+        "github_branch_lookup": cleaned.get("github_branch_lookup"),
+    }
+
+
+def project_shared_for_support(shared: dict[str, Any]) -> dict[str, Any]:
+    """Shared allowlist — no userId, apiKeyName, or unrelated repo inventory."""
+    cleaned = redact_for_support(shared)
+    return {
+        "claire_repository_listed": bool(cleaned.get("claire_repository_listed")),
+        "models_endpoint_reachable": cleaned.get("models_count") is not None,
+        "numeric_account_id_omitted": True,
+        "api_key_display_name_omitted": True,
+        "unrelated_repositories_omitted": True,
+        "account_workspace_identity": "not_exposed",
+    }
 
 
 def claimed_branches(run_body: dict[str, Any] | None) -> list[str]:
@@ -133,12 +251,9 @@ def summarize_stream(events: list[dict[str, Any]]) -> dict[str, Any]:
 
 def classify_workspace_binding(me: dict[str, Any] | None) -> str:
     """Account mismatch only when concrete IDs contradict — else UNKNOWN."""
-    if not isinstance(me, dict) or not me:
-        return "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
-    # Public /v1/me has userId/apiKeyName but no workspace/team id to compare
-    # against GitHub App installation workspace. Match cannot be proven.
-    if me.get("userId") or me.get("apiKeyName"):
-        return "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
+    # Public /v1/me may carry userId/apiKeyName but those are not exposed externally.
+    # No workspace/team id is available to compare against GitHub App installation.
+    _ = me
     return "CURSOR_WORKSPACE_IDENTITY_UNKNOWN"
 
 
@@ -200,6 +315,8 @@ def failure_phase_model(
             "PR_CREATE",
         ],
         "git_push_attempt_proven": False,
+        "commit_attempt_proven": False,
+        "pr_create_attempt_proven": False,
         "note": (
             "Phantom git.branches without GitHub object does not prove push was "
             "attempted; usage tokens prove model execution only."
@@ -395,7 +512,7 @@ def build_support_bundle(
     cursor_posts: int = 0,
     observed_at: str | None = None,
 ) -> dict[str, Any]:
-    """Build deterministic redacted dual-run support bundle from state objects."""
+    """Build deterministic minimized dual-run support bundle from state objects."""
     if cursor_posts != 0:
         raise SupportBundleError(
             "BUNDLE_POST_FORBIDDEN",
@@ -406,9 +523,13 @@ def build_support_bundle(
     if env_config_digest is None and env_path.is_file():
         env_config_digest = _sha256_bytes(env_path.read_bytes())
 
+    # Internal redaction for token extraction only — never copied wholesale.
     r1 = redact_for_support(state_run1)
     r2 = redact_for_support(state_run2)
-    shared_r = redact_for_support(shared or {})
+
+    proj1 = project_run_for_support(state_run1)
+    proj2 = project_run_for_support(state_run2)
+    shared_proj = project_shared_for_support(shared or {})
 
     run1_body = r1.get("run") or r1.get("get_run") or {}
     run2_body = r2.get("run") or r2.get("get_run") or {}
@@ -417,12 +538,8 @@ def build_support_bundle(
     if not isinstance(run2_body, dict):
         run2_body = {}
 
-    claimed1 = claimed_branches(run1_body) or list(
-        filter(None, [r1.get("claimed_branch")])
-    )
-    claimed2 = claimed_branches(run2_body) or list(
-        filter(None, [r2.get("claimed_branch")])
-    )
+    claimed1 = list(proj1.get("claimed_branches") or [])
+    claimed2 = list(proj2.get("claimed_branches") or [])
 
     lookups = github_lookups or {}
     gh1 = {
@@ -437,27 +554,20 @@ def build_support_bundle(
         claimed1 and claimed2
     )
 
+    tokens1 = int(proj1.get("usage_total_tokens") or 0)
+    tokens2 = int(proj2.get("usage_total_tokens") or 0)
+
+    stream_sum1 = proj1.get("stream") if isinstance(proj1.get("stream"), dict) else {}
+    stream_sum2 = proj2.get("stream") if isinstance(proj2.get("stream"), dict) else {}
+
+    status1 = proj1.get("status")
+    status2 = proj2.get("status")
+    both_error = status1 == "ERROR" and status2 == "ERROR"
+    structured = bool(proj1.get("structured_error") or proj2.get("structured_error"))
+
+    workspace_class = classify_workspace_binding(None)
     usage1 = r1.get("usage") if isinstance(r1.get("usage"), dict) else {}
     usage2 = r2.get("usage") if isinstance(r2.get("usage"), dict) else {}
-    tokens1 = _usage_tokens(usage1)
-    tokens2 = _usage_tokens(usage2)
-
-    stream1 = (
-        r1.get("stream_events") if isinstance(r1.get("stream_events"), list) else []
-    )
-    stream2 = (
-        r2.get("stream_events") if isinstance(r2.get("stream_events"), list) else []
-    )
-    stream_sum1 = summarize_stream(stream1)
-    stream_sum2 = summarize_stream(stream2)
-
-    status1 = run1_body.get("status")
-    status2 = run2_body.get("status")
-    both_error = status1 == "ERROR" and status2 == "ERROR"
-    structured = has_structured_error(run1_body) or has_structured_error(run2_body)
-
-    me = shared_r.get("me") if isinstance(shared_r.get("me"), dict) else {}
-    workspace_class = classify_workspace_binding(me)
     model_class = classify_model_phase(usage1 if tokens1 else usage2)
 
     phases = failure_phase_model(
@@ -477,8 +587,8 @@ def build_support_bundle(
         workspace_class=workspace_class,
     )
 
-    duration1 = _duration_ms(run1_body.get("createdAt"), run1_body.get("updatedAt"))
-    duration2 = _duration_ms(run2_body.get("createdAt"), run2_body.get("updatedAt"))
+    duration1 = proj1.get("duration_ms")
+    duration2 = proj2.get("duration_ms")
 
     identical = []
     different = []
@@ -494,11 +604,11 @@ def build_support_bundle(
             stream_sum1.get("event_count"),
             stream_sum2.get("event_count"),
         ),
-        ("artifacts_empty", _artifacts_empty(r1), _artifacts_empty(r2)),
+        ("artifacts_empty", proj1.get("artifacts_empty"), proj2.get("artifacts_empty")),
         (
             "structured_error",
-            has_structured_error(run1_body),
-            has_structured_error(run2_body),
+            proj1.get("structured_error"),
+            proj2.get("structured_error"),
         ),
     ]:
         entry = {"field": field, "run1": a, "run2": b}
@@ -530,7 +640,6 @@ def build_support_bundle(
         "repository": "jannekbuengener/Claire_de_Binare",
         "observed_at": observed_at or _utc_now(),
         "api_version": "cursor-cloud-agents-v1",
-        "credential_present": True,
         "safety": {
             "cursor_http_posts": 0,
             "new_agents": 0,
@@ -540,66 +649,58 @@ def build_support_bundle(
         },
         "direct_evidence": {
             "run1": {
-                "cdb_run_id": r1.get("cdb_run_id")
-                or r1.get("meta", {}).get("cdb_run_id"),
-                "evidence_id": r1.get("evidence_id"),
-                "agent_id": r1.get("agent_id"),
-                "run_id": r1.get("run_id"),
+                "cdb_run_id": proj1.get("cdb_run_id"),
+                "evidence_id": proj1.get("evidence_id"),
+                "agent_id": proj1.get("agent_id"),
+                "run_id": proj1.get("run_id"),
                 "status": status1,
+                "created_at": proj1.get("created_at"),
+                "terminal_at": proj1.get("terminal_at"),
                 "duration_ms": duration1,
                 "claimed_branches": claimed1,
                 "github_branch_status": gh1,
                 "usage_total_tokens": tokens1,
-                "artifacts_empty": _artifacts_empty(r1),
-                "structured_error": has_structured_error(run1_body),
+                "artifacts_empty": proj1.get("artifacts_empty"),
+                "structured_error": proj1.get("structured_error"),
                 "stream": stream_sum1,
-                "agent_env": (
-                    (r1.get("agent") or {}).get("env")
-                    if isinstance(r1.get("agent"), dict)
-                    else None
-                ),
-                "autoCreatePR": (
-                    (r1.get("agent") or {}).get("autoCreatePR")
-                    if isinstance(r1.get("agent"), dict)
-                    else None
-                ),
+                "create_config": proj1.get("create_config"),
             },
             "run2": {
-                "cdb_run_id": r2.get("cdb_run_id")
-                or r2.get("meta", {}).get("cdb_run_id"),
-                "evidence_id": r2.get("evidence_id"),
-                "agent_id": r2.get("agent_id"),
-                "run_id": r2.get("run_id"),
+                "cdb_run_id": proj2.get("cdb_run_id"),
+                "evidence_id": proj2.get("evidence_id"),
+                "agent_id": proj2.get("agent_id"),
+                "run_id": proj2.get("run_id"),
                 "status": status2,
+                "created_at": proj2.get("created_at"),
+                "terminal_at": proj2.get("terminal_at"),
                 "duration_ms": duration2,
                 "claimed_branches": claimed2,
                 "github_branch_status": gh2,
                 "usage_total_tokens": tokens2,
-                "artifacts_empty": _artifacts_empty(r2),
-                "structured_error": has_structured_error(run2_body),
+                "artifacts_empty": proj2.get("artifacts_empty"),
+                "structured_error": proj2.get("structured_error"),
                 "stream": stream_sum2,
-                "agent_env": (
-                    (r2.get("agent") or {}).get("env")
-                    if isinstance(r2.get("agent"), dict)
-                    else None
-                ),
-                "autoCreatePR": (
-                    (r2.get("agent") or {}).get("autoCreatePR")
-                    if isinstance(r2.get("agent"), dict)
-                    else None
-                ),
+                "create_config": proj2.get("create_config"),
             },
-            "shared": {
-                "me_keys": sorted(me.keys()) if me else [],
-                "apiKeyName": me.get("apiKeyName"),
-                "userId_present": me.get("userId") is not None,
-                "repositories_claire_listed": shared_r.get("claire_repository_listed"),
-                "models_count": shared_r.get("models_count"),
+            "shared": shared_proj,
+            "repo_config": {
+                "path": ".cursor/environment.json",
+                "digest": env_config_digest,
+                "named_environment_present": False,
+                "named_environment": None,
+                "branchName_present": False,
+                "branchName": None,
             },
-            "environment_config_digest": env_config_digest,
             "binding_mode": "repos_plus_repo_config",
             "startingRef": "main",
             "autoCreatePR": True,
+            "workOnCurrentBranch": False,
+            "create_acceptance": {
+                "accepted_creates_per_documented_run": 1,
+                "earlier_rejected_http_400_created_no_resource": True,
+                "rejected_400_not_a_reported_run": True,
+                "third_run_started": False,
+            },
             "successful_reference": ref,
             "usage_path_documented": USAGE_PATH,
             "artifacts_path_documented": ARTIFACTS_PATH,
@@ -634,12 +735,39 @@ def build_support_bundle(
                 "usage_tokens_nonzero": tokens1 > 0 and tokens2 > 0,
             },
         },
-        "redacted_states": {"run1": r1, "run2": r2, "shared": shared_r},
+        # Allowlist projections only — never full redacted_states.
+        "support_projections": {
+            "run1": proj1,
+            "run2": proj2,
+            "shared": shared_proj,
+        },
         "support_request_ready": True,
         "external_send_allowed": False,
     }
+
+    # #region agent log
+    dumped = json.dumps(bundle)
+    _agent_dbg(
+        "H_privacy",
+        "cursor_support_bundle.py:build_support_bundle",
+        "privacy_scan_after_build",
+        {
+            "has_userId": '"userId"' in dumped or "363812814" in dumped,
+            "has_apiKeyName": "apiKeyName" in dumped or "api.CDB" in dumped,
+            "has_usageUuid": "usageUuid" in dumped,
+            "has_cost": '"cost"' in dumped or "chargedCents" in dumped,
+            "has_sample_brain": "sample-brain" in dumped,
+            "has_gpt_mcp": "gpt-mcp-server" in dumped,
+            "has_redacted_states": "redacted_states" in dumped,
+            "has_datetime_now_import_path": False,
+            "primary": rc["primary_classification"],
+            "posts": bundle["safety"]["cursor_http_posts"],
+            "third_run": bundle["safety"]["third_run_started"],
+        },
+    )
+    # #endregion
+
     assert_no_secrets(bundle)
-    # PII placeholders are intentional and not secret-like.
     return bundle
 
 
@@ -660,100 +788,154 @@ def render_support_request_draft(bundle: dict[str, Any]) -> str:
     d = bundle["direct_evidence"]
     r1, r2 = d["run1"], d["run2"]
     rc = bundle["inferences"]["root_cause"]
+    ph = bundle["inferences"]["failure_phases"]
+    sig = bundle["comparison"]["repeated_failure_signature"]
+    ref = d["successful_reference"]
+    repo_cfg = d["repo_config"]
+    create = d["create_acceptance"]
     return f"""# Cursor Cloud Agents API — Dual-run ERROR support request
 
 ## Summary
-Two consecutive Cloud Agents API v1 creates against `jannekbuengener/Claire_de_Binare`
+Two consecutive Cloud Agents API v1 creates against `{bundle["repository"]}`
 ended in terminal `ERROR` (~8s each). Both runs report `git.branches` names, but the
 corresponding GitHub refs return 404. No structured error object is present on the
 Run resource. Public API observability is insufficient to prove a single root cause
 (`primary_classification={rc["primary_classification"]}`, confidence={rc["confidence"]}).
-
-## Account and repository
-- API key name (non-secret): `{d["shared"].get("apiKeyName")}`
-- userId present: {d["shared"].get("userId_present")}
-- Repository: `{bundle["repository"]}`
-- Repo listed by `GET /v1/repositories`: {d["shared"].get("repositories_claire_listed")}
-- Binding: `repos` + repo `.cursor/environment.json` (`repos_plus_repo_config`)
-- `startingRef=main`, `autoCreatePR=true`
-- Environment config digest: `{d.get("environment_config_digest")}`
+No third agent or run was started. `external_send_allowed=false` (operator must
+explicitly authorize any send).
 
 ## Expected behavior
 Agent run finishes with FINISHED (or a structured error), pushes a real GitHub branch
 when `git.branches` is populated, and optionally opens a PR when `autoCreatePR=true`.
 
-## Observed behavior
+## Actual behavior
 - Terminal status: ERROR for both runs
-- Stream events: status → result → done (no error field)
+- Stream signature: status → result → done (no error field)
 - `git.branches` populated; GitHub branch refs 404
 - Artifacts list empty
-- Usage shows non-zero tokens (model did execute)
-- No third agent/run was started after these two failures
+- Usage shows non-zero tokens (model/reasoning activity only — not proof of
+  successful runtime, tool, Git, or PR path)
+- Structured error object: absent
+- Git push attempt proven: `{ph["git_push_attempt_proven"]}`
+- Commit attempt proven: `{ph["commit_attempt_proven"]}`
+- PR create attempt proven: `{ph["pr_create_attempt_proven"]}`
 
-## Run 1 identifiers
+## Run 1 identifiers and timestamps
 - CDB run: `{r1.get("cdb_run_id")}`
 - Evidence: `{r1.get("evidence_id")}`
 - Agent: `{r1.get("agent_id")}`
-- Run: `{r1.get("run_id")}`
+- Cursor run: `{r1.get("run_id")}`
+- created_at (UTC): `{r1.get("created_at")}`
+- terminal_at (UTC): `{r1.get("terminal_at")}`
 - Duration ms: {r1.get("duration_ms")}
+- Status: `{r1.get("status")}`
 - Claimed branch: {r1.get("claimed_branches")}
+- GitHub ref status: {r1.get("github_branch_status")}
 - Usage totalTokens: {r1.get("usage_total_tokens")}
+- Artifacts empty: {r1.get("artifacts_empty")}
+- Structured error: {r1.get("structured_error")}
+- Stream: {json.dumps(r1.get("stream"), sort_keys=True)}
 
-## Run 2 identifiers
+## Run 2 identifiers and timestamps
 - CDB run: `{r2.get("cdb_run_id")}`
 - Evidence: `{r2.get("evidence_id")}`
 - Agent: `{r2.get("agent_id")}`
-- Run: `{r2.get("run_id")}`
+- Cursor run: `{r2.get("run_id")}`
+- created_at (UTC): `{r2.get("created_at")}`
+- terminal_at (UTC): `{r2.get("terminal_at")}`
 - Duration ms: {r2.get("duration_ms")}
+- Status: `{r2.get("status")}`
 - Claimed branch: {r2.get("claimed_branches")}
+- GitHub ref status: {r2.get("github_branch_status")}
 - Usage totalTokens: {r2.get("usage_total_tokens")}
+- Artifacts empty: {r2.get("artifacts_empty")}
+- Structured error: {r2.get("structured_error")}
+- Stream: {json.dumps(r2.get("stream"), sort_keys=True)}
 
 ## Repeated failure signature
-{json.dumps(bundle["comparison"]["repeated_failure_signature"], indent=2)}
-
-## GitHub verification
-- Claimed branches: 404 on `git/ref/heads/...`
-- Successful reference PR #4295 includes `cursoragent` commits on branch
-  `cloud-cursor/area-entry-link-canon-4a6a` (proves GitHub App write capability
-  at some path; does **not** prove the failed API runs shared that workspace binding)
-
-## Environment configuration
 ```json
-{json.dumps({
-  "build": {"dockerfile": "../ci/Dockerfile", "context": ".."},
-  "install": "python -m pip install -r requirements.txt -r requirements-dev.txt -r requirements-mcp.txt",
-  "agentCanUpdateSnapshot": False,
-}, indent=2)}
+{json.dumps(sig, indent=2, sort_keys=True)}
 ```
 
-## API request shape (redacted)
-- `repos[0].url` = https://github.com/jannekbuengener/Claire_de_Binare
-- `repos[0].startingRef` = main
-- `autoCreatePR` = true
-- `workOnCurrentBranch` = false
-- no named `env.name` (repos mode)
-- prompt text omitted from this package
+## Create and configuration details
+- Binding mode: `{d.get("binding_mode")}`
+- Repository: `{bundle["repository"]}`
+- `startingRef=main`
+- `autoCreatePR=true`
+- `workOnCurrentBranch=false`
+- Named environment: absent (`named_environment_present={repo_cfg.get("named_environment_present")}`)
+- `branchName`: absent (`branchName_present={repo_cfg.get("branchName_present")}`)
+- Repo config path: `{repo_cfg.get("path")}`
+- Repo config SHA-256 digest: `{repo_cfg.get("digest")}`
+- Accepted Create per documented run: {create.get("accepted_creates_per_documented_run")}
+- Earlier rejected HTTP 400 created no resource and is not a reported run:
+  {create.get("earlier_rejected_http_400_created_no_resource")}
+- Third run started: {create.get("third_run_started")}
+- Safety counters: `{json.dumps(bundle["safety"], sort_keys=True)}`
 
-## What has been ruled out
+## Repository visibility
+- Target repository listed by `GET /v1/repositories`: {d["shared"].get("claire_repository_listed")}
+- Unrelated repository inventory: omitted from this package
+- Account identifiers (numeric Cursor account id, API key display name): omitted
+
+## Successful reference PR #4295
+- PR: #{ref.get("pr")} / branch `{ref.get("branch")}`
+- Includes cursoragent commits: {ref.get("commit_authors_include_cursoragent")}
+- Proves GitHub App can write at some path: {ref.get("proves_github_app_can_write_at_some_path")}
+- Proves same API workspace as the failed runs: {ref.get("proves_same_api_workspace")}
+- Note: {ref.get("note")}
+
+## Ruled-out causes and evidence limits
 {chr(10).join("- " + x for x in bundle["inferences"]["excluded_causes"])}
+- Tokens prove model/reasoning activity only, not successful runtime/tool/Git/PR path
+- Primary classification remains `{rc["primary_classification"]}`
 
 ## Requested backend investigation
-1. Backend error reason for both run IDs above
-2. Workspace linked to the API key vs GitHub App installation
-3. Repository authorization at execution time
-4. Environment/bootstrap resolution for repos+repo-config mode
-5. Model/runtime startup details (model id actually used)
-6. Whether Git push or PR creation was attempted
-7. Why `run.git.branches` was populated without a GitHub branch object
-8. Whether this is a known v1 public-beta issue
+1. Internal backend error for both run IDs above
+2. Workspace associated with the API key
+3. Workspace associated with the GitHub App installation
+4. Repository authorization and effective permissions at execution time
+5. Environment selection, repo-config resolution and bootstrap result
+6. Selected model and model/runtime startup result
+7. Whether file changes, commits or Git pushes were attempted
+8. Whether PR creation was attempted
+9. Why `run.git.branches` was populated without an existing GitHub ref
+10. Whether this is a known defect in the public Cloud Agents v1 API
 
-## Security and privacy note
-No API keys, Authorization headers, or secret values are included. Prompt bodies are
-omitted. Please do not request dashboard-only private endpoints as a prerequisite for
-answering the backend error reason for these two run IDs.
+## Security and privacy statement
+No API key values, Authorization headers, HTTP auth credentials, PEM private keys,
+token length/prefix/suffix/hash, local secret paths, numeric Cursor account ids, API key
+display names, unrelated repository inventories, usage UUIDs, cost data, or full
+internal prompts are included. Attachment set is minimized to diagnostic necessity.
+
+## Attachment list
+- `CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md` — tracked evidence summary
+- `.cursor/environment.json` — repo Cloud environment config
+- `support_bundle_redacted.json` — minimized dual-run support bundle
+- `ATTACHMENT_MANIFEST.md` — attachment purpose / redaction matrix
 
 ---
 external_send_allowed: false (operator must explicitly authorize any send)
+"""
+
+
+def render_attachment_manifest() -> str:
+    """Markdown table of permitted support attachments."""
+    return """# Attachment Manifest — Cursor dual-run support (#4258)
+
+| filename | purpose | redacted | contains_secrets | required_for_cursor_support |
+| --- | --- | --- | --- | --- |
+| CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md | Tracked dual-run evidence summary | yes | no | yes |
+| .cursor/environment.json | Repo Cloud Agents environment config | n/a (no secrets) | no | yes |
+| support_bundle_redacted.json | Minimized allowlist dual-run bundle | yes | no | yes |
+
+## Not attached
+- `dual_run_shared_meta.json` (contains account metadata / unrelated repos)
+- raw fixtures
+- full prompts
+- `ci/Dockerfile` (unless Cursor asks)
+- session logs
+- complete repository archive
 """
 
 
@@ -802,19 +984,26 @@ def run_support_bundle_from_states(
     output_dir.mkdir(parents=True, exist_ok=True)
     bundle_path = output_dir / "support_bundle_redacted.json"
     draft_path = output_dir / "cursor_support_request_draft.md"
+    manifest_path = output_dir / "ATTACHMENT_MANIFEST.md"
     payload = json.dumps(bundle, indent=2, sort_keys=True) + "\n"
     bundle_path.write_text(payload, encoding="utf-8")
     draft_path.write_text(render_support_request_draft(bundle), encoding="utf-8")
+    manifest_path.write_text(render_attachment_manifest(), encoding="utf-8")
     digest = _sha256_bytes(payload.encode("utf-8"))
     result = {
         "bundle_path": str(bundle_path),
         "draft_path": str(draft_path),
+        "manifest_path": str(manifest_path),
         "bundle_digest": digest,
         "primary_classification": bundle["inferences"]["root_cause"][
             "primary_classification"
         ],
         "confidence": bundle["inferences"]["root_cause"]["confidence"],
         "cursor_http_posts": 0,
+        "new_agents": 0,
+        "new_runs": 0,
+        "third_run_started": False,
+        "external_send_allowed": False,
         "run_ids": [
             bundle["direct_evidence"]["run1"]["run_id"],
             bundle["direct_evidence"]["run2"]["run_id"],
@@ -846,6 +1035,7 @@ def _tracked_summary_markdown(bundle: dict[str, Any], digest: str) -> str:
 - Issue: #4258 (remains OPEN)
 - Third Cursor run: **not started**
 - `cursor_http_posts`: 0
+- `external_send_allowed`: false
 
 ## Direct evidence
 
@@ -855,6 +1045,8 @@ def _tracked_summary_markdown(bundle: dict[str, Any], digest: str) -> str:
 | Evidence | `{d["run1"].get("evidence_id")}` | `{d["run2"].get("evidence_id")}` |
 | Agent | `{d["run1"].get("agent_id")}` | `{d["run2"].get("agent_id")}` |
 | Run | `{d["run1"].get("run_id")}` | `{d["run2"].get("run_id")}` |
+| created_at (UTC) | `{d["run1"].get("created_at")}` | `{d["run2"].get("created_at")}` |
+| terminal_at (UTC) | `{d["run1"].get("terminal_at")}` | `{d["run2"].get("terminal_at")}` |
 | Status | `{d["run1"].get("status")}` | `{d["run2"].get("status")}` |
 | Duration ms | {d["run1"].get("duration_ms")} | {d["run2"].get("duration_ms")} |
 | Tokens | {d["run1"].get("usage_total_tokens")} | {d["run2"].get("usage_total_tokens")} |
@@ -863,11 +1055,22 @@ def _tracked_summary_markdown(bundle: dict[str, Any], digest: str) -> str:
 | Structured error | {d["run1"].get("structured_error")} | {d["run2"].get("structured_error")} |
 | Artifacts empty | {d["run1"].get("artifacts_empty")} | {d["run2"].get("artifacts_empty")} |
 
+## Create / config
+
+- Binding: `{d.get("binding_mode")}`
+- `startingRef=main`, `autoCreatePR=true`, `workOnCurrentBranch=false`
+- Named environment: absent
+- `branchName`: absent
+- Repo config: `{d["repo_config"].get("path")}` digest `{d["repo_config"].get("digest")}`
+- Exactly one accepted Create per documented run; earlier HTTP 400 created no resource
+
 ## Failure phases
 
 - Last proven successful: `{ph["last_proven_successful_phase"]}`
 - First failed/missing: `{ph["first_proven_failed_or_missing_phase"]}`
 - Git push attempt proven: `{ph["git_push_attempt_proven"]}`
+- Commit attempt proven: `{ph["commit_attempt_proven"]}`
+- PR create attempt proven: `{ph["pr_create_attempt_proven"]}`
 
 ## Root-cause classification
 
@@ -891,6 +1094,12 @@ A 404 on run-scoped `/runs/{{runId}}/usage` is **not** evidence that usage is mi
 PR #4295 / `cloud-cursor/area-entry-link-canon-4a6a` includes `cursoragent` commits.
 This proves GitHub write capability on some path; it does **not** prove the failed
 API runs used the same workspace binding.
+
+## Privacy
+
+Numeric Cursor account ids, API key display names, unrelated repositories, usage UUIDs,
+cost data, full prompts, and credential presence metadata are omitted from the
+external package.
 
 ## Limitations
 

--- a/tools/agent_control/cursor_support_bundle.py
+++ b/tools/agent_control/cursor_support_bundle.py
@@ -10,10 +10,11 @@ import hashlib
 import json
 import re
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
+from tools.agent_control.clock import SystemClock
 from tools.agent_control.cursor_preflight import (
     HttpGet,
     default_cursor_http_get,
@@ -45,7 +46,8 @@ class SupportBundleError(DispatchError):
 
 def _utc_now() -> str:
     return (
-        datetime.now(timezone.utc)
+        SystemClock()
+        .now()
         .replace(microsecond=0)
         .isoformat()
         .replace("+00:00", "Z")

--- a/tools/agent_control/cursor_support_bundle.py
+++ b/tools/agent_control/cursor_support_bundle.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import time
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
@@ -63,31 +62,6 @@ _PII_KEYS = re.compile(
     r"(?i)^(useremail|userfirstname|userlastname|email|first_name|last_name|"
     r"userid|apikeyname)$"
 )
-
-# #region agent log
-_DEBUG_LOG = Path(__file__).resolve().parents[2] / "debug-45fdf8.log"
-
-
-def _agent_dbg(
-    hypothesis_id: str, location: str, message: str, data: dict[str, Any]
-) -> None:
-    try:
-        payload = {
-            "sessionId": "45fdf8",
-            "runId": "support-harden",
-            "hypothesisId": hypothesis_id,
-            "location": location,
-            "message": message,
-            "data": data,
-            "timestamp": int(time.time() * 1000),
-        }
-        with _DEBUG_LOG.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(payload, sort_keys=True) + "\n")
-    except OSError:
-        pass
-
-
-# #endregion
 
 
 class SupportBundleError(DispatchError):
@@ -744,28 +718,6 @@ def build_support_bundle(
         "support_request_ready": True,
         "external_send_allowed": False,
     }
-
-    # #region agent log
-    dumped = json.dumps(bundle)
-    _agent_dbg(
-        "H_privacy",
-        "cursor_support_bundle.py:build_support_bundle",
-        "privacy_scan_after_build",
-        {
-            "has_userId": '"userId"' in dumped or "363812814" in dumped,
-            "has_apiKeyName": "apiKeyName" in dumped or "api.CDB" in dumped,
-            "has_usageUuid": "usageUuid" in dumped,
-            "has_cost": '"cost"' in dumped or "chargedCents" in dumped,
-            "has_sample_brain": "sample-brain" in dumped,
-            "has_gpt_mcp": "gpt-mcp-server" in dumped,
-            "has_redacted_states": "redacted_states" in dumped,
-            "has_datetime_now_import_path": False,
-            "primary": rc["primary_classification"],
-            "posts": bundle["safety"]["cursor_http_posts"],
-            "third_run": bundle["safety"]["third_run_started"],
-        },
-    )
-    # #endregion
 
     assert_no_secrets(bundle)
     return bundle

--- a/tools/agent_control/providers/cursor_cloud_api.py
+++ b/tools/agent_control/providers/cursor_cloud_api.py
@@ -552,6 +552,21 @@ class CursorCloudApiDriver:
         state = self._agents.get(agent_id or "")
         if state is None:
             raise DispatchError("DISPATCH_PROVIDER_RUN_NOT_FOUND", provider_run_id)
+        # Documented v1 path is agent-scoped: GET /v1/agents/{id}/artifacts
+        # (NOT /runs/{runId}/artifacts — that route 404s and is not evidence).
+        if self._http is not None and agent_id:
+            body = self._request("GET", f"/v1/agents/{agent_id}/artifacts")
+            items = body.get("items") if isinstance(body, dict) else None
+            if isinstance(items, list):
+                state.artifacts = [
+                    {
+                        "path": item.get("path"),
+                        "size": item.get("sizeBytes") or item.get("size"),
+                        "digest": item.get("digest") or item.get("sha256"),
+                    }
+                    for item in items
+                    if isinstance(item, dict) and item.get("path")
+                ]
         out = []
         for item in state.artifacts:
             path = validate_artifact_path(item["path"])
@@ -574,6 +589,57 @@ class CursorCloudApiDriver:
         state = self._agents.get(agent_id or "")
         if state is None:
             raise DispatchError("DISPATCH_PROVIDER_RUN_NOT_FOUND", provider_run_id)
+        # Documented v1 path is agent-scoped: GET /v1/agents/{id}/usage
+        # Optional ?runId= filter. Run-scoped /runs/{id}/usage is NOT documented.
+        if self._http is not None and agent_id:
+            body = self._request(
+                "GET",
+                f"/v1/agents/{agent_id}/usage?runId={provider_run_id}",
+            )
+            usage: dict[str, Any] = {"cost": None}
+            if isinstance(body, dict):
+                runs = body.get("runs") if isinstance(body.get("runs"), list) else []
+                matched = None
+                for item in runs:
+                    if isinstance(item, dict) and item.get("id") == provider_run_id:
+                        matched = item
+                        break
+                if matched is None and runs:
+                    matched = runs[0] if isinstance(runs[0], dict) else None
+                if isinstance(matched, dict):
+                    u = (
+                        matched.get("usage")
+                        if isinstance(matched.get("usage"), dict)
+                        else {}
+                    )
+                    cost = (
+                        matched.get("cost")
+                        if isinstance(matched.get("cost"), dict)
+                        else {}
+                    )
+                    usage = {
+                        "cost": cost.get("chargedCents"),
+                        "input_tokens": u.get("inputTokens"),
+                        "output_tokens": u.get("outputTokens"),
+                        "total_tokens": u.get("totalTokens"),
+                        "usage_uuid": matched.get("usageUuid"),
+                        "source_path": f"/v1/agents/{agent_id}/usage",
+                    }
+                elif isinstance(body.get("totalUsage"), dict):
+                    tu = body["totalUsage"]
+                    usage = {
+                        "cost": (
+                            (body.get("cost") or {}).get("chargedCents")
+                            if isinstance(body.get("cost"), dict)
+                            else None
+                        ),
+                        "input_tokens": tu.get("inputTokens"),
+                        "output_tokens": tu.get("outputTokens"),
+                        "total_tokens": tu.get("totalTokens"),
+                        "source_path": f"/v1/agents/{agent_id}/usage",
+                    }
+            state.runs[provider_run_id]["usage"] = usage
+            return dict(usage)
         return dict(state.runs[provider_run_id].get("usage") or {"cost": None})
 
     def archive(self, provider_run_id: str) -> ProviderResult:


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: agent-skills
lane: agent-skills
base_branch: main
validation_profile: agent-skills-v1
merge_mode: batch
steward_state: open
objective_key: cursor-dual-run-debug
planned_issues: #4258
contract_keys: agent-control-v1
risk_flags: none
-->

## Summary
- Dual-run root-cause diagnosis for the two existing Cursor Cloud ERROR runs (no third create).
- New `pilot cursor-support-bundle` CLI + redacted support package + ready-to-send Cursor Support draft (not sent).
- Fix live `get_usage` / `list_artifacts` to documented agent-scoped paths (`/v1/agents/{id}/usage|artifacts`).

## CDB Batch Ledger
| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4258 | SLICE_DELIVERED (debug) | 5a86d8f15eea8180cd1ea5bf0104903d3cecc32f | support-bundle + provider unit tests | skills | Cursor backend error text still unavailable |

## Delivered
- `tools/agent_control/cursor_support_bundle.py`
- CLI: `python -m tools.agent_control pilot cursor-support-bundle`
- Fixtures for both ERROR runs + shared meta
- Tracked evidence: `docs/evidence/agent_control/CURSOR_CLOUD_DUAL_RUN_FAILURE_4258.md`
- Provider path fix for usage/artifacts
- Runbook note

## Root-cause (public API)
- Primary: `UNKNOWN_OBSERVABILITY_GAP` (confidence MEDIUM)
- Both runs: ERROR ~8s, tokens > 0, empty artifacts, phantom `git.branches`, GitHub 404
- No structured error object
- Workspace mismatch: UNKNOWN (no contradictory IDs)
- Successful reference PR #4295 proves GitHub write on some path; does **not** prove same API workspace

## Validation
```bash
pytest --noconftest -q tests/unit/governance/test_cursor_support_bundle_v1.py \
  tests/unit/governance/test_cursor_providers_v1.py::test_cloud_fake_http_sse_and_guards
ruff check …
black --check …
python -m tools.agent_control registry validate
git diff --check
```
9 targeted tests passed. `cursor_http_posts=0`. No live create.

## Non-goals
- Refs #4258 only — do not close
- No merge / no `cdb-local-ci` / no third Cursor run / no external support send
- Does not implement #4259/#4260

## Remaining uncertainty
Exact Cursor backend failure reason is not exposed on the public Run resource.

Refs #4258