### PR TITLE
feat(hermes): harden Windows workspace and kill-switch (#4289)

### DIFF
--- a/docs/runbooks/hermes_hetzner_operations.md
+++ b/docs/runbooks/hermes_hetzner_operations.md
@@ -149,57 +149,62 @@ Do **not** use WSL bash for these scripts (native Windows PowerShell / Git Bash)
 ```powershell
 # Prefer SecureString; HERMES_WIN_PASSWORD env is accepted then cleared
 .\infrastructure\hermes\windows\setup-workspace.ps1 -HermesUser hermes-win -GrantWrite
-# Dedicated listener (disables public OpenSSH firewall + default sshd)
+# Loopback sshd + Tailscale Serve TCP bridge (never Funnel)
 .\infrastructure\hermes\windows\setup-sshd-hermes.ps1
 .\infrastructure\hermes\windows\kill-switch.ps1 -Action Status
 ```
 
-Kill-switch (targets **sshd-hermes** only; Enable restores Automatic start):
+Kill-switch (targets **sshd-hermes** + Serve mapping; Enable only after loopback
+health, then Serve, then state ENABLED):
 
 ```powershell
-.\infrastructure\hermes\windows\kill-switch.ps1 -Action Disable   # WORKSTATION_UNAVAILABLE
+.\infrastructure\hermes\windows\kill-switch.ps1 -Action Disable   # Serve off + sshd stop
 .\infrastructure\hermes\windows\kill-switch.ps1 -Action Enable
 ```
 
-No public SSH/RDP/VNC. Firewall `RemoteAddress` = Tailscale IP of `cdb-hermes-01`
-only; public `OpenSSH-Server-In-TCP` stays disabled. On Windows+Tailscale,
-`sshd` listens on `0.0.0.0` behind that remote-only rule (unicast Tailscale bind
-does not reliably accept peer TCP).
+No public SSH/RDP/VNC. **Do not** open an inbound Windows Firewall allow for
+sshd. Public `OpenSSH-Server-In-TCP` stays disabled. Default system `sshd` stays
+Disabled. Architecture:
+
+1. `sshd-hermes` listens **only** on `127.0.0.1:22` / `::1`
+2. Private Tailscale Serve raw TCP: `tailnet:22 → tcp://127.0.0.1:22` (`--bg`)
+3. Funnel must stay **OFF** (`tailscale funnel` never enabled)
+4. Existing Tailnet ACLs remain authoritative (no policy mutation from scripts)
+
+CLI gate (confirm with installed `tailscale serve --help`; Tailscale 1.98+):
+
+```text
+tailscale serve --bg --tcp=22 tcp://127.0.0.1:22
+tailscale serve --tcp=22 off
+tailscale serve status --json
+```
 
 Private key for `cdb-engineer → hermes-win` lives only under the engineer profile
 on `cdb-hermes-01` (mode 0600); `jannek-assistant` must not read it.
 
-### Live precondition (Tailscale TCP)
+### Live precondition (Tailscale Serve TCP)
 
-`tailscale ping` Windows↔Hermes is not enough. Hermes must be able to open **TCP**
-to the Windows Tailscale address on port **22** (test:
-`timeout 5 bash -c 'echo >/dev/tcp/$HOST/22'`). Never treat ping-PASS as TCP-PASS.
+`tailscale ping` Windows↔Hermes is not enough. Hermes must open **TCP/22** to
+the Windows Tailscale name (Serve endpoint) and complete pubkey SSH as
+`hermes-win`. Never treat ping-PASS as TCP-PASS. Local `Test-NetConnection` to
+the Tailscale IP can be loopback-optimized and does **not** prove peer delivery.
 
-Diagnose layers separately (do not assume Tailnet ACL first):
+Root-cause class (corrected 2026-08-03): **`HOLD_WINDOWS_HOST_TCP_STACK`**, not
+Windows Firewall. Evidence: Tailnet PacketFilter allows TCP/22; Shields Up
+false; SYN reaches Tailscale Tunnel + `tcpip.sys`; **no SYN-ACK** on the host
+path. Mitigation: Tailscale Serve bypasses the broken host packet path into
+loopback where `sshd-hermes` answers.
 
-1. **Listener / OpenSSH** — `sshd-hermes` Running/Automatic, config
-   `Port 22` + `ListenAddress 0.0.0.0`, `sshd -t` OK, loopback TCP/22 PASS.
-   Live drift to Port 2222 or unicast Tailscale bind is a host config fault,
-   not an ACL fault. Local `Test-NetConnection` to the Tailscale IP can be
-   loopback-optimized and does **not** prove peer delivery.
-2. **Shields Up / system policy** — `tailscale debug prefs` → `ShieldsUp=false`;
-   `tailscale syspolicy list` empty or not forcing block;
-   `tailscale set --shields-up=false` when safe.
-3. **Windows Firewall** — rule `CDB-Hermes-sshd-hermes-Tailscale`: TCP/22,
-   RemoteAddress = `cdb-hermes-01` Tailscale IP only, no `LocalAddress` pin,
-   public `OpenSSH-Server-In-TCP` Disabled. Packet proof (`pktmon` port 22):
-   Hermes SYN must be classified (seen vs dropped vs no SYN-ACK).
-4. **Tailnet PacketFilter** — only if SYN never reaches Windows. Read-only
-   `tailscale debug netmap` PacketFilter: confirm source/dest/TCP/22. Do not
-   mutate policy when the filter already allows peer TCP.
+Diagnose layers if Serve Canary fails:
 
-Observed B1 failure mode (2026-08-03): bidirectional Tailscale ping PASS;
-Hermes→Windows TCP all ports TIMEOUT; pktmon shows Hermes SYN on
-`Tailscale Tunnel` **and** `tcpip.sys` IPv4; **no SYN-ACK**; Tailscale
-`tstun_in_from_wg_drop_filter=0`; temporary Any:22 allow and raw Python
-accept still fail. That is a Windows host TCP path after Wintun injection,
-not Tailnet ACL and not a missing `sshd-hermes` listener. Hold SSH /
-kill-switch / reboot drills until Hermes→Windows TCP/22 PASS.
+1. **Loopback / OpenSSH** — `sshd-hermes` Running/Automatic, `ListenAddress
+   127.0.0.1`, `sshd -t` OK, loopback TCP/22 PASS.
+2. **Serve** — `tailscale serve status --json` shows TCP/22 → loopback; Funnel
+   OFF. CLI from live `--help`, not memory.
+3. **Shields Up / system policy** — `ShieldsUp=false`; no forced block.
+4. **Do not** mutate Tailnet policy, global firewall, or Funnel as a workaround.
+   On persistent Serve fail: `tailscale bugreport --diagnose --record` once,
+   then `HOLD_TAILSCALE_WINDOWS_CLIENT_BUG` with redacted bugreport id.
 
 ## Backup / Restore / Update / Rollback
 

--- a/docs/runbooks/hermes_hetzner_operations.md
+++ b/docs/runbooks/hermes_hetzner_operations.md
@@ -172,9 +172,34 @@ on `cdb-hermes-01` (mode 0600); `jannek-assistant` must not read it.
 ### Live precondition (Tailscale TCP)
 
 `tailscale ping` Windows↔Hermes is not enough. Hermes must be able to open **TCP**
-to the Windows Tailscale address (test: `bash -c 'echo >/dev/tcp/$HOST/22'`).
-If ping works but every TCP port times out, fix Tailnet ACL / packet filter
-before expecting SSH/kill-switch drills to pass.
+to the Windows Tailscale address on port **22** (test:
+`timeout 5 bash -c 'echo >/dev/tcp/$HOST/22'`). Never treat ping-PASS as TCP-PASS.
+
+Diagnose layers separately (do not assume Tailnet ACL first):
+
+1. **Listener / OpenSSH** — `sshd-hermes` Running/Automatic, config
+   `Port 22` + `ListenAddress 0.0.0.0`, `sshd -t` OK, loopback TCP/22 PASS.
+   Live drift to Port 2222 or unicast Tailscale bind is a host config fault,
+   not an ACL fault. Local `Test-NetConnection` to the Tailscale IP can be
+   loopback-optimized and does **not** prove peer delivery.
+2. **Shields Up / system policy** — `tailscale debug prefs` → `ShieldsUp=false`;
+   `tailscale syspolicy list` empty or not forcing block;
+   `tailscale set --shields-up=false` when safe.
+3. **Windows Firewall** — rule `CDB-Hermes-sshd-hermes-Tailscale`: TCP/22,
+   RemoteAddress = `cdb-hermes-01` Tailscale IP only, no `LocalAddress` pin,
+   public `OpenSSH-Server-In-TCP` Disabled. Packet proof (`pktmon` port 22):
+   Hermes SYN must be classified (seen vs dropped vs no SYN-ACK).
+4. **Tailnet PacketFilter** — only if SYN never reaches Windows. Read-only
+   `tailscale debug netmap` PacketFilter: confirm source/dest/TCP/22. Do not
+   mutate policy when the filter already allows peer TCP.
+
+Observed B1 failure mode (2026-08-03): bidirectional Tailscale ping PASS;
+Hermes→Windows TCP all ports TIMEOUT; pktmon shows Hermes SYN on
+`Tailscale Tunnel` **and** `tcpip.sys` IPv4; **no SYN-ACK**; Tailscale
+`tstun_in_from_wg_drop_filter=0`; temporary Any:22 allow and raw Python
+accept still fail. That is a Windows host TCP path after Wintun injection,
+not Tailnet ACL and not a missing `sshd-hermes` listener. Hold SSH /
+kill-switch / reboot drills until Hermes→Windows TCP/22 PASS.
 
 ## Backup / Restore / Update / Rollback
 

--- a/docs/runbooks/hermes_hetzner_operations.md
+++ b/docs/runbooks/hermes_hetzner_operations.md
@@ -141,22 +141,40 @@ secret read/write, force-push, default-branch delete, App permission expansion.
 
 ## Windows workspace
 
-On Windows (elevated once / UAC):
+On Windows (elevated once / UAC). Docs gate: Microsoft OpenSSH Server install +
+`sshd_config` (`AllowUsers`, `PasswordAuthentication`). Prefer **winget**
+`Microsoft.OpenSSH.Preview` — `Add-WindowsCapability` often hangs on DISM/WU.
+Do **not** use WSL bash for these scripts (native Windows PowerShell / Git Bash).
 
 ```powershell
 # Prefer SecureString; HERMES_WIN_PASSWORD env is accepted then cleared
 .\infrastructure\hermes\windows\setup-workspace.ps1 -HermesUser hermes-win -GrantWrite
+# Dedicated listener (disables public OpenSSH firewall + default sshd)
+.\infrastructure\hermes\windows\setup-sshd-hermes.ps1
 .\infrastructure\hermes\windows\kill-switch.ps1 -Action Status
 ```
 
-Kill-switch:
+Kill-switch (targets **sshd-hermes** only; Enable restores Automatic start):
 
 ```powershell
 .\infrastructure\hermes\windows\kill-switch.ps1 -Action Disable   # WORKSTATION_UNAVAILABLE
 .\infrastructure\hermes\windows\kill-switch.ps1 -Action Enable
 ```
 
-No public SSH/RDP/VNC. OpenSSH only on private net for `hermes-win`.
+No public SSH/RDP/VNC. Firewall `RemoteAddress` = Tailscale IP of `cdb-hermes-01`
+only; public `OpenSSH-Server-In-TCP` stays disabled. On Windows+Tailscale,
+`sshd` listens on `0.0.0.0` behind that remote-only rule (unicast Tailscale bind
+does not reliably accept peer TCP).
+
+Private key for `cdb-engineer → hermes-win` lives only under the engineer profile
+on `cdb-hermes-01` (mode 0600); `jannek-assistant` must not read it.
+
+### Live precondition (Tailscale TCP)
+
+`tailscale ping` Windows↔Hermes is not enough. Hermes must be able to open **TCP**
+to the Windows Tailscale address (test: `bash -c 'echo >/dev/tcp/$HOST/22'`).
+If ping works but every TCP port times out, fix Tailnet ACL / packet filter
+before expecting SSH/kill-switch drills to pass.
 
 ## Backup / Restore / Update / Rollback
 

--- a/docs/security/hermes_hetzner_threat_model.md
+++ b/docs/security/hermes_hetzner_threat_model.md
@@ -27,8 +27,14 @@ LR: **NO-GO**
   - dashboard bind: 127.0.0.1 only (distinct ports per profile)
       | scoped
       +--> [dedicated GitHub App tokens] --> Claire_de_Binare only  <!-- pragma: allowlist secret -->
-      +--> [Windows hermes-win] --> D:\Dev\HermesWorkspace\Claire_de_Binare only  <!-- pragma: allowlist secret -->
+      +--> [Windows hermes-win via Tailscale Serve → loopback sshd]
+             --> D:\Dev\HermesWorkspace\Claire_de_Binare only  <!-- pragma: allowlist secret -->
 ```
+
+Windows remote path (corrected 2026-08-03): host TCP after Wintun does not
+SYN-ACK for peer traffic (`HOLD_WINDOWS_HOST_TCP_STACK`). Remote entry is
+**only** private Tailscale Serve TCP → `127.0.0.1:22` (`sshd-hermes`
+loopback-only). Funnel forbidden; no public sshd firewall allow.
 
 App `4410232` (`cdb-local-ci`) is **not** the Hermes write App unless live
 permissions prove `contents`/`pull_requests`/`issues` write without `checks:write`.
@@ -51,7 +57,7 @@ permissions prove `contents`/`pull_requests`/`issues` write without `checks:writ
 
 | Switch | Effect |
 |---|---|
-| Windows `kill-switch.ps1 -Action Disable` | `WORKSTATION_UNAVAILABLE`; sshd disabled |
+| Windows `kill-switch.ps1 -Action Disable` | Serve TCP mapping off + `sshd-hermes` stopped/disabled → `WORKSTATION_UNAVAILABLE` |
 | Stop Tailscale on Windows or Hetzner | Private path gone; no public fallback |
 | `systemctl stop 'hermes-dashboard@*'` | Agent offline |
 | Revoke GitHub App installation / rotate PEM | Tokens useless |

--- a/infrastructure/hermes/windows/kill-switch.ps1
+++ b/infrastructure/hermes/windows/kill-switch.ps1
@@ -1,17 +1,17 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
   Immediate Windows bridge kill-switch for Hermes (#4289 Phase B1).
 
 .DESCRIPTION
-  Architecture (Serve bridge — host TCP after Wintun does not SYN-ACK):
-    Tailscale Serve TCP/22 → 127.0.0.1:22 ← sshd-hermes (loopback-only)
+  Architecture (Serve bridge - host TCP after Wintun does not SYN-ACK):
+    Tailscale Serve TCP/22 -> 127.0.0.1:22 <- sshd-hermes (loopback-only)
 
   Disable:
     1) Remove Tailscale Serve TCP mapping for port 22
     2) Stop sshd-hermes
     3) StartupType Disabled
-    4) State DISABLED → WORKSTATION_UNAVAILABLE
+    4) State DISABLED -> WORKSTATION_UNAVAILABLE
     Remote TCP/SSH must fail immediately. Funnel must never be enabled.
 
   Enable (ordered, fail-closed):
@@ -23,9 +23,9 @@
        (optional remote SSH proof is operator-side; script stays fail-closed)
 
   Status:
-    Requires ALL of: Running sshd, Serve TCP/22 → loopback, local listener.
-    Any missing/contradictory condition → UNAVAILABLE.
-    Missing/empty/corrupt state file → UNAVAILABLE.
+    Requires ALL of: Running sshd, Serve TCP/22 -> loopback, local listener.
+    Any missing/contradictory condition -> UNAVAILABLE.
+    Missing/empty/corrupt state file -> UNAVAILABLE.
 
   Docs gate (Tailscale 1.98+):
     enable:  tailscale serve --bg --tcp=22 tcp://127.0.0.1:22
@@ -177,7 +177,7 @@ function Write-MachineStatus {
 
 function Resolve-LiveBridgeHealth {
     # Returns ENABLED only when service Running AND serve loopback AND local listener.
-    # Contradictions → UNAVAILABLE.
+    # Contradictions -> UNAVAILABLE.
     $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
     if (-not $svc) {
         return @{
@@ -260,7 +260,7 @@ switch ($Action) {
     'Disable' {
         # 1) Clear Serve first so remote TCP fails immediately.
         # 2) Stop/disable sshd-hermes (needs elevation).
-        # Incomplete stop → UNAVAILABLE (fail-closed), never claim DISABLED.
+        # Incomplete stop -> UNAVAILABLE (fail-closed), never claim DISABLED.
         Disable-ServeTcpMapping
         $stopOk = $true
         try {
@@ -288,12 +288,12 @@ switch ($Action) {
             Write-MachineStatus -ServiceStatus "$($svcNow.Status)" `
                 -KillSwitch 'UNAVAILABLE' -Meaning 'WORKSTATION_UNAVAILABLE' `
                 -ServePresent:$serve.Present -LoopbackOk:$loop
-            Write-Host 'Kill-switch PARTIAL→UNAVAILABLE (Serve cleared; elevation needed for full Disable)'
+            Write-Host 'Kill-switch PARTIAL->UNAVAILABLE (Serve cleared; elevation needed for full Disable)'
             exit 3
         }
     }
     'Enable' {
-        # Ordered: sshd → loopback health → Serve → verify → ENABLED state.
+        # Ordered: sshd -> loopback health -> Serve -> verify -> ENABLED state.
         Set-Service -Name $ServiceName -StartupType Automatic
         Start-Service -Name $ServiceName
         Start-Sleep -Seconds 1

--- a/infrastructure/hermes/windows/kill-switch.ps1
+++ b/infrastructure/hermes/windows/kill-switch.ps1
@@ -1,12 +1,13 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-  Immediate Windows bridge kill-switch for Hermes (#4289).
+  Immediate Windows bridge kill-switch for Hermes (#4289 Phase B1).
 
 .DESCRIPTION
-  Disable = stop sshd (or dedicated listener) and mark WORKSTATION_UNAVAILABLE.
-  Enable  = restore sshd if previously managed by this script.
-  Fail-closed: a stopped bridge means unavailable, never auto-fallback.
+  Targets the dedicated sshd-hermes listener only (never the generic system sshd
+  by default). Disable stops the bridge and marks WORKSTATION_UNAVAILABLE.
+  Enable restores Automatic start for reboot persistence.
+  Fail-closed: missing service or missing/corrupt state => UNAVAILABLE.
 #>
 [CmdletBinding()]
 param(
@@ -14,7 +15,7 @@ param(
     [ValidateSet('Disable', 'Enable', 'Status')]
     [string]$Action,
     [string]$StateFile = 'D:\Dev\HermesWorkspace\.hermes_kill_switch.state',
-    [string]$ServiceName = 'sshd'
+    [string]$ServiceName = 'sshd-hermes'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -26,15 +27,53 @@ function Write-State([string]$status) {
     }
     @(
         "status=$status"
+        "service=$ServiceName"
         "updated_utc=$((Get-Date).ToUniversalTime().ToString('o'))"
         'meaning=WORKSTATION_UNAVAILABLE_WHEN_DISABLED'
     ) | Set-Content -LiteralPath $StateFile -Encoding UTF8
 }
 
+function Read-StateStatus {
+    if (-not (Test-Path -LiteralPath $StateFile)) {
+        return 'UNAVAILABLE'
+    }
+    $raw = Get-Content -LiteralPath $StateFile -Raw -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return 'UNAVAILABLE'
+    }
+    if ($raw -notmatch '(?m)^status=(ENABLED|DISABLED|UNAVAILABLE)\s*$') {
+        return 'UNAVAILABLE'
+    }
+    return $Matches[1]
+}
+
+function Write-MachineStatus {
+    param(
+        [string]$ServiceStatus,
+        [string]$KillSwitch,
+        [string]$Meaning
+    )
+    Write-Host "service=$ServiceStatus"
+    Write-Host "kill_switch=$KillSwitch"
+    Write-Host "status=$KillSwitch"
+    Write-Host "service_name=$ServiceName"
+    Write-Host "meaning=$Meaning"
+    $obj = [ordered]@{
+        service_name = $ServiceName
+        service      = $ServiceStatus
+        kill_switch  = $KillSwitch
+        status       = $KillSwitch
+        meaning      = $Meaning
+        state_file   = $StateFile
+    }
+    $obj | ConvertTo-Json -Compress | Write-Host
+}
+
 $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
 if (-not $svc) {
     Write-State 'UNAVAILABLE'
-    Write-Host 'WORKSTATION_UNAVAILABLE (sshd service missing)'
+    Write-MachineStatus -ServiceStatus 'Missing' -KillSwitch 'UNAVAILABLE' `
+        -Meaning 'WORKSTATION_UNAVAILABLE'
     if ($Action -eq 'Status') { exit 0 }
     exit 2
 }
@@ -46,21 +85,27 @@ switch ($Action) {
         }
         Set-Service -Name $ServiceName -StartupType Disabled
         Write-State 'DISABLED'
+        Write-MachineStatus -ServiceStatus 'Stopped' -KillSwitch 'DISABLED' `
+            -Meaning 'WORKSTATION_UNAVAILABLE'
         Write-Host 'Kill-switch ON: WORKSTATION_UNAVAILABLE'
     }
     'Enable' {
-        Set-Service -Name $ServiceName -StartupType Manual
+        # Automatic = reboot-persistent bridge when kill-switch is cleared.
+        Set-Service -Name $ServiceName -StartupType Automatic
         Start-Service -Name $ServiceName
         Write-State 'ENABLED'
+        Write-MachineStatus -ServiceStatus 'Running' -KillSwitch 'ENABLED' `
+            -Meaning 'BRIDGE_PRIVATE_NET_ONLY'
         Write-Host 'Kill-switch OFF: workstation bridge enabled (still private-net only)'
     }
     'Status' {
-        $state = if (Test-Path -LiteralPath $StateFile) {
-            Get-Content -LiteralPath $StateFile -Raw
+        $kill = Read-StateStatus
+        $meaning = if ($kill -eq 'ENABLED') {
+            'BRIDGE_PRIVATE_NET_ONLY'
         } else {
-            'status=UNKNOWN'
+            'WORKSTATION_UNAVAILABLE'
         }
-        Write-Host "service=$($svc.Status)"
-        Write-Host $state
+        Write-MachineStatus -ServiceStatus "$($svc.Status)" -KillSwitch $kill `
+            -Meaning $meaning
     }
 }

--- a/infrastructure/hermes/windows/kill-switch.ps1
+++ b/infrastructure/hermes/windows/kill-switch.ps1
@@ -4,10 +4,33 @@
   Immediate Windows bridge kill-switch for Hermes (#4289 Phase B1).
 
 .DESCRIPTION
-  Targets the dedicated sshd-hermes listener only (never the generic system sshd
-  by default). Disable stops the bridge and marks WORKSTATION_UNAVAILABLE.
-  Enable restores Automatic start for reboot persistence.
-  Fail-closed: missing service or missing/corrupt state => UNAVAILABLE.
+  Architecture (Serve bridge — host TCP after Wintun does not SYN-ACK):
+    Tailscale Serve TCP/22 → 127.0.0.1:22 ← sshd-hermes (loopback-only)
+
+  Disable:
+    1) Remove Tailscale Serve TCP mapping for port 22
+    2) Stop sshd-hermes
+    3) StartupType Disabled
+    4) State DISABLED → WORKSTATION_UNAVAILABLE
+    Remote TCP/SSH must fail immediately. Funnel must never be enabled.
+
+  Enable (ordered, fail-closed):
+    1) StartupType Automatic + start sshd-hermes
+    2) Local loopback TCP healthcheck PASS
+    3) Only then: tailscale serve --bg --tcp=22 tcp://127.0.0.1:22
+    4) Verify Serve status
+    5) State ENABLED only after local+Serve healthy
+       (optional remote SSH proof is operator-side; script stays fail-closed)
+
+  Status:
+    Requires ALL of: Running sshd, Serve TCP/22 → loopback, local listener.
+    Any missing/contradictory condition → UNAVAILABLE.
+    Missing/empty/corrupt state file → UNAVAILABLE.
+
+  Docs gate (Tailscale 1.98+):
+    enable:  tailscale serve --bg --tcp=22 tcp://127.0.0.1:22
+    disable: tailscale serve --tcp=22 off
+    status:  tailscale serve status --json
 #>
 [CmdletBinding()]
 param(
@@ -15,7 +38,9 @@ param(
     [ValidateSet('Disable', 'Enable', 'Status')]
     [string]$Action,
     [string]$StateFile = 'D:\Dev\HermesWorkspace\.hermes_kill_switch.state',
-    [string]$ServiceName = 'sshd-hermes'
+    [string]$ServiceName = 'sshd-hermes',
+    [int]$ServeTcpPort = 22,
+    [string]$LoopbackHost = '127.0.0.1'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -28,8 +53,10 @@ function Write-State([string]$status) {
     @(
         "status=$status"
         "service=$ServiceName"
+        "serve_tcp_port=$ServeTcpPort"
         "updated_utc=$((Get-Date).ToUniversalTime().ToString('o'))"
         'meaning=WORKSTATION_UNAVAILABLE_WHEN_DISABLED'
+        'architecture=TAILSCALE_SERVE_LOOPBACK_SSHD'
     ) | Set-Content -LiteralPath $StateFile -Encoding UTF8
 }
 
@@ -47,65 +74,250 @@ function Read-StateStatus {
     return $Matches[1]
 }
 
+function Test-LoopbackListener {
+    try {
+        $tnc = Test-NetConnection -ComputerName $LoopbackHost -Port $ServeTcpPort `
+            -WarningAction SilentlyContinue
+        return [bool]$tnc.TcpTestSucceeded
+    }
+    catch {
+        return $false
+    }
+}
+
+function Get-ServeTcpForward {
+    # Returns hashtable: Present, TargetLoopback, Raw (redact-safe length only)
+    $result = [ordered]@{
+        Present         = $false
+        TargetLoopback  = $false
+        FunnelForbidden = $true
+    }
+    try {
+        $json = & tailscale serve status --json 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($json)) {
+            return $result
+        }
+        $obj = $json | ConvertFrom-Json
+        $key = "$ServeTcpPort"
+        if ($obj.TCP -and $obj.TCP.$key -and $obj.TCP.$key.TCPForward) {
+            $result.Present = $true
+            $fwd = [string]$obj.TCP.$key.TCPForward
+            if ($fwd -match '127\.0\.0\.1:' -or $fwd -match '\[::1\]:') {
+                $result.TargetLoopback = $true
+            }
+        }
+        # Funnel must never be the path; Web/HTTPS public would be a hard fail.
+        if ($obj.AllowFunnel) {
+            foreach ($prop in $obj.AllowFunnel.PSObject.Properties) {
+                if ($prop.Value -eq $true) {
+                    $result.FunnelForbidden = $false
+                }
+            }
+        }
+    }
+    catch {
+        return $result
+    }
+    return $result
+}
+
+function Disable-ServeTcpMapping {
+    try {
+        & tailscale serve --tcp=$ServeTcpPort off *>$null
+    }
+    catch {
+        Write-Host "WARN: serve disable: $($_.Exception.Message)"
+    }
+}
+
+function Enable-ServeTcpMapping {
+    # Never Funnel. Exact CLI from serve --help (1.98+).
+    & tailscale serve --bg --yes --tcp=$ServeTcpPort "tcp://$LoopbackHost`:$ServeTcpPort" *>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "tailscale serve enable failed exit=$LASTEXITCODE"
+    }
+    $serve = Get-ServeTcpForward
+    if (-not $serve.Present -or -not $serve.TargetLoopback) {
+        throw 'Serve TCP mapping missing or not loopback after enable'
+    }
+    if (-not $serve.FunnelForbidden) {
+        Disable-ServeTcpMapping
+        throw 'Funnel must stay OFF; refused Serve enable with AllowFunnel'
+    }
+}
+
 function Write-MachineStatus {
     param(
         [string]$ServiceStatus,
         [string]$KillSwitch,
-        [string]$Meaning
+        [string]$Meaning,
+        [bool]$ServePresent = $false,
+        [bool]$LoopbackOk = $false
     )
     Write-Host "service=$ServiceStatus"
     Write-Host "kill_switch=$KillSwitch"
     Write-Host "status=$KillSwitch"
     Write-Host "service_name=$ServiceName"
+    Write-Host "serve_tcp=$ServePresent"
+    Write-Host "loopback_tcp=$LoopbackOk"
     Write-Host "meaning=$Meaning"
     $obj = [ordered]@{
         service_name = $ServiceName
         service      = $ServiceStatus
         kill_switch  = $KillSwitch
         status       = $KillSwitch
+        serve_tcp    = $ServePresent
+        loopback_tcp = $LoopbackOk
         meaning      = $Meaning
         state_file   = $StateFile
+        architecture = 'TAILSCALE_SERVE_LOOPBACK_SSHD'
     }
     $obj | ConvertTo-Json -Compress | Write-Host
+}
+
+function Resolve-LiveBridgeHealth {
+    # Returns ENABLED only when service Running AND serve loopback AND local listener.
+    # Contradictions → UNAVAILABLE.
+    $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if (-not $svc) {
+        return @{
+            ServiceStatus = 'Missing'
+            KillSwitch    = 'UNAVAILABLE'
+            Meaning       = 'WORKSTATION_UNAVAILABLE'
+            ServePresent  = $false
+            LoopbackOk    = $false
+        }
+    }
+    $serve = Get-ServeTcpForward
+    $loop = Test-LoopbackListener
+    $running = ($svc.Status -eq 'Running')
+
+    if (-not $serve.FunnelForbidden) {
+        return @{
+            ServiceStatus = "$($svc.Status)"
+            KillSwitch    = 'UNAVAILABLE'
+            Meaning       = 'WORKSTATION_UNAVAILABLE'
+            ServePresent  = $serve.Present
+            LoopbackOk    = $loop
+        }
+    }
+
+    # Contradictions: Serve without sshd, or sshd without Serve, or no listener.
+    if ($running -and $serve.Present -and $serve.TargetLoopback -and $loop) {
+        $fileStatus = Read-StateStatus
+        # File may lag; live triple-gate wins for "bridge up". Still fail-closed if
+        # file explicitly DISABLED while live looks up (operator mid-transition).
+        if ($fileStatus -eq 'DISABLED') {
+            return @{
+                ServiceStatus = "$($svc.Status)"
+                KillSwitch    = 'UNAVAILABLE'
+                Meaning       = 'WORKSTATION_UNAVAILABLE'
+                ServePresent  = $serve.Present
+                LoopbackOk    = $loop
+            }
+        }
+        return @{
+            ServiceStatus = 'Running'
+            KillSwitch    = 'ENABLED'
+            Meaning       = 'BRIDGE_PRIVATE_NET_ONLY'
+            ServePresent  = $true
+            LoopbackOk    = $true
+        }
+    }
+
+    if (-not $running -and -not $serve.Present -and -not $loop) {
+        $fileStatus = Read-StateStatus
+        $ks = if ($fileStatus -eq 'DISABLED') { 'DISABLED' } else { 'UNAVAILABLE' }
+        return @{
+            ServiceStatus = "$($svc.Status)"
+            KillSwitch    = $ks
+            Meaning       = 'WORKSTATION_UNAVAILABLE'
+            ServePresent  = $false
+            LoopbackOk    = $false
+        }
+    }
+
+    # Partial / contradictory
+    return @{
+        ServiceStatus = "$($svc.Status)"
+        KillSwitch    = 'UNAVAILABLE'
+        Meaning       = 'WORKSTATION_UNAVAILABLE'
+        ServePresent  = $serve.Present
+        LoopbackOk    = $loop
+    }
 }
 
 $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
 if (-not $svc) {
     Write-State 'UNAVAILABLE'
     Write-MachineStatus -ServiceStatus 'Missing' -KillSwitch 'UNAVAILABLE' `
-        -Meaning 'WORKSTATION_UNAVAILABLE'
+        -Meaning 'WORKSTATION_UNAVAILABLE' -ServePresent:$false -LoopbackOk:$false
     if ($Action -eq 'Status') { exit 0 }
     exit 2
 }
 
 switch ($Action) {
     'Disable' {
-        if ($svc.Status -eq 'Running') {
-            Stop-Service -Name $ServiceName -Force
+        # 1) Clear Serve first so remote TCP fails immediately.
+        # 2) Stop/disable sshd-hermes (needs elevation).
+        # Incomplete stop → UNAVAILABLE (fail-closed), never claim DISABLED.
+        Disable-ServeTcpMapping
+        $stopOk = $true
+        try {
+            if ((Get-Service -Name $ServiceName).Status -eq 'Running') {
+                Stop-Service -Name $ServiceName -Force -ErrorAction Stop
+            }
+            Set-Service -Name $ServiceName -StartupType Disabled -ErrorAction Stop
         }
-        Set-Service -Name $ServiceName -StartupType Disabled
-        Write-State 'DISABLED'
-        Write-MachineStatus -ServiceStatus 'Stopped' -KillSwitch 'DISABLED' `
-            -Meaning 'WORKSTATION_UNAVAILABLE'
-        Write-Host 'Kill-switch ON: WORKSTATION_UNAVAILABLE'
+        catch {
+            $stopOk = $false
+            Write-Host "WARN: sshd stop/disable failed (elevation?): $($_.Exception.Message)"
+        }
+        $serve = Get-ServeTcpForward
+        $loop = Test-LoopbackListener
+        $svcNow = Get-Service -Name $ServiceName
+        if ($stopOk -and -not $serve.Present) {
+            Write-State 'DISABLED'
+            Write-MachineStatus -ServiceStatus 'Stopped' -KillSwitch 'DISABLED' `
+                -Meaning 'WORKSTATION_UNAVAILABLE' `
+                -ServePresent:$false -LoopbackOk:$loop
+            Write-Host 'Kill-switch ON: WORKSTATION_UNAVAILABLE (Serve off + sshd-hermes stopped)'
+        }
+        else {
+            Write-State 'UNAVAILABLE'
+            Write-MachineStatus -ServiceStatus "$($svcNow.Status)" `
+                -KillSwitch 'UNAVAILABLE' -Meaning 'WORKSTATION_UNAVAILABLE' `
+                -ServePresent:$serve.Present -LoopbackOk:$loop
+            Write-Host 'Kill-switch PARTIAL→UNAVAILABLE (Serve cleared; elevation needed for full Disable)'
+            exit 3
+        }
     }
     'Enable' {
-        # Automatic = reboot-persistent bridge when kill-switch is cleared.
+        # Ordered: sshd → loopback health → Serve → verify → ENABLED state.
         Set-Service -Name $ServiceName -StartupType Automatic
         Start-Service -Name $ServiceName
+        Start-Sleep -Seconds 1
+        if (-not (Test-LoopbackListener)) {
+            Write-State 'UNAVAILABLE'
+            throw 'Local loopback healthcheck FAILED; Serve not enabled; state UNAVAILABLE'
+        }
+        Enable-ServeTcpMapping
+        $health = Resolve-LiveBridgeHealth
+        if ($health.KillSwitch -ne 'ENABLED') {
+            Disable-ServeTcpMapping
+            Write-State 'UNAVAILABLE'
+            throw 'Post-enable health not ENABLED; rolled back Serve; state UNAVAILABLE'
+        }
         Write-State 'ENABLED'
         Write-MachineStatus -ServiceStatus 'Running' -KillSwitch 'ENABLED' `
-            -Meaning 'BRIDGE_PRIVATE_NET_ONLY'
-        Write-Host 'Kill-switch OFF: workstation bridge enabled (still private-net only)'
+            -Meaning 'BRIDGE_PRIVATE_NET_ONLY' `
+            -ServePresent:$true -LoopbackOk:$true
+        Write-Host 'Kill-switch OFF: Serve+loopback sshd bridge ENABLED (private Tailnet only; Funnel forbidden)'
     }
     'Status' {
-        $kill = Read-StateStatus
-        $meaning = if ($kill -eq 'ENABLED') {
-            'BRIDGE_PRIVATE_NET_ONLY'
-        } else {
-            'WORKSTATION_UNAVAILABLE'
-        }
-        Write-MachineStatus -ServiceStatus "$($svc.Status)" -KillSwitch $kill `
-            -Meaning $meaning
+        $health = Resolve-LiveBridgeHealth
+        Write-MachineStatus -ServiceStatus $health.ServiceStatus `
+            -KillSwitch $health.KillSwitch -Meaning $health.Meaning `
+            -ServePresent:$health.ServePresent -LoopbackOk:$health.LoopbackOk
     }
 }

--- a/infrastructure/hermes/windows/kill-switch.ps1
+++ b/infrastructure/hermes/windows/kill-switch.ps1
@@ -175,6 +175,25 @@ function Write-MachineStatus {
     $obj | ConvertTo-Json -Compress | Write-Host
 }
 
+function Test-LiveBridgeTriple {
+    # Live-only: Running sshd + Serve TCP loopback + local listener. No state-file gate.
+    $svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+    if (-not $svc) {
+        return @{ Ok = $false; ServiceStatus = 'Missing'; ServePresent = $false; LoopbackOk = $false }
+    }
+    $serve = Get-ServeTcpForward
+    $loop = Test-LoopbackListener
+    $running = ($svc.Status -eq 'Running')
+    $ok = $running -and $serve.Present -and $serve.TargetLoopback -and $loop -and $serve.FunnelForbidden
+    return @{
+        Ok            = $ok
+        ServiceStatus = "$($svc.Status)"
+        ServePresent  = $serve.Present
+        LoopbackOk    = $loop
+        FunnelOk      = $serve.FunnelForbidden
+    }
+}
+
 function Resolve-LiveBridgeHealth {
     # Returns ENABLED only when service Running AND serve loopback AND local listener.
     # Contradictions -> UNAVAILABLE.
@@ -205,8 +224,7 @@ function Resolve-LiveBridgeHealth {
     # Contradictions: Serve without sshd, or sshd without Serve, or no listener.
     if ($running -and $serve.Present -and $serve.TargetLoopback -and $loop) {
         $fileStatus = Read-StateStatus
-        # File may lag; live triple-gate wins for "bridge up". Still fail-closed if
-        # file explicitly DISABLED while live looks up (operator mid-transition).
+        # Status path: DISABLED file while live bridge is up is contradictory.
         if ($fileStatus -eq 'DISABLED') {
             return @{
                 ServiceStatus = "$($svc.Status)"
@@ -293,7 +311,10 @@ switch ($Action) {
         }
     }
     'Enable' {
-        # Ordered: sshd -> loopback health -> Serve -> verify -> ENABLED state.
+        # Ordered: sshd -> loopback -> Serve -> live triple (ignore DISABLED file
+        # mid-transition) -> optional remote proof by operator -> ENABLED state.
+        # Do NOT call the Status health resolver here: file still DISABLED would
+        # wrongly roll back Serve after a successful enable.
         Set-Service -Name $ServiceName -StartupType Automatic
         Start-Service -Name $ServiceName
         Start-Sleep -Seconds 1
@@ -302,11 +323,11 @@ switch ($Action) {
             throw 'Local loopback healthcheck FAILED; Serve not enabled; state UNAVAILABLE'
         }
         Enable-ServeTcpMapping
-        $health = Resolve-LiveBridgeHealth
-        if ($health.KillSwitch -ne 'ENABLED') {
+        $live = Test-LiveBridgeTriple
+        if (-not $live.Ok) {
             Disable-ServeTcpMapping
             Write-State 'UNAVAILABLE'
-            throw 'Post-enable health not ENABLED; rolled back Serve; state UNAVAILABLE'
+            throw 'Post-enable live triple FAILED; rolled back Serve; state UNAVAILABLE'
         }
         Write-State 'ENABLED'
         Write-MachineStatus -ServiceStatus 'Running' -KillSwitch 'ENABLED' `

--- a/infrastructure/hermes/windows/setup-sshd-hermes.ps1
+++ b/infrastructure/hermes/windows/setup-sshd-hermes.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
   Install/configure dedicated loopback OpenSSH + Tailscale Serve bridge (#4289).
@@ -8,7 +8,7 @@
   (live evidence 2026-08-03). Architecture:
 
   - sshd-hermes listens ONLY on 127.0.0.1:22 (and ::1).
-  - Tailscale Serve raw TCP forwarder: tailnet:22 → tcp://127.0.0.1:22 (--bg).
+  - Tailscale Serve raw TCP forwarder: tailnet:22 -> tcp://127.0.0.1:22 (--bg).
   - No inbound Windows Firewall allow for sshd (Serve is the only remote path).
   - Funnel is forbidden and must stay off.
   - Default system sshd Disabled; public OpenSSH-Server-In-TCP Disabled.
@@ -213,7 +213,7 @@ function Enable-TailscaleServeTcp {
     if ($fwd -notmatch '127\.0\.0\.1:' -and $fwd -notmatch '\[::1\]:') {
         throw "Serve TCPForward must target loopback (got redacted length=$($fwd.Length))"
     }
-    Write-Host "Tailscale Serve TCP/$Port → loopback READY (Funnel forbidden)"
+    Write-Host "Tailscale Serve TCP/$Port -> loopback READY (Funnel forbidden)"
 }
 
 function Ensure-AuthorizedKeysDir {

--- a/infrastructure/hermes/windows/setup-sshd-hermes.ps1
+++ b/infrastructure/hermes/windows/setup-sshd-hermes.ps1
@@ -224,8 +224,9 @@ function Ensure-TailscaleFirewallRule {
         # IMPORTANT: do not set -LocalAddress to the Tailscale IP. On Windows this
         # often fails to match packets even when sshd ListenAddress is correct,
         # causing Hermes→Windows TCP timeouts while `tailscale ping` still works.
-        # Restriction is RemoteAddress = cdb-hermes-01 Tailscale IP only + sshd
-        # ListenAddress bind (no 0.0.0.0). Public OpenSSH rule stays disabled.
+        # Restriction is RemoteAddress = cdb-hermes-01 Tailscale IP only; sshd
+        # binds 0.0.0.0 (peer TCP to a unicast Tailscale bind is unreliable).
+        # Public OpenSSH rule stays disabled.
         New-NetFirewallRule -Name $RuleName `
             -DisplayName 'CDB Hermes sshd-hermes (Tailscale from cdb-hermes-01)' `
             -Direction Inbound -Action Allow -Enabled True -Profile Any `
@@ -324,7 +325,7 @@ if ($svc.Status -ne 'Running') {
     throw "Service $ServiceName failed to start"
 }
 
-Write-Host "sshd-hermes READY (ListenAddress=Tailscale/self port=$ListenPort AllowUsers=$HermesUser)"
+Write-Host "sshd-hermes READY (ListenAddress=0.0.0.0 port=$ListenPort AllowUsers=$HermesUser; FW remote=hermes-ts only)"
 Write-Host "sshd_exe=$sshdExe"
 Write-Host 'PasswordAuthentication no; public OpenSSH firewall rule disabled; default sshd Disabled.'
 Write-Host 'Install pubkey into hermes-win .ssh\authorized_keys; private key only on cdb-engineer profile.'

--- a/infrastructure/hermes/windows/setup-sshd-hermes.ps1
+++ b/infrastructure/hermes/windows/setup-sshd-hermes.ps1
@@ -1,22 +1,22 @@
 #Requires -Version 5.1
 <#
 .SYNOPSIS
-  Install/configure dedicated Tailscale-only OpenSSH listener sshd-hermes (#4289).
+  Install/configure dedicated loopback OpenSSH + Tailscale Serve bridge (#4289).
 
 .DESCRIPTION
-  Based on Microsoft OpenSSH Server docs (Add-WindowsCapability OpenSSH.Server,
-  sshd_config ListenAddress / AllowUsers / PasswordAuthentication).
+  Windows host TCP after Wintun injection does not SYN-ACK for peer traffic
+  (live evidence 2026-08-03). Architecture:
 
-  - Installs OpenSSH.Server if missing.
-  - Disables the default system-wide sshd service and the public
-    OpenSSH-Server-In-TCP firewall rule.
-  - Creates sshd-hermes with a private config bound to the Windows Tailscale IP.
-  - Firewall allows inbound only from the cdb-hermes-01 Tailscale IP.
-  - Pubkey-only auth for hermes-win. No password SSH, no RDP/VNC, no forwarding.
+  - sshd-hermes listens ONLY on 127.0.0.1:22 (and ::1).
+  - Tailscale Serve raw TCP forwarder: tailnet:22 → tcp://127.0.0.1:22 (--bg).
+  - No inbound Windows Firewall allow for sshd (Serve is the only remote path).
+  - Funnel is forbidden and must stay off.
+  - Default system sshd Disabled; public OpenSSH-Server-In-TCP Disabled.
 
-.NOTES
-  Run elevated once. Does not print Tailscale IPs to GitHub evidence files.
-  Docs gate: learn.microsoft.com OpenSSH install + server configuration (2025).
+  Docs gate (Tailscale 1.98+):
+    tailscale serve --bg --tcp=22 tcp://127.0.0.1:22
+    tailscale serve --tcp=22 off
+    tailscale serve status --json
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
@@ -24,9 +24,8 @@ param(
     [string]$ServiceName = 'sshd-hermes',
     [string]$ConfigPath = 'C:\ProgramData\ssh\sshd_hermes_config',
     [string]$HostKeyPath = 'C:\ProgramData\ssh\ssh_host_ed25519_key',
-    [string]$HermesPeerName = 'cdb-hermes-01',
     [int]$ListenPort = 22,
-    [string]$FirewallRuleName = 'CDB-Hermes-sshd-hermes-Tailscale'
+    [string]$LegacyFirewallRuleName = 'CDB-Hermes-sshd-hermes-Tailscale'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -37,26 +36,6 @@ function Assert-Elevated {
     if (-not $p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
         throw 'setup-sshd-hermes.ps1 must run elevated (Administrator).'
     }
-}
-
-function Get-TailscaleIPv4 {
-    param([string]$HostName)
-    $json = & tailscale status --json 2>$null | ConvertFrom-Json
-    if (-not $json) { throw 'tailscale status --json failed' }
-    if ($HostName -eq 'self') {
-        $ips = @($json.Self.TailscaleIPs)
-    }
-    else {
-        $peer = $json.Peer.PSObject.Properties.Value |
-            Where-Object { $_.HostName -eq $HostName -or $_.DNSName -like "$HostName*" } |
-            Select-Object -First 1
-        if (-not $peer) { throw "Tailscale peer not found: $HostName" }
-        if (-not $peer.Online) { throw "Tailscale peer offline: $HostName" }
-        $ips = @($peer.TailscaleIPs)
-    }
-    $v4 = $ips | Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } | Select-Object -First 1
-    if (-not $v4) { throw "No Tailscale IPv4 for $HostName" }
-    return $v4
 }
 
 function Resolve-SshdExe {
@@ -78,65 +57,54 @@ function Install-OpenSSHServerCapability {
         Write-Host "OpenSSH Server already present: $existing"
         return $existing
     }
-
-    # Prefer winget MSI path — Add-WindowsCapability/-Online often hangs on DISM/WU.
-    # Docs gate: Win32-OpenSSH via winget (package id Microsoft.OpenSSH.Preview).
-    # Avoid WSL/bash shims entirely.
     $winget = Get-Command winget.exe -ErrorAction SilentlyContinue
     if ($winget) {
         $packageId = 'Microsoft.OpenSSH.Preview'
         if ($PSCmdlet.ShouldProcess($packageId, 'winget install OpenSSH Server')) {
             Write-Host "Installing OpenSSH Server via winget ($packageId, no DISM)..."
-            # IMPORTANT: swallow winget stdout — otherwise it becomes the function's
-            # return value in PowerShell and corrupts $sshdExe (empty Path errors).
             & winget.exe install --id $packageId -e --source winget `
                 --accept-package-agreements --accept-source-agreements `
                 --disable-interactivity *>$null
             $wingetExit = $LASTEXITCODE
-            # Common benign codes: already installed / no newer version.
             if ($wingetExit -notin @(0, -1978335189, -1978335135)) {
                 throw "winget install $packageId failed exit=$wingetExit"
             }
         }
+        Start-Sleep -Seconds 2
+        $existing = Resolve-SshdExe
+        if ($existing) { return $existing }
     }
-    else {
-        # Fallback only when winget is unavailable.
-        Write-Host 'winget missing; falling back to Add-WindowsCapability (may be slow)...'
-        $cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0' -ErrorAction Stop
-        if ($cap.State -ne 'Installed') {
-            if ($PSCmdlet.ShouldProcess('OpenSSH.Server~~~~0.0.1.0', 'Add-WindowsCapability')) {
-                Add-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0' | Out-Null
-            }
-        }
-    }
-
-    $sshd = Resolve-SshdExe
-    if ([string]::IsNullOrWhiteSpace($sshd)) {
-        throw 'OpenSSH Server install did not provide sshd.exe'
-    }
-    # Explicit single-string return (no accidental pipeline pollution).
-    return [string]$sshd
+    throw 'OpenSSH Server not found after install attempt'
 }
 
 function Disable-DefaultPublicSshd {
-    $default = Get-Service -Name 'sshd' -ErrorAction SilentlyContinue
-    if ($default) {
-        if ($default.Status -eq 'Running') {
-            Stop-Service -Name 'sshd' -Force -ErrorAction SilentlyContinue
-        }
-        Set-Service -Name 'sshd' -StartupType Disabled
-        Write-Host 'Default sshd service set to Disabled (Hermes uses sshd-hermes only).'
+    $svc = Get-Service -Name 'sshd' -ErrorAction SilentlyContinue
+    if ($svc) {
+        if ($svc.Status -eq 'Running') { Stop-Service -Name 'sshd' -Force -ErrorAction SilentlyContinue }
+        Set-Service -Name 'sshd' -StartupType Disabled -ErrorAction SilentlyContinue
     }
-    $pubRule = Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
-    if ($pubRule) {
+    $pub = Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
+    if ($pub -and $pub.Enabled) {
         Disable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP'
-        Write-Host 'Disabled public OpenSSH-Server-In-TCP firewall rule.'
+    }
+    Get-NetFirewallRule -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -eq 'OpenSSH SSH Server Preview (sshd)' -and $_.Enabled } |
+        ForEach-Object { Disable-NetFirewallRule -Name $_.Name }
+}
+
+function Remove-LegacyExternalSshFirewall {
+    param([string]$RuleName)
+    foreach ($n in @($RuleName, 'CDB-Hermes-sshd-program', 'CDB-Hermes-sshd-TailscaleIF', 'CDB-Hermes-DIAG-tcp22-any-TEMP')) {
+        $existing = Get-NetFirewallRule -Name $n -ErrorAction SilentlyContinue
+        if ($existing) {
+            Remove-NetFirewallRule -Name $n
+            Write-Host "Removed legacy/external firewall rule: $n"
+        }
     }
 }
 
 function Write-HermesSshdConfig {
     param(
-        [string]$ListenIp,
         [int]$Port,
         [string]$UserName,
         [string]$ConfigFile,
@@ -147,7 +115,6 @@ function Write-HermesSshdConfig {
     if ([string]::IsNullOrWhiteSpace($ConfigFile)) { throw 'ConfigFile is required' }
     if ([string]::IsNullOrWhiteSpace($HostKey)) { throw 'HostKey is required' }
     if ([string]::IsNullOrWhiteSpace($KeygenExe)) { throw 'KeygenExe is required' }
-    if ([string]::IsNullOrWhiteSpace($ListenIp)) { throw 'ListenIp is required' }
     $dir = Split-Path -Parent $ConfigFile
     if (-not (Test-Path -LiteralPath $dir)) {
         New-Item -ItemType Directory -Path $dir -Force | Out-Null
@@ -158,17 +125,23 @@ function Write-HermesSshdConfig {
     if ([string]::IsNullOrWhiteSpace($SftpServer)) {
         $SftpServer = 'sftp-server.exe'
     }
+    $authKeys = "C:/Users/$UserName/.ssh/authorized_keys"
     $content = @"
-# CDB Hermes dedicated sshd (#4289). Do not expose publicly.
-# Windows+Tailscale: ListenAddress 0.0.0.0 is required in practice — peer TCP is
-# not reliably delivered to a unicast Tailscale bind (local TS bind tests can
-# still pass). Public exposure is prevented by:
+# CDB Hermes dedicated sshd (#4289). Loopback-only backend.
+# Remote access is ONLY via Tailscale Serve TCP forwarder (never Funnel):
+#   tailscale serve --bg --tcp=$Port tcp://127.0.0.1:$Port
+# Host TCP after Wintun does not SYN-ACK for peer traffic on this Windows build;
+# Serve proxies tailnet TCP into loopback where sshd answers.
+# Public exposure prevented by:
+#   - ListenAddress 127.0.0.1 / ::1 only
+#   - no inbound Windows Firewall allow for sshd
 #   - OpenSSH-Server-In-TCP disabled
-#   - firewall RemoteAddress = cdb-hermes-01 Tailscale IP only
-#   - PasswordAuthentication no / AllowUsers hermes-win
+#   - Funnel forbidden
+#   - PasswordAuthentication no / AllowUsers $UserName
 #   - default system sshd Disabled
 Port $Port
-ListenAddress 0.0.0.0
+ListenAddress 127.0.0.1
+ListenAddress ::1
 HostKey $HostKey
 PubkeyAuthentication yes
 PasswordAuthentication no
@@ -176,7 +149,8 @@ KbdInteractiveAuthentication no
 ChallengeResponseAuthentication no
 PermitEmptyPasswords no
 AllowUsers $UserName
-AuthorizedKeysFile .ssh/authorized_keys
+AuthorizedKeysFile $authKeys
+StrictModes no
 AllowTcpForwarding no
 AllowAgentForwarding no
 X11Forwarding no
@@ -198,8 +172,8 @@ function Ensure-HermesSshService {
     if (-not $existing) {
         if ($PSCmdlet.ShouldProcess($Name, 'New-Service sshd-hermes')) {
             New-Service -Name $Name -BinaryPathName $binPath `
-                -DisplayName 'CDB Hermes OpenSSH (Tailscale-only)' `
-                -Description 'Dedicated Hermes bridge for hermes-win (#4289). Not the public sshd.' `
+                -DisplayName 'CDB Hermes OpenSSH (Tailscale Serve backend)' `
+                -Description 'Loopback-only Hermes bridge; remote via Tailscale Serve (#4289).' `
                 -StartupType Automatic | Out-Null
         }
     }
@@ -209,44 +183,49 @@ function Ensure-HermesSshService {
     }
 }
 
-function Ensure-TailscaleFirewallRule {
-    param(
-        [string]$RuleName,
-        [string]$LocalIp,
-        [string]$RemoteIp,
-        [int]$Port
-    )
-    $existing = Get-NetFirewallRule -Name $RuleName -ErrorAction SilentlyContinue
-    if ($existing) {
-        Remove-NetFirewallRule -Name $RuleName
+function Assert-FunnelOff {
+    $funnel = & tailscale funnel status 2>&1 | Out-String
+    if ($funnel -match '(?i)Funnel on|https://.*ts\.net' -and $funnel -notmatch 'tailnet only') {
+        # Funnel status may echo Serve config; require explicit Funnel enablement markers.
+        if ($funnel -match '(?i)Funnel on:') {
+            throw 'Tailscale Funnel must be OFF for Hermes bridge'
+        }
     }
-    if ($PSCmdlet.ShouldProcess($RuleName, 'New-NetFirewallRule Tailscale-only')) {
-        # IMPORTANT: do not set -LocalAddress to the Tailscale IP. On Windows this
-        # often fails to match packets even when sshd ListenAddress is correct,
-        # causing Hermes→Windows TCP timeouts while `tailscale ping` still works.
-        # Restriction is RemoteAddress = cdb-hermes-01 Tailscale IP only; sshd
-        # binds 0.0.0.0 (peer TCP to a unicast Tailscale bind is unreliable).
-        # Public OpenSSH rule stays disabled.
-        New-NetFirewallRule -Name $RuleName `
-            -DisplayName 'CDB Hermes sshd-hermes (Tailscale from cdb-hermes-01)' `
-            -Direction Inbound -Action Allow -Enabled True -Profile Any `
-            -Protocol TCP -LocalPort $Port `
-            -RemoteAddress $RemoteIp | Out-Null
-        Write-Host "Firewall rule ${RuleName}: remote=hermes-ts only; localAddress=any (sshd still firewalled)"
+    Write-Host 'Funnel check: not enabled (Serve-only path)'
+}
+
+function Enable-TailscaleServeTcp {
+    param([int]$Port)
+    Assert-FunnelOff
+    if ($PSCmdlet.ShouldProcess("tcp/$Port", 'tailscale serve --bg TCP forwarder')) {
+        # Docs (1.98): tailscale serve --bg --tcp=<port> tcp://127.0.0.1:<port>
+        & tailscale serve --bg --yes --tcp=$Port "tcp://127.0.0.1:$Port" *>$null
+        if ($LASTEXITCODE -ne 0) {
+            throw "tailscale serve enable failed exit=$LASTEXITCODE"
+        }
     }
+    $status = & tailscale serve status --json 2>$null | ConvertFrom-Json
+    $key = "$Port"
+    if (-not $status.TCP -or -not $status.TCP.$key -or -not $status.TCP.$key.TCPForward) {
+        throw "tailscale serve status missing TCP/$Port forward"
+    }
+    $fwd = [string]$status.TCP.$key.TCPForward
+    if ($fwd -notmatch '127\.0\.0\.1:' -and $fwd -notmatch '\[::1\]:') {
+        throw "Serve TCPForward must target loopback (got redacted length=$($fwd.Length))"
+    }
+    Write-Host "Tailscale Serve TCP/$Port → loopback READY (Funnel forbidden)"
 }
 
 function Ensure-AuthorizedKeysDir {
     param([string]$UserName)
-    $home = "C:\Users\$UserName"
-    if (-not (Test-Path -LiteralPath $home)) {
+    $userHome = "C:\Users\$UserName"
+    if (-not (Test-Path -LiteralPath $userHome)) {
         throw "User profile missing for $UserName (logon once or create profile before keys)."
     }
-    $sshDir = Join-Path $home '.ssh'
+    $sshDir = Join-Path $userHome '.ssh'
     if (-not (Test-Path -LiteralPath $sshDir)) {
         New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
     }
-    # Restrict .ssh to SYSTEM, Administrators, and the user.
     $acl = Get-Acl -LiteralPath $sshDir
     $acl.SetAccessRuleProtection($true, $false)
     @($acl.Access) | ForEach-Object { [void]$acl.RemoveAccessRule($_) }
@@ -294,17 +273,12 @@ if (-not (Test-Path -LiteralPath $sshKeygen)) {
     throw "ssh-keygen.exe missing next to $sshdExe"
 }
 Disable-DefaultPublicSshd
+Remove-LegacyExternalSshFirewall -RuleName $LegacyFirewallRuleName
 
-$localTs = Get-TailscaleIPv4 -HostName 'self'
-$remoteTs = Get-TailscaleIPv4 -HostName $HermesPeerName
-
-Write-HermesSshdConfig -ListenIp $localTs -Port $ListenPort -UserName $HermesUser `
+Write-HermesSshdConfig -Port $ListenPort -UserName $HermesUser `
     -ConfigFile $ConfigPath -HostKey $HostKeyPath -KeygenExe $sshKeygen -SftpServer $sftpServer
 Ensure-HermesSshService -Name $ServiceName -Config $ConfigPath -SshdExe $sshdExe
-Ensure-TailscaleFirewallRule -RuleName $FirewallRuleName -LocalIp $localTs `
-    -RemoteIp $remoteTs -Port $ListenPort
 
-# Profile/.ssh may not exist until user profile is created — try best-effort.
 try {
     $null = Ensure-AuthorizedKeysDir -UserName $HermesUser
     Write-Host "authorized_keys path prepared for $HermesUser"
@@ -325,7 +299,14 @@ if ($svc.Status -ne 'Running') {
     throw "Service $ServiceName failed to start"
 }
 
-Write-Host "sshd-hermes READY (ListenAddress=0.0.0.0 port=$ListenPort AllowUsers=$HermesUser; FW remote=hermes-ts only)"
+$loop = Test-NetConnection -ComputerName '127.0.0.1' -Port $ListenPort -WarningAction SilentlyContinue
+if (-not $loop.TcpTestSucceeded) {
+    throw "Local loopback TCP/$ListenPort failed after sshd-hermes start"
+}
+
+Enable-TailscaleServeTcp -Port $ListenPort
+
+Write-Host "sshd-hermes READY (ListenAddress=127.0.0.1 port=$ListenPort AllowUsers=$HermesUser; Serve TCP forwarder; Funnel forbidden)"
 Write-Host "sshd_exe=$sshdExe"
-Write-Host 'PasswordAuthentication no; public OpenSSH firewall rule disabled; default sshd Disabled.'
+Write-Host 'PasswordAuthentication no; no external sshd firewall rule; default sshd Disabled.'
 Write-Host 'Install pubkey into hermes-win .ssh\authorized_keys; private key only on cdb-engineer profile.'

--- a/infrastructure/hermes/windows/setup-sshd-hermes.ps1
+++ b/infrastructure/hermes/windows/setup-sshd-hermes.ps1
@@ -1,0 +1,330 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Install/configure dedicated Tailscale-only OpenSSH listener sshd-hermes (#4289).
+
+.DESCRIPTION
+  Based on Microsoft OpenSSH Server docs (Add-WindowsCapability OpenSSH.Server,
+  sshd_config ListenAddress / AllowUsers / PasswordAuthentication).
+
+  - Installs OpenSSH.Server if missing.
+  - Disables the default system-wide sshd service and the public
+    OpenSSH-Server-In-TCP firewall rule.
+  - Creates sshd-hermes with a private config bound to the Windows Tailscale IP.
+  - Firewall allows inbound only from the cdb-hermes-01 Tailscale IP.
+  - Pubkey-only auth for hermes-win. No password SSH, no RDP/VNC, no forwarding.
+
+.NOTES
+  Run elevated once. Does not print Tailscale IPs to GitHub evidence files.
+  Docs gate: learn.microsoft.com OpenSSH install + server configuration (2025).
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$HermesUser = 'hermes-win',
+    [string]$ServiceName = 'sshd-hermes',
+    [string]$ConfigPath = 'C:\ProgramData\ssh\sshd_hermes_config',
+    [string]$HostKeyPath = 'C:\ProgramData\ssh\ssh_host_ed25519_key',
+    [string]$HermesPeerName = 'cdb-hermes-01',
+    [int]$ListenPort = 22,
+    [string]$FirewallRuleName = 'CDB-Hermes-sshd-hermes-Tailscale'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Assert-Elevated {
+    $id = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $p = New-Object Security.Principal.WindowsPrincipal($id)
+    if (-not $p.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+        throw 'setup-sshd-hermes.ps1 must run elevated (Administrator).'
+    }
+}
+
+function Get-TailscaleIPv4 {
+    param([string]$HostName)
+    $json = & tailscale status --json 2>$null | ConvertFrom-Json
+    if (-not $json) { throw 'tailscale status --json failed' }
+    if ($HostName -eq 'self') {
+        $ips = @($json.Self.TailscaleIPs)
+    }
+    else {
+        $peer = $json.Peer.PSObject.Properties.Value |
+            Where-Object { $_.HostName -eq $HostName -or $_.DNSName -like "$HostName*" } |
+            Select-Object -First 1
+        if (-not $peer) { throw "Tailscale peer not found: $HostName" }
+        if (-not $peer.Online) { throw "Tailscale peer offline: $HostName" }
+        $ips = @($peer.TailscaleIPs)
+    }
+    $v4 = $ips | Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } | Select-Object -First 1
+    if (-not $v4) { throw "No Tailscale IPv4 for $HostName" }
+    return $v4
+}
+
+function Resolve-SshdExe {
+    $candidates = @(
+        'C:\Windows\System32\OpenSSH\sshd.exe',
+        'C:\Program Files\OpenSSH\sshd.exe',
+        "${env:SystemDrive}\OpenSSH\sshd.exe",
+        'C:\Program Files (x86)\OpenSSH\sshd.exe'
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path -LiteralPath $c) { return $c }
+    }
+    return $null
+}
+
+function Install-OpenSSHServerCapability {
+    $existing = Resolve-SshdExe
+    if ($existing) {
+        Write-Host "OpenSSH Server already present: $existing"
+        return $existing
+    }
+
+    # Prefer winget MSI path — Add-WindowsCapability/-Online often hangs on DISM/WU.
+    # Docs gate: Win32-OpenSSH via winget (package id Microsoft.OpenSSH.Preview).
+    # Avoid WSL/bash shims entirely.
+    $winget = Get-Command winget.exe -ErrorAction SilentlyContinue
+    if ($winget) {
+        $packageId = 'Microsoft.OpenSSH.Preview'
+        if ($PSCmdlet.ShouldProcess($packageId, 'winget install OpenSSH Server')) {
+            Write-Host "Installing OpenSSH Server via winget ($packageId, no DISM)..."
+            # IMPORTANT: swallow winget stdout — otherwise it becomes the function's
+            # return value in PowerShell and corrupts $sshdExe (empty Path errors).
+            & winget.exe install --id $packageId -e --source winget `
+                --accept-package-agreements --accept-source-agreements `
+                --disable-interactivity *>$null
+            $wingetExit = $LASTEXITCODE
+            # Common benign codes: already installed / no newer version.
+            if ($wingetExit -notin @(0, -1978335189, -1978335135)) {
+                throw "winget install $packageId failed exit=$wingetExit"
+            }
+        }
+    }
+    else {
+        # Fallback only when winget is unavailable.
+        Write-Host 'winget missing; falling back to Add-WindowsCapability (may be slow)...'
+        $cap = Get-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0' -ErrorAction Stop
+        if ($cap.State -ne 'Installed') {
+            if ($PSCmdlet.ShouldProcess('OpenSSH.Server~~~~0.0.1.0', 'Add-WindowsCapability')) {
+                Add-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0' | Out-Null
+            }
+        }
+    }
+
+    $sshd = Resolve-SshdExe
+    if ([string]::IsNullOrWhiteSpace($sshd)) {
+        throw 'OpenSSH Server install did not provide sshd.exe'
+    }
+    # Explicit single-string return (no accidental pipeline pollution).
+    return [string]$sshd
+}
+
+function Disable-DefaultPublicSshd {
+    $default = Get-Service -Name 'sshd' -ErrorAction SilentlyContinue
+    if ($default) {
+        if ($default.Status -eq 'Running') {
+            Stop-Service -Name 'sshd' -Force -ErrorAction SilentlyContinue
+        }
+        Set-Service -Name 'sshd' -StartupType Disabled
+        Write-Host 'Default sshd service set to Disabled (Hermes uses sshd-hermes only).'
+    }
+    $pubRule = Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
+    if ($pubRule) {
+        Disable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP'
+        Write-Host 'Disabled public OpenSSH-Server-In-TCP firewall rule.'
+    }
+}
+
+function Write-HermesSshdConfig {
+    param(
+        [string]$ListenIp,
+        [int]$Port,
+        [string]$UserName,
+        [string]$ConfigFile,
+        [string]$HostKey,
+        [string]$KeygenExe,
+        [string]$SftpServer
+    )
+    if ([string]::IsNullOrWhiteSpace($ConfigFile)) { throw 'ConfigFile is required' }
+    if ([string]::IsNullOrWhiteSpace($HostKey)) { throw 'HostKey is required' }
+    if ([string]::IsNullOrWhiteSpace($KeygenExe)) { throw 'KeygenExe is required' }
+    if ([string]::IsNullOrWhiteSpace($ListenIp)) { throw 'ListenIp is required' }
+    $dir = Split-Path -Parent $ConfigFile
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+    if (-not (Test-Path -LiteralPath $HostKey)) {
+        & $KeygenExe -t ed25519 -f $HostKey -N '""' -q
+    }
+    if ([string]::IsNullOrWhiteSpace($SftpServer)) {
+        $SftpServer = 'sftp-server.exe'
+    }
+    $content = @"
+# CDB Hermes dedicated sshd (#4289). Do not expose publicly.
+# Windows+Tailscale: ListenAddress 0.0.0.0 is required in practice — peer TCP is
+# not reliably delivered to a unicast Tailscale bind (local TS bind tests can
+# still pass). Public exposure is prevented by:
+#   - OpenSSH-Server-In-TCP disabled
+#   - firewall RemoteAddress = cdb-hermes-01 Tailscale IP only
+#   - PasswordAuthentication no / AllowUsers hermes-win
+#   - default system sshd Disabled
+Port $Port
+ListenAddress 0.0.0.0
+HostKey $HostKey
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PermitEmptyPasswords no
+AllowUsers $UserName
+AuthorizedKeysFile .ssh/authorized_keys
+AllowTcpForwarding no
+AllowAgentForwarding no
+X11Forwarding no
+PermitTunnel no
+GatewayPorts no
+MaxAuthTries 3
+LoginGraceTime 20
+Subsystem sftp $SftpServer
+"@
+    if ($PSCmdlet.ShouldProcess($ConfigFile, 'Write sshd_hermes_config')) {
+        Set-Content -LiteralPath $ConfigFile -Value $content -Encoding ascii
+    }
+}
+
+function Ensure-HermesSshService {
+    param([string]$Name, [string]$Config, [string]$SshdExe)
+    $binPath = "`"$SshdExe`" -f `"$Config`""
+    $existing = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if (-not $existing) {
+        if ($PSCmdlet.ShouldProcess($Name, 'New-Service sshd-hermes')) {
+            New-Service -Name $Name -BinaryPathName $binPath `
+                -DisplayName 'CDB Hermes OpenSSH (Tailscale-only)' `
+                -Description 'Dedicated Hermes bridge for hermes-win (#4289). Not the public sshd.' `
+                -StartupType Automatic | Out-Null
+        }
+    }
+    else {
+        & sc.exe config $Name binPath= $binPath | Out-Null
+        Set-Service -Name $Name -StartupType Automatic
+    }
+}
+
+function Ensure-TailscaleFirewallRule {
+    param(
+        [string]$RuleName,
+        [string]$LocalIp,
+        [string]$RemoteIp,
+        [int]$Port
+    )
+    $existing = Get-NetFirewallRule -Name $RuleName -ErrorAction SilentlyContinue
+    if ($existing) {
+        Remove-NetFirewallRule -Name $RuleName
+    }
+    if ($PSCmdlet.ShouldProcess($RuleName, 'New-NetFirewallRule Tailscale-only')) {
+        # IMPORTANT: do not set -LocalAddress to the Tailscale IP. On Windows this
+        # often fails to match packets even when sshd ListenAddress is correct,
+        # causing Hermes→Windows TCP timeouts while `tailscale ping` still works.
+        # Restriction is RemoteAddress = cdb-hermes-01 Tailscale IP only + sshd
+        # ListenAddress bind (no 0.0.0.0). Public OpenSSH rule stays disabled.
+        New-NetFirewallRule -Name $RuleName `
+            -DisplayName 'CDB Hermes sshd-hermes (Tailscale from cdb-hermes-01)' `
+            -Direction Inbound -Action Allow -Enabled True -Profile Any `
+            -Protocol TCP -LocalPort $Port `
+            -RemoteAddress $RemoteIp | Out-Null
+        Write-Host "Firewall rule ${RuleName}: remote=hermes-ts only; localAddress=any (sshd still firewalled)"
+    }
+}
+
+function Ensure-AuthorizedKeysDir {
+    param([string]$UserName)
+    $home = "C:\Users\$UserName"
+    if (-not (Test-Path -LiteralPath $home)) {
+        throw "User profile missing for $UserName (logon once or create profile before keys)."
+    }
+    $sshDir = Join-Path $home '.ssh'
+    if (-not (Test-Path -LiteralPath $sshDir)) {
+        New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
+    }
+    # Restrict .ssh to SYSTEM, Administrators, and the user.
+    $acl = Get-Acl -LiteralPath $sshDir
+    $acl.SetAccessRuleProtection($true, $false)
+    @($acl.Access) | ForEach-Object { [void]$acl.RemoveAccessRule($_) }
+    foreach ($sidObj in @(
+            (New-Object System.Security.Principal.SecurityIdentifier('S-1-5-18')),
+            (New-Object System.Security.Principal.SecurityIdentifier('S-1-5-32-544')),
+            (New-Object System.Security.Principal.NTAccount("$env:COMPUTERNAME\$UserName")).Translate([System.Security.Principal.SecurityIdentifier])
+        )) {
+        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            $sidObj, 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow'
+        )
+        $acl.AddAccessRule($rule)
+    }
+    Set-Acl -LiteralPath $sshDir -AclObject $acl
+    $auth = Join-Path $sshDir 'authorized_keys'
+    if (-not (Test-Path -LiteralPath $auth)) {
+        New-Item -ItemType File -Path $auth -Force | Out-Null
+    }
+    $acl2 = Get-Acl -LiteralPath $auth
+    $acl2.SetAccessRuleProtection($true, $false)
+    @($acl2.Access) | ForEach-Object { [void]$acl2.RemoveAccessRule($_) }
+    foreach ($sidObj in @(
+            (New-Object System.Security.Principal.SecurityIdentifier('S-1-5-18')),
+            (New-Object System.Security.Principal.SecurityIdentifier('S-1-5-32-544')),
+            (New-Object System.Security.Principal.NTAccount("$env:COMPUTERNAME\$UserName")).Translate([System.Security.Principal.SecurityIdentifier])
+        )) {
+        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            $sidObj, 'FullControl', 'None', 'None', 'Allow'
+        )
+        $acl2.AddAccessRule($rule)
+    }
+    Set-Acl -LiteralPath $auth -AclObject $acl2
+    return $auth
+}
+
+Assert-Elevated
+$sshdExe = [string](Install-OpenSSHServerCapability)
+if ([string]::IsNullOrWhiteSpace($sshdExe) -or -not (Test-Path -LiteralPath $sshdExe)) {
+    throw "sshd.exe unresolved after install (got='$sshdExe')"
+}
+$sshDirBin = Split-Path -Parent $sshdExe
+$sshKeygen = Join-Path $sshDirBin 'ssh-keygen.exe'
+$sftpServer = Join-Path $sshDirBin 'sftp-server.exe'
+if (-not (Test-Path -LiteralPath $sshKeygen)) {
+    throw "ssh-keygen.exe missing next to $sshdExe"
+}
+Disable-DefaultPublicSshd
+
+$localTs = Get-TailscaleIPv4 -HostName 'self'
+$remoteTs = Get-TailscaleIPv4 -HostName $HermesPeerName
+
+Write-HermesSshdConfig -ListenIp $localTs -Port $ListenPort -UserName $HermesUser `
+    -ConfigFile $ConfigPath -HostKey $HostKeyPath -KeygenExe $sshKeygen -SftpServer $sftpServer
+Ensure-HermesSshService -Name $ServiceName -Config $ConfigPath -SshdExe $sshdExe
+Ensure-TailscaleFirewallRule -RuleName $FirewallRuleName -LocalIp $localTs `
+    -RemoteIp $remoteTs -Port $ListenPort
+
+# Profile/.ssh may not exist until user profile is created — try best-effort.
+try {
+    $null = Ensure-AuthorizedKeysDir -UserName $HermesUser
+    Write-Host "authorized_keys path prepared for $HermesUser"
+}
+catch {
+    Write-Host "WARN: authorized_keys prep deferred: $($_.Exception.Message)"
+}
+
+& $sshdExe -t -f $ConfigPath
+if ($LASTEXITCODE -ne 0) {
+    throw "sshd -t failed for $ConfigPath"
+}
+
+Restart-Service -Name $ServiceName -Force -ErrorAction SilentlyContinue
+Start-Service -Name $ServiceName
+$svc = Get-Service -Name $ServiceName
+if ($svc.Status -ne 'Running') {
+    throw "Service $ServiceName failed to start"
+}
+
+Write-Host "sshd-hermes READY (ListenAddress=Tailscale/self port=$ListenPort AllowUsers=$HermesUser)"
+Write-Host "sshd_exe=$sshdExe"
+Write-Host 'PasswordAuthentication no; public OpenSSH firewall rule disabled; default sshd Disabled.'
+Write-Host 'Install pubkey into hermes-win .ssh\authorized_keys; private key only on cdb-engineer profile.'

--- a/infrastructure/hermes/windows/setup-workspace.ps1
+++ b/infrastructure/hermes/windows/setup-workspace.ps1
@@ -71,26 +71,28 @@ function Ensure-HermesUser {
         Write-Host "Local user already exists: $UserName"
     }
 
-    # Ensure NOT in Administrators.
-    $admins = Get-LocalGroupMember -Group 'Administrators' -ErrorAction SilentlyContinue |
+    # Ensure NOT in Administrators (SID S-1-5-32-544; locale-independent).
+    $adminGroup = Get-LocalGroup -SID 'S-1-5-32-544'
+    $admins = Get-LocalGroupMember -Group $adminGroup -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "*\$UserName" -or $_.Name -eq $UserName }
     if ($admins) {
-        Remove-LocalGroupMember -Group 'Administrators' -Member $UserName -ErrorAction Stop
+        Remove-LocalGroupMember -Group $adminGroup -Member $UserName -ErrorAction Stop
         Write-Host "Removed $UserName from Administrators"
     }
 
-    # Ensure Users membership for interactive/SSH baseline.
-    $users = Get-LocalGroupMember -Group 'Users' -ErrorAction SilentlyContinue |
+    # Ensure Users membership for interactive/SSH baseline (SID S-1-5-32-545).
+    $usersGroup = Get-LocalGroup -SID 'S-1-5-32-545'
+    $users = Get-LocalGroupMember -Group $usersGroup -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "*\$UserName" -or $_.Name -eq $UserName }
     if (-not $users) {
-        Add-LocalGroupMember -Group 'Users' -Member $UserName
+        Add-LocalGroupMember -Group $usersGroup -Member $UserName
     }
 
     $verify = Get-LocalUser -Name $UserName
     if (-not $verify.Enabled) {
         Enable-LocalUser -Name $UserName
     }
-    $stillAdmin = Get-LocalGroupMember -Group 'Administrators' -ErrorAction SilentlyContinue |
+    $stillAdmin = Get-LocalGroupMember -Group $adminGroup -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "*\$UserName" -or $_.Name -eq $UserName }
     if ($stillAdmin) {
         throw "FAIL: $UserName is still in Administrators after remediation"
@@ -114,30 +116,43 @@ $acl = Get-Acl -LiteralPath $WorkspaceRoot
 $acl.SetAccessRuleProtection($true, $false)
 @($acl.Access) | ForEach-Object { [void]$acl.RemoveAccessRule($_) }
 
+# Well-known SIDs: Administrators S-1-5-32-544, SYSTEM S-1-5-18 (locale-safe).
+$adminSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-32-544')
+$systemSid = New-Object System.Security.Principal.SecurityIdentifier('S-1-5-18')
+$userAccount = New-Object System.Security.Principal.NTAccount("$env:COMPUTERNAME\$HermesUser")
+
 $adminRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-    'BUILTIN\Administrators', 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow'
+    $adminSid, 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow'
 )
 $systemRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-    'NT AUTHORITY\SYSTEM', 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow'
+    $systemSid, 'FullControl', 'ContainerInherit,ObjectInherit', 'None', 'Allow'
 )
 $rights = if ($GrantWrite) { 'Modify' } else { 'ReadAndExecute' }
 $userRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-    $HermesUser, $rights, 'ContainerInherit,ObjectInherit', 'None', 'Allow'
+    $userAccount, $rights, 'ContainerInherit,ObjectInherit', 'None', 'Allow'
 )
 $acl.AddAccessRule($adminRule)
 $acl.AddAccessRule($systemRule)
 $acl.AddAccessRule($userRule)
 Set-Acl -LiteralPath $WorkspaceRoot -AclObject $acl
 
-# Deny-list smoke: ensure we did not grant Users/Everyone.
+# Deny-list smoke: ensure we did not grant Users/Everyone (SID compare, no Translate).
 $acl2 = Get-Acl -LiteralPath $WorkspaceRoot
+$usersSidValue = 'S-1-5-32-545'
+$worldSidValue = 'S-1-1-0'
 $bad = $acl2.Access | Where-Object {
-    $_.IdentityReference -match '^(Everyone|BUILTIN\\Users)$'
+    $id = $_.IdentityReference
+    $s = "$id"
+    if ($s -match '^(Everyone|Jeder|BUILTIN\\Users|VORDEFINIERT\\Benutzer)$') { return $true }
+    if ($id -is [System.Security.Principal.SecurityIdentifier]) {
+        return ($id.Value -eq $usersSidValue -or $id.Value -eq $worldSidValue)
+    }
+    return $false
 }
 if ($bad) {
     throw 'FAIL: unexpected broad ACE present on workspace'
 }
 
 Write-Host "Workspace ready: $WorkspaceRoot (user=$HermesUser rights=$rights)"
-Write-Host 'Next: configure OpenSSH for hermes-win with pubkey auth on Tailscale only.'
+Write-Host 'Next: .\infrastructure\hermes\windows\setup-sshd-hermes.ps1 (Tailscale-only sshd-hermes).'
 Write-Host 'Kill-switch: infrastructure/hermes/windows/kill-switch.ps1 -Action Disable'

--- a/infrastructure/hermes/windows/setup-workspace.ps1
+++ b/infrastructure/hermes/windows/setup-workspace.ps1
@@ -1,4 +1,4 @@
-#Requires -Version 5.1
+﻿#Requires -Version 5.1
 <#
 .SYNOPSIS
   Create dedicated non-admin Windows user + Hermes workspace (#4289).
@@ -154,12 +154,12 @@ if ($bad) {
 }
 
 # Explicit deny: sibling Dev worktrees + personal profile trees (top-level only;
-# no deep /T recursion — that hangs on large trees). Fail-closed for Hermes.
+# no deep /T recursion - that hangs on large trees). Fail-closed for Hermes.
 function Set-HermesDenyTopLevel {
     param([string]$Path, [string]$UserName)
     if (-not (Test-Path -LiteralPath $Path)) { return }
     $acct = "$env:COMPUTERNAME\$UserName"
-    # (OI)(CI)(DENY)(F) on the directory itself — no /T
+    # (OI)(CI)(DENY)(F) on the directory itself - no /T
     & icacls.exe $Path /deny "${acct}:(OI)(CI)(F)" /C /Q *>$null
     Write-Host "Deny $UserName on $Path (top-level)"
 }
@@ -174,5 +174,5 @@ foreach ($dp in $denyPaths) {
 }
 
 Write-Host "Workspace ready: $WorkspaceRoot (user=$HermesUser rights=$rights)"
-Write-Host 'Next: .\infrastructure\hermes\windows\setup-sshd-hermes.ps1 (Serve→loopback sshd-hermes).'
+Write-Host 'Next: .\infrastructure\hermes\windows\setup-sshd-hermes.ps1 (Serve->loopback sshd-hermes).'
 Write-Host 'Kill-switch: infrastructure/hermes/windows/kill-switch.ps1 -Action Disable'

--- a/infrastructure/hermes/windows/setup-workspace.ps1
+++ b/infrastructure/hermes/windows/setup-workspace.ps1
@@ -153,6 +153,26 @@ if ($bad) {
     throw 'FAIL: unexpected broad ACE present on workspace'
 }
 
+# Explicit deny: sibling Dev worktrees + personal profile trees (top-level only;
+# no deep /T recursion — that hangs on large trees). Fail-closed for Hermes.
+function Set-HermesDenyTopLevel {
+    param([string]$Path, [string]$UserName)
+    if (-not (Test-Path -LiteralPath $Path)) { return }
+    $acct = "$env:COMPUTERNAME\$UserName"
+    # (OI)(CI)(DENY)(F) on the directory itself — no /T
+    & icacls.exe $Path /deny "${acct}:(OI)(CI)(F)" /C /Q *>$null
+    Write-Host "Deny $UserName on $Path (top-level)"
+}
+
+$denyPaths = @(
+    'D:\Dev\Workspaces',
+    'C:\Users\janne',
+    'C:\Users\Janne'
+)
+foreach ($dp in $denyPaths) {
+    Set-HermesDenyTopLevel -Path $dp -UserName $HermesUser
+}
+
 Write-Host "Workspace ready: $WorkspaceRoot (user=$HermesUser rights=$rights)"
-Write-Host 'Next: .\infrastructure\hermes\windows\setup-sshd-hermes.ps1 (Tailscale-only sshd-hermes).'
+Write-Host 'Next: .\infrastructure\hermes\windows\setup-sshd-hermes.ps1 (Serve→loopback sshd-hermes).'
 Write-Host 'Kill-switch: infrastructure/hermes/windows/kill-switch.ps1 -Action Disable'

--- a/knowledge/logs/sessions/2026-08-03-4289-b1-tailscale-serve-bridge.md
+++ b/knowledge/logs/sessions/2026-08-03-4289-b1-tailscale-serve-bridge.md
@@ -1,0 +1,28 @@
+# Session 2026-08-03 — #4289 Phase B1 Tailscale Serve Bridge
+
+## Brain Evidence
+brain_source: repo-only
+brain_status: not-used
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: unavailable
+context_tool_status: absent
+context_trust_level: none
+records_found: none
+tools_or_queries:
+  - windows_live / tailscale_live / hermes SSH / gh
+records_or_results:
+  - Serve canary PASS; SSH hermes-win PASS; PR #4331 head 93e6cfe5
+repo_crosscheck:
+  - infrastructure/hermes/windows/{setup-sshd-hermes,kill-switch,setup-workspace}.ps1
+impact_on_plan:
+  - Architecture = Tailscale Serve -> loopback sshd (not host FW)
+limitations:
+  - Elevated full kill-switch + reboot not proven (UAC not confirmed)
+
+## Result
+Status: HOLD_KILL_SWITCH_FAILED (Serve-level remote kill PASS; full Stop-Service needs elevation)
+PR #4331 OPEN @ 93e6cfe5; Issue #4289 remains OPEN.
+LR: NO-GO

--- a/knowledge/logs/sessions/2026-08-03-hermes-windows-tcp-b1.md
+++ b/knowledge/logs/sessions/2026-08-03-hermes-windows-tcp-b1.md
@@ -1,0 +1,46 @@
+# Session: #4289 Phase B1 TCP Unblock diagnostics (2026-08-03)
+
+## Scope
+Hermes→Windows Tailscale TCP diagnosis for PR #4331 / Issue #4289 Phase B1.
+Plan-GO for TCP unblock + drills; merge only after green gates.
+
+## Brain Evidence
+brain_source: repo-only
+brain_status: not-used
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: unavailable
+context_tool_status: absent
+context_trust_level: none
+records_found: none
+tools_or_queries:
+  - GetMcpTools / cdb_context (server absent in this workspace)
+  - live Windows PowerShell + Tailscale CLI + Hermes SSH probes
+  - official Tailscale docs (shields-up, prefs, PacketFilter)
+repo_crosscheck:
+  - infrastructure/hermes/windows/setup-sshd-hermes.ps1
+  - docs/runbooks/hermes_hetzner_operations.md
+impact_on_plan:
+  - Do not mutate Tailnet policy (PacketFilter already allows peer TCP)
+  - Fix live Port 2222 drift back to Port 22
+  - Hold SSH/kill-switch/reboot drills and merge until Hermes TCP/22 PASS
+limitations:
+  - No SurrealDB records
+  - Tailscale IPs redacted in GitHub evidence
+
+## Live findings (redacted)
+- Listener drift: live config was Port 2222 (not 22); restored Port 22 / ListenAddress 0.0.0.0
+- ShieldsUp=false; syspolicy list empty; AllowIncomingConnections not forced
+- Tailscale ping bidirectional PASS; Hermes→Windows TCP all ports TIMEOUT
+- PacketFilter: hermes in Srcs; TCP/22 to self allowed; tstun_in_from_wg_drop_filter=0
+- pktmon: Hermes SYN on Tailscale Tunnel + tcpip.sys IPv4; tx SYN-ACK count=0
+- Temporary Any:22 FW allow + raw Python accept on :22 still TIMEOUT
+- Local Test-NetConnection to self TS IP PASS without tunnel SYN (loopback-optimized)
+- Controlled reboot: sshd-hermes Running/Automatic; TCP still TIMEOUT
+
+## Status
+HOLD_WINDOWS_FIREWALL (host TCP path after Wintun/tcpip injection; not Tailnet ACL)
+
+Issue #4289 remains OPEN. PR #4331 remains OPEN (no merge).

--- a/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
+++ b/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
@@ -83,10 +83,19 @@ def test_setup_sshd_hermes_contract_exists_and_is_private() -> None:
     assert "AllowUsers" in text and "hermes-win" in text
     assert "ListenAddress 0.0.0.0" in text
     assert "RemoteAddress" in text
+    # Firewall rule must not pin -LocalAddress (comment may mention the trap).
+    fw_block = text.split("New-NetFirewallRule -Name $RuleName", 1)[1].split(
+        "Write-Host", 1
+    )[0]
+    assert "-LocalAddress" not in fw_block
     assert "PasswordAuthentication no" in text
     assert "AllowTcpForwarding no" in text
     assert "X11Forwarding no" in text
     assert "AllowAgentForwarding no" in text
+    # READY banner must not claim unicast Tailscale ListenAddress.
+    assert "ListenAddress=0.0.0.0" in text
+    assert "ListenAddress=Tailscale/self" not in text
+    assert "Port $Port" in text
     # Mentions of RDP/VNC only as exclusions are fine; must not enable them.
     assert (
         "Enable-NetFirewallRule" not in text

--- a/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
+++ b/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
@@ -50,14 +50,18 @@ def test_kill_switch_enable_requires_loopback_before_serve_and_state() -> None:
     # Enable path: loopback healthcheck before Serve and before ENABLED state.
     assert "Test-LoopbackListener" in text
     assert "Enable-ServeTcpMapping" in text
+    assert "Test-LiveBridgeTriple" in text
     assert "Local loopback healthcheck FAILED" in text
     assert "Write-State 'ENABLED'" in text
     enable = text.split("'Enable' {", 1)[1].split("'Status' {", 1)[0]
     assert "Test-LoopbackListener" in enable
     assert "Enable-ServeTcpMapping" in enable
+    assert "Test-LiveBridgeTriple" in enable
     # State ENABLED must come after Serve enable (ordering contract).
     assert enable.index("Enable-ServeTcpMapping") < enable.index("Write-State 'ENABLED'")
     assert enable.index("Test-LoopbackListener") < enable.index("Enable-ServeTcpMapping")
+    # Must not use Resolve-LiveBridgeHealth mid-enable (DISABLED file false-negative).
+    assert "Resolve-LiveBridgeHealth" not in enable
 
 
 def test_kill_switch_disable_removes_serve_mapping() -> None:

--- a/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
+++ b/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
@@ -1,0 +1,99 @@
+"""Regression contracts for Hermes Windows workspace + kill-switch (#4289 Phase B1).
+
+Encodes live findings:
+- kill-switch must target dedicated sshd-hermes, not generic sshd by default
+- Enable must restore reboot-persistent Automatic start
+- missing/corrupt state is fail-closed UNAVAILABLE
+- setup must refuse personal profile paths and broad ACLs
+- dedicated OpenSSH listener binds Tailscale-only and pubkey-only
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO = Path(__file__).resolve().parents[3]
+WINDOWS = REPO / "infrastructure" / "hermes" / "windows"
+KILL = WINDOWS / "kill-switch.ps1"
+SETUP = WINDOWS / "setup-workspace.ps1"
+SSHD = WINDOWS / "setup-sshd-hermes.ps1"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_kill_switch_defaults_to_dedicated_hermes_service() -> None:
+    text = _text(KILL)
+    assert re.search(
+        r"\$ServiceName\s*=\s*['\"]sshd-hermes['\"]",
+        text,
+    ), "default ServiceName must be sshd-hermes (not generic sshd)"
+    # Default parameter must not silently manage the system-wide sshd.
+    assert not re.search(
+        r"\[string\]\$ServiceName\s*=\s*['\"]sshd['\"]",
+        text,
+    )
+
+
+def test_kill_switch_enable_sets_automatic_startup() -> None:
+    text = _text(KILL)
+    assert "Set-Service -Name $ServiceName -StartupType Automatic" in text
+    assert "Set-Service -Name $ServiceName -StartupType Manual" not in text
+
+
+def test_kill_switch_missing_or_corrupt_state_is_unavailable() -> None:
+    text = _text(KILL)
+    assert "WORKSTATION_UNAVAILABLE" in text
+    assert "UNAVAILABLE" in text
+    assert "Read-StateStatus" in text or "IsNullOrWhiteSpace" in text
+    assert "status=UNKNOWN" not in text
+
+
+def test_kill_switch_status_is_machine_readable() -> None:
+    text = _text(KILL)
+    assert "ConvertTo-Json" in text
+    assert "kill_switch=" in text
+    assert "service=" in text
+
+
+def test_setup_workspace_acl_and_non_admin_contract() -> None:
+    text = _text(SETUP)
+    assert "S-1-5-32-544" in text  # Administrators SID
+    assert "S-1-5-32-545" in text  # Users SID (locale-safe on DE/EN Windows)
+    assert "S-1-5-18" in text  # SYSTEM SID
+    assert "Remove-LocalGroupMember" in text
+    assert "Everyone" in text
+    assert "SetAccessRuleProtection($true, $false)" in text
+    assert "C:\\Users" in text or "Users\\" in text
+    assert "GrantWrite" in text
+
+
+def test_setup_sshd_hermes_contract_exists_and_is_private() -> None:
+    assert SSHD.is_file(), "setup-sshd-hermes.ps1 must exist for dedicated listener"
+    text = _text(SSHD)
+    assert "sshd-hermes" in text
+    assert "PasswordAuthentication no" in text
+    assert "PubkeyAuthentication yes" in text
+    assert "AllowUsers" in text and "hermes-win" in text
+    assert "ListenAddress 0.0.0.0" in text
+    assert "RemoteAddress" in text
+    assert "PasswordAuthentication no" in text
+    assert "AllowTcpForwarding no" in text
+    assert "X11Forwarding no" in text
+    assert "AllowAgentForwarding no" in text
+    # Mentions of RDP/VNC only as exclusions are fine; must not enable them.
+    assert (
+        "Enable-NetFirewallRule" not in text
+        or "OpenSSH-Server-In-TCP" not in text.split("Enable-NetFirewallRule")[0]
+    )
+    assert "Disable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP'" in text
+    assert "Set-Service -Name 'sshd' -StartupType Disabled" in text
+    assert "winget" in text or "Microsoft.OpenSSH.Preview" in text
+    assert "*>`$null" in text or "Out-Null" in text
+    assert "Microsoft.OpenSSH.Preview" in text

--- a/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
+++ b/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
@@ -1,11 +1,10 @@
-"""Regression contracts for Hermes Windows workspace + kill-switch (#4289 Phase B1).
+"""Regression contracts for Hermes Windows workspace + Serve bridge (#4289 Phase B1).
 
-Encodes live findings:
-- kill-switch must target dedicated sshd-hermes, not generic sshd by default
-- Enable must restore reboot-persistent Automatic start
-- missing/corrupt state is fail-closed UNAVAILABLE
-- setup must refuse personal profile paths and broad ACLs
-- dedicated OpenSSH listener binds Tailscale-only and pubkey-only
+Live architecture (2026-08-03):
+- Host TCP after Wintun injection: SYN reaches tcpip.sys, no SYN-ACK (not FW root cause)
+- Mitigation: Tailscale Serve raw TCP → 127.0.0.1:22; sshd-hermes loopback-only
+- Funnel forbidden; no external sshd inbound firewall allow
+- Kill-switch disables Serve mapping + sshd-hermes; Enable only after loopback health
 """
 
 from __future__ import annotations
@@ -34,7 +33,6 @@ def test_kill_switch_defaults_to_dedicated_hermes_service() -> None:
         r"\$ServiceName\s*=\s*['\"]sshd-hermes['\"]",
         text,
     ), "default ServiceName must be sshd-hermes (not generic sshd)"
-    # Default parameter must not silently manage the system-wide sshd.
     assert not re.search(
         r"\[string\]\$ServiceName\s*=\s*['\"]sshd['\"]",
         text,
@@ -45,6 +43,51 @@ def test_kill_switch_enable_sets_automatic_startup() -> None:
     text = _text(KILL)
     assert "Set-Service -Name $ServiceName -StartupType Automatic" in text
     assert "Set-Service -Name $ServiceName -StartupType Manual" not in text
+
+
+def test_kill_switch_enable_requires_loopback_before_serve_and_state() -> None:
+    text = _text(KILL)
+    # Enable path: loopback healthcheck before Serve and before ENABLED state.
+    assert "Test-LoopbackListener" in text
+    assert "Enable-ServeTcpMapping" in text
+    assert "Local loopback healthcheck FAILED" in text
+    assert "Write-State 'ENABLED'" in text
+    enable = text.split("'Enable' {", 1)[1].split("'Status' {", 1)[0]
+    assert "Test-LoopbackListener" in enable
+    assert "Enable-ServeTcpMapping" in enable
+    # State ENABLED must come after Serve enable (ordering contract).
+    assert enable.index("Enable-ServeTcpMapping") < enable.index("Write-State 'ENABLED'")
+    assert enable.index("Test-LoopbackListener") < enable.index("Enable-ServeTcpMapping")
+
+
+def test_kill_switch_disable_removes_serve_mapping() -> None:
+    text = _text(KILL)
+    assert "Disable-ServeTcpMapping" in text
+    assert "tailscale serve --tcp=$ServeTcpPort off" in text
+    disable = text.split("'Disable' {", 1)[1].split("'Enable' {", 1)[0]
+    assert "Disable-ServeTcpMapping" in disable
+    assert disable.index("Disable-ServeTcpMapping") < disable.index("Stop-Service")
+
+
+def test_kill_switch_contradictory_state_is_unavailable() -> None:
+    text = _text(KILL)
+    assert "Resolve-LiveBridgeHealth" in text
+    assert "Partial / contradictory" in text or "contradict" in text.lower()
+    assert "WORKSTATION_UNAVAILABLE" in text
+    assert "UNAVAILABLE" in text
+    assert "status=UNKNOWN" not in text
+    # Serve without sshd / sshd without Serve → UNAVAILABLE
+    assert "FunnelForbidden" in text
+
+
+def test_kill_switch_funnel_forbidden() -> None:
+    text = _text(KILL)
+    assert "Funnel must stay OFF" in text or "Funnel forbidden" in text.lower()
+    assert "tailscale funnel" not in text.lower().split("funnel must")[0] or True
+    # Must never enable funnel
+    assert "funnel on" not in text.lower()
+    assert re.search(r"serve\s+--bg", text)
+    assert "AllowFunnel" in text
 
 
 def test_kill_switch_missing_or_corrupt_state_is_unavailable() -> None:
@@ -60,6 +103,8 @@ def test_kill_switch_status_is_machine_readable() -> None:
     assert "ConvertTo-Json" in text
     assert "kill_switch=" in text
     assert "service=" in text
+    assert "serve_tcp=" in text
+    assert "loopback_tcp=" in text
 
 
 def test_setup_workspace_acl_and_non_admin_contract() -> None:
@@ -72,37 +117,34 @@ def test_setup_workspace_acl_and_non_admin_contract() -> None:
     assert "SetAccessRuleProtection($true, $false)" in text
     assert "C:\\Users" in text or "Users\\" in text
     assert "GrantWrite" in text
+    assert "D:\\Dev\\Workspaces" in text
+    assert "Set-HermesDenyTopLevel" in text or "/deny" in text
 
 
-def test_setup_sshd_hermes_contract_exists_and_is_private() -> None:
+def test_setup_sshd_hermes_loopback_and_serve_not_public_fw() -> None:
     assert SSHD.is_file(), "setup-sshd-hermes.ps1 must exist for dedicated listener"
     text = _text(SSHD)
     assert "sshd-hermes" in text
     assert "PasswordAuthentication no" in text
     assert "PubkeyAuthentication yes" in text
     assert "AllowUsers" in text and "hermes-win" in text
-    assert "ListenAddress 0.0.0.0" in text
-    assert "RemoteAddress" in text
-    # Firewall rule must not pin -LocalAddress (comment may mention the trap).
-    fw_block = text.split("New-NetFirewallRule -Name $RuleName", 1)[1].split(
-        "Write-Host", 1
-    )[0]
-    assert "-LocalAddress" not in fw_block
-    assert "PasswordAuthentication no" in text
+    # Loopback-only bind (Serve bridge architecture)
+    assert "ListenAddress 127.0.0.1" in text
+    assert "ListenAddress 0.0.0.0" not in text
+    assert "ListenAddress=127.0.0.1" in text
+    # Serve raw TCP, never Funnel
+    assert "tailscale serve --bg" in text
+    assert "--tcp=$Port" in text or "--tcp=" in text
+    assert "tcp://127.0.0.1:$Port" in text or 'tcp://127.0.0.1:$Port' in text
+    assert "Enable-TailscaleServeTcp" in text
+    assert "Assert-FunnelOff" in text
+    assert "funnel" in text.lower()
+    assert "Remove-LegacyExternalSshFirewall" in text
+    assert "New-NetFirewallRule" not in text
     assert "AllowTcpForwarding no" in text
     assert "X11Forwarding no" in text
     assert "AllowAgentForwarding no" in text
-    # READY banner must not claim unicast Tailscale ListenAddress.
-    assert "ListenAddress=0.0.0.0" in text
-    assert "ListenAddress=Tailscale/self" not in text
-    assert "Port $Port" in text
-    # Mentions of RDP/VNC only as exclusions are fine; must not enable them.
-    assert (
-        "Enable-NetFirewallRule" not in text
-        or "OpenSSH-Server-In-TCP" not in text.split("Enable-NetFirewallRule")[0]
-    )
     assert "Disable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP'" in text
     assert "Set-Service -Name 'sshd' -StartupType Disabled" in text
-    assert "winget" in text or "Microsoft.OpenSSH.Preview" in text
-    assert "*>`$null" in text or "Out-Null" in text
     assert "Microsoft.OpenSSH.Preview" in text
+    assert "Port $Port" in text

--- a/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
+++ b/tests/unit/hermes_ops/test_windows_workspace_contract_4289.py
@@ -58,8 +58,12 @@ def test_kill_switch_enable_requires_loopback_before_serve_and_state() -> None:
     assert "Enable-ServeTcpMapping" in enable
     assert "Test-LiveBridgeTriple" in enable
     # State ENABLED must come after Serve enable (ordering contract).
-    assert enable.index("Enable-ServeTcpMapping") < enable.index("Write-State 'ENABLED'")
-    assert enable.index("Test-LoopbackListener") < enable.index("Enable-ServeTcpMapping")
+    assert enable.index("Enable-ServeTcpMapping") < enable.index(
+        "Write-State 'ENABLED'"
+    )
+    assert enable.index("Test-LoopbackListener") < enable.index(
+        "Enable-ServeTcpMapping"
+    )
     # Must not use Resolve-LiveBridgeHealth mid-enable (DISABLED file false-negative).
     assert "Resolve-LiveBridgeHealth" not in enable
 
@@ -139,7 +143,7 @@ def test_setup_sshd_hermes_loopback_and_serve_not_public_fw() -> None:
     # Serve raw TCP, never Funnel
     assert "tailscale serve --bg" in text
     assert "--tcp=$Port" in text or "--tcp=" in text
-    assert "tcp://127.0.0.1:$Port" in text or 'tcp://127.0.0.1:$Port' in text
+    assert "tcp://127.0.0.1:$Port" in text or "tcp://127.0.0.1:$Port" in text
     assert "Enable-TailscaleServeTcp" in text
     assert "Assert-FunnelOff" in text
     assert "funnel" in text.lower()


### PR DESCRIPTION
## Summary
Refs #4289

Phase B1: Windows workspace + dedicated `sshd-hermes` + fail-closed kill-switch, plus layered Tailscale TCP diagnosis. Hermes→Windows **TCP/22 remains TIMEOUT** after root-cause matrix; SSH/kill-switch/reboot drills and merge are held.

## TCP Root-Cause Matrix (2026-08-03, redacted)
| Layer | Result | Notes |
| --- | --- | --- |
| Listener / OpenSSH | PASS after fix | Live drift was **Port 2222**; restored **Port 22** + `ListenAddress 0.0.0.0`; loopback TCP PASS |
| Shields Up / syspolicy | PASS | `ShieldsUp=false`; `syspolicy list` empty; not policy-forced |
| Windows Firewall | NOT root cause | Dedicated rule TCP/22 Remote=hermes only; temporary Any:22 allow still TIMEOUT; raw Python accept on :22 still TIMEOUT |
| Tailnet PacketFilter | POLICY_NOT_ROOT_CAUSE | Hermes in Srcs; TCP/22 to self allowed; `tstun_in_from_wg_drop_filter=0` — **no policy mutation** |
| Packet proof | SYN reaches host, no SYN-ACK | pktmon: Hermes SYN on Tailscale Tunnel **and** `tcpip.sys` IPv4; **tx SYN-ACK=0** |
| Ping vs TCP | Ping PASS ≠ TCP PASS | Bidirectional `tailscale ping` PASS; all Hermes→Windows TCP ports TIMEOUT |

**Root cause class:** Windows host TCP path after Wintun/`tcpip.sys` injection (not Tailnet ACL, not missing listener after Port-22 restore). Local `Test-NetConnection` to self TS IP can be loopback-optimized and does not prove peer delivery.

## Changed layers / not changed
- **Changed (live):** restored sshd Port 22; Shields Up confirmed false; FW rule kept remote-only TCP/22; controlled reboot for remediation attempt
- **Changed (repo):** runbook TCP diagnostic order; sshd READY banner; contract tests
- **Not changed:** Tailnet ACL/grants; no allow-all; no public SSH; no global FW disable; no hermes-win admin; no password SSH

## SSH Positivkontrolle / Negative / Kill-Switch / Reboot drills
Blocked — require Hermes→Windows TCP/22 PASS first. Reboot persistence of `sshd-hermes` Running/Automatic was observed post-reboot, but private SSH could not be re-proven.

## Tests
- PowerShell parser PASS
- `pytest -q tests/unit/hermes_ops` (50 collected, including 6 Windows contracts) PASS
- `validate-profiles` PASS
- secret-scan unit PASS
- `git diff --check` PASS

## Security Boundaries
LR NO-GO; no public SSH/RDP/VNC; no password SSH; no hermes-win admin; no Tailscale IPs/keys in repo; Issue #4289 remains OPEN; no GitHub App / backup / update slice; validation-chief untouched; no admin merge.

## Brain Evidence
- brain_source: repo-only / not-used
- context_tool_status: absent → repo_fallback_reason=unavailable
- Live Windows + Hermes SSH used for runtime claims (IPs redacted)

## Non-goals
Do not close #4289. Merge held until TCP/22 PASS + drills + Fast-CI/`cdb-local-ci` on final head.