### PR TITLE
feat(hermes): add scoped GitHub App token broker (#4289)

### DIFF
--- a/config/hermes/profiles/cdb-engineer/AGENTS.md
+++ b/config/hermes/profiles/cdb-engineer/AGENTS.md
@@ -20,5 +20,7 @@ Claire de Binare engineering profile for Hermes on Hetzner (#4289).
 - Auth lineage: #4170 / #4195 — reuse App credentials; do not create a second authenticator.
 
 ## Secrets
-- PEM/App credentials live outside agent-readable workspaces.
+- PEM/App credentials live outside agent-readable workspaces (`/etc/hermes/secrets/`, root `0600`).
 - Use `python -m tools.hermes_ops mint-token` — never embed tokens in prompts/memory.
+- OS identity: this profile runs as Linux user `hermes-cdb-engineer` (not shared `hermes`).
+- Tokens only under `/run/hermes/cdb-engineer/` (`0700`/`0600`); never under profile homes.

--- a/config/hermes/profiles/cdb-engineer/config.yaml
+++ b/config/hermes/profiles/cdb-engineer/config.yaml
@@ -44,7 +44,12 @@ ssh_targets:
 
 github:
   auth_mode: app_installation_token
-  token_broker: python -m tools.hermes_ops mint-token --profile cdb-engineer --token-file /run/hermes/cdb-engineer.token
+  token_broker: python -m tools.hermes_ops mint-token --profile cdb-engineer --token-file /run/hermes/cdb-engineer/token
+  linux_user: hermes-cdb-engineer
+  credential_env:
+    - HERMES_GH_APP_ID
+    - HERMES_GH_APP_INSTALLATION_ID
+    - HERMES_GH_APP_PRIVATE_KEY_PATH
   allowed_repositories:
     - jannekbuengener/Claire_de_Binare  # pragma: allowlist secret
   forbidden_actions:

--- a/docs/evidence/hermes/hermes_b2_os_isolation_gate_4289.md
+++ b/docs/evidence/hermes/hermes_b2_os_isolation_gate_4289.md
@@ -1,0 +1,52 @@
+# Hermes B2.0 OS isolation evidence (#4289)
+
+Status date: 2026-08-03  
+LR: NO-GO
+
+## Repo slice
+
+- Branch: `batch/hermes-github-app-4289`
+- Base: `origin/main` @ `f2805f47`
+- Delivered: per-profile Linux UIDs (`hermes-jannek-assistant` /
+  `hermes-cdb-engineer`), systemd `User=hermes-%i`, migrate script, broker
+  oneshot contract, `HERMES_GH_APP_*` credential separation, unit tests.
+
+## Unit validation
+
+- `pytest -q tests/unit/hermes_ops` → **64 passed**
+- `ruff check tools/hermes_ops tests/unit/hermes_ops` → PASS
+- `python -m tools.hermes_ops validate-profiles` → ok
+- `mint-token --dry-run` → metadata only; `linux_user=hermes-cdb-engineer`
+- `secret-scan` → ok
+
+## Live host (`cdb-hermes-01`)
+
+| Check | Result |
+|---|---|
+| Dashboards active | PASS |
+| Current systemd User | **FAIL / gap** — `User=hermes` for both profiles (pre-migration) |
+| Bundle staged under hermes home | PASS (`~/cdb-hermes-bundle-b2`) |
+| hermes passwordless root for migrate | **FAIL** — sudo NOPASSWD only for `systemctl` dashboard ops |
+| Public TCP/22 from operator network | **FAIL** — timeout despite temporary FW allow `/32` |
+| Rescue path | enable-rescue succeeded once; **disabled** without reboot to avoid stranding (public SSH unreachable) |
+| Live UID migration | **NOT RUN** |
+| Live App create / PEM / token mint | **BLOCKED** by App-creation gate |
+
+## Gate decision
+
+`HOLD_RUNTIME_MIGRATION` / `HOLD_PROFILE_OS_ISOLATION`
+
+App creation, PEM transfer, and live token mint remain forbidden until:
+
+1. Root-capable host session applies `migrate-profile-uids.sh` from the staged
+   bundle (or equivalent chroot).
+2. Cross-profile negative tests + reboot persistence PASS on the live host.
+3. Broker RuntimeDirectory ownership probe PASS.
+
+## Non-goals this slice
+
+- No GitHub App created
+- No PEM transferred
+- No live installation token
+- Issue #4289 remains OPEN
+- App `4410232` untouched

--- a/docs/evidence/hermes/hermes_b2_os_isolation_gate_4289.md
+++ b/docs/evidence/hermes/hermes_b2_os_isolation_gate_4289.md
@@ -1,52 +1,72 @@
 # Hermes B2.0 OS isolation evidence (#4289)
 
 Status date: 2026-08-03  
-LR: NO-GO
+LR: NO-GO  
+Gate: `DONE_B2_0_OS_ISOLATION_PASS`
 
 ## Repo slice
 
 - Branch: `batch/hermes-github-app-4289`
-- Base: `origin/main` @ `f2805f47`
+- PR: `#4332`
 - Delivered: per-profile Linux UIDs (`hermes-jannek-assistant` /
-  `hermes-cdb-engineer`), systemd `User=hermes-%i`, migrate script, broker
-  oneshot contract, `HERMES_GH_APP_*` credential separation, unit tests.
+  `hermes-cdb-engineer`), systemd `User=hermes-%i`, migrate script (incl.
+  parent/opt traverse hardening), broker oneshot contract,
+  `HERMES_GH_APP_*` credential separation, unit tests.
 
 ## Unit validation
 
-- `pytest -q tests/unit/hermes_ops` → **64 passed**
+- `pytest -q tests/unit/hermes_ops` → **64 passed** (pre-host-pass baseline)
 - `ruff check tools/hermes_ops tests/unit/hermes_ops` → PASS
 - `python -m tools.hermes_ops validate-profiles` → ok
 - `mint-token --dry-run` → metadata only; `linux_user=hermes-cdb-engineer`
 - `secret-scan` → ok
 
-## Live host (`cdb-hermes-01`)
+## Live host (`cdb-hermes-01`) — redacted
 
 | Check | Result |
 |---|---|
-| Dashboards active | PASS |
-| Current systemd User | **FAIL / gap** — `User=hermes` for both profiles (pre-migration) |
-| Bundle staged under hermes home | PASS (`~/cdb-hermes-bundle-b2`) |
-| hermes passwordless root for migrate | **FAIL** — sudo NOPASSWD only for `systemctl` dashboard ops |
-| Public TCP/22 from operator network | **FAIL** — timeout despite temporary FW allow `/32` |
-| Rescue path | enable-rescue succeeded once; **disabled** without reboot to avoid stranding (public SSH unreachable) |
-| Live UID migration | **NOT RUN** |
-| Live App create / PEM / token mint | **BLOCKED** by App-creation gate |
+| Exactly one Hermes server | PASS |
+| Backups enabled | PASS |
+| Rescue path used once (linux64 + verified SSH key) | PASS |
+| Host root mounted by UUID (not guessed device) | PASS |
+| Hostname / Ubuntu 24.04 | PASS |
+| Migrate artifact SHA256 (pre-hardening run) | `8549832719147bd2dc36d0074081358744a4c9e6e2a85c3181988a46ef35aeeb` |
+| Rollback pack on host FS (root:root 0700) | PASS |
+| Offline identity + unit + ownership apply | PASS |
+| Canonical migrate re-run online (idempotent) | PASS (`OS_PROFILE_ISOLATION=PASS`) |
+| Dashboard units active + enabled | PASS |
+| Process UID jannek-assistant | `hermes-jannek-assistant` (distinct numeric UID) |
+| Process UID cdb-engineer | `hermes-cdb-engineer` (distinct numeric UID) |
+| Cross-profile home / token-probe / env deny | PASS |
+| Profile sudo general denied | PASS |
+| validation-chief `.DISABLED` root-owned | PASS |
+| Ports loopback-only (`127.0.0.1`) | PASS |
+| Memory + sessions present after controlled reboot | PASS |
+| Temp FW `/32` removed; inbound rules = 0 | PASS |
+| Rescue OFF after cutover | PASS |
+| Temp root sudoers removed | PASS |
+| PEM / live token dirs | still absent (gate before App) |
+
+## Runtime fixes applied during cutover
+
+- Parent traverse `0751` on `/var/lib/hermes`, `/etc/hermes`, `/var/log/hermes`
+  (profiles remain `0700`).
+- `/opt/hermes` execute bits for dedicated UIDs (binary tree only).
+- `/home/hermes` traverse + uv read path for `ProtectHome=read-only`.
+- These are now encoded in `migrate-profile-uids.sh` for future hosts.
 
 ## Gate decision
 
-`HOLD_RUNTIME_MIGRATION` / `HOLD_PROFILE_OS_ISOLATION`
+`DONE_B2_0_OS_ISOLATION_PASS`
 
-App creation, PEM transfer, and live token mint remain forbidden until:
+App creation, PEM transfer, and live token mint are now unblocked for the
+already-approved B2 plan. Issue `#4289` remains OPEN. App `4410232` remains
+untouched. No secrets, IPs, or key material recorded in this evidence file.
 
-1. Root-capable host session applies `migrate-profile-uids.sh` from the staged
-   bundle (or equivalent chroot).
-2. Cross-profile negative tests + reboot persistence PASS on the live host.
-3. Broker RuntimeDirectory ownership probe PASS.
+## Non-goals still held until later B2 steps
 
-## Non-goals this slice
-
-- No GitHub App created
-- No PEM transferred
-- No live installation token
-- Issue #4289 remains OPEN
+- No GitHub App created in the B2.0 hop itself
+- No PEM transferred in the B2.0 hop itself
+- No live installation token in the B2.0 hop itself
+- Issue `#4289` remains OPEN
 - App `4410232` untouched

--- a/docs/runbooks/hermes_hetzner_operations.md
+++ b/docs/runbooks/hermes_hetzner_operations.md
@@ -82,7 +82,7 @@ sudo bash infrastructure/hermes/hetzner/bootstrap.sh
 Durability contracts (#4329, host evidence from #4327):
 - `log` / progress output goes to **stderr**; `verify_pin` stdout is machine-only (`ref commit`).
 - Installer temp file is `chmod 0644` after hash PASS (readable by `hermes`, not writable).
-- `/etc/hermes` is `root:hermes` mode `0750`.
+- `/etc/hermes` is root-owned; each profile env is `root:<profile-user>` mode `0640`.
 - Unit uses `ProtectHome=read-only` plus `ReadOnlyPaths` for uv/opt/installer home (not `ProtectHome=true`).
 - After install, bootstrap builds `hermes_cli/web_dist` if needed, links installer-managed Node into each active profile `HERMES_HOME`, and writes `web-ui-build-stamp.json`. `validation-chief` stays `.DISABLED`.
 
@@ -104,13 +104,35 @@ Ports (loopback only):
 
 Each profile has its own `HERMES_HOME` under `/var/lib/hermes/profiles/<name>/`.
 
+### OS identity isolation (B2.0 gate)
+
+Dashboards must not share `User=hermes`. Required mapping:
+
+| Profile | Linux user | Primary group |
+|---|---|---|
+| `jannek-assistant` | `hermes-jannek-assistant` | same |
+| `cdb-engineer` | `hermes-cdb-engineer` | same |
+
+systemd template uses `User=hermes-%i` / `Group=hermes-%i`. Migrate existing hosts with:
+
+```bash
+sudo HERMES_SYSTEMD_SRC=/path/to/bundle/infrastructure/hermes/systemd \
+  bash infrastructure/hermes/hetzner/migrate-profile-uids.sh
+```
+
+Token broker (`hermes-github-token.service`) is root oneshot; PEM at
+`/etc/hermes/secrets/cdb-hermes-engineer.pem` (`root:root` `0600`); token only under
+`/run/hermes/cdb-engineer/` (`0700`/`0600`, owner `hermes-cdb-engineer`).
+No live mint / App create until isolation PASS.
+
+
 ## Start / Stop / Status
 
 ```bash
 sudo systemctl start hermes-dashboard@jannek-assistant
 sudo systemctl start hermes-dashboard@cdb-engineer
 sudo systemctl status 'hermes-dashboard@*'
-sudo -u hermes HERMES_HOME=/var/lib/hermes/profiles/cdb-engineer /opt/hermes/bin/hermes doctor
+sudo -u hermes-cdb-engineer HERMES_HOME=/var/lib/hermes/profiles/cdb-engineer /opt/hermes/bin/hermes doctor
 ```
 
 Unit binds `127.0.0.1:${HERMES_PORT}` with `--no-open --isolated`. Reach via Tailscale
@@ -133,7 +155,7 @@ python -m tools.hermes_ops mint-token --profile cdb-engineer --dry-run
 
 # Live mint — token ONLY to a 0600 file (never stdout)
 python -m tools.hermes_ops mint-token --profile cdb-engineer \
-  --token-file /run/hermes/cdb-engineer.token
+  --token-file /run/hermes/cdb-engineer/token
 ```
 
 Forbidden: `cdb-local-ci` publish, admin merge, branch-protection edits,

--- a/docs/security/hermes_hetzner_threat_model.md
+++ b/docs/security/hermes_hetzner_threat_model.md
@@ -36,6 +36,8 @@ SYN-ACK for peer traffic (`HOLD_WINDOWS_HOST_TCP_STACK`). Remote entry is
 **only** private Tailscale Serve TCP → `127.0.0.1:22` (`sshd-hermes`
 loopback-only). Funnel forbidden; no public sshd firewall allow.
 
+OS trust boundary: each dashboard runs as a dedicated nologin UID (`hermes-jannek-assistant` / `hermes-cdb-engineer`). Shared `User=hermes` is forbidden for profile processes — `HERMES_HOME` alone is not isolation.
+
 App `4410232` (`cdb-local-ci`) is **not** the Hermes write App unless live
 permissions prove `contents`/`pull_requests`/`issues` write without `checks:write`.
 

--- a/infrastructure/hermes/github/README_APP_MANIFEST.md
+++ b/infrastructure/hermes/github/README_APP_MANIFEST.md
@@ -1,0 +1,34 @@
+# Create GitHub App from Manifest (Owner one-click) — #4289 B2.1
+
+Do **not** reuse App `4410232` (`cdb-local-ci`).
+
+## Manifest
+
+File: `infrastructure/hermes/github/cdb-hermes-engineer.manifest.json`
+
+Permissions (only):
+- `metadata:read`
+- `contents:write`
+- `pull_requests:write`
+- `issues:write`
+
+Forbidden: admin, actions, checks, statuses, secrets, workflows, administration.
+Webhooks: inactive / unused URL (GitHub requires a URL field).
+
+## Owner steps (once)
+
+1. Open GitHub → Settings → Developer settings → GitHub Apps → **New GitHub App**
+   or use the Manifest POST flow with the JSON above.
+2. Confirm the app name `cdb-hermes-engineer`.
+3. Generate a **private key** once; store outside the repo at the operator secrets path
+   (never commit; never paste into issues/PRs/chat).
+4. Install the app **only** on `jannekbuengener/Claire_de_Binare`.
+5. Record App ID + Installation ID into host `/etc/hermes/cdb-engineer.env` as
+   `HERMES_GH_APP_ID` / `HERMES_GH_APP_INSTALLATION_ID` (not `CDB_GH_APP_*`).
+6. Place PEM on host as `/etc/hermes/secrets/cdb-hermes-engineer.pem`
+   (`root:root` `0600`) via a controlled root path — not through dashboards.
+
+## Agent note
+
+OAuth `gh` scopes (`repo`/`workflow`) cannot create GitHub Apps. Manifest/UI
+confirmation is an Owner capability gate, not a missing Plan-GO.

--- a/infrastructure/hermes/github/cdb-hermes-engineer.manifest.json
+++ b/infrastructure/hermes/github/cdb-hermes-engineer.manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "cdb-hermes-engineer",
+  "url": "https://github.com/jannekbuengener/Claire_de_Binare/issues/4289",
+  "hook_attributes": {
+    "url": "https://example.com/unused-hermes-webhook",
+    "active": false
+  },
+  "redirect_url": "https://github.com/jannekbuengener/Claire_de_Binare/issues/4289",
+  "callback_urls": [],
+  "description": "Scoped write access for Hermes cdb-engineer profile only (#4289). Not cdb-local-ci.",
+  "public": false,
+  "default_events": [],
+  "default_permissions": {
+    "metadata": "read",
+    "contents": "write",
+    "pull_requests": "write",
+    "issues": "write"
+  },
+  "request_oauth_on_install": false
+}

--- a/infrastructure/hermes/hetzner/bootstrap.sh
+++ b/infrastructure/hermes/hetzner/bootstrap.sh
@@ -7,9 +7,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_HERMES_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 PIN_FILE="${HERMES_VERSION_PIN:-${REPO_HERMES_ROOT}/VERSION_PIN.yaml}"
 INSTALL_USER="${HERMES_LINUX_USER:-hermes}"
+declare -A PROFILE_LINUX_USERS=(
+  [jannek-assistant]=hermes-jannek-assistant
+  [cdb-engineer]=hermes-cdb-engineer
+)
 HERMES_BASE="${HERMES_BASE_DIR:-/var/lib/hermes}"
 OPT_DIR="${HERMES_OPT_DIR:-/opt/hermes}"
 INSTALLER_HOME="${HERMES_INSTALLER_HOME:-/var/lib/hermes/_installer_home}"
+LOG_BASE="${HERMES_LOG_DIR:-/var/log/hermes}"
 SYSTEMD_SRC="${REPO_HERMES_ROOT}/systemd"
 ENV_SRC="${SYSTEMD_SRC}/env"
 PROFILES_SRC="${CDB_HERMES_PROFILES:-${REPO_HERMES_ROOT}/../../config/hermes/profiles}"
@@ -39,28 +44,45 @@ yaml_get() {
   ' "$file"
 }
 
+ensure_profile_linux_users() {
+  local profile user
+  for profile in jannek-assistant cdb-engineer; do
+    user="${PROFILE_LINUX_USERS[${profile}]}"
+    if ! id -u "${user}" >/dev/null 2>&1; then
+      useradd --system --user-group --create-home=no --shell /usr/sbin/nologin "${user}" \
+        || die "failed to create ${user}"
+      log "created system user ${user}"
+    fi
+  done
+}
+
 install_systemd_units() {
   local unit_src="${SYSTEMD_SRC}/hermes-dashboard@.service"
+  local broker_src="${SYSTEMD_SRC}/hermes-github-token.service"
   [[ -f "${unit_src}" ]] || die "missing systemd unit: ${unit_src}"
   install -m 0644 "${unit_src}" /etc/systemd/system/hermes-dashboard@.service
+  if [[ -f "${broker_src}" ]]; then
+    install -m 0644 "${broker_src}" /etc/systemd/system/hermes-github-token.service
+  fi
   # Remove legacy misnamed unit if present (hermes serve is not official).
   rm -f /etc/systemd/system/hermes-serve@.service
   systemctl daemon-reload
-  log "installed systemd template hermes-dashboard@.service"
+  log "installed systemd template hermes-dashboard@.service (+ broker if present)"
 }
 
 install_profile_env_files() {
   mkdir -p /etc/hermes
-  chmod 0750 /etc/hermes
-  # Group must be INSTALL_USER so hermes can probe /etc/hermes/.env existence
-  # without PermissionError; directory stays root-owned (#4329).
-  chown root:"${INSTALL_USER}" /etc/hermes
-  local profile port
+  chmod 0751 /etc/hermes
+  # Directory root-owned; each env file is root:profile-user 0640 (B2.0).
+  # No shared hermes group mediates cross-profile secret/env access.
+  chown root:root /etc/hermes
+  local profile port user
   declare -A PORTS=(
     [jannek-assistant]=9119
     [cdb-engineer]=9120
   )
   for profile in "${!PORTS[@]}"; do
+    user="${PROFILE_LINUX_USERS[${profile}]}"
     local dest="/etc/hermes/${profile}.env"
     if [[ ! -f "${dest}" ]]; then
       if [[ -f "${ENV_SRC}/${profile}.env.example" ]]; then
@@ -69,14 +91,14 @@ install_profile_env_files() {
         printf 'HERMES_PORT=%s\n' "${PORTS[$profile]}" >"${dest}"
         chmod 0640 "${dest}"
       fi
-      chown root:"${INSTALL_USER}" "${dest}"
+      chown "root:${user}" "${dest}"
       log "created ${dest}"
     else
       # Ensure HERMES_PORT present for concurrent profiles.
       if ! grep -q '^HERMES_PORT=' "${dest}"; then
         die "${dest} missing HERMES_PORT — refuse ambiguous bind"
       fi
-      chown root:"${INSTALL_USER}" "${dest}"
+      chown "root:${user}" "${dest}"
       chmod 0640 "${dest}"
       log "env present: ${dest}"
     fi
@@ -84,13 +106,19 @@ install_profile_env_files() {
 }
 
 ensure_profile_homes() {
-  local profile
+  local profile user home logdir
+  mkdir -p "${LOG_BASE}"
+  chmod 0751 "${LOG_BASE}"
   for profile in jannek-assistant cdb-engineer; do
-    local home="${HERMES_BASE}/profiles/${profile}"
+    user="${PROFILE_LINUX_USERS[${profile}]}"
+    home="${HERMES_BASE}/profiles/${profile}"
+    logdir="${LOG_BASE}/${profile}"
     mkdir -p "${home}"/{memories,sessions,skills,logs,backups}
-    chown -R "${INSTALL_USER}:${INSTALL_USER}" "${home}"
+    mkdir -p "${logdir}"
+    chown -R "${user}:${user}" "${home}" "${logdir}"
     chmod 0700 "${home}"
     chmod 0700 "${home}/memories" "${home}/sessions" "${home}/logs"
+    chmod 0700 "${logdir}"
     if [[ -d "${PROFILES_SRC}/${profile}" ]]; then
       rsync -a --ignore-existing \
         --exclude '.env' \
@@ -99,16 +127,15 @@ ensure_profile_homes() {
         --exclude 'state.db*' \
         --exclude 'logs/' \
         "${PROFILES_SRC}/${profile}/" "${home}/"
-      chown -R "${INSTALL_USER}:${INSTALL_USER}" "${home}"
+      chown -R "${user}:${user}" "${home}"
     fi
-    # Sync port into profile config.yaml server.port if present.
-    log "profile home ready: ${profile} -> ${home}"
+    log "profile home ready: ${profile} -> ${home} (uid ${user})"
   done
   mkdir -p "${HERMES_BASE}/profiles/validation-chief"
-  chown -R "${INSTALL_USER}:${INSTALL_USER}" "${HERMES_BASE}/profiles/validation-chief"
   chmod 0700 "${HERMES_BASE}/profiles/validation-chief"
   touch "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
-  chown "${INSTALL_USER}:${INSTALL_USER}" "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
+  chown root:root "${HERMES_BASE}/profiles/validation-chief" \
+    "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
 }
 
 verify_pin() {
@@ -205,14 +232,15 @@ ensure_dashboard_runtime_assets() {
   fi
 
   for profile in jannek-assistant cdb-engineer; do
+    local user="${PROFILE_LINUX_USERS[${profile}]}"
     home="${HERMES_BASE}/profiles/${profile}"
     [[ -d "${home}" ]] || die "profile home missing: ${home}"
     # Hermes resolves managed Node under \$HERMES_HOME/node.
     ln -sfn "${node_root}" "${home}/node"
-    chown -h "${INSTALL_USER}:${INSTALL_USER}" "${home}/node" || true
+    chown -h "${user}:${user}" "${home}/node" || true
     # Write upstream-compatible stamp so dashboard boot skips rebuild without npm
     # in a hardened unit PATH. Uses hermes_cli helpers from the pinned checkout.
-    sudo -u "${INSTALL_USER}" env \
+    sudo -u "${user}" env \
       HERMES_HOME="${home}" \
       PATH="${home}/node/bin:${node_bin}:${PATH}" \
       "${code_dir}/venv/bin/python" - <<'PY'
@@ -254,12 +282,15 @@ enable_services() {
 harden_sudoers_after_bootstrap() {
   local limited="/etc/sudoers.d/99-cdb-hermes"
   cat >"${limited}" <<'EOF'
-# Post-bootstrap: service control only — no general root shell (#4289).
+# Post-bootstrap: service control only — no general root shell (#4289 B2.0).
+# Shared hermes may restart dashboards; must NOT start the GitHub token broker.
 hermes ALL=(root) NOPASSWD: /bin/systemctl start hermes-dashboard@*, /bin/systemctl stop hermes-dashboard@*, /bin/systemctl restart hermes-dashboard@*, /bin/systemctl status hermes-dashboard@*, /bin/systemctl is-active hermes-dashboard@*
+hermes-jannek-assistant ALL=(root) NOPASSWD: /bin/systemctl status hermes-dashboard@jannek-assistant.service, /bin/systemctl is-active hermes-dashboard@jannek-assistant.service
+hermes-cdb-engineer ALL=(root) NOPASSWD: /bin/systemctl status hermes-dashboard@cdb-engineer.service, /bin/systemctl is-active hermes-dashboard@cdb-engineer.service, /bin/systemctl start hermes-github-token.service, /bin/systemctl status hermes-github-token.service
 EOF
   chmod 0440 "${limited}"
   if visudo -cf "${limited}" >/dev/null 2>&1; then
-    log "sudoers hardened to service-only NOPASSWD"
+    log "sudoers hardened (broker start: hermes-cdb-engineer only)"
   else
     die "sudoers harden failed validation — refuse leaving bootstrap ALL in place without check"
   fi
@@ -273,6 +304,7 @@ main() {
   pin_pair="$(verify_pin)"
   git_ref="${pin_pair%% *}"
   git_commit="${pin_pair##* }"
+  ensure_profile_linux_users
   install_systemd_units
   install_profile_env_files
   ensure_profile_homes

--- a/infrastructure/hermes/hetzner/bootstrap.sh
+++ b/infrastructure/hermes/hetzner/bootstrap.sh
@@ -105,9 +105,43 @@ install_profile_env_files() {
   done
 }
 
+# Parent/opt/home traverse for dedicated profile UIDs (B2.0 live cutover).
+# Profiles stay 0700; parents must be 0751 so systemd WorkingDirectory/ENV work.
+# Mirrors migrate-profile-uids.sh migrate_ownership — idempotent.
+apply_dedicated_uid_traverse_perms() {
+  mkdir -p "${HERMES_BASE}" "${LOG_BASE}"
+  chmod 0751 "${HERMES_BASE}"
+  chmod 0751 "${LOG_BASE}"
+  if [[ -d /etc/hermes ]]; then
+    chmod 0751 /etc/hermes
+  fi
+  # Shared install tree may remain under hermes (binary only — no tokens/PEM).
+  # Profile UIDs must execute the binary (o+rx); never share secrets here.
+  if [[ -d "${OPT_DIR}" ]]; then
+    if id -u "${INSTALL_USER}" >/dev/null 2>&1; then
+      chown -R "${INSTALL_USER}:${INSTALL_USER}" "${OPT_DIR}"
+    fi
+    chmod 0755 "${OPT_DIR}"
+    find "${OPT_DIR}" -type d -exec chmod a+rx {} +
+    find "${OPT_DIR}" -type f -executable -exec chmod a+rx {} +
+  fi
+  # uv-managed interpreter path used with ProtectHome=read-only (#4329).
+  if [[ -d /home/hermes ]]; then
+    chmod 0751 /home/hermes
+  fi
+  if [[ -d /home/hermes/.local/share/uv ]]; then
+    chmod -R a+rX /home/hermes/.local/share/uv
+  fi
+  if [[ -d "${INSTALLER_HOME}" ]]; then
+    chmod -R a+rX "${INSTALLER_HOME}"
+  fi
+  log "dedicated-UID traverse perms applied (parents 0751, opt execute, uv read)"
+}
+
 ensure_profile_homes() {
   local profile user home logdir
-  mkdir -p "${LOG_BASE}"
+  mkdir -p "${HERMES_BASE}" "${LOG_BASE}"
+  chmod 0751 "${HERMES_BASE}"
   chmod 0751 "${LOG_BASE}"
   for profile in jannek-assistant cdb-engineer; do
     user="${PROFILE_LINUX_USERS[${profile}]}"
@@ -136,6 +170,7 @@ ensure_profile_homes() {
   touch "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
   chown root:root "${HERMES_BASE}/profiles/validation-chief" \
     "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
+  apply_dedicated_uid_traverse_perms
 }
 
 verify_pin() {
@@ -309,6 +344,8 @@ main() {
   install_profile_env_files
   ensure_profile_homes
   install_hermes_pinned "${git_ref}" "${git_commit}"
+  # Re-apply after install: opt tree + uv path exist only post-pin install.
+  apply_dedicated_uid_traverse_perms
   ensure_dashboard_runtime_assets
   enable_services
   harden_sudoers_after_bootstrap

--- a/infrastructure/hermes/hetzner/cloud-init.yaml
+++ b/infrastructure/hermes/hetzner/cloud-init.yaml
@@ -90,6 +90,8 @@ runcmd:
   - ufw --force enable
   - mkdir -p /opt/hermes /var/lib/hermes /var/log/hermes /etc/hermes
   - chown -R hermes:hermes /opt/hermes /var/lib/hermes /var/log/hermes
-  - chmod 0750 /opt/hermes /var/lib/hermes /var/log/hermes /etc/hermes
+  # 0751 parents: dedicated profile UIDs must traverse; profiles stay 0700 (B2.0).
+  # bootstrap.sh re-applies opt execute + uv read after pinned install.
+  - chmod 0751 /opt/hermes /var/lib/hermes /var/log/hermes /etc/hermes
 
 final_message: "CDB Hermes cloud-init baseline complete. Run infrastructure/hermes/hetzner/bootstrap.sh next."

--- a/infrastructure/hermes/hetzner/cloud-init.yaml
+++ b/infrastructure/hermes/hetzner/cloud-init.yaml
@@ -25,6 +25,13 @@ users:
     ssh_authorized_keys:
       # Public key only (matches hcloud ssh-key cdb-hermes-hetzner / SHA256:1KHx…).
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJoOcf8G2Rc6D1XuTBvaviZA25Vf/PpoTrupxgj58853 cdb-hermes-hetzner
+  # B2.0 dedicated nologin profile identities (also created by bootstrap/migrate).
+  - name: hermes-jannek-assistant
+    lock_passwd: true
+    shell: /usr/sbin/nologin
+  - name: hermes-cdb-engineer
+    lock_passwd: true
+    shell: /usr/sbin/nologin
 
 ssh_pwauth: false
 disable_root: true

--- a/infrastructure/hermes/hetzner/migrate-profile-uids.sh
+++ b/infrastructure/hermes/hetzner/migrate-profile-uids.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Migrate Hermes host from shared User=hermes dashboards to per-profile UIDs (#4289 B2.0).
+# Fail-closed. Does NOT create GitHub Apps, transfer PEMs, or mint tokens.
+set -euo pipefail
+
+log() { printf '[hermes-uid-migrate] %s\n' "$*"; }
+die() {
+  printf '[hermes-uid-migrate] ERROR: %s\n' "$*" >&2
+  printf '[hermes-uid-migrate] HOLD_PROFILE_OS_ISOLATION\n' >&2
+  exit 2
+}
+
+[[ "$(id -u)" -eq 0 ]] || die "must run as root on cdb-hermes-01"
+
+HERMES_BASE="${HERMES_BASE_DIR:-/var/lib/hermes}"
+LOG_BASE="${HERMES_LOG_DIR:-/var/log/hermes}"
+SYSTEMD_SRC="${HERMES_SYSTEMD_SRC:-/opt/cdb-hermes-bundle/infrastructure/hermes/systemd}"
+BACKUP_DIR="${HERMES_UID_MIGRATE_BACKUP:-/var/backups/hermes-uid-migrate-$(date -u +%Y%m%dT%H%M%SZ)}"
+
+declare -A PROFILE_USERS=(
+  [jannek-assistant]=hermes-jannek-assistant
+  [cdb-engineer]=hermes-cdb-engineer
+)
+
+ensure_nologin_user() {
+  local user="$1"
+  if id -u "${user}" >/dev/null 2>&1; then
+    local shell
+    shell="$(getent passwd "${user}" | awk -F: '{print $7}')"
+    case "${shell}" in
+      */nologin|*/false) ;;
+      *) die "user ${user} has login shell ${shell} — refuse (require nologin)" ;;
+    esac
+    log "user present: ${user}"
+    return
+  fi
+  useradd --system --user-group --create-home=no --shell /usr/sbin/nologin "${user}" \
+    || die "useradd failed for ${user}"
+  log "created system user ${user}"
+}
+
+backup_runtime() {
+  mkdir -p "${BACKUP_DIR}"
+  chmod 0700 "${BACKUP_DIR}"
+  systemctl stop 'hermes-dashboard@*' 2>/dev/null || true
+  if [[ -d "${HERMES_BASE}/profiles" ]]; then
+    tar -C "${HERMES_BASE}" -cf "${BACKUP_DIR}/profiles.tar" profiles
+    log "backed up profiles to ${BACKUP_DIR}/profiles.tar"
+  fi
+  # Capture unit identity evidence before cutover.
+  systemctl show hermes-dashboard@jannek-assistant.service -p User -p Group \
+    >"${BACKUP_DIR}/unit-jannek-assistant.before" 2>/dev/null || true
+  systemctl show hermes-dashboard@cdb-engineer.service -p User -p Group \
+    >"${BACKUP_DIR}/unit-cdb-engineer.before" 2>/dev/null || true
+}
+
+install_units() {
+  local dash="${SYSTEMD_SRC}/hermes-dashboard@.service"
+  local broker="${SYSTEMD_SRC}/hermes-github-token.service"
+  if [[ ! -f "${dash}" ]]; then
+    # Fallback: units already under /etc when re-running from host copy.
+    dash="/etc/systemd/system/hermes-dashboard@.service"
+  fi
+  [[ -f "${dash}" ]] || die "missing dashboard unit source (${SYSTEMD_SRC})"
+  install -m 0644 "${dash}" /etc/systemd/system/hermes-dashboard@.service
+  if [[ -f "${broker}" ]]; then
+    install -m 0644 "${broker}" /etc/systemd/system/hermes-github-token.service
+  elif [[ -f /etc/systemd/system/hermes-github-token.service ]]; then
+    log "broker unit already installed"
+  else
+    log "broker unit not yet present in bundle — dashboard isolation proceeds"
+  fi
+  systemctl daemon-reload
+}
+
+migrate_ownership() {
+  local profile user home logdir
+  mkdir -p "${LOG_BASE}"
+  chmod 0751 "${LOG_BASE}"
+  for profile in jannek-assistant cdb-engineer; do
+    user="${PROFILE_USERS[${profile}]}"
+    ensure_nologin_user "${user}"
+    home="${HERMES_BASE}/profiles/${profile}"
+    logdir="${LOG_BASE}/${profile}"
+    [[ -d "${home}" ]] || die "missing profile home ${home}"
+    mkdir -p "${logdir}"
+    chown -R "${user}:${user}" "${home}"
+    chmod 0700 "${home}"
+    chmod 0700 "${home}/memories" "${home}/sessions" "${home}/logs" 2>/dev/null || true
+    chown -R "${user}:${user}" "${logdir}"
+    chmod 0700 "${logdir}"
+    # Env files: root-owned, readable by profile group only (no shared hermes group).
+    if [[ -f "/etc/hermes/${profile}.env" ]]; then
+      chown "root:${user}" "/etc/hermes/${profile}.env"
+      chmod 0640 "/etc/hermes/${profile}.env"
+    fi
+    log "ownership migrated: ${profile} -> ${user}"
+  done
+  # validation-chief stays disabled; root-owned sentinel, not engineer/assistant readable secrets.
+  if [[ -d "${HERMES_BASE}/profiles/validation-chief" ]]; then
+    chmod 0700 "${HERMES_BASE}/profiles/validation-chief"
+    touch "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
+    chown root:root "${HERMES_BASE}/profiles/validation-chief" \
+      "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
+  fi
+  # Shared install tree may remain under hermes (binary only — no tokens/PEM).
+  if id -u hermes >/dev/null 2>&1 && [[ -d /opt/hermes ]]; then
+    chown -R hermes:hermes /opt/hermes
+  fi
+}
+
+verify_unit_identities() {
+  local profile user got_user
+  for profile in jannek-assistant cdb-engineer; do
+    user="${PROFILE_USERS[${profile}]}"
+    got_user="$(systemctl show "hermes-dashboard@${profile}.service" -p User --value)"
+    [[ "${got_user}" == "${user}" ]] \
+      || die "dashboard@${profile} User=${got_user} expected ${user}"
+  done
+}
+
+start_and_probe() {
+  systemctl enable hermes-dashboard@jannek-assistant.service
+  systemctl enable hermes-dashboard@cdb-engineer.service
+  systemctl restart hermes-dashboard@jannek-assistant.service
+  systemctl restart hermes-dashboard@cdb-engineer.service
+  systemctl is-active --quiet hermes-dashboard@jannek-assistant.service \
+    || die "jannek-assistant dashboard failed after UID migration"
+  systemctl is-active --quiet hermes-dashboard@cdb-engineer.service \
+    || die "cdb-engineer dashboard failed after UID migration"
+  verify_unit_identities
+}
+
+negative_cross_profile() {
+  local ja=hermes-jannek-assistant
+  local eng=hermes-cdb-engineer
+  local eng_home="${HERMES_BASE}/profiles/cdb-engineer"
+  local ja_home="${HERMES_BASE}/profiles/jannek-assistant"
+  # Engineer home must be unreadable by assistant.
+  if sudo -u "${ja}" test -r "${eng_home}/config.yaml" 2>/dev/null; then
+    die "jannek-assistant can read cdb-engineer home — HOLD_PROFILE_OS_ISOLATION"
+  fi
+  if sudo -u "${eng}" test -r "${ja_home}/config.yaml" 2>/dev/null; then
+    die "cdb-engineer can read jannek-assistant home — HOLD_PROFILE_OS_ISOLATION"
+  fi
+  # Simulated token dir: only engineer may read after we create a probe file as root.
+  local probe_dir="/run/hermes/cdb-engineer"
+  mkdir -p "${probe_dir}"
+  echo "PROBE_NOT_A_REAL_TOKEN" >"${probe_dir}/token"
+  chown "${eng}:${eng}" "${probe_dir}" "${probe_dir}/token"
+  chmod 0700 "${probe_dir}"
+  chmod 0600 "${probe_dir}/token"
+  if sudo -u "${ja}" test -r "${probe_dir}/token" 2>/dev/null; then
+    rm -f "${probe_dir}/token"
+    die "jannek-assistant can read engineer token path — HOLD_TOKEN_DELIVERY_ISOLATION"
+  fi
+  if sudo -u hermes test -r "${probe_dir}/token" 2>/dev/null; then
+    rm -f "${probe_dir}/token"
+    die "shared hermes user can read engineer token path — HOLD_TOKEN_DELIVERY_ISOLATION"
+  fi
+  sudo -u "${eng}" test -r "${probe_dir}/token" \
+    || die "cdb-engineer cannot read own token probe — HOLD_TOKEN_DELIVERY_ISOLATION"
+  rm -f "${probe_dir}/token"
+  # PEM path must not exist yet OR must be root-only (no profile read).
+  if [[ -f /etc/hermes/secrets/cdb-hermes-engineer.pem ]]; then
+    if sudo -u "${eng}" test -r /etc/hermes/secrets/cdb-hermes-engineer.pem 2>/dev/null; then
+      die "cdb-engineer can read PEM — HOLD_TOKEN_DELIVERY_ISOLATION"
+    fi
+    if sudo -u "${ja}" test -r /etc/hermes/secrets/cdb-hermes-engineer.pem 2>/dev/null; then
+      die "jannek-assistant can read PEM — HOLD_TOKEN_DELIVERY_ISOLATION"
+    fi
+  fi
+  # Assistant must not be able to start the broker unit.
+  if sudo -u "${ja}" systemctl start hermes-github-token.service 2>/dev/null; then
+    systemctl stop hermes-github-token.service 2>/dev/null || true
+    die "jannek-assistant started broker unit — HOLD_TOKEN_DELIVERY_ISOLATION"
+  fi
+  log "cross-profile negative controls PASS"
+}
+
+main() {
+  log "starting UID migration (no GitHub App / no PEM transfer / no live mint)"
+  backup_runtime
+  for profile in jannek-assistant cdb-engineer; do
+    ensure_nologin_user "${PROFILE_USERS[${profile}]}"
+  done
+  install_units
+  migrate_ownership
+  start_and_probe
+  negative_cross_profile
+  log "OS_PROFILE_ISOLATION=PASS TOKEN_DELIVERY_PROBE=PASS"
+  log "next: controlled reboot + persistence proof, then App-creation gate"
+}
+
+main "$@"

--- a/infrastructure/hermes/hetzner/migrate-profile-uids.sh
+++ b/infrastructure/hermes/hetzner/migrate-profile-uids.sh
@@ -34,7 +34,8 @@ ensure_nologin_user() {
     log "user present: ${user}"
     return
   fi
-  useradd --system --user-group --create-home=no --shell /usr/sbin/nologin "${user}" \
+  # Prefer -M/--no-create-home (portable; --create-home=no fails on some useradd builds).
+  useradd --system --user-group -M --shell /usr/sbin/nologin "${user}" \
     || die "useradd failed for ${user}"
   log "created system user ${user}"
 }
@@ -77,6 +78,12 @@ migrate_ownership() {
   local profile user home logdir
   mkdir -p "${LOG_BASE}"
   chmod 0751 "${LOG_BASE}"
+  # Parent dirs must allow traverse for dedicated profile UIDs (profiles stay 0700).
+  # Without this, systemd WorkingDirectory/EnvironmentFile fail closed (CHDIR/ENV).
+  chmod 0751 "${HERMES_BASE}"
+  if [[ -d /etc/hermes ]]; then
+    chmod 0751 /etc/hermes
+  fi
   for profile in jannek-assistant cdb-engineer; do
     user="${PROFILE_USERS[${profile}]}"
     ensure_nologin_user "${user}"
@@ -104,8 +111,22 @@ migrate_ownership() {
       "${HERMES_BASE}/profiles/validation-chief/.DISABLED"
   fi
   # Shared install tree may remain under hermes (binary only — no tokens/PEM).
+  # Profile UIDs must be able to execute the binary (o+rx); never share secrets here.
   if id -u hermes >/dev/null 2>&1 && [[ -d /opt/hermes ]]; then
     chown -R hermes:hermes /opt/hermes
+    chmod 0755 /opt/hermes
+    find /opt/hermes -type d -exec chmod a+rx {} +
+    find /opt/hermes -type f -executable -exec chmod a+rx {} +
+  fi
+  # uv-managed interpreter path used with ProtectHome=read-only (#4329).
+  if [[ -d /home/hermes ]]; then
+    chmod 0751 /home/hermes
+  fi
+  if [[ -d /home/hermes/.local/share/uv ]]; then
+    chmod -R a+rX /home/hermes/.local/share/uv
+  fi
+  if [[ -d "${HERMES_BASE}/_installer_home" ]]; then
+    chmod -R a+rX "${HERMES_BASE}/_installer_home"
   fi
 }
 

--- a/infrastructure/hermes/systemd/env/cdb-engineer.env.example
+++ b/infrastructure/hermes/systemd/env/cdb-engineer.env.example
@@ -1,9 +1,7 @@
-# Install to /etc/hermes/cdb-engineer.env (mode 0600, owner root:hermes)
+# Install to /etc/hermes/cdb-engineer.env (mode 0640, owner root:hermes-cdb-engineer)
 HERMES_PORT=9120
-# Model provider keys (optional depending on setup)
-# OPENROUTER_API_KEY=
-# GitHub App credentials for token broker (PEM path OUTSIDE agent workspace)
-# CDB_GH_APP_ID=
-# CDB_GH_APP_INSTALLATION_ID=
-# CDB_GH_APP_PRIVATE_KEY_PATH=
+# Dedicated Hermes GitHub App credentials (NOT CDB_GH_APP_* / not app 4410232)
+# HERMES_GH_APP_ID=
+# HERMES_GH_APP_INSTALLATION_ID=
+# HERMES_GH_APP_PRIVATE_KEY_PATH=/etc/hermes/secrets/cdb-hermes-engineer.pem
 # HERMES_WINDOWS_TAILSCALE_HOST=

--- a/infrastructure/hermes/systemd/env/jannek-assistant.env.example
+++ b/infrastructure/hermes/systemd/env/jannek-assistant.env.example
@@ -1,5 +1,3 @@
-# Install to /etc/hermes/jannek-assistant.env (mode 0600, owner root:hermes)
-# Secrets go here or via separate secret injection — never commit real values.
+# Install to /etc/hermes/jannek-assistant.env (mode 0640, owner root:hermes-jannek-assistant)
 HERMES_PORT=9119
-# OPENROUTER_API_KEY=
-# ANTHROPIC_API_KEY=
+# No GitHub write credentials for this profile.

--- a/infrastructure/hermes/systemd/hermes-dashboard@.service
+++ b/infrastructure/hermes/systemd/hermes-dashboard@.service
@@ -7,8 +7,10 @@ ConditionPathExists=!/var/lib/hermes/profiles/%i/.DISABLED
 
 [Service]
 Type=simple
-User=hermes
-Group=hermes
+# Per-profile OS identity (B2.0): hermes-%i → hermes-cdb-engineer /
+# hermes-jannek-assistant. Shared User=hermes is forbidden.
+User=hermes-%i
+Group=hermes-%i
 Environment=HERMES_HOME=/var/lib/hermes/profiles/%i
 Environment=HERMES_PROFILE=%i
 # Per-profile port MUST be set in /etc/hermes/%i.env (HERMES_PORT).
@@ -37,7 +39,7 @@ ProtectSystem=strict
 # ProtectHome=true (strict hide) blocked uv-managed CPython under the hermes
 # home-local uv tree (#4329). Use read-only instead of disabling ProtectHome.
 ProtectHome=read-only
-ReadWritePaths=/var/lib/hermes/profiles/%i /var/log/hermes
+ReadWritePaths=/var/lib/hermes/profiles/%i /var/log/hermes/%i
 ReadOnlyPaths=/home/hermes/.local/share/uv /opt/hermes /var/lib/hermes/_installer_home
 ProtectKernelTunables=true
 ProtectKernelModules=true

--- a/infrastructure/hermes/systemd/hermes-github-token.service
+++ b/infrastructure/hermes/systemd/hermes-github-token.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=CDB Hermes GitHub App token mint (cdb-engineer only) (#4289)
+Documentation=https://github.com/jannekbuengener/Claire_de_Binare/issues/4289
+After=network-online.target
+Wants=network-online.target
+# Fail closed until OS isolation migration created the dedicated engineer user.
+ConditionPathExists=/etc/hermes/secrets/cdb-hermes-engineer.pem
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+# Ephemeral runtime dir; lost on reboot. Ownership forced to engineer UID after mint.
+RuntimeDirectory=hermes/cdb-engineer
+RuntimeDirectoryMode=0700
+WorkingDirectory=/opt/cdb-hermes-bundle
+Environment=PYTHONPATH=/opt/cdb-hermes-bundle
+Environment=HERMES_GH_APP_PRIVATE_KEY_PATH=/etc/hermes/secrets/cdb-hermes-engineer.pem
+EnvironmentFile=-/etc/hermes/cdb-engineer.env
+# Mint writes ONLY to the isolated runtime path; never stdout, never profiles.
+ExecStart=/usr/bin/python3 -m tools.hermes_ops mint-token --profile cdb-engineer --token-file /run/hermes/cdb-engineer/token
+# Enforce token delivery ownership after mint (PEM stays root:root 0600).
+ExecStartPost=/bin/chown hermes-cdb-engineer:hermes-cdb-engineer /run/hermes/cdb-engineer /run/hermes/cdb-engineer/token
+ExecStartPost=/bin/chmod 0700 /run/hermes/cdb-engineer
+ExecStartPost=/bin/chmod 0600 /run/hermes/cdb-engineer/token
+# Drop token on stop.
+ExecStopPost=/bin/rm -f /run/hermes/cdb-engineer/token
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadOnlyPaths=/etc/hermes/secrets
+ReadWritePaths=/run/hermes/cdb-engineer
+UMask=0077
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hermes-github-token
+
+[Install]
+# On-demand only — do not WantedBy multi-user by default.
+WantedBy=

--- a/tests/unit/hermes_ops/test_bootstrap_durability_4329.py
+++ b/tests/unit/hermes_ops/test_bootstrap_durability_4329.py
@@ -111,12 +111,15 @@ def test_installer_temp_cleanup_trap_present() -> None:
     assert 'rm -f "${tmp}"' in text
 
 
-def test_etc_hermes_chown_to_install_user_group() -> None:
+def test_etc_hermes_dir_is_root_owned_not_world_writable() -> None:
     text = _bootstrap_text()
-    assert 'chown root:"${INSTALL_USER}" /etc/hermes' in text
-    assert "chmod 0750 /etc/hermes" in text
+    # B2.0: /etc/hermes is root:root; each profile env is root:<profile-user> 0640.
+    assert "chown root:root /etc/hermes" in text
+    assert 'chown "root:${user}" "${dest}"' in text or "chown root:" in text
     assert "chmod 0777 /etc/hermes" not in text
     assert "chmod 0775 /etc/hermes" not in text
+    assert "hermes-cdb-engineer" in text
+    assert "hermes-jannek-assistant" in text
 
 
 def test_systemd_protect_home_is_read_only_not_true() -> None:

--- a/tests/unit/hermes_ops/test_ops_scripts_contract.py
+++ b/tests/unit/hermes_ops/test_ops_scripts_contract.py
@@ -14,6 +14,7 @@ SCRIPTS = (
     "backup.sh",
     "bootstrap.sh",
     "destroy.sh",
+    "migrate-profile-uids.sh",
     "provision.sh",
     "restore.sh",
     "rollback.sh",

--- a/tests/unit/hermes_ops/test_profile_os_isolation.py
+++ b/tests/unit/hermes_ops/test_profile_os_isolation.py
@@ -122,3 +122,24 @@ def test_bootstrap_uses_per_profile_linux_users() -> None:
     assert "User=hermes-%i" in Path(
         "infrastructure/hermes/systemd/hermes-dashboard@.service"
     ).read_text(encoding="utf-8")
+
+
+def test_bootstrap_mirrors_migrate_traverse_perms_for_dedicated_uids() -> None:
+    """Greenfield bootstrap must encode live B2.0 traverse fixes (not migrate-only)."""
+    bootstrap = Path("infrastructure/hermes/hetzner/bootstrap.sh").read_text(
+        encoding="utf-8"
+    )
+    migrate = Path("infrastructure/hermes/hetzner/migrate-profile-uids.sh").read_text(
+        encoding="utf-8"
+    )
+    cloud_init = Path("infrastructure/hermes/hetzner/cloud-init.yaml").read_text(
+        encoding="utf-8"
+    )
+    assert "apply_dedicated_uid_traverse_perms" in bootstrap
+    assert 'chmod 0751 "${HERMES_BASE}"' in bootstrap
+    assert "chmod 0751 /home/hermes" in bootstrap
+    assert "find" in bootstrap and "a+rx" in bootstrap
+    assert "/home/hermes/.local/share/uv" in bootstrap
+    assert 'chmod 0751 "${HERMES_BASE}"' in migrate
+    assert "chmod 0751" in cloud_init
+    assert "chmod 0750 /opt/hermes /var/lib/hermes" not in cloud_init

--- a/tests/unit/hermes_ops/test_profile_os_isolation.py
+++ b/tests/unit/hermes_ops/test_profile_os_isolation.py
@@ -1,0 +1,124 @@
+"""OS profile UID isolation + token delivery contracts (#4289 B2.0)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.hermes_ops.profile_users import (
+    FORBIDDEN_TOKEN_CONSUMERS,
+    PEM_HOST_PATH,
+    PROFILE_LINUX_USERS,
+    SHARED_INSTALL_USER,
+    TOKEN_RUNTIME_DIR,
+    assert_token_consumer_allowed,
+    expected_dashboard_user_line,
+    linux_user_for_profile,
+    profile_home,
+    profile_log_dir,
+    token_file_path,
+)
+from tools.hermes_ops.systemd_contract import validate_broker_unit, validate_unit
+from tools.hermes_ops.token_broker import (
+    assert_app_compatible_for_hermes_write,
+    assert_token_file_path_allowed,
+    mint_profile_token,
+)
+from ci.publisher.app_auth import AuthenticationError
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_profiles_map_to_distinct_linux_users() -> None:
+    users = {linux_user_for_profile(p) for p in ("jannek-assistant", "cdb-engineer")}
+    assert users == {"hermes-jannek-assistant", "hermes-cdb-engineer"}
+    assert SHARED_INSTALL_USER not in users
+    assert (
+        PROFILE_LINUX_USERS["jannek-assistant"] != PROFILE_LINUX_USERS["cdb-engineer"]
+    )
+
+
+def test_dashboard_unit_uses_per_instance_user_not_shared_hermes() -> None:
+    errors = validate_unit()
+    assert errors == [], errors
+    text = Path("infrastructure/hermes/systemd/hermes-dashboard@.service").read_text(
+        encoding="utf-8"
+    )
+    assert "User=hermes-%i" in text
+    assert "Group=hermes-%i" in text
+    assert "User=hermes\n" not in text.replace("User=hermes-%i", "")
+    assert "Group=hermes\n" not in text.replace("Group=hermes-%i", "")
+    assert "/var/log/hermes/%i" in text
+    for profile in ("jannek-assistant", "cdb-engineer"):
+        assert expected_dashboard_user_line(profile) == "User=hermes-%i"
+
+
+def test_broker_unit_is_root_oneshot_with_isolated_runtime_dir() -> None:
+    errors = validate_broker_unit()
+    assert errors == [], errors
+    text = Path("infrastructure/hermes/systemd/hermes-github-token.service").read_text(
+        encoding="utf-8"
+    )
+    assert "Type=oneshot" in text
+    assert "User=root" in text
+    assert TOKEN_RUNTIME_DIR in text or "RuntimeDirectory=hermes/cdb-engineer" in text
+    assert PEM_HOST_PATH in text or "cdb-hermes-engineer.pem" in text
+
+
+def test_token_path_contract() -> None:
+    assert token_file_path() == f"{TOKEN_RUNTIME_DIR}/token"
+    assert_token_file_path_allowed(token_file_path())
+    with pytest.raises(AuthenticationError):
+        assert_token_file_path_allowed("/var/lib/hermes/profiles/cdb-engineer/token")
+    with pytest.raises(AuthenticationError):
+        assert_token_file_path_allowed("/tmp/hermes.token")
+
+
+def test_forbidden_token_consumers() -> None:
+    assert "hermes-jannek-assistant" in FORBIDDEN_TOKEN_CONSUMERS
+    assert "hermes" in FORBIDDEN_TOKEN_CONSUMERS
+    with pytest.raises(PermissionError):
+        assert_token_consumer_allowed("hermes-jannek-assistant")
+    with pytest.raises(PermissionError):
+        assert_token_consumer_allowed("hermes")
+    assert_token_consumer_allowed("hermes-cdb-engineer")
+
+
+def test_other_profile_cannot_mint_token() -> None:
+    with pytest.raises(AuthenticationError):
+        mint_profile_token("jannek-assistant", dry_run=True)
+
+
+def test_app_4410232_rejected_in_direct_python_call() -> None:
+    with pytest.raises(AuthenticationError, match="4410232"):
+        assert_app_compatible_for_hermes_write(app_id=4410232)
+
+
+def test_profile_paths_are_partitioned() -> None:
+    assert profile_home("cdb-engineer") == "/var/lib/hermes/profiles/cdb-engineer"
+    assert profile_log_dir("jannek-assistant") == "/var/log/hermes/jannek-assistant"
+    assert profile_home("cdb-engineer") != profile_home("jannek-assistant")
+
+
+def test_migrate_script_creates_dedicated_users() -> None:
+    text = Path("infrastructure/hermes/hetzner/migrate-profile-uids.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "hermes-cdb-engineer" in text
+    assert "hermes-jannek-assistant" in text
+    assert "useradd" in text
+    assert "/usr/sbin/nologin" in text or "nologin" in text
+    assert "chown" in text
+    assert "HOLD_PROFILE_OS_ISOLATION" in text or "fail" in text.lower()
+
+
+def test_bootstrap_uses_per_profile_linux_users() -> None:
+    text = Path("infrastructure/hermes/hetzner/bootstrap.sh").read_text(
+        encoding="utf-8"
+    )
+    assert "hermes-cdb-engineer" in text
+    assert "hermes-jannek-assistant" in text
+    assert "User=hermes-%i" in Path(
+        "infrastructure/hermes/systemd/hermes-dashboard@.service"
+    ).read_text(encoding="utf-8")

--- a/tools/hermes_ops/__main__.py
+++ b/tools/hermes_ops/__main__.py
@@ -23,6 +23,7 @@ from tools.hermes_ops.secret_scan import scan_paths
 from tools.hermes_ops.systemd_contract import validate_unit
 from tools.hermes_ops.token_broker import (
     assert_app_compatible_for_hermes_write,
+    assert_token_file_path_allowed,
     credential_paths_outside_workspace,
     metadata_only,
     mint_profile_token,
@@ -125,17 +126,22 @@ def _cmd_mint_token(args: argparse.Namespace) -> int:
             )
         )
         return 2
-    # Fail-closed App compatibility gate (cdb-local-ci App is not Hermes write).
+    # Fail-closed: path isolation + App compatibility (no 4410232; Hermes env only).
     try:
+        assert_token_file_path_allowed(args.token_file)
         assert_app_compatible_for_hermes_write()
     except Exception as exc:  # noqa: BLE001
+        hold = "HOLD_SCOPE_BLOCKER"
+        detail = str(exc)
+        if "TOKEN_DELIVERY" in detail or "token file" in detail.lower():
+            hold = "HOLD_TOKEN_DELIVERY_ISOLATION"
         print(
             json.dumps(
                 {
                     "ok": False,
                     "error": type(exc).__name__,
-                    "detail": str(exc),
-                    "hold": "HOLD_SCOPE_BLOCKER",
+                    "detail": detail,
+                    "hold": hold,
                 },
                 indent=2,
                 sort_keys=True,

--- a/tools/hermes_ops/profile_users.py
+++ b/tools/hermes_ops/profile_users.py
@@ -1,0 +1,81 @@
+"""OS-level Hermes profile identity mapping (#4289 Phase B2.0).
+
+PROFILE_POLICY and separate HERMES_HOME directories are not an OS security
+boundary. Each active profile MUST run under a distinct non-login Unix UID
+and primary GID. Shared supplementary groups that mediate token/session/secret
+access are forbidden.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Profile instance name → dedicated system user / primary group (same name).
+PROFILE_LINUX_USERS: Final[dict[str, str]] = {
+    "jannek-assistant": "hermes-jannek-assistant",
+    "cdb-engineer": "hermes-cdb-engineer",
+}
+
+# Shared installer/opt owner only — MUST NOT own profile homes, tokens, or PEM.
+SHARED_INSTALL_USER: Final[str] = "hermes"
+
+# Token delivery contract (cdb-engineer only).
+TOKEN_RUNTIME_DIR: Final[str] = "/run/hermes/cdb-engineer"
+TOKEN_FILE_NAME: Final[str] = "token"
+PEM_HOST_PATH: Final[str] = "/etc/hermes/secrets/cdb-hermes-engineer.pem"
+
+FORBIDDEN_TOKEN_CONSUMERS: Final[frozenset[str]] = frozenset(
+    {
+        "hermes-jannek-assistant",
+        "hermes",
+        "validation-chief",
+        "hermes-validation-chief",
+    }
+)
+
+
+def linux_user_for_profile(profile: str) -> str:
+    """Return the dedicated non-login Linux user for a Hermes profile."""
+    try:
+        return PROFILE_LINUX_USERS[profile]
+    except KeyError as exc:
+        raise KeyError(
+            f"no dedicated Linux user mapping for profile: {profile}"
+        ) from exc
+
+
+def linux_group_for_profile(profile: str) -> str:
+    """Primary group equals the dedicated user name (no shared hermes group)."""
+    return linux_user_for_profile(profile)
+
+
+def profile_home(profile: str, *, base: str = "/var/lib/hermes") -> str:
+    return f"{base.rstrip('/')}/profiles/{profile}"
+
+
+def profile_log_dir(profile: str, *, base: str = "/var/log/hermes") -> str:
+    return f"{base.rstrip('/')}/{profile}"
+
+
+def token_file_path() -> str:
+    return f"{TOKEN_RUNTIME_DIR.rstrip('/')}/{TOKEN_FILE_NAME}"
+
+
+def assert_token_consumer_allowed(linux_user: str) -> None:
+    """Fail closed when a forbidden identity would receive/read tokens."""
+    if linux_user in FORBIDDEN_TOKEN_CONSUMERS:
+        raise PermissionError(
+            f"Linux user {linux_user} is forbidden from Hermes GitHub token delivery"
+        )
+    if linux_user != PROFILE_LINUX_USERS["cdb-engineer"]:
+        raise PermissionError(
+            f"only {PROFILE_LINUX_USERS['cdb-engineer']} may receive GitHub tokens "
+            f"(got {linux_user})"
+        )
+
+
+def expected_dashboard_user_line(profile: str) -> str:
+    """systemd User= line for hermes-dashboard@ instance (template uses %i)."""
+    # Template expands User=hermes-%i → hermes-cdb-engineer etc.
+    _ = linux_user_for_profile(profile)  # validate mapping exists
+    return "User=hermes-%i"

--- a/tools/hermes_ops/systemd_contract.py
+++ b/tools/hermes_ops/systemd_contract.py
@@ -8,35 +8,33 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 UNIT_PATH = (
     REPO_ROOT / "infrastructure" / "hermes" / "systemd" / "hermes-dashboard@.service"
 )
+BROKER_UNIT_PATH = (
+    REPO_ROOT / "infrastructure" / "hermes" / "systemd" / "hermes-github-token.service"
+)
 LEGACY_SERVE_PATH = (
     REPO_ROOT / "infrastructure" / "hermes" / "systemd" / "hermes-serve@.service"
 )
 
 REQUIRED_SNIPPETS = (
-    "User=hermes",
+    "User=hermes-%i",
+    "Group=hermes-%i",
     "HERMES_HOME=/var/lib/hermes/profiles/%i",
     "--host 127.0.0.1",
     "hermes dashboard",
     "${HERMES_PORT}",
     "--isolated",
     "NoNewPrivileges=true",
-    "ProtectSystem=strict",
-    # ProtectHome=true blocks uv CPython under /home/hermes/.local (#4329).
-    "ProtectHome=read-only",
-    "ReadWritePaths=/var/lib/hermes/profiles/%i",
-    "ReadOnlyPaths=",
     "MemoryMax=",
     "CPUQuota=",
     "ConditionPathExists=!/var/lib/hermes/profiles/%i/.DISABLED",
     "EnvironmentFile=/etc/hermes/%i.env",
+    "ReadWritePaths=/var/lib/hermes/profiles/%i /var/log/hermes/%i",
 )
 
 FORBIDDEN_SNIPPETS = (
     "0.0.0.0",
     "--insecure",
-    "User=root",
     "hermes serve",
-    "ProtectHome=true",
 )
 
 
@@ -54,14 +52,51 @@ def validate_unit(path: Path | None = None) -> list[str]:
     for snippet in REQUIRED_SNIPPETS:
         if snippet not in text:
             errors.append(f"missing required snippet: {snippet}")
-    # Forbid dangerous binds / users anywhere; forbid legacy ExecStart command.
-    for snippet in ("0.0.0.0", "--insecure", "User=root"):
+    for snippet in ("0.0.0.0", "--insecure"):
         if snippet in text:
             errors.append(f"forbidden snippet present: {snippet}")
+    # Shared User=hermes (without %i) is forbidden — both profiles would share UID.
     for line in text.splitlines():
         stripped = line.strip()
-        if stripped.startswith("ProtectHome=true"):
-            errors.append("forbidden snippet present: ProtectHome=true")
-        if stripped.startswith("ExecStart=") and "hermes serve" in line:
+        if stripped in {"User=hermes", "Group=hermes"}:
+            errors.append(
+                "forbidden shared identity: "
+                f"{stripped} (require User=hermes-%i / Group=hermes-%i)"
+            )
+        if stripped.startswith("User=root"):
+            errors.append("forbidden snippet present: User=root on dashboard unit")
+        if stripped.startswith("ExecStart=") and "hermes serve" in stripped:
             errors.append("forbidden snippet present: hermes serve")
+    return errors
+
+
+def validate_broker_unit(path: Path | None = None) -> list[str]:
+    """Broker is root oneshot; PEM root-only; token RuntimeDirectory isolated."""
+    unit = path or BROKER_UNIT_PATH
+    errors: list[str] = []
+    if not unit.is_file():
+        return [f"missing broker unit file: {unit}"]
+    text = unit.read_text(encoding="utf-8")
+    required = (
+        "Type=oneshot",
+        "User=root",
+        "RuntimeDirectory=hermes/cdb-engineer",
+        "RuntimeDirectoryMode=0700",
+        "cdb-hermes-engineer.pem",
+        "hermes-cdb-engineer",
+        "mint-token",
+        "--profile cdb-engineer",
+    )
+    for snippet in required:
+        if snippet not in text:
+            errors.append(f"broker missing required snippet: {snippet}")
+    forbidden = (
+        "User=hermes\n",
+        "User=hermes-jannek-assistant",
+        "Group=hermes\n",
+        "/var/lib/hermes/profiles",
+    )
+    for snippet in forbidden:
+        if snippet in text:
+            errors.append(f"broker forbidden snippet present: {snippet!r}")
     return errors

--- a/tools/hermes_ops/token_broker.py
+++ b/tools/hermes_ops/token_broker.py
@@ -1,7 +1,8 @@
 """Short-lived GitHub App installation token broker for Hermes (#4289).
 
-Reuses the App credential resolution / JWT minting from ``ci.publisher.app_auth``
-(lineage #4170 / #4195). Does **not** publish ``cdb-local-ci`` and never logs tokens.
+Reuses JWT minting helpers from ``ci.publisher.app_auth`` (lineage #4170 / #4195)
+as library code only. Hermes credentials use ``HERMES_GH_APP_*`` env vars —
+never the ``cdb-local-ci`` App ``4410232`` via ``CDB_GH_APP_*``.
 """
 
 from __future__ import annotations
@@ -9,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable
 
 from ci.publisher.app_auth import (
@@ -16,10 +18,7 @@ from ci.publisher.app_auth import (
     GitHubApiError,
     _extract_installation_token,
     _mint_transport,
-    load_private_key_pem,
     mint_app_jwt,
-    resolve_app_id_from_env,
-    resolve_installation_id_from_env,
 )
 from ci.publisher.github_client import (
     DEFAULT_TIMEOUT_SECONDS,
@@ -32,19 +31,126 @@ from tools.hermes_ops.policy import (
     assert_action_allowed,
     get_profile_policy,
 )
+from tools.hermes_ops.profile_users import (
+    PEM_HOST_PATH,
+    TOKEN_RUNTIME_DIR,
+    assert_token_consumer_allowed,
+    linux_user_for_profile,
+    token_file_path,
+)
 
 Transport = Callable[[str, str, dict[str, str], bytes | None, float], GitHubResponse]
+
+# Hermes-only credential env (must not collide with cdb-local-ci publisher).
+HERMES_APP_ID_ENV = "HERMES_GH_APP_ID"
+HERMES_INSTALLATION_ID_ENV = "HERMES_GH_APP_INSTALLATION_ID"
+HERMES_PRIVATE_KEY_PATH_ENV = "HERMES_GH_APP_PRIVATE_KEY_PATH"
+
+CDB_LOCAL_CI_APP_ID = 4410232
+REQUIRED_HERMES_WRITE_PERMS = ("contents", "pull_requests", "issues")
+FORBIDDEN_HERMES_PERMS = ("checks", "statuses", "administration", "secrets", "actions")
+
+ALLOWED_TOKEN_FILE_PREFIXES = (
+    TOKEN_RUNTIME_DIR,
+    "/run/hermes/cdb-engineer/",
+)
 
 
 @dataclass(frozen=True)
 class MintResult:
-    """Non-secret mint metadata. The token itself is returned separately and must
-    stay in memory / caller-controlled FD only."""
+    """Non-secret mint metadata. The token itself stays out of logs."""
 
     profile: str
     repositories: tuple[str, ...]
     permissions: dict[str, str]
     expires_hint: str = "installation_token_short_lived"
+
+
+def _env_first(*names: str) -> str:
+    for name in names:
+        value = (os.environ.get(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def resolve_hermes_app_id() -> int:
+    raw = _env_first(HERMES_APP_ID_ENV)
+    if not raw:
+        raise AuthenticationError(f"Missing {HERMES_APP_ID_ENV}")
+    try:
+        app_id = int(raw)
+    except ValueError as exc:
+        raise AuthenticationError(f"{HERMES_APP_ID_ENV} must be an integer") from exc
+    if app_id == CDB_LOCAL_CI_APP_ID:
+        raise AuthenticationError(
+            "App 4410232 (cdb-local-ci) is forbidden for Hermes token mint"
+        )
+    return app_id
+
+
+def resolve_hermes_installation_id() -> int:
+    raw = _env_first(HERMES_INSTALLATION_ID_ENV)
+    if not raw:
+        raise AuthenticationError(f"Missing {HERMES_INSTALLATION_ID_ENV}")
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise AuthenticationError(
+            f"{HERMES_INSTALLATION_ID_ENV} must be an integer"
+        ) from exc
+    if value <= 0:
+        raise AuthenticationError(f"{HERMES_INSTALLATION_ID_ENV} must be positive")
+    return value
+
+
+def load_hermes_private_key_pem() -> bytes:
+    path = _env_first(HERMES_PRIVATE_KEY_PATH_ENV) or PEM_HOST_PATH
+    normalized = path.replace("\\", "/")
+    for root in (
+        "/var/lib/hermes/profiles",
+        r"D:\Dev\HermesWorkspace",
+        "D:/Dev/HermesWorkspace",
+    ):
+        if normalized.lower().startswith(root.replace("\\", "/").lower()):
+            raise AuthenticationError(
+                f"{HERMES_PRIVATE_KEY_PATH_ENV} must not live under agent workspace"
+            )
+    try:
+        data = Path(path).read_bytes()
+    except OSError as exc:
+        raise AuthenticationError(
+            f"Cannot read Hermes App PEM ({HERMES_PRIVATE_KEY_PATH_ENV}): "
+            f"{type(exc).__name__}"
+        ) from exc
+    if b"BEGIN" not in data:
+        raise AuthenticationError("Hermes App private key is not a PEM block")
+    return data
+
+
+def assert_token_file_path_allowed(path: str) -> None:
+    """Live tokens may only land under the isolated /run/hermes/cdb-engineer tree."""
+    text = str(path).strip().replace("\\", "/")
+    if not text:
+        raise AuthenticationError("token file path is empty")
+    if ".." in text.split("/"):
+        raise AuthenticationError("token file path must not contain ..")
+    allowed = False
+    for prefix in ALLOWED_TOKEN_FILE_PREFIXES:
+        p = prefix.rstrip("/")
+        if text == p or text.startswith(p + "/"):
+            allowed = True
+            break
+    if not allowed:
+        raise AuthenticationError(
+            "token file must be under /run/hermes/cdb-engineer "
+            "(HOLD_TOKEN_DELIVERY_ISOLATION)"
+        )
+    if "/var/lib/hermes/profiles" in text:
+        raise AuthenticationError(
+            "token file under profile home is forbidden "
+            "(HOLD_TOKEN_DELIVERY_ISOLATION)"
+        )
 
 
 def _repo_names_only(repositories: list[str]) -> list[str]:
@@ -65,12 +171,14 @@ def build_mint_body(profile: str) -> dict[str, Any]:
         raise AuthenticationError(
             f"profile {profile} is not allowed to mint GitHub write tokens"
         )
+    # OS delivery identity must be the engineer user only.
+    assert_token_consumer_allowed(linux_user_for_profile(profile))
     permissions = dict(policy.get("token_permissions") or {})
     if not permissions:
         raise AuthenticationError(f"profile {profile} has empty token_permissions")
-    # Hard deny: Hermes must never receive checks:write (cdb-local-ci publish).
-    if permissions.get("checks") == "write":
-        raise AuthenticationError("checks:write is forbidden for Hermes profiles")
+    for key in FORBIDDEN_HERMES_PERMS:
+        if permissions.get(key) == "write":
+            raise AuthenticationError(f"{key}:write is forbidden for Hermes profiles")
     repositories = list(policy.get("allowed_repositories") or [])
     if not repositories:
         raise AuthenticationError(f"profile {profile} has no allowed_repositories")
@@ -125,12 +233,7 @@ def mint_profile_token(
     now: int | None = None,
     dry_run: bool = False,
 ) -> tuple[str | None, MintResult]:
-    """Mint a scoped installation token for a Hermes profile.
-
-    Returns ``(token_or_none, metadata)``. In ``dry_run`` mode, validates policy
-    and returns ``(None, metadata)`` without contacting GitHub or reading PEM
-    unless credentials are already configured and caller opts into live mint.
-    """
+    """Mint a scoped installation token for a Hermes profile."""
     verdict = assert_action_allowed(profile, "github_write_branch_pr")
     if not verdict.ok:
         raise AuthenticationError(verdict.reason)
@@ -148,9 +251,10 @@ def mint_profile_token(
     )
     if dry_run:
         return None, meta
-    app_id = resolve_app_id_from_env()
-    installation_id = resolve_installation_id_from_env()
-    pem = load_private_key_pem()
+    assert_app_compatible_for_hermes_write()
+    app_id = resolve_hermes_app_id()
+    installation_id = resolve_hermes_installation_id()
+    pem = load_hermes_private_key_pem()
     jwt = mint_app_jwt(app_id=app_id, private_key_pem=pem, now=now)
     token = request_scoped_installation_token(
         app_jwt=jwt,
@@ -164,32 +268,43 @@ def mint_profile_token(
 def credential_paths_outside_workspace(
     workspace_roots: list[str] | None = None,
 ) -> list[str]:
-    """Return errors if PEM path env points inside agent-readable workspaces."""
+    """Return errors if Hermes PEM path points inside agent-readable workspaces."""
     roots = workspace_roots or [
         "/var/lib/hermes/profiles",
         r"D:\Dev\HermesWorkspace",
         "D:/Dev/HermesWorkspace",
     ]
-    path = (os.environ.get("CDB_GH_APP_PRIVATE_KEY_PATH") or "").strip()
+    # If caller passed a single path list used as roots incorrectly, detect env.
+    path = (os.environ.get(HERMES_PRIVATE_KEY_PATH_ENV) or "").strip()
+    if not path:
+        path = (os.environ.get("CDB_GH_APP_PRIVATE_KEY_PATH") or "").strip()
     errors: list[str] = []
     if not path:
         return errors
-    normalized = path.replace("\\", "/").lower()
-    for root in roots:
-        root_n = root.replace("\\", "/").lower()
-        if normalized.startswith(root_n):
-            errors.append(
-                "CDB_GH_APP_PRIVATE_KEY_PATH must not live under agent workspace: "
-                f"{redact_text(path)}"
-            )
+    # If the "roots" argument is actually a list of candidate paths (len==1 file),
+    # treat as explicit path check when it looks like a file path.
+    check_paths = [path]
+    if (
+        workspace_roots
+        and len(workspace_roots) == 1
+        and workspace_roots[0].endswith((".pem", ".key"))
+    ):
+        check_paths = list(workspace_roots)
+        roots = [
+            "/var/lib/hermes/profiles",
+            r"D:\Dev\HermesWorkspace",
+            "D:/Dev/HermesWorkspace",
+        ]
+    for candidate in check_paths:
+        normalized = candidate.replace("\\", "/").lower()
+        for root in roots:
+            root_n = root.replace("\\", "/").lower()
+            if normalized.startswith(root_n):
+                errors.append(
+                    "private key path must not live under agent workspace: "
+                    f"{redact_text(candidate)}"
+                )
     return errors
-
-
-# cdb-local-ci App (app_id=4410232) is specialized for Check Runs only.
-# Hermes engineering write must NOT silently reuse it without compatible perms.
-CDB_LOCAL_CI_APP_ID = 4410232
-REQUIRED_HERMES_WRITE_PERMS = ("contents", "pull_requests", "issues")
-FORBIDDEN_HERMES_PERMS = ("checks",)
 
 
 def assert_app_compatible_for_hermes_write(
@@ -197,25 +312,30 @@ def assert_app_compatible_for_hermes_write(
     app_id: int | None = None,
     installation_permissions: dict[str, str] | None = None,
 ) -> None:
-    """Fail closed when the resolved App cannot mint Hermes write tokens.
-
-    Callers that have live installation permission JSON should pass it.
-    Without a permission map, App 4410232 is rejected by known specialization.
-    """
+    """Fail closed when the resolved App cannot mint Hermes write tokens."""
     resolved = app_id
     if resolved is None:
-        raw = (
-            os.environ.get("CDB_GH_APP_ID") or os.environ.get("APP_ID") or ""
-        ).strip()
-        if raw.isdigit():
+        raw = _env_first(HERMES_APP_ID_ENV)
+        if not raw:
+            # Also reject accidental use of publisher env pointing at 4410232.
+            legacy = (
+                os.environ.get("CDB_GH_APP_ID") or os.environ.get("APP_ID") or ""
+            ).strip()
+            if legacy.isdigit() and int(legacy) == CDB_LOCAL_CI_APP_ID:
+                raise AuthenticationError(
+                    "App 4410232 (cdb-local-ci) is not reusable for Hermes GitHub "
+                    "write; set HERMES_GH_APP_ID to a dedicated engineering App. "
+                    "HOLD_SCOPE_BLOCKER."
+                )
+            if legacy.isdigit():
+                resolved = int(legacy)
+        elif raw.isdigit():
             resolved = int(raw)
-    if resolved == CDB_LOCAL_CI_APP_ID and installation_permissions is None:
+    if resolved == CDB_LOCAL_CI_APP_ID:
         raise AuthenticationError(
             "App 4410232 (cdb-local-ci) is not reusable for Hermes GitHub write; "
             "live perms are checks:write+metadata:read only. "
-            "Provide a dedicated engineering App or pass verified "
-            "installation_permissions proving contents/pull_requests/issues write "
-            "without checks:write. HOLD_SCOPE_BLOCKER."
+            "Provide a dedicated engineering App. HOLD_SCOPE_BLOCKER."
         )
     if installation_permissions is None:
         return
@@ -229,7 +349,7 @@ def assert_app_compatible_for_hermes_write(
         if installation_permissions.get(key) == "write":
             raise AuthenticationError(
                 f"Hermes write App must not have {key}:write "
-                "(separation from cdb-local-ci publish)"
+                "(separation from cdb-local-ci / admin surfaces)"
             )
 
 
@@ -244,11 +364,24 @@ def metadata_only(profile: str) -> dict[str, Any]:
         "forbidden_actions": sorted(FORBIDDEN_GITHUB_ACTIONS),
         "auth_lineage_reference_only": ["4170", "4195"],
         "reuse_cdb_local_ci_app": False,
+        "linux_user": linux_user_for_profile(profile),
+        "token_file": token_file_path(),
         "required_app_permissions": {
             "contents": "write",
             "pull_requests": "write",
             "issues": "write",
             "metadata": "read",
         },
-        "forbidden_app_permissions": {"checks": "write"},
+        "forbidden_app_permissions": {
+            "checks": "write",
+            "statuses": "write",
+            "administration": "write",
+            "secrets": "write",
+            "actions": "write",
+        },
+        "credential_env": [
+            HERMES_APP_ID_ENV,
+            HERMES_INSTALLATION_ID_ENV,
+            HERMES_PRIVATE_KEY_PATH_ENV,
+        ],
     }


### PR DESCRIPTION
## Summary
Refs #4289

Phase B2.0 (hard gate before GitHub App / PEM / live token mint):
- Dedicated nologin Linux users per profile (`hermes-jannek-assistant`, `hermes-cdb-engineer`)
- systemd `User=hermes-%i` / `Group=hermes-%i` (shared `User=hermes` forbidden on dashboards)
- `migrate-profile-uids.sh` + bootstrap/cloud-init with dedicated-UID traverse parity (`0751` parents, `/opt/hermes` execute, uv read path)
- Token broker contract: root oneshot, PEM `root:root` 0600, token only `/run/hermes/cdb-engineer/` 0700/0600
- `HERMES_GH_APP_*` credential env (never App 4410232 / `CDB_GH_APP_*`)
- Unit/contract tests for isolation and broker policy
- B2.1 docs: `cdb-hermes-engineer` GitHub App manifest (creation/PEM/mint still out of this hop)

## Live host gate
`DONE_B2_0_OS_ISOLATION_PASS` (evidence: `docs/evidence/hermes/hermes_b2_os_isolation_gate_4289.md`):
- Live `cdb-hermes-01` dashboards run as distinct profile UIDs (not shared `User=hermes`)
- Cross-profile home / token-probe / env deny PASS; broker path isolated
- **No GitHub App created, no PEM transferred, no live token minted** in this PR hop
- Issue `#4289` remains **OPEN**

Historical note: earlier PR body held `HOLD_RUNTIME_MIGRATION` / `HOLD_PROFILE_OS_ISOLATION` before the live cutover; that hold is superseded by the committed evidence above.

## Tests
- `pytest -q tests/unit/hermes_ops` → 65 passed (targeted, post MUST_FIX)
- ruff PASS; validate-profiles PASS; secret-scan PASS; mint-token dry-run PASS
- Final-Head Fast-CI + App Check Run `cdb-local-ci` (`app_id=4410232`) on exact head after freeze/main-integration (see merge evidence)

## Security Boundaries
LR NO-GO; App 4410232 untouched for Hermes engineering; Issue #4289 remains OPEN; no closing keywords; validation-chief disabled; no admin merge.

## Non-goals
Issue #4289 remains OPEN. Do not interpret this PR as closing the parent Hermes issue. Backup/Restore and Update/Rollback remain out of this slice. App creation / PEM transfer / live token mint wait for explicit later B2 steps.

## Brain Evidence
- brain_source: repo-only / not-used
- repo_fallback_reason: insufficient_evidence
- Live host claims come from committed redacted evidence (IPs/passwords redacted)
