### PR TITLE
fix(security): triage and remediate alert wave #4314–#4323

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -36,9 +36,9 @@ jobs:
             scan_name: redis
           - image: postgres:18.4-alpine@sha256:ecafd34249b5c248f3cb6ebe339584ee6448b36fad3f0a827ae5e8efbae6afda
             scan_name: postgres
-          - image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
+          - image: prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69
             scan_name: prometheus
-          - image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
+          - image: grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8
             scan_name: grafana
       fail-fast: false
 

--- a/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.json
+++ b/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.json
@@ -1,0 +1,290 @@
+{
+  "schema": "cdb.security_alert_wave.v1",
+  "wave_id": "security-alert-wave-2026-08-03",
+  "snapshot_date": "2026-08-03",
+  "base_sha": "a52a0e90b702cd2758736bfa4ed25e2b9fd382ab",
+  "base_ref": "origin/main",
+  "branch": "dedicated/security-alert-wave-2026-08-03",
+  "routing_decision": "CREATE_DEDICATED_PR",
+  "preferred_objective": "security-alert-wave-2026-08-03",
+  "merge_mode": false,
+  "merge_allowed": false,
+  "issue_closure_before_merge_allowed": false,
+  "alert_dismissal_allowed": false,
+  "trivyignore_growth_allowed": false,
+  "lr_verdict": "NO-GO",
+  "board_stage": "trade-capable",
+  "readout_run_id": 30803956049,
+  "readout_run_url": "https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/30803956049",
+  "related_merged_prs": {
+    "4303": {
+      "title": "fix(security): reconcile open vulnerability backlog",
+      "merge_commit": "312d12e04ab312c14266ff579d09c3b694045f85",
+      "note": "Do not reuse dedicated/security-backlog-reconciliation-2513"
+    },
+    "4310": {
+      "title": "deps(docker-compose): bump prom/prometheus from v3.13.1 to v3.13.2",
+      "merge_commit": "c18fc695274d3045fae3831b228e6fc7a31632f9",
+      "note": "Partial pin: RED + prometheus-v3 overlay only before this wave"
+    },
+    "4162": {
+      "title": "deps(docker-compose): bump grafana/grafana from 13.0.3-ubuntu to 13.1.1-ubuntu",
+      "merge_commit": "4608aeff96ad9832a0335ab55676eea70021ae44",
+      "note": "RED runtime pin; GHSA-r277 not cleared on 13.1.1"
+    }
+  },
+  "prometheus_target_pin": "prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69",
+  "grafana_runtime_pin": "grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8",
+  "pin_surfaces_synced": [
+    "infrastructure/compose/base.yml",
+    ".github/workflows/security-scan.yml",
+    "knowledge/governance/SERVICE_CATALOG.md"
+  ],
+  "pin_surfaces_already_current_on_base": [
+    "infrastructure/compose/compose.red.yml",
+    "infrastructure/compose/compose.prometheus-v3.yml"
+  ],
+  "pin_surfaces_comment_only": [
+    "infrastructure/compose/compose.prometheus-v3.yml"
+  ],
+  "trivy_evidence": {
+    "tool_version": "0.72.0",
+    "db_updated_at": "2026-08-03",
+    "prometheus_v3_13_2": {
+      "image": "prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69",
+      "cve_2026_56852_hits": 0,
+      "high_critical_total": 0,
+      "bin_prometheus_cleared": true,
+      "bin_promtool_cleared": true
+    },
+    "prometheus_v3_13_1_contrast": {
+      "image": "prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893",
+      "cve_2026_56852_hits": 2,
+      "targets": ["bin/prometheus", "bin/promtool"],
+      "installed_x_text": "v0.38.0",
+      "fixed_x_text": "0.39.0"
+    },
+    "grafana_13_1_1": {
+      "image": "grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8",
+      "ghsa_r277_hits": 1,
+      "kin_openapi_installed": "v0.140.0",
+      "kin_openapi_fixed": "0.144.0",
+      "cve_2026_56852_hits_on_grafana_binaries": 3,
+      "high_critical_total": 19,
+      "newer_supported_release_with_kin_openapi_gte_0_144_0": null
+    }
+  },
+  "perl_hold_evidence": {
+    "cve": "CVE-2026-57433",
+    "package": "perl-base",
+    "installed": "5.40.1-6",
+    "fixed_version_trivy": "",
+    "debian_trixie_status": "vulnerable",
+    "debian_forky_sid_fixed": "5.42.2-3",
+    "suite_native_fix_available": false,
+    "storable_usage_in_cdb_services": false,
+    "forbidden_actions": [
+      "no forky/sid mix into trixie",
+      "no alpine base migration",
+      "no trivyignore growth",
+      "no alert dismissal"
+    ],
+    "re_eval_date": "2026-09-03",
+    "canonical_tracker": 2932
+  },
+  "grafana_hold_evidence": {
+    "advisory": "GHSA-r277-6w6q-xmqw",
+    "alert": 5677,
+    "scanned_path_on_alert": "usr/share/grafana/bin/grafana",
+    "alert_installed_kin_openapi": "v0.133.0",
+    "runtime_pin_kin_openapi": "v0.140.0",
+    "required_fixed": "0.144.0",
+    "suite_native_fix_available": false,
+    "pin_sync_only": true,
+    "re_eval_date": "2026-09-03",
+    "canonical_tracker": 2933
+  },
+  "cap45_out_of_scope": {
+    "documented": true,
+    "note": "45 additional readout-cap candidates from Security Alert Readout 2026-08-03 remain out of scope for this wave; no issue mutation or remediation claimed."
+  },
+  "clusters": [
+    {
+      "cluster_id": "perl-storable-cve-2026-57433",
+      "issues": [4314, 4315, 4316, 4317, 4318, 4319, 4320, 4321],
+      "disposition": "HOLD_UPSTREAM_NO_FIXED_VERSION",
+      "canonical_tracker": 2932
+    },
+    {
+      "cluster_id": "grafana-kin-openapi-ghsa-r277",
+      "issues": [4322],
+      "disposition": "HOLD_UPSTREAM_NO_FIXED_VERSION",
+      "canonical_tracker": 2933
+    },
+    {
+      "cluster_id": "prometheus-x-text-cve-2026-56852",
+      "issues": [4323],
+      "disposition": "FIX_READY",
+      "canonical_tracker": 4323
+    }
+  ],
+  "allowed_dispositions": [
+    "FIX_READY",
+    "HOLD_UPSTREAM_NO_FIXED_VERSION",
+    "DUPLICATE_TRACKING",
+    "FALSE_POSITIVE_WITH_EVIDENCE",
+    "NEEDS_EVIDENCE"
+  ],
+  "issues": [
+    {
+      "issue": 4314,
+      "alert": 5580,
+      "component": "library/cdb_allocation",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "ef063292d083a91b",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "HOLD_UPSTREAM_NO_FIXED_VERSION",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Suite-native FixedVersion for perl-base CVE-2026-57433 on pinned Trixie image + rebuild/scan clears alert 5580; do not close as duplicate alone"
+    },
+    {
+      "issue": 4315,
+      "alert": 5571,
+      "component": "library/cdb_db_writer",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "cabce4d818688770",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Same as #4314 / #2932 suite-native FixedVersion + scan clear for alert 5571; mark duplicate only, do not close before clear"
+    },
+    {
+      "issue": 4316,
+      "alert": 5583,
+      "component": "library/cdb_execution",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "9b5a2caf0f4c84ad",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Suite-native FixedVersion + scan clear for alert 5583; no premature close"
+    },
+    {
+      "issue": 4317,
+      "alert": 5574,
+      "component": "library/cdb_market",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "bb8ffd00d7850e16",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Suite-native FixedVersion + scan clear for alert 5574; no premature close"
+    },
+    {
+      "issue": 4318,
+      "alert": 5536,
+      "component": "library/cdb_regime",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "748dff5ab77026f0",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Suite-native FixedVersion + scan clear for alert 5536; no premature close"
+    },
+    {
+      "issue": 4319,
+      "alert": 5530,
+      "component": "library/cdb_risk",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "d63ba2fc042e9fe7",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Suite-native FixedVersion + scan clear for alert 5530; no premature close"
+    },
+    {
+      "issue": 4320,
+      "alert": 5533,
+      "component": "library/cdb_signal",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "5f0d96a8e36636c5",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Suite-native FixedVersion + scan clear for alert 5533; no premature close"
+    },
+    {
+      "issue": 4321,
+      "alert": 5577,
+      "component": "library/cdb_ws",
+      "package": "perl-base",
+      "installed": "5.40.1-6",
+      "fixed_version": "",
+      "fingerprint": "358a4ae5131baf18",
+      "runtime_reachability": "package_present_no_cdb_storable_callpath",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2932,
+      "closure_condition": "Suite-native FixedVersion + scan clear for alert 5577; no premature close"
+    },
+    {
+      "issue": 4322,
+      "alert": 5677,
+      "component": "usr/share/grafana/bin/grafana",
+      "package": "github.com/getkin/kin-openapi",
+      "installed": "v0.133.0 (alert) / v0.140.0 (13.1.1 runtime pin)",
+      "fixed_version": "0.144.0",
+      "fingerprint": "12d747eb0eea75e0",
+      "runtime_reachability": "bundled_in_upstream_grafana_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "HOLD_UPSTREAM_NO_FIXED_VERSION",
+      "duplicate_of_cluster": false,
+      "canonical_tracker": 2933,
+      "closure_condition": "Upstream grafana/grafana release with kin-openapi>=0.144.0 scan-clears alert 5677 on pinned digest; re-eval by 2026-09-03; no source vendoring"
+    },
+    {
+      "issue": 4323,
+      "alert": 5585,
+      "component": "bin/prometheus",
+      "package": "golang.org/x/text",
+      "installed": "v0.38.0 (v3.13.1 alert) / cleared on v3.13.2",
+      "fixed_version": "0.39.0",
+      "fingerprint": "91b27a2a006ede02",
+      "runtime_reachability": "bundled_in_prometheus_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "FIX_READY",
+      "duplicate_of_cluster": false,
+      "canonical_tracker": 4323,
+      "closure_condition": "After this PR merges to main AND post-merge Trivy/code-scanning recount shows alert 5585 fixed/absent for CVE-2026-56852 on bin/prometheus and bin/promtool"
+    }
+  ]
+}

--- a/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md
+++ b/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md
@@ -1,0 +1,129 @@
+# CDB Security Alert Wave #4314–#4323 (2026-08-03)
+
+Machine-readable twin: [`CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.json`](./CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.json)
+
+## Scope
+
+Triage and bounded remediation for the ten Security Alert Readout issues created
+2026-08-03 (`#4314`–`#4323`). Merge mode is **false**. No alert dismissal, no
+`trivyignore` growth, no LR/live/echtgeld implication.
+
+| Field | Value |
+| --- | --- |
+| `origin/main` base | `a52a0e90b702cd2758736bfa4ed25e2b9fd382ab` |
+| Readout run | [30803956049](https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/30803956049) (SUCCESS on same SHA) |
+| Routing | `CREATE_DEDICATED_PR` (preferred objective `security-alert-wave-2026-08-03`) |
+| Branch | `dedicated/security-alert-wave-2026-08-03` |
+| Cap-45 candidates | **OUT OF SCOPE** (documented only) |
+
+## Brain Evidence (session)
+
+- `brain_source`: repo-only
+- `brain_status`: not-used
+- `context_brain_attempted`: true
+- `context_brain_used`: false
+- `context_available`: false
+- `repo_fallback_used`: true
+- `repo_fallback_reason`: insufficient_evidence
+- `context_tool_status`: available
+- `context_trust_level`: none
+- `records_found`: none
+
+## Live alert inventory (revalidated)
+
+| Issue | Alert | Rule | Component | Installed | FixedVersion | State |
+| --- | --- | --- | --- | --- | --- | --- |
+| #4314 | 5580 | CVE-2026-57433 | library/cdb_allocation | perl-base 5.40.1-6 | *(empty)* | open |
+| #4315 | 5571 | CVE-2026-57433 | library/cdb_db_writer | perl-base 5.40.1-6 | *(empty)* | open |
+| #4316 | 5583 | CVE-2026-57433 | library/cdb_execution | perl-base 5.40.1-6 | *(empty)* | open |
+| #4317 | 5574 | CVE-2026-57433 | library/cdb_market | perl-base 5.40.1-6 | *(empty)* | open |
+| #4318 | 5536 | CVE-2026-57433 | library/cdb_regime | perl-base 5.40.1-6 | *(empty)* | open |
+| #4319 | 5530 | CVE-2026-57433 | library/cdb_risk | perl-base 5.40.1-6 | *(empty)* | open |
+| #4320 | 5533 | CVE-2026-57433 | library/cdb_signal | perl-base 5.40.1-6 | *(empty)* | open |
+| #4321 | 5577 | CVE-2026-57433 | library/cdb_ws | perl-base 5.40.1-6 | *(empty)* | open |
+| #4322 | 5677 | GHSA-r277-6w6q-xmqw | usr/share/grafana/bin/grafana | kin-openapi v0.133.0 | 0.144.0 | open |
+| #4323 | 5585 | CVE-2026-56852 | bin/prometheus | golang.org/x/text v0.38.0 | 0.39.0 | open |
+
+Alert create dates are historical (2026-07-14/15/31); issues were generated 2026-08-03.
+
+## Clusterbildung (after per-issue triage)
+
+1. **perl-storable-cve-2026-57433** — `#4314`–`#4321` → HOLD under canonical `#2932`
+2. **grafana-kin-openapi-ghsa-r277** — `#4322` → HOLD under canonical `#2933`
+3. **prometheus-x-text-cve-2026-56852** — `#4323` → FIX_READY (pin wiring complete)
+
+## Prometheus remediation (#4323)
+
+PR [#4310](https://github.com/jannekbuengener/Claire_de_Binare/pull/4310) already moved
+`compose.red.yml` and `compose.prometheus-v3.yml` to
+`prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69`.
+Stale surfaces on `origin/main` before this wave:
+
+- `infrastructure/compose/base.yml` still `v3.13.1`
+- `.github/workflows/security-scan.yml` still `v3.13.1`
+- `knowledge/governance/SERVICE_CATALOG.md` still `v3.13.1`
+
+This wave syncs stale Prometheus pins in `base.yml`, `security-scan.yml`, and
+`SERVICE_CATALOG.md` to the verified `v3.13.2` digest. `compose.red.yml` and
+the prometheus-v3 overlay image were already current after #4310; the overlay
+comment was updated to say `v3.13.2`. Grafana `base.yml` / scan / catalog pins
+are aligned to the already-merged RED `13.1.1` digest for consistency only
+(not a GHSA fix).
+
+### Scan evidence
+
+| Image | CVE-2026-56852 | HIGH/CRITICAL total |
+| --- | --- | --- |
+| `prom/prometheus:v3.13.1@sha256:3c42b892…` | **2** (`bin/prometheus`, `bin/promtool`, x/text v0.38.0) | present |
+| `prom/prometheus:v3.13.2@sha256:508729e0…` | **0** | **0** |
+
+`promtool check config` / `check rules` against repo monitoring configs: SUCCESS.
+
+**Closure for #4323:** only after this PR merges **and** post-merge recount shows
+alert `5585` cleared. No `Closes #4323` in the PR body.
+
+## Perl HOLD (#4314–#4321 → #2932)
+
+- Trivy FixedVersion empty on all eight alerts.
+- Debian Security Tracker: **trixie** `perl` 5.40.1-6 remains **vulnerable** for
+  CVE-2026-57433; fix present in **forky/sid** (`5.42.2-3`) only.
+- Forbidden: forky/sid mix into Trixie, Alpine migration, unsupported perl
+  backport, `trivyignore`, alert dismissal.
+- Repo search: no CDB service call path uses Perl `Storable` thaw/retrieve.
+- Package remains present via `python:*-slim-trixie` base images.
+- Canonical tracker: [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932)
+- Absolute re-eval date: **2026-09-03**
+- Duplicates marked; **issues stay open** until suite-native FixedVersion + scan clear.
+
+## Grafana HOLD (#4322 → #2933)
+
+- Alert `5677` (scanned against older `13.0.3` path) reports kin-openapi `v0.133.0`,
+  Fixed `0.144.0`.
+- Local Trivy on repo RED digest
+  `grafana/grafana:13.1.1-ubuntu@sha256:5a9df011…` still reports
+  **GHSA-r277-6w6q-xmqw** with kin-openapi **v0.140.0** (still < 0.144.0).
+- Also still has CVE-2026-56852 on Grafana binaries (x/text < 0.39.0).
+- Docker Hub: no newer supported `13.1.x` / `13.2.x-ubuntu` release beyond
+  `13.1.1-ubuntu` found at triage time that claims kin-openapi ≥ 0.144.0.
+- Pin sync of `base.yml` / `security-scan.yml` / catalog to the already-merged
+  RED `13.1.1` digest is **consistency only**, not a GHSA fix claim.
+- Forbidden: Grafana source patch / vendoring.
+- Canonical tracker: [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933)
+- Absolute re-eval date: **2026-09-03**
+
+## Related merged work (do not reuse)
+
+- PR [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303) merged;
+  branch `dedicated/security-backlog-reconciliation-2513` must not be re-pushed.
+- Meta residual trackers remain open: [#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513),
+  [#2932](https://github.com/jannekbuengener/Claire_de_Binare/issues/2932),
+  [#2933](https://github.com/jannekbuengener/Claire_de_Binare/issues/2933).
+
+## Safety boundaries
+
+- LR = **NO-GO**
+- No live / Echtgeld / productive deploy
+- No alert dismissal / mutation
+- No merge / no `cdb-local-ci` publish in this delivery wave
+- No productive DB / MCP mutations
+- Cap-45 readout candidates untouched

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -57,7 +57,7 @@ services:
       - cdb_network
 
   cdb_prometheus:
-    image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
+    image: prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69
     container_name: cdb_prometheus
     restart: unless-stopped
     volumes:
@@ -76,7 +76,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084
+    image: grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.prometheus-v3.yml
+++ b/infrastructure/compose/compose.prometheus-v3.yml
@@ -4,7 +4,7 @@
 #
 # Scope:
 # - Adds an optional parallel Prometheus v3 canary service
-# - Does not change default runtime service cdb_prometheus (v3.13.1)
+# - Does not change default runtime service cdb_prometheus (v3.13.2)
 
 services:
   cdb_prometheus_v3:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -139,8 +139,8 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
-| **Prometheus** | cdb_prometheus | prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893 | 19090→9090 | **AKTIV** | Metrics Collection |
-| **Grafana** | cdb_grafana | grafana/grafana:13.0.3-ubuntu@sha256:7c1acd41225a05af53fa2af32a044a2a96cdef2540f2c415ee5b1e98fae99084 | 3000 | **AKTIV** | Dashboards |
+| **Prometheus** | cdb_prometheus | prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69 | 19090→9090 | **AKTIV** | Metrics Collection |
+| **Grafana** | cdb_grafana | grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |
 | **cAdvisor** | cdb_cadvisor | gcr.io/cadvisor/cadvisor:v0.49.2 | — | **AKTIV** | Container Metrics |

--- a/tests/unit/security/test_security_alert_wave_4314_4323_contract.py
+++ b/tests/unit/security/test_security_alert_wave_4314_4323_contract.py
@@ -1,0 +1,178 @@
+"""Contract for security alert wave #4314–#4323 (2026-08-03).
+
+Validates machine-readable wave evidence and Prometheus pin surfaces.
+Static parsing only — no GitHub writes, no alert mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+WAVE_JSON = (
+    REPO_ROOT
+    / "docs"
+    / "evidence"
+    / "security"
+    / "CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.json"
+)
+WAVE_MD = (
+    REPO_ROOT
+    / "docs"
+    / "evidence"
+    / "security"
+    / "CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md"
+)
+
+PROM_PIN = (
+    "prom/prometheus:v3.13.2@"
+    "sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69"
+)
+GRAFANA_PIN = (
+    "grafana/grafana:13.1.1-ubuntu@"
+    "sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8"
+)
+STALE_PROM = "prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893"
+
+EXPECTED_ISSUES = frozenset(range(4314, 4324))
+ALLOWED_DISPOSITIONS = frozenset(
+    {
+        "FIX_READY",
+        "HOLD_UPSTREAM_NO_FIXED_VERSION",
+        "DUPLICATE_TRACKING",
+        "FALSE_POSITIVE_WITH_EVIDENCE",
+        "NEEDS_EVIDENCE",
+    }
+)
+ALLOWED_VERDICTS = frozenset({"confirmed", "not_actionable", "needs_review"})
+
+PIN_FILES = (
+    REPO_ROOT / "infrastructure" / "compose" / "base.yml",
+    REPO_ROOT / "infrastructure" / "compose" / "compose.red.yml",
+    REPO_ROOT / "infrastructure" / "compose" / "compose.prometheus-v3.yml",
+    REPO_ROOT / ".github" / "workflows" / "security-scan.yml",
+    REPO_ROOT / "knowledge" / "governance" / "SERVICE_CATALOG.md",
+)
+
+
+def _load_wave() -> dict:
+    assert WAVE_JSON.is_file(), f"missing wave json: {WAVE_JSON}"
+    return json.loads(WAVE_JSON.read_text(encoding="utf-8"))
+
+
+def test_wave_markdown_and_json_exist() -> None:
+    assert WAVE_MD.is_file(), f"missing markdown: {WAVE_MD}"
+    assert WAVE_JSON.is_file(), f"missing json: {WAVE_JSON}"
+    md = WAVE_MD.read_text(encoding="utf-8")
+    assert "CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.json" in md
+    assert "a52a0e90b702cd2758736bfa4ed25e2b9fd382ab" in md
+    assert "No alert dismissal" in md or "no alert dismissal" in md.lower()
+    assert "2026-09-03" in md
+    assert "OUT OF SCOPE" in md or "out of scope" in md.lower()
+
+
+def test_wave_schema_and_safety_flags() -> None:
+    data = _load_wave()
+    assert data["schema"] == "cdb.security_alert_wave.v1"
+    assert data["wave_id"] == "security-alert-wave-2026-08-03"
+    assert data["snapshot_date"] == "2026-08-03"
+    assert data["base_sha"] == "a52a0e90b702cd2758736bfa4ed25e2b9fd382ab"
+    assert data["routing_decision"] == "CREATE_DEDICATED_PR"
+    assert data["merge_allowed"] is False
+    assert data["merge_mode"] is False
+    assert data["issue_closure_before_merge_allowed"] is False
+    assert data["alert_dismissal_allowed"] is False
+    assert data["trivyignore_growth_allowed"] is False
+    assert data["lr_verdict"] == "NO-GO"
+    assert data["prometheus_target_pin"] == PROM_PIN
+    assert data["grafana_runtime_pin"] == GRAFANA_PIN
+    assert data["cap45_out_of_scope"]["documented"] is True
+
+
+def test_exactly_ten_issues_with_required_fields() -> None:
+    data = _load_wave()
+    rows = data["issues"]
+    assert len(rows) == 10
+    numbers = [row["issue"] for row in rows]
+    assert set(numbers) == EXPECTED_ISSUES
+    assert len(numbers) == len(set(numbers))
+    for row in rows:
+        assert row["cdb_disposition"] in ALLOWED_DISPOSITIONS
+        assert row["codex_verdict"] in ALLOWED_VERDICTS
+        assert isinstance(row["alert"], int)
+        assert isinstance(row["component"], str) and row["component"]
+        assert isinstance(row["package"], str) and row["package"]
+        assert isinstance(row["canonical_tracker"], int)
+        assert isinstance(row["closure_condition"], str) and row["closure_condition"]
+        assert isinstance(row["fingerprint"], str) and row["fingerprint"]
+
+
+def test_cluster_partition_matches_dispositions() -> None:
+    data = _load_wave()
+    by_issue = {row["issue"]: row for row in data["issues"]}
+    perl = {4314, 4315, 4316, 4317, 4318, 4319, 4320, 4321}
+    assert by_issue[4314]["cdb_disposition"] == "HOLD_UPSTREAM_NO_FIXED_VERSION"
+    for issue in perl - {4314}:
+        assert by_issue[issue]["cdb_disposition"] == "DUPLICATE_TRACKING"
+        assert by_issue[issue]["canonical_tracker"] == 2932
+    assert by_issue[4314]["canonical_tracker"] == 2932
+    assert by_issue[4322]["cdb_disposition"] == "HOLD_UPSTREAM_NO_FIXED_VERSION"
+    assert by_issue[4322]["canonical_tracker"] == 2933
+    assert by_issue[4323]["cdb_disposition"] == "FIX_READY"
+    assert "merge" in by_issue[4323]["closure_condition"].lower()
+    assert "recount" in by_issue[4323]["closure_condition"].lower()
+    forbidden_fixed = {
+        "FIXED_BY_PIN",
+        "FIXED_SCAN_VERIFIED",
+        "REMEDIATED_SCAN_VERIFIED",
+    }
+    for row in data["issues"]:
+        assert row["cdb_disposition"] not in forbidden_fixed
+        if row["issue"] != 4323:
+            assert "closes #" not in row["closure_condition"].lower()
+
+
+def test_prometheus_and_grafana_pins_synced_no_stale_prom() -> None:
+    for path in PIN_FILES:
+        text = path.read_text(encoding="utf-8")
+        assert STALE_PROM not in text, f"stale prometheus pin still in {path}"
+        assert PROM_PIN in text, f"missing prometheus v3.13.2 pin in {path}"
+        if path.name in {
+            "base.yml",
+            "compose.red.yml",
+            "security-scan.yml",
+            "SERVICE_CATALOG.md",
+        }:
+            assert GRAFANA_PIN in text, f"missing grafana 13.1.1 pin in {path}"
+
+
+def test_trivy_evidence_claims_are_internally_consistent() -> None:
+    data = _load_wave()
+    prom = data["trivy_evidence"]["prometheus_v3_13_2"]
+    assert prom["cve_2026_56852_hits"] == 0
+    assert prom["high_critical_total"] == 0
+    assert prom["bin_prometheus_cleared"] is True
+    assert prom["bin_promtool_cleared"] is True
+    contrast = data["trivy_evidence"]["prometheus_v3_13_1_contrast"]
+    assert contrast["cve_2026_56852_hits"] == 2
+    grafana = data["trivy_evidence"]["grafana_13_1_1"]
+    assert grafana["ghsa_r277_hits"] >= 1
+    assert grafana["kin_openapi_installed"].startswith("v0.140")
+    assert data["perl_hold_evidence"]["suite_native_fix_available"] is False
+    assert data["perl_hold_evidence"]["re_eval_date"] == "2026-09-03"
+    assert data["grafana_hold_evidence"]["re_eval_date"] == "2026-09-03"
+
+
+def test_compose_prometheus_comment_mentions_v3_13_2() -> None:
+    overlay = (
+        REPO_ROOT / "infrastructure" / "compose" / "compose.prometheus-v3.yml"
+    ).read_text(encoding="utf-8")
+    assert re.search(r"cdb_prometheus \(v3\.13\.2\)", overlay)
+    assert "v3.13.1)" not in overlay


### PR DESCRIPTION
## Summary
- Complete Prometheus CVE-2026-56852 pin wiring to `prom/prometheus:v3.13.2@sha256:508729e0…` across `base.yml`, `security-scan.yml`, and `SERVICE_CATALOG.md` (RED/overlay already current after #4310).
- Triage security alert wave `#4314`–`#4323`: perl cluster HOLD under `#2932`, Grafana GHSA HOLD under `#2933`, Prometheus FIX_READY pending merge+recount.
- Align Grafana base/scan/catalog pins to already-merged RED `13.1.1` for consistency only (not a GHSA fix).
- Add wave evidence + contract tests; Cap-45 readout candidates remain out of scope.

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: none
- records_found: none

## Live Alert Inventory
| Issue | Alert | Rule | Component | FixedVersion | State |
| --- | --- | --- | --- | --- | --- |
| #4314–#4321 | 5580/5571/5583/5574/5536/5530/5533/5577 | CVE-2026-57433 | cdb_* images | empty | open |
| #4322 | 5677 | GHSA-r277-6w6q-xmqw | grafana bin | 0.144.0 | open |
| #4323 | 5585 | CVE-2026-56852 | bin/prometheus | 0.39.0 | open |

Readout run: https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/30803956049 on `a52a0e90`.

## Per-Issue Triage
See `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md` (Codex verdict + CDB disposition per issue).

## Prometheus Remediation
- Target pin: `prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69`
- Local Trivy: CVE-2026-56852 **0** hits on v3.13.2; **2** hits on v3.13.1 (`bin/prometheus` + `bin/promtool`)
- promtool check config/rules: SUCCESS
- `#4323` stays open until merge + post-merge recount

## Perl HOLD
- Debian trixie `perl-base` 5.40.1-6 still vulnerable; FixedVersion empty; forky/sid only
- Canonical tracker `#2932`; re-eval **2026-09-03**
- No suite mix, no trivyignore, no dismissal; duplicates marked, not closed

## Grafana Fix or HOLD
- **HOLD**: `grafana/grafana:13.1.1-ubuntu@sha256:5a9df011…` still has GHSA-r277 (kin-openapi v0.140.0 < 0.144.0)
- Pin sync to RED digest is consistency-only
- Canonical tracker `#2933`; re-eval **2026-09-03**; no source vendoring

## Changed Files
- `infrastructure/compose/base.yml`
- `infrastructure/compose/compose.prometheus-v3.yml` (comment)
- `.github/workflows/security-scan.yml`
- `knowledge/governance/SERVICE_CATALOG.md`
- `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.{md,json}`
- `tests/unit/security/test_security_alert_wave_4314_4323_contract.py`

## Validation
- `pytest -q tests/unit/security/test_security_alert_wave_4314_4323_contract.py` → 7 passed
- ruff + black on changed test
- `docker compose … config --quiet` base+red OK
- promtool check config/rules SUCCESS
- Trivy HIGH/CRITICAL on target Prometheus digest: 0
- gitleaks on wave files: no leaks
- Independent reviews: security-triage PASS, code-reviewer PASS, validation-evidence PASS, governance PASS
- No full Fast-CI / no `cdb-local-ci` publish (merge_mode=false)

## Remaining Alerts
- Perl cluster alerts remain open
- Grafana alert 5677 remains open
- Prometheus alert 5585 remains open until post-merge recount
- Cap-45 readout candidates untouched

## Non-goals
- No alert dismissal / mutation
- No trivyignore growth
- No merge / no issue close in this session
- No runtime deploy / no productive DB / MCP mutations
- No forky/sid/alpine base migration / no Grafana source patch

## Post-Merge Recount Plan
1. Merge this PR to `main`
2. Re-scan / wait for code-scanning refresh on exact merged SHA
3. Confirm alert 5585 (and related promtool path) cleared for CVE-2026-56852
4. Only then close `#4323`
5. Re-eval perl/grafana HOLDs by **2026-09-03** or earlier if FixedVersion appears

## Safety Boundaries
- LR = **NO-GO**
- Board stage `trade-capable` ≠ Live-Go
- No live / Echtgeld / secrets exposure
- github_writes_via = gh_cli_only

Refs #4314 #4315 #4316 #4317 #4318 #4319 #4320 #4321 #4322 #4323 #2513 #2932 #2933