### PR TITLE
fix(hermes): persist bootstrap durability fixes (#4329)

### DIFF
--- a/docs/evidence/hermes/hermes_hetzner_repo_slice_evidence.md
+++ b/docs/evidence/hermes/hermes_hetzner_repo_slice_evidence.md
@@ -131,3 +131,19 @@ Classification: token is **not** read-only; server/volume create specifically de
 
 - #4287 / #4288 already CLOSED with “Permission-Probe, superseded by #4289.”
   Verified live; no re-open.
+
+## Session 2026-08-03 — bootstrap durability (#4329)
+
+Host runtime PASS on existing `cdb-hermes-01` closed [#4327](https://github.com/jannekbuengener/Claire_de_Binare/issues/4327)
+via constrained Rescue. Repo slice [#4329](https://github.com/jannekbuengener/Claire_de_Binare/issues/4329)
+persists the fail-closed host fixes into canonical `bootstrap.sh` + systemd unit:
+
+| Host failure | Durable fix |
+|---|---|
+| `verify_pin` stdout pollution | `log` → stderr |
+| install.sh `0600` under `sudo -u hermes` | `chmod 0644` after hash + EXIT trap cleanup |
+| `/etc/hermes` `root:root` | `chown root:$INSTALL_USER` + `0750` |
+| `ProtectHome=true` → 203/EXEC | `ProtectHome=read-only` + ReadOnlyPaths for uv/opt/installer |
+| missing web_dist / stamp / Node | `ensure_dashboard_runtime_assets` (installer Node only; no floating latest) |
+
+No host mutation in the #4329 repo slice. LR NO-GO unchanged.

--- a/docs/runbooks/hermes_hetzner_operations.md
+++ b/docs/runbooks/hermes_hetzner_operations.md
@@ -79,6 +79,13 @@ sudo bash infrastructure/hermes/hetzner/bootstrap.sh
 `provision.sh` is idempotent (no duplicate `cdb-hermes-01`).
 `bootstrap.sh` fails closed on empty pin, sha256 mismatch, or service start errors (no `|| true`).
 
+Durability contracts (#4329, host evidence from #4327):
+- `log` / progress output goes to **stderr**; `verify_pin` stdout is machine-only (`ref commit`).
+- Installer temp file is `chmod 0644` after hash PASS (readable by `hermes`, not writable).
+- `/etc/hermes` is `root:hermes` mode `0750`.
+- Unit uses `ProtectHome=read-only` plus `ReadOnlyPaths` for uv/opt/installer home (not `ProtectHome=true`).
+- After install, bootstrap builds `hermes_cli/web_dist` if needed, links installer-managed Node into each active profile `HERMES_HOME`, and writes `web-ui-build-stamp.json`. `validation-chief` stays `.DISABLED`.
+
 Ports (loopback only):
 
 | Profile | Port |

--- a/infrastructure/hermes/hetzner/bootstrap.sh
+++ b/infrastructure/hermes/hetzner/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Idempotent Hermes host bootstrap for Hetzner (#4289).
+# Idempotent Hermes host bootstrap for Hetzner (#4289 / #4329).
 # Fail-closed: refuses unpinned installs; fails on service start errors.
 set -euo pipefail
 
@@ -9,6 +9,7 @@ PIN_FILE="${HERMES_VERSION_PIN:-${REPO_HERMES_ROOT}/VERSION_PIN.yaml}"
 INSTALL_USER="${HERMES_LINUX_USER:-hermes}"
 HERMES_BASE="${HERMES_BASE_DIR:-/var/lib/hermes}"
 OPT_DIR="${HERMES_OPT_DIR:-/opt/hermes}"
+INSTALLER_HOME="${HERMES_INSTALLER_HOME:-/var/lib/hermes/_installer_home}"
 SYSTEMD_SRC="${REPO_HERMES_ROOT}/systemd"
 ENV_SRC="${SYSTEMD_SRC}/env"
 PROFILES_SRC="${CDB_HERMES_PROFILES:-${REPO_HERMES_ROOT}/../../config/hermes/profiles}"
@@ -16,7 +17,9 @@ if [[ ! -d "${PROFILES_SRC}" ]]; then
   PROFILES_SRC="$(cd "${REPO_HERMES_ROOT}/../../config/hermes/profiles" 2>/dev/null && pwd || true)"
 fi
 
-log() { printf '[hermes-bootstrap] %s\n' "$*"; }
+# Progress/status logs MUST go to stderr so command-substitution callers
+# (e.g. pin_pair="$(verify_pin)") only capture machine values on stdout (#4329).
+log() { printf '[hermes-bootstrap] %s\n' "$*" >&2; }
 die() { printf '[hermes-bootstrap] ERROR: %s\n' "$*" >&2; exit 1; }
 
 require_cmd() {
@@ -49,6 +52,9 @@ install_systemd_units() {
 install_profile_env_files() {
   mkdir -p /etc/hermes
   chmod 0750 /etc/hermes
+  # Group must be INSTALL_USER so hermes can probe /etc/hermes/.env existence
+  # without PermissionError; directory stays root-owned (#4329).
+  chown root:"${INSTALL_USER}" /etc/hermes
   local profile port
   declare -A PORTS=(
     [jannek-assistant]=9119
@@ -70,6 +76,8 @@ install_profile_env_files() {
       if ! grep -q '^HERMES_PORT=' "${dest}"; then
         die "${dest} missing HERMES_PORT — refuse ambiguous bind"
       fi
+      chown root:"${INSTALL_USER}" "${dest}"
+      chmod 0640 "${dest}"
       log "env present: ${dest}"
     fi
   done
@@ -119,7 +127,7 @@ verify_pin() {
 install_hermes_pinned() {
   local git_ref="$1"
   local git_commit="$2"
-  local install_url install_sha tmp sum code_dir bin_link
+  local install_url install_sha tmp sum code_dir
   install_url="$(yaml_get install_url "${PIN_FILE}")"
   install_sha="$(yaml_get install_script_sha256 "${PIN_FILE}")"
   [[ -n "${install_url}" ]] || die "install_url missing in pin file"
@@ -127,18 +135,24 @@ install_hermes_pinned() {
   require_cmd sha256sum
   require_cmd git
   tmp="$(mktemp)"
+  # Always remove the temp installer — success or fail (#4329).
+  _cleanup_install_tmp() { rm -f "${tmp}"; }
+  trap _cleanup_install_tmp EXIT
   curl -fsSL "${install_url}" -o "${tmp}"
   sum="$(sha256sum "${tmp}" | awk '{print $1}')"
   [[ "${sum}" == "${install_sha}" ]] || die "install.sh sha256 mismatch (got ${sum})"
+  # mktemp defaults to 0600 root:root; hermes must read it under sudo -u (#4329).
+  # Mode 0644 = readable, not writable, by INSTALL_USER.
+  chmod 0644 "${tmp}"
   # Official installer supports --dir/--hermes-home/--branch/--commit (NOT HERMES_GIT_REF).
   code_dir="${OPT_DIR}/hermes-agent"
-  mkdir -p "${OPT_DIR}/bin" /var/lib/hermes/_installer_home
-  chown -R "${INSTALL_USER}:${INSTALL_USER}" "${OPT_DIR}" /var/lib/hermes/_installer_home
+  mkdir -p "${OPT_DIR}/bin" "${INSTALLER_HOME}"
+  chown -R "${INSTALL_USER}:${INSTALL_USER}" "${OPT_DIR}" "${INSTALLER_HOME}"
   if [[ ! -x "${OPT_DIR}/bin/hermes" ]]; then
     log "running pinned install.sh --branch ${git_ref} --commit ${git_commit}"
     sudo -u "${INSTALL_USER}" bash "${tmp}" \
       --dir "${code_dir}" \
-      --hermes-home /var/lib/hermes/_installer_home \
+      --hermes-home "${INSTALLER_HOME}" \
       --branch "${git_ref}" \
       --commit "${git_commit}" \
       --skip-browser \
@@ -147,7 +161,8 @@ install_hermes_pinned() {
   else
     log "hermes binary already present; verifying checkout pin"
   fi
-  rm -f "${tmp}"
+  _cleanup_install_tmp
+  trap - EXIT
   # Prefer venv launcher from the pinned checkout.
   if [[ -x "${code_dir}/venv/bin/hermes" ]]; then
     ln -sfn "${code_dir}/venv/bin/hermes" "${OPT_DIR}/bin/hermes"
@@ -164,6 +179,60 @@ install_hermes_pinned() {
     die "hermes binary missing or broken after install"
 }
 
+ensure_dashboard_runtime_assets() {
+  # After pinned install: managed Node from installer home, web_dist, per-profile
+  # stamps. Uses only the installer-provided Node tree — no floating nodejs.org
+  # latest download (#4329 / host evidence from #4327).
+  local code_dir="${OPT_DIR}/hermes-agent"
+  local node_root="${INSTALLER_HOME}/node"
+  local node_bin="${node_root}/bin"
+  local dist_index="${code_dir}/hermes_cli/web_dist/index.html"
+  local profile home
+
+  [[ -x "${OPT_DIR}/bin/hermes" ]] || die "hermes binary missing before dashboard asset prep"
+  [[ -d "${code_dir}" ]] || die "hermes checkout missing: ${code_dir}"
+  [[ -x "${node_bin}/node" ]] || die "managed node missing at ${node_bin}/node — refuse floating Node install"
+  [[ -x "${node_bin}/npm" ]] || die "managed npm missing at ${node_bin}/npm"
+
+  if [[ ! -f "${dist_index}" ]]; then
+    log "building web UI into hermes_cli/web_dist (index.html missing)"
+    [[ -f "${code_dir}/web/package.json" ]] || die "web/package.json missing — cannot build dashboard UI"
+    sudo -u "${INSTALL_USER}" env PATH="${node_bin}:${PATH}" \
+      bash -lc "cd '${code_dir}/web' && npm install --no-fund --no-audit && npm run build"
+    [[ -f "${dist_index}" ]] || die "web UI build failed — ${dist_index} still missing"
+  else
+    log "web UI dist present: hermes_cli/web_dist/index.html"
+  fi
+
+  for profile in jannek-assistant cdb-engineer; do
+    home="${HERMES_BASE}/profiles/${profile}"
+    [[ -d "${home}" ]] || die "profile home missing: ${home}"
+    # Hermes resolves managed Node under \$HERMES_HOME/node.
+    ln -sfn "${node_root}" "${home}/node"
+    chown -h "${INSTALL_USER}:${INSTALL_USER}" "${home}/node" || true
+    # Write upstream-compatible stamp so dashboard boot skips rebuild without npm
+    # in a hardened unit PATH. Uses hermes_cli helpers from the pinned checkout.
+    sudo -u "${INSTALL_USER}" env \
+      HERMES_HOME="${home}" \
+      PATH="${home}/node/bin:${node_bin}:${PATH}" \
+      "${code_dir}/venv/bin/python" - <<'PY'
+from hermes_cli.main import PROJECT_ROOT, _web_ui_build_needed, _write_web_ui_build_stamp
+
+web = PROJECT_ROOT / "web"
+_write_web_ui_build_stamp(PROJECT_ROOT, web)
+if _web_ui_build_needed(web):
+    raise SystemExit("web UI stamp still indicates rebuild after write")
+PY
+    [[ -f "${home}/web-ui-build-stamp.json" ]] || \
+      die "missing web-ui-build-stamp.json for profile ${profile}"
+    log "dashboard assets ready for profile ${profile}"
+  done
+
+  # Never initialize/enable validation-chief here.
+  [[ -f "${HERMES_BASE}/profiles/validation-chief/.DISABLED" ]] || \
+    die "validation-chief/.DISABLED missing — refuse enabling disabled profile path"
+}
+
 enable_services() {
   systemctl enable hermes-dashboard@jannek-assistant.service
   systemctl enable hermes-dashboard@cdb-engineer.service
@@ -175,8 +244,8 @@ enable_services() {
     || die "cdb-engineer dashboard failed to start"
   # Port conflict probe: both must listen on distinct loopback ports.
   local p1 p2
-  p1="$(grep -E '^HERMES_PORT=' /etc/hermes/jannek-assistant.env | cut -d= -f2)"
-  p2="$(grep -E '^HERMES_PORT=' /etc/hermes/cdb-engineer.env | cut -d= -f2)"
+  p1="$(grep -E '^HERMES_PORT=' /etc/hermes/jannek-assistant.env | cut -d= -f2 | tr -d '\r')"
+  p2="$(grep -E '^HERMES_PORT=' /etc/hermes/cdb-engineer.env | cut -d= -f2 | tr -d '\r')"
   [[ -n "${p1}" && -n "${p2}" && "${p1}" != "${p2}" ]] \
     || die "profile ports must be distinct (got ${p1:-empty} vs ${p2:-empty})"
   log "enabled profile dashboards on ports ${p1} and ${p2}"
@@ -208,6 +277,7 @@ main() {
   install_profile_env_files
   ensure_profile_homes
   install_hermes_pinned "${git_ref}" "${git_commit}"
+  ensure_dashboard_runtime_assets
   enable_services
   harden_sudoers_after_bootstrap
   log "bootstrap complete (idempotent re-run safe for homes + units)"

--- a/infrastructure/hermes/systemd/hermes-dashboard@.service
+++ b/infrastructure/hermes/systemd/hermes-dashboard@.service
@@ -34,8 +34,11 @@ LimitNOFILE=8192
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
+# ProtectHome=true (strict hide) blocked uv-managed CPython under the hermes
+# home-local uv tree (#4329). Use read-only instead of disabling ProtectHome.
+ProtectHome=read-only
 ReadWritePaths=/var/lib/hermes/profiles/%i /var/log/hermes
+ReadOnlyPaths=/home/hermes/.local/share/uv /opt/hermes /var/lib/hermes/_installer_home
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/tests/unit/hermes_ops/test_bootstrap_durability_4329.py
+++ b/tests/unit/hermes_ops/test_bootstrap_durability_4329.py
@@ -1,0 +1,155 @@
+"""Regression contracts for Hermes bootstrap durability fixes (#4329).
+
+These encode the host failures proven on cdb-hermes-01 during #4327:
+pin stdout pollution, install.sh 0600, /etc/hermes root:root, ProtectHome=true,
+missing web_dist/stamp, and missing per-profile managed Node.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tools.hermes_ops.systemd_contract import validate_unit
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO = Path(__file__).resolve().parents[3]
+BOOTSTRAP = REPO / "infrastructure" / "hermes" / "hetzner" / "bootstrap.sh"
+UNIT = REPO / "infrastructure" / "hermes" / "systemd" / "hermes-dashboard@.service"
+
+
+def _bootstrap_text() -> str:
+    return BOOTSTRAP.read_text(encoding="utf-8")
+
+
+def _resolve_bash() -> str:
+    """Prefer Git Bash on Windows; WSL system32 bash mishandles multiline -c."""
+    if sys.platform.startswith("win"):
+        for candidate in (
+            Path(r"C:\Program Files\Git\bin\bash.exe"),
+            Path(r"C:\Program Files\Git\usr\bin\bash.exe"),
+        ):
+            if candidate.is_file():
+                return str(candidate)
+    found = shutil.which("bash")
+    if not found:
+        pytest.skip("bash not available for pin stdout contract proof")
+    if sys.platform.startswith("win") and found.lower().endswith(r"system32\bash.exe"):
+        pytest.skip("WSL bash unsuitable for multiline -c; use Git Bash")
+    return found
+
+
+def test_log_function_writes_to_stderr_not_stdout() -> None:
+    """Status logs must not pollute command substitution for verify_pin."""
+    text = _bootstrap_text()
+    assert re.search(
+        r'^log\(\)\s*\{\s*printf\s+[\'"]\[hermes-bootstrap\][^\'"]*[\'"]\s+"\$\*"\s+>&2',
+        text,
+        re.MULTILINE,
+    ), "log() must write to stderr (>&2) so verify_pin stdout stays machine-only"
+
+
+def test_verify_pin_command_substitution_is_machine_only() -> None:
+    """verify_pin stdout must be machine-only; logs must not enter the capture."""
+    text = _bootstrap_text()
+    assert 'pin_pair="$(verify_pin)"' in text
+    assert re.search(
+        r"^log\(\)\s*\{[^}]*printf[^}]*>&2",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    # Behavioral proof of the required log/stdout split (same contract as bootstrap).
+    script = textwrap.dedent(r"""
+        set -euo pipefail
+        log() { printf '[hermes-bootstrap] %s\n' "$*" >&2; }
+        verify_pin() {
+          log "pin ok: ref=v2026.7.30 commit=cc4cab2f592e..."
+          printf '%s %s' "v2026.7.30" "cc4cab2f592e60a197e796506de9168f74baf3ea"
+        }
+        pair="$(verify_pin)"
+        printf '%s' "$pair"
+        """)
+    proc = subprocess.run(
+        [_resolve_bash(), "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert proc.stdout == "v2026.7.30 cc4cab2f592e60a197e796506de9168f74baf3ea"
+    assert "[hermes-bootstrap]" not in proc.stdout
+    assert "pin ok:" in proc.stderr
+    # Bootstrap verify_pin must end with the machine printf (no trailing log on stdout).
+    vp = text.split("verify_pin()")[1].split("\n}\n")[0]
+    assert "printf '%s %s'" in vp or 'printf "%s %s"' in vp
+
+
+def test_installer_temp_chmod_0644_after_hash_before_sudo_u() -> None:
+    text = _bootstrap_text()
+    assert "chmod 0644" in text
+    hash_idx = text.find('die "install.sh sha256 mismatch')
+    chmod_idx = text.find("chmod 0644")
+    sudo_idx = text.find('sudo -u "${INSTALL_USER}" bash "${tmp}"')
+    assert hash_idx != -1 and chmod_idx != -1 and sudo_idx != -1
+    assert (
+        hash_idx < chmod_idx < sudo_idx
+    ), "chmod 0644 must run after hash PASS and before sudo -u INSTALL_USER"
+
+
+def test_installer_temp_cleanup_trap_present() -> None:
+    text = _bootstrap_text()
+    assert re.search(r"trap\s+_cleanup_install_tmp\s+EXIT", text)
+    assert "_cleanup_install_tmp()" in text
+    assert 'rm -f "${tmp}"' in text
+
+
+def test_etc_hermes_chown_to_install_user_group() -> None:
+    text = _bootstrap_text()
+    assert 'chown root:"${INSTALL_USER}" /etc/hermes' in text
+    assert "chmod 0750 /etc/hermes" in text
+    assert "chmod 0777 /etc/hermes" not in text
+    assert "chmod 0775 /etc/hermes" not in text
+
+
+def test_systemd_protect_home_is_read_only_not_true() -> None:
+    text = UNIT.read_text(encoding="utf-8")
+    assert not any(
+        line.strip().startswith("ProtectHome=true") for line in text.splitlines()
+    ), "ProtectHome=true blocks uv CPython under /home/hermes/.local (#4329)"
+    assert "ProtectHome=read-only" in text
+    assert "NoNewPrivileges=true" in text
+    assert "ProtectSystem=strict" in text
+    assert "--host 127.0.0.1" in text
+    assert "ReadOnlyPaths=" in text
+    assert "/home/hermes/.local/share/uv" in text
+    assert "/opt/hermes" in text
+    assert "ReadWritePaths=/var/lib/hermes/profiles/%i" in text
+    errors = validate_unit(UNIT)
+    assert errors == [], errors
+
+
+def test_bootstrap_wires_web_ui_and_managed_node_for_active_profiles() -> None:
+    text = _bootstrap_text()
+    assert "ensure_dashboard_runtime_assets" in text
+    assert "web_dist" in text
+    assert "web-ui-build-stamp.json" in text
+    assert "_installer_home/node" in text or "${INSTALLER_HOME}/node" in text
+    assert "nodejs.org/dist/latest" not in text
+    main = text.split("main()")[-1]
+    assert "ensure_dashboard_runtime_assets" in main
+    assert main.find("ensure_dashboard_runtime_assets") < main.find("enable_services")
+
+
+def test_bootstrap_does_not_enable_validation_chief() -> None:
+    text = _bootstrap_text()
+    assert "systemctl enable hermes-dashboard@validation-chief" not in text
+    assert "systemctl start hermes-dashboard@validation-chief" not in text
+    assert "validation-chief/.DISABLED" in text

--- a/tools/hermes_ops/systemd_contract.py
+++ b/tools/hermes_ops/systemd_contract.py
@@ -20,6 +20,11 @@ REQUIRED_SNIPPETS = (
     "${HERMES_PORT}",
     "--isolated",
     "NoNewPrivileges=true",
+    "ProtectSystem=strict",
+    # ProtectHome=true blocks uv CPython under /home/hermes/.local (#4329).
+    "ProtectHome=read-only",
+    "ReadWritePaths=/var/lib/hermes/profiles/%i",
+    "ReadOnlyPaths=",
     "MemoryMax=",
     "CPUQuota=",
     "ConditionPathExists=!/var/lib/hermes/profiles/%i/.DISABLED",
@@ -31,6 +36,7 @@ FORBIDDEN_SNIPPETS = (
     "--insecure",
     "User=root",
     "hermes serve",
+    "ProtectHome=true",
 )
 
 
@@ -53,6 +59,9 @@ def validate_unit(path: Path | None = None) -> list[str]:
         if snippet in text:
             errors.append(f"forbidden snippet present: {snippet}")
     for line in text.splitlines():
-        if line.strip().startswith("ExecStart=") and "hermes serve" in line:
+        stripped = line.strip()
+        if stripped.startswith("ProtectHome=true"):
+            errors.append("forbidden snippet present: ProtectHome=true")
+        if stripped.startswith("ExecStart=") and "hermes serve" in line:
             errors.append("forbidden snippet present: hermes serve")
     return errors


### PR DESCRIPTION
Closes #4329

## Summary Refs #4329 Refs #4289 Refs #4327  Persist the host fixes proven during the #4327 rescue bootstrap into the canonical repo bootstrap, with fail-closed regression tests. Dedicated durability slice only; no host mutation in this PR.  ## Root Cause On `cdb-hermes-01`, bootstrap left several fail-closed gaps that only surfaced at live install: 1. `verify_pin` status logs polluted stdout ├ö├Ñ├å `git_ref` command substitution captured log text. 2. Root `mktemp` left `install.sh` as `0600` ├ö├Ñ├å `sudo -u hermes` could not read it. 3. `/etc/hermes` stayed `root:root 0750` ├ö├Ñ├å Hermes PermissionError on `.env`. 4. `ProtectHome=true` blocked uv-managed Python under `/home/hermes/.local`. 5. Dashboard required `hermes_cli/web_dist`, profile stamp, and managed Node per active profile.  ## Host Evidence Verified during #4327 rescue bootstrap: runtime PASS with both active profiles, loopback-only dashboards, validation-chief `.DISABLED`, public ports filtered. This PR does **not** re-patch the live host; it encodes the same contracts in repo artifacts and tests.  ## Durable Repo Fixes - `bootstrap.sh`: `log()` ├ö├Ñ├å stderr; `chmod 0644` after hash PASS + trap cleanup; `chown root:INSTALL_USER` for `/etc/hermes`; `ensure_dashboard_runtime_assets` (installer-managed Node, web_dist/stamp, both profiles; validation-chief untouched). - `hermes-dashboard@.service`: `ProtectHome=read-only` + explicit `ReadOnlyPaths` for uv/installer trees; keep `NoNewPrivileges` and loopback bind. - `systemd_contract.py`: require `ProtectHome=read-only` / `ReadOnlyPaths`; forbid `ProtectHome=true`.  ## Security Properties - No world-writable `/etc/hermes`; secrets stay restrictive. - ProtectHome not disabled; only minimal read-only exception for proven uv paths. - No floating Node latest; installer-home Node only. - No public ports, no general sudo expansion, no validation-chief enable. - Two active profiles remain isolated.  ## Regression Tests - `tests/unit/hermes_ops/test_bootstrap_durability_4329.py` covers pin stdout/stderr split, install chmod order, cleanup trap, `/etc/hermes` ownership, ProtectHome contract, web/node helpers. - Existing hermes_ops unit suite remains green (44 passed).  ## Validation - `python -m tools.hermes_ops pin-check --require-pinned` - `python -m tools.hermes_ops validate-profiles` - `python -m tools.hermes_ops secret-scan` - `pytest -q tests/unit/hermes_ops` (44 passed) - `ruff check` / `python -m black --check` on hermes_ops surfaces - `bash -n infrastructure/hermes/hetzner/bootstrap.sh` - Fast-CI + `cdb-local-ci` Check Run to follow on exact head before merge  ## Non-goals - No host/Rescue/firewall/Tailscale mutation - No Windows workspace cutover - No GitHub App setup for Hermes - No backup/restore/update/rollback/kill-switch drills - Issue #4289 remains OPEN; no reopen/modify of #4327 - No Live / Echtgeld / trading / risk authority  ## Brain Evidence - `brain_source`: repo-only - `brain_status`: not-used - Context MCP server absent in this session; repo + live GitHub + #4327 host evidence used - `context_brain_attempted`: true - `context_brain_used`: false - `context_available`: false - `repo_fallback_used`: true - `repo_fallback_reason`: unavailable - `context_tool_status`: absent - `context_trust_level`: none - `records_found`: none  ## Test plan - [x] Unit regressions for six host fixes - [x] hermes_ops pin/profile/secret contracts - [ ] Full Fast-CI on PR head - [ ] `cdb-local-ci` App Check Run SUCCESS on exact head - [ ] Regular squash-merge; close #4329 via PR keywords only; #4289 remains OPEN 
