### PR TITLE
[DATA][PROVENANCE] Propagate runner request/content fingerprints (#4335)

### DIFF
--- a/knowledge/logs/sessions/2026-08-04-4335-runner-fingerprint-propagation.md
+++ b/knowledge/logs/sessions/2026-08-04-4335-runner-fingerprint-propagation.md
@@ -1,0 +1,35 @@
+# Session: #4335 Runner FP propagation
+
+- **Date**: 2026-08-04
+- **Base**: `origin/main` @ `10ddcc09`
+- **Branch**: `batch/validation-research-issue-4335`
+- **Commit**: `850722101e4e532bcc33ff6a8ae2a74a7f199a02`
+- **PR**: [#4337](https://github.com/jannekbuengener/Claire_de_Binare/pull/4337) open
+
+## Delivered
+
+- `strategy_replay_runner`: file + `binance_window` propagate/recompute request/content fingerprints
+- Regression tests for fingerprint propagation
+
+## Validation
+
+- 6 targeted tests pass
+- ruff / black pass
+- preflight READY (readiness only)
+
+## Status
+
+`DONE_SLICE_ADDED_TO_BATCH_PR`
+
+## Residuals
+
+- #4336 open
+- #4153 / #4147 open
+- no merge
+- LR NO-GO
+
+## Boundaries
+
+- no campaign
+- no #4336
+- no live / echtgeld

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -76,6 +76,7 @@ from core.replay.binance_window_bank_adapter import (
     load_binance_window_dataset,
 )
 from core.replay.canonical_json import canonical_hash, canonical_json_dumps
+from core.replay.dataset_identity import content_fingerprint, request_fingerprint
 from core.replay.execution_economics_v1 import (
     ExecutionEconomicsError,
     resolve_scenario_overrides,
@@ -783,12 +784,21 @@ def _load_dataset_result(
         except DatasetSpecError as exc:
             raise ReplayRunnerError(f"dataset spec validation failed: {exc}") from exc
 
+        # Request identity follows the *final* windowed spec (not temp start/end=0).
+        # Content identity is the loaded candle series (propagate or recompute).
+        req_fp = request_fingerprint(spec)
+        content_fp = temp_result.content_fingerprint
+        if content_fp is None:
+            content_fp = content_fingerprint(temp_result.candles)
+
         return DatasetResult(
             spec=spec,
             candles=temp_result.candles,
-            fingerprint=spec.fingerprint(),
+            fingerprint=req_fp,
             warmup_count=warmup_count,
             effective_candle_count=len(candles) - warmup_count,
+            request_fingerprint=req_fp,
+            content_fingerprint=content_fp,
         )
 
     if dataset_source == "db":
@@ -828,12 +838,21 @@ def _load_dataset_result(
             )
         except BinanceWindowBankAdapterError as exc:
             raise ReplayRunnerError(str(exc)) from exc
+        inner = dataset.dataset_result
+        req_fp = inner.request_fingerprint
+        if req_fp is None:
+            req_fp = request_fingerprint(inner.spec)
+        content_fp = inner.content_fingerprint
+        if content_fp is None:
+            content_fp = content_fingerprint(inner.candles)
         return DatasetResult(
-            spec=dataset.dataset_result.spec,
-            candles=dataset.dataset_result.candles,
-            fingerprint=dataset.dataset_result.fingerprint,
+            spec=inner.spec,
+            candles=inner.candles,
+            fingerprint=req_fp,
             warmup_count=warmup_count,
-            effective_candle_count=dataset.dataset_result.effective_candle_count,
+            effective_candle_count=inner.effective_candle_count,
+            request_fingerprint=req_fp,
+            content_fingerprint=content_fp,
         )
 
     raise ReplayRunnerError(f"unsupported dataset_source: {config.dataset_source!r}")

--- a/tests/unit/validation/test_strategy_replay_runner.py
+++ b/tests/unit/validation/test_strategy_replay_runner.py
@@ -1889,3 +1889,176 @@ class TestMainArgParse:
             with patch("sys.argv", ["prog", "--input-candles", str(f)]):
                 result = main()
         assert result == 2
+
+
+# ---------------------------------------------------------------------------
+# #4335 — runner retains request/content fingerprints after DatasetResult wrap
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestLoadDatasetResultFingerprints4335:
+    """Regression: file/binance_window wrappers must not drop identity fields."""
+
+    def _candles_file(self, tmp_path: Path, count: int = 20) -> Path:
+        candles = [
+            {
+                "ts_ms": 1_000_000 + i * 60_000,
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 10.0,
+            }
+            for i in range(count)
+        ]
+        path = tmp_path / "candles.json"
+        path.write_text(json.dumps(candles), encoding="utf-8")
+        return path
+
+    def test_file_path_retains_non_none_request_and_content_fingerprints(
+        self, tmp_path: Path
+    ):
+        from core.replay.dataset_identity import (
+            content_fingerprint as compute_content_fp,
+            request_fingerprint as compute_request_fp,
+        )
+        from services.validation.strategy_replay_runner import _load_dataset_result
+
+        path = self._candles_file(tmp_path, count=20)
+        warmup = 5
+        cfg = ARVPReplayConfig(
+            dataset_source="file",
+            input_candles_file=str(path),
+            output_directory=str(tmp_path / "out"),
+            entry_lookback_minutes=warmup,
+            exit_lookback_minutes=2,
+        )
+
+        result = _load_dataset_result(cfg, warmup_count=warmup)
+
+        assert result.request_fingerprint is not None
+        assert result.content_fingerprint is not None
+        assert len(result.request_fingerprint) == 64
+        assert len(result.content_fingerprint) == 64
+        assert result.fingerprint == result.request_fingerprint
+        assert result.request_fingerprint == compute_request_fp(result.spec)
+        assert result.content_fingerprint == compute_content_fp(result.candles)
+        # Request (spec window) and content (candle bytes) are distinct hashes.
+        assert result.request_fingerprint != result.content_fingerprint
+
+    def test_binance_window_path_propagates_provider_fingerprints(self, tmp_path: Path):
+        from core.replay.binance_window_bank_adapter import BinanceWindowDataset
+        from core.replay.dataset_provider import DatasetResult
+        from core.replay.dataset_spec import DatasetSpec
+        from services.validation.strategy_replay_runner import _load_dataset_result
+
+        warmup = 3
+        spec = DatasetSpec(
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=1_000_000,
+            end_ts_ms=1_000_000 + 9 * 60_000,
+            warmup_candles=warmup,
+            source="file",
+            file_path="virtual.jsonl",
+        )
+        candles = tuple(
+            {
+                "ts_ms": 1_000_000 + i * 60_000,
+                "open": 1.0,
+                "high": 2.0,
+                "low": 0.5,
+                "close": 1.5,
+                "volume": 3.0,
+            }
+            for i in range(10)
+        )
+        provider_result = DatasetResult(
+            spec=spec,
+            candles=candles,
+            fingerprint="a" * 64,
+            warmup_count=warmup,
+            effective_candle_count=7,
+            request_fingerprint="b" * 64,
+            content_fingerprint="c" * 64,
+        )
+        mock_dataset = MagicMock(spec=BinanceWindowDataset)
+        mock_dataset.dataset_result = provider_result
+
+        cfg = ARVPReplayConfig(
+            dataset_source="binance_window",
+            binance_window_id="binance_1m_month_2021_01",
+            output_directory=str(tmp_path / "out"),
+            entry_lookback_minutes=warmup,
+            exit_lookback_minutes=2,
+        )
+
+        with patch(
+            "services.validation.strategy_replay_runner.load_binance_window_dataset",
+            return_value=mock_dataset,
+        ):
+            result = _load_dataset_result(cfg, warmup_count=warmup)
+
+        assert result.request_fingerprint == "b" * 64
+        assert result.content_fingerprint == "c" * 64
+        assert result.fingerprint == "b" * 64
+
+    def test_binance_window_recomputes_when_provider_omits_fingerprints(
+        self, tmp_path: Path
+    ):
+        from core.replay.dataset_identity import (
+            content_fingerprint as compute_content_fp,
+            request_fingerprint as compute_request_fp,
+        )
+        from core.replay.dataset_provider import DatasetResult
+        from core.replay.dataset_spec import DatasetSpec
+        from services.validation.strategy_replay_runner import _load_dataset_result
+
+        warmup = 2
+        spec = DatasetSpec(
+            symbol="BTCUSDT",
+            timeframe="1m",
+            start_ts_ms=1_000_000,
+            end_ts_ms=1_000_000 + 5 * 60_000,
+            warmup_candles=warmup,
+            source="file",
+            file_path="virtual.jsonl",
+        )
+        candles = tuple(
+            {
+                "ts_ms": 1_000_000 + i * 60_000,
+                "open": 1.0,
+                "high": 2.0,
+                "low": 0.5,
+                "close": 1.5,
+                "volume": 3.0,
+            }
+            for i in range(6)
+        )
+        # Legacy wrap: identity fields omitted (the pre-#4335 failure mode).
+        provider_result = DatasetResult(
+            spec=spec,
+            candles=candles,
+            fingerprint=spec.fingerprint(),
+            warmup_count=warmup,
+            effective_candle_count=4,
+        )
+        mock_dataset = MagicMock()
+        mock_dataset.dataset_result = provider_result
+
+        cfg = ARVPReplayConfig(
+            dataset_source="binance_window",
+            binance_window_id="legacy_window",
+            output_directory=str(tmp_path / "out"),
+            entry_lookback_minutes=warmup,
+            exit_lookback_minutes=1,
+        )
+
+        with patch(
+            "services.validation.strategy_replay_runner.load_binance_window_dataset",
+            return_value=mock_dataset,
+        ):
+            result = _load_dataset_result(cfg, warmup_count=warmup)
+
+        assert result.request_fingerprint == compute_request_fp(spec)
+        assert result.content_fingerprint == compute_content_fp(candles)
+        assert result.fingerprint == result.request_fingerprint


### PR DESCRIPTION
## Summary
Propagate `request_fingerprint` / `content_fingerprint` through `strategy_replay_runner` file and `binance_window` `DatasetResult` wraps so runner-backed loads no longer drop provider identity fields.

Closes #4335
Refs #4151
Refs #4153
Refs #4147
Residual: #4336 remains OPEN (CDB-049..052; not in this PR)

## Delivered
- `_load_dataset_result` file path: set `fingerprint`/`request_fingerprint` from final windowed spec; propagate/recompute `content_fingerprint`
- `binance_window` path: propagate inner identity fields; recompute via canonical helpers only when missing
- Unit regression coverage (`TestLoadDatasetResultFingerprints4335`)

## Brain Evidence
- brain_source: repo-only
- brain_status: not-used
- context_brain_attempted: true
- context_brain_used: false
- context_available: false
- repo_fallback_used: true
- repo_fallback_reason: insufficient_evidence
- context_tool_status: available
- context_trust_level: none
- records_found: none

## Validation
- Targeted unit: `pytest -q tests/unit/validation/test_strategy_replay_runner.py -k "Fingerprints4335 or dataset_fingerprint or successful_run_returns_0 or binance"` → 6 passed
- Live R8 (real runner path): all 39 `LOCKED_BATCH_A_DEVELOPMENT_WINDOW_IDS` via `_load_dataset_result(dataset_source=binance_window)` → OK=39 FAIL=0; request≠content; deterministic reload True → `R8_PASS_READY_FOR_CAMPAIGN_EXECUTION`
- Preflight: `python -m tools.arvp_vacation.sensitivity_campaign_preflight` → `READY_FOR_REPLAY_SENSITIVITY` (7/7; readiness only; READY ≠ R8 alone)
- Code review: PASS (cdb-code-reviewer)
- Validation evidence: R8 PASS narrow provenance; #4336 residual correctness open

## Non-goals
- No #4336 scope
- No sensitivity/OFAT/grid/interaction campaign runs
- No DQ threshold / rankability / window redesign
- No LR / paper / live / echtgeld

## Safety Boundaries
- LR=NO-GO
- No runtime stack mutations
- No productive DB / context mutations
- No secrets in fingerprints/logs

## Remaining uncertainty
- #4336 CDB-049..052 remain open for trustworthy campaign conclusions beyond R8 fingerprint propagation
- Campaign execution requires a separate #4153 session after this merge