### PR TITLE
fix(hermes): bind installer pin to release commit (#4327)

### DIFF
--- a/docs/evidence/hermes/hermes_hetzner_repo_slice_evidence.md
+++ b/docs/evidence/hermes/hermes_hetzner_repo_slice_evidence.md
@@ -14,15 +14,20 @@ Sensitive host inventory stays outside the repository.
 
 ## Pin (verified)
 
+Authoritative live pin is `infrastructure/hermes/VERSION_PIN.yaml` (refreshed
+[#4327](https://github.com/jannekbuengener/Claire_de_Binare/issues/4327) after
+floating CDN drift blocked [#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289)
+Phase A). Historical 2026-08-02 floating-CDN values below are superseded.
+
 | Field | Value |
 |---|---|
 | git_ref | `v2026.7.30` |
 | git_commit | `cc4cab2f592e60a197e796506de9168f74baf3ea` |
 | release | Hermes Agent v0.19.1 |
-| install.sh sha256 | `f493957fc9700b8f05470fc620efade5122595ebdba0df455a8b5ebaa0558128` |
-| install URL | `https://hermes-agent.nousresearch.com/install.sh` |
+| install.sh sha256 | `ab3e6ae1a1bda828941df8911ae44ed5de68412805124f338f157aa0360eb660` |
+| install URL | commit-bound `…/cc4cab2f…/scripts/install.sh` (floating `hermes-agent.nousresearch.com/install.sh` forbidden for `--require-pinned`) |
 | dashboard entrypoint | `hermes dashboard --host 127.0.0.1 --port <N> --no-open --isolated` |
-| cost estimate | 14.89 EUR/mo (CPX21 + IPv4 + backups) |
+| cost estimate | 14.89 EUR/mo (CPX21 + IPv4 + backups); live provision default CX23≈9.03 EUR/mo |
 
 ## Session 2026-08-02 — CI root cause
 

--- a/docs/runbooks/hermes_hetzner_operations.md
+++ b/docs/runbooks/hermes_hetzner_operations.md
@@ -38,7 +38,10 @@ Installer env `HERMES_GIT_REF` is **not** supported; use `--branch` / `--commit`
    - Do not set `HCLOUD_TOKEN` from Object Storage credentials.
 2. `hcloud` CLI authenticated (`hcloud server list` succeeds).
 3. Tailscale (or equivalent private net) for Jannek ↔ Hetzner ↔ Windows.
-4. `infrastructure/hermes/VERSION_PIN.yaml` filled; `python -m tools.hermes_ops pin-check --require-pinned` exits 0.
+4. `infrastructure/hermes/VERSION_PIN.yaml` filled with a **commit-bound**
+   `install_url` (full 40-char `git_commit` in path, `…/scripts/install.sh`);
+   floating `hermes-agent.nousresearch.com/install.sh` is rejected.
+   `python -m tools.hermes_ops pin-check --require-pinned` exits 0.
 5. Dedicated GitHub App for Hermes write with minimal perms (see below).
    **Do not** expand App `4410232` (`cdb-local-ci`: `checks:write` + `metadata:read` only).
    Auth lineage [#4170](https://github.com/jannekbuengener/Claire_de_Binare/issues/4170) /  <!-- pragma: allowlist secret -->

--- a/infrastructure/hermes/VERSION_PIN.yaml
+++ b/infrastructure/hermes/VERSION_PIN.yaml
@@ -1,23 +1,29 @@
-# Hermes runtime version pin for Hetzner bootstrap (#4289).
+# Hermes runtime version pin for Hetzner bootstrap (#4289 / #4327).
 # Live bootstrap REJECTS empty git_ref / sha256 / commit.
+# Floating CDN tip URLs are NOT acceptable for --require-pinned (#4327).
 
 schema_version: cdb.hermes.version_pin/v1
-issue: 4289
-pinned_at_utc: "2026-08-01T20:55:00Z"
+issue: 4327
+issue_lineage:
+  - 4289
+  - 4327
+pinned_at_utc: "2026-08-03T15:58:00Z"
 source_docs:
   - "https://hermes-agent.nousresearch.com/docs/getting-started/installation"
   - "https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.30"
+  - "https://raw.githubusercontent.com/NousResearch/hermes-agent/cc4cab2f592e60a197e796506de9168f74baf3ea/scripts/install.sh"
 
 hermes:
-  # Official installer (sha256 of bytes downloaded at pin time).
-  install_url: https://hermes-agent.nousresearch.com/install.sh
-  install_script_sha256: "f493957fc9700b8f05470fc620efade5122595ebdba0df455a8b5ebaa0558128"
+  # Commit-bound installer (immutable raw.githubusercontent.com bytes at pin time).
+  # Do NOT use https://hermes-agent.nousresearch.com/install.sh for live pins.
+  install_url: https://raw.githubusercontent.com/NousResearch/hermes-agent/cc4cab2f592e60a197e796506de9168f74baf3ea/scripts/install.sh
+  install_script_sha256: "ab3e6ae1a1bda828941df8911ae44ed5de68412805124f338f157aa0360eb660"
   # Official release tag + peeled commit (annotated tag object resolves to this SHA).
   git_ref: "v2026.7.30"
   git_commit: "cc4cab2f592e60a197e796506de9168f74baf3ea"
   release_name: "Hermes Agent v0.19.1 (v2026.7.30)"
   # Installer CLI flags that actually exist (verified by reading install.sh):
-  #   --dir / --hermes-home / --branch / --commit / --skip-browser / --non-interactive
+  #   --dir / --hermes-home / --branch / --commit / --skip-browser / --non-interactive / --skip-setup
   # HERMES_GIT_REF is NOT supported by the official installer.
   installer_supports:
     hermes_install_dir_env: true
@@ -28,11 +34,16 @@ hermes:
     cli_hermes_home: true
     cli_skip_browser: true
     cli_non_interactive: true
+    cli_skip_setup: true
   requires_min: ">=0.12.0"
   dashboard_command: "hermes dashboard"
   # hermes serve is NOT the official dashboard entrypoint for v0.19.1.
   serve_command_deprecated: true
-  provenance_note: "Pin verified 2026-08-01 against official install.sh + GitHub tag v2026.7.30."
+  provenance_note: >
+    Pin refreshed 2026-08-03 (#4327): commit-bound scripts/install.sh at
+    cc4cab2f592e60a197e796506de9168f74baf3ea (tag v2026.7.30). Floating CDN
+    tip hermes-agent.nousresearch.com/install.sh drifted from prior pin
+    f493957f… and is rejected by pin-check --require-pinned.
 
 os:
   image: ubuntu-24.04
@@ -45,6 +56,7 @@ hetzner:
   # Official price table (excl. IPv4): CPX21 = 11.99 EUR/mo in NBG/HEL after 2026-06-15 adjustment.
   # IPv4 Primary IP = 0.50 EUR/mo. Backups ≈ 20% of server ≈ 2.40 EUR/mo.
   # Planning ceiling: 11.99 + 0.50 + 2.40 = 14.89 EUR/mo < 15.00.
+  # Live provision defaults (ops): cx23/fsn1 ≈ 9.03 EUR/mo — see provision.sh / runbook.
   monthly_cost_eur_limit: 15
   monthly_cost_eur_estimate:
     server_cpx21_excl_ipv4: 11.99

--- a/tests/unit/hermes_ops/test_pin_and_cli_contract.py
+++ b/tests/unit/hermes_ops/test_pin_and_cli_contract.py
@@ -1,4 +1,4 @@
-"""Pin-check and mint CLI contracts (#4289)."""
+"""Pin-check and mint CLI contracts (#4289 / #4327)."""
 
 from __future__ import annotations
 
@@ -11,6 +11,22 @@ from tools.hermes_ops.__main__ import main
 
 pytestmark = [pytest.mark.unit]
 
+_COMMIT = "cc4cab2f592e60a197e796506de9168f74baf3ea"
+_SHA = "ab3e6ae1a1bda828941df8911ae44ed5de68412805124f338f157aa0360eb660"
+_BOUND_URL = (
+    f"https://raw.githubusercontent.com/NousResearch/hermes-agent/"
+    f"{_COMMIT}/scripts/install.sh"
+)
+
+
+def _write_pin(tmp_path: Path, hermes_block: str) -> None:
+    pin_dir = tmp_path / "infrastructure" / "hermes"
+    pin_dir.mkdir(parents=True)
+    (pin_dir / "VERSION_PIN.yaml").write_text(
+        "schema_version: cdb.hermes.version_pin/v1\n" f"hermes:\n{hermes_block}",
+        encoding="utf-8",
+    )
+
 
 def test_pin_check_require_pinned_passes_with_filled_pin(
     capsys: pytest.CaptureFixture[str],
@@ -20,18 +36,22 @@ def test_pin_check_require_pinned_passes_with_filled_pin(
     assert code == 0
     assert out["ok"] is True
     assert out["missing_fields"] == []
+    assert out["contract_errors"] == []
     assert out["git_ref"]
+    assert out["install_url"].startswith("https://")
+    assert _COMMIT in out["install_url"]
+    assert out["install_url"].endswith("/scripts/install.sh")
 
 
 def test_pin_check_empty_pin_fails_require_pinned(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    pin_dir = tmp_path / "infrastructure" / "hermes"
-    pin_dir.mkdir(parents=True)
-    (pin_dir / "VERSION_PIN.yaml").write_text(
-        'schema_version: cdb.hermes.version_pin/v1\nhermes:\n  git_ref: ""\n'
-        '  git_commit: ""\n  install_script_sha256: ""\n  install_url: ""\n',
-        encoding="utf-8",
+    _write_pin(
+        tmp_path,
+        '  git_ref: ""\n'
+        '  git_commit: ""\n'
+        '  install_script_sha256: ""\n'
+        '  install_url: ""\n',
     )
     monkeypatch.chdir(tmp_path)
     code = main(["pin-check", "--require-pinned"])
@@ -39,6 +59,96 @@ def test_pin_check_empty_pin_fails_require_pinned(
     assert code == 2
     assert out["ok"] is False
     assert "hermes.git_ref" in out["missing_fields"]
+
+
+def test_pin_check_rejects_floating_cdn_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_pin(
+        tmp_path,
+        f'  git_ref: "v2026.7.30"\n'
+        f'  git_commit: "{_COMMIT}"\n'
+        f'  install_script_sha256: "{_SHA}"\n'
+        '  install_url: "https://hermes-agent.nousresearch.com/install.sh"\n',
+    )
+    monkeypatch.chdir(tmp_path)
+    code = main(["pin-check", "--require-pinned"])
+    out = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert out["ok"] is False
+    assert "hermes.install_url_floating_cdn_forbidden" in out["contract_errors"]
+
+
+def test_pin_check_rejects_url_commit_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    other = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    _write_pin(
+        tmp_path,
+        f'  git_ref: "v2026.7.30"\n'
+        f'  git_commit: "{_COMMIT}"\n'
+        f'  install_script_sha256: "{_SHA}"\n'
+        f'  install_url: "https://raw.githubusercontent.com/NousResearch/'
+        f'hermes-agent/{other}/scripts/install.sh"\n',
+    )
+    monkeypatch.chdir(tmp_path)
+    code = main(["pin-check", "--require-pinned"])
+    out = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert "hermes.install_url_missing_git_commit" in out["contract_errors"]
+
+
+def test_pin_check_rejects_malformed_sha256(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_pin(
+        tmp_path,
+        f'  git_ref: "v2026.7.30"\n'
+        f'  git_commit: "{_COMMIT}"\n'
+        '  install_script_sha256: "not-a-sha"\n'
+        f'  install_url: "{_BOUND_URL}"\n',
+    )
+    monkeypatch.chdir(tmp_path)
+    code = main(["pin-check", "--require-pinned"])
+    out = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert "hermes.install_script_sha256_malformed" in out["contract_errors"]
+
+
+def test_pin_check_rejects_malformed_git_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_pin(
+        tmp_path,
+        '  git_ref: "v2026.7.30"\n'
+        '  git_commit: "deadbeef"\n'
+        f'  install_script_sha256: "{_SHA}"\n'
+        f'  install_url: "{_BOUND_URL}"\n',
+    )
+    monkeypatch.chdir(tmp_path)
+    code = main(["pin-check", "--require-pinned"])
+    out = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert "hermes.git_commit_malformed" in out["contract_errors"]
+
+
+def test_pin_check_accepts_commit_bound_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_pin(
+        tmp_path,
+        f'  git_ref: "v2026.7.30"\n'
+        f'  git_commit: "{_COMMIT}"\n'
+        f'  install_script_sha256: "{_SHA}"\n'
+        f'  install_url: "{_BOUND_URL}"\n',
+    )
+    monkeypatch.chdir(tmp_path)
+    code = main(["pin-check", "--require-pinned"])
+    out = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert out["ok"] is True
+    assert out["contract_errors"] == []
+    assert out["install_url"] == _BOUND_URL
 
 
 def test_mint_token_live_requires_token_file(

--- a/tools/hermes_ops/__main__.py
+++ b/tools/hermes_ops/__main__.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import stat
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 
@@ -159,6 +161,11 @@ def _cmd_mint_token(args: argparse.Namespace) -> int:
     return 0
 
 
+_FLOATING_INSTALL_HOST = "hermes-agent.nousresearch.com"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_GIT_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
 def _pin_fields_missing(pin: dict) -> list[str]:
     hermes = pin.get("hermes") or {}
     missing: list[str] = []
@@ -167,6 +174,55 @@ def _pin_fields_missing(pin: dict) -> list[str]:
         if val is None or (isinstance(val, str) and not val.strip()):
             missing.append(f"hermes.{key}")
     return missing
+
+
+def _pin_contract_errors(pin: dict) -> list[str]:
+    """Structural reproducibility checks for a live Hermes installer pin (#4327).
+
+    No network I/O. Rejects floating CDN tips and URL/commit mismatches.
+    """
+    hermes = pin.get("hermes") or {}
+    errors: list[str] = []
+    install_url = str(hermes.get("install_url") or "").strip()
+    install_sha = str(hermes.get("install_script_sha256") or "").strip()
+    git_commit = str(hermes.get("git_commit") or "").strip()
+    git_ref = str(hermes.get("git_ref") or "").strip()
+
+    if not git_ref:
+        errors.append("hermes.git_ref_empty")
+    if not _GIT_COMMIT_RE.fullmatch(git_commit):
+        errors.append("hermes.git_commit_malformed")
+    if not _SHA256_RE.fullmatch(install_sha):
+        errors.append("hermes.install_script_sha256_malformed")
+
+    if not install_url:
+        errors.append("hermes.install_url_empty")
+        return errors
+
+    if not install_url.lower().startswith("https://"):
+        errors.append("hermes.install_url_not_https")
+
+    try:
+        parsed = urlparse(install_url)
+    except ValueError:
+        errors.append("hermes.install_url_unparseable")
+        return errors
+
+    host = (parsed.hostname or "").lower()
+    path = parsed.path or ""
+    if host == _FLOATING_INSTALL_HOST and path.rstrip("/").endswith("/install.sh"):
+        errors.append("hermes.install_url_floating_cdn_forbidden")
+
+    if git_commit and git_commit not in install_url:
+        errors.append("hermes.install_url_missing_git_commit")
+    if not path.endswith("/scripts/install.sh"):
+        errors.append("hermes.install_url_not_commit_bound_scripts_install")
+    if any(
+        token in path.lower() for token in ("/main/", "/master/", "/latest/", "/HEAD/")
+    ):
+        errors.append("hermes.install_url_unbound_ref_path")
+
+    return errors
 
 
 def _cmd_hcloud_preflight(_: argparse.Namespace) -> int:
@@ -188,21 +244,32 @@ def _cmd_pin_check(args: argparse.Namespace) -> int:
         return 2
     pin = yaml.safe_load(pin_path.read_text(encoding="utf-8")) or {}
     missing = _pin_fields_missing(pin)
+    hermes = pin.get("hermes") or {}
+    install_url = str(hermes.get("install_url") or "").strip()
     require_pinned = bool(args.require_pinned)
-    # Default: report presence; with --require-pinned (live install): fail empty.
-    ok = not missing if require_pinned else True
+    contract_errors = _pin_contract_errors(pin) if require_pinned else []
+    # Default: report presence; with --require-pinned: fail empty OR non-reproducible.
+    ok = (not missing and not contract_errors) if require_pinned else True
+    if require_pinned and missing:
+        note = "Live install / bootstrap must pass pin-check --require-pinned."
+    elif require_pinned and contract_errors:
+        note = "Pin fields present but install URL/hash/commit contract failed."
+    elif missing:
+        note = "Pin fields incomplete (ok without --require-pinned)."
+    else:
+        note = "Pin fields present."
+        if require_pinned:
+            note = "Pin fields present and commit-bound installer contract OK."
     payload = {
         "ok": ok,
         "pin_file": str(pin_path),
         "require_pinned": require_pinned,
         "missing_fields": missing,
-        "git_ref": (pin.get("hermes") or {}).get("git_ref") or "",
-        "git_commit": (pin.get("hermes") or {}).get("git_commit") or "",
-        "note": (
-            "Live install / bootstrap must pass pin-check --require-pinned."
-            if missing
-            else "Pin fields present."
-        ),
+        "contract_errors": contract_errors,
+        "git_ref": hermes.get("git_ref") or "",
+        "git_commit": hermes.get("git_commit") or "",
+        "install_url": install_url,
+        "note": note,
     }
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0 if ok else 2
@@ -249,7 +316,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_pin.add_argument(
         "--require-pinned",
         action="store_true",
-        help="Fail (exit 2) when git_ref/commit/sha256 are empty (live install gate)",
+        help=(
+            "Fail (exit 2) when pin fields are empty or the installer URL is not "
+            "commit-bound/reproducible (live install gate; #4327)"
+        ),
     )
     p_pin.set_defaults(func=_cmd_pin_check)
 


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: hermes-pin-4327
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: accepting_slices
objective_key: issue-4327
planned_issues: #4327
contract_keys: ci-tooling-v1
risk_flags: none
-->

## Summary
- Bind Hermes `install_url` / `install_script_sha256` to commit `cc4cab2f…` `scripts/install.sh` (SHA256 `ab3e6ae1…`) after floating CDN tip drift blocked #4289 Phase A.
- Harden `pin-check --require-pinned` to reject floating CDN URLs, malformed SHA/commit, and URL↔commit mismatch (`contract_errors`).
- Update unit tests + stale pin evidence/runbook claims.

Refs #4327
Refs #4289

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4327 | SLICE_DELIVERED | 793fbf3e13e20021c4649bf7f2c265d161f844f8 | hermes_ops pin-check/tests/ruff/black PASS | none | Runtime bootstrap on cdb-hermes-01 pending after merge; may HOLD on root path |

## Root Cause
`VERSION_PIN.yaml` pinned floating `hermes-agent.nousresearch.com/install.sh`. Upstream tip changed; live bootstrap fail-closed on SHA mismatch. Historical pin bytes were not recoverable.

## Reproducible Pin
- URL: `https://raw.githubusercontent.com/NousResearch/hermes-agent/cc4cab2f592e60a197e796506de9168f74baf3ea/scripts/install.sh`
- SHA256: `ab3e6ae1a1bda828941df8911ae44ed5de68412805124f338f157aa0360eb660`
- `git_ref`/`git_commit`: `v2026.7.30` / `cc4cab2f592e60a197e796506de9168f74baf3ea`

## Contract Hardening
`--require-pinned` requires HTTPS commit-bound `…/<40hex>/scripts/install.sh`, matching `hermes.git_commit`, 64-hex SHA256; floating CDN forbidden.

## Validation
- `python -m tools.hermes_ops pin-check --require-pinned` PASS
- `validate-profiles` / `secret-scan` PASS
- `pytest -q tests/unit/hermes_ops` 36 passed
- `ruff` / `black --check` PASS
- External download SHA256 matches pin

## Runtime Reproof Plan
After merge: transfer pin/surfaces to existing `cdb-hermes-01` only (no second server / no provision). Bootstrap as root only if an authorized root path exists; otherwise `DONE_PIN_MERGED_HOLD_ROOT_BOOTSTRAP_PATH`.

## Non-goals
No Windows workspace, GitHub App, validation-chief, destroy/rebuild, close #4289, Live/Echtgeld. No `Closes #4327` until runtime PASS.

## Brain Evidence
```
brain_source: repo-only
brain_status: not-used
context_brain_attempted: true
context_brain_used: false
context_available: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: partial
context_trust_level: none
records_found: none
```

## Safety Boundaries
LR NO-GO. No admin merge, no branch-protection edits, no second Hermes server.
