### PR TITLE
[DATA][CORRECTNESS] CDB-050 DQ consumer content-binding (#4336)

### DIFF
--- a/config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.json
+++ b/config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.json
@@ -73,7 +73,7 @@
   },
   "rule_count": 56,
   "unresolved_count": 0,
-  "register_fingerprint": "fec8a7f5baf3c801aae943079ee443fd30dda6d4e0274ee628b712e218d40a5a",
+  "register_fingerprint": "772823d0bc0401ec4adfc82dddb7c70f023c74bc506695366fca4fd9453833a7",
   "rules": [
     {
       "parameter_id": "CDB-001",
@@ -4463,17 +4463,25 @@
         "derivation": "system_area=Import/Replay; SERVICE_CATALOG/path ownership convention",
         "evidence": [
           "core/replay/dataset_spec.py",
-          "tools/market_data/historical_common.py"
+          "tools/market_data/historical_common.py",
+          "core/replay/binance_window_bank_adapter.py",
+          "services/validation/strategy_replay_runner.py"
         ]
       },
       "repository_paths": [
         "core/replay/dataset_spec.py",
-        "tools/market_data/historical_common.py"
+        "tools/market_data/historical_common.py",
+        "tools/market_data/binance_window_bank.py",
+        "core/replay/binance_window_bank_adapter.py",
+        "services/validation/strategy_replay_runner.py",
+        "tools/market_data/binance_historical_probe.py",
+        "tools/market_data/binance_full_archive_import.py"
       ],
       "consumers": [
         "Provenance",
         "Rankability",
-        "Window Bank"
+        "Window Bank",
+        "Strategy Replay Runner"
       ],
       "effective_default": {
         "value": "Hash der Anfrage; STRICT_COMPLETE nur ohne Kernfehler",
@@ -4520,8 +4528,8 @@
       "lifecycle_status": "implicit",
       "analysis": {
         "source_commit": "224cfd49398b329b315781372658fab1fbf15362",
-        "effect": "DQ-Verdict bindet an content_fingerprint der geprüften Candle-Serie; Request-Hash allein reicht nicht.",
-        "finding": "geschlossen via #4336 — DQ content binding fail-closed",
+        "effect": "DQ-Verdict bindet an content_fingerprint der geprüften Candle-Serie; Request-Hash allein reicht nicht. Consumer (Runner, Window-Bank, Probes) erzwingen Binding fail-closed.",
+        "finding": "CDB-050 consumer-binding Forward-Fix in flight via #4336 — enforce_dq_content_binding on Runner/Window-Bank/Probes; not closed on main until merge",
         "dependencies": [
           "Provenance",
           "Rankability",
@@ -4529,14 +4537,17 @@
         ],
         "change_risk": "hoch",
         "suitability": "keine direkte Optimierung",
-        "compact_decision": "CLOSED_CORRECTNESS",
+        "compact_decision": "CORRECTNESS_FIX_ONLY",
         "blocked_by_issues": [
           4336
         ],
         "evidence_notes": [
           "Content-Hash-Reconciliation",
           "DQ-Bindung an tatsächliche Daten",
-          "assert_dq_content_binding"
+          "assert_dq_content_binding",
+          "enforce_dq_content_binding",
+          "binance_window_bank_adapter._enforce_window_dq_content_binding",
+          "strategy_replay_runner._enforce_replay_dq_sidecar_binding"
         ],
         "name_drift": null,
         "may_change_compact": true

--- a/config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.yaml
+++ b/config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.yaml
@@ -5,7 +5,7 @@ canonical:
   path: config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.json
   format: json
   json_is_yaml_1_2_compatible: true
-  canonical_json_sha256: 4acece147940911f6527e5257acc2f92a95bab4790685d2c77b3bcabb1109062
+  canonical_json_sha256: 1e8ef201f69ff36e6821f81368969bae8e8763482fe6f6ece8027814a4fa058c
   register_fingerprint: 772823d0bc0401ec4adfc82dddb7c70f023c74bc506695366fca4fd9453833a7
 schema:
   path: config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.schema.json

--- a/config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.yaml
+++ b/config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.yaml
@@ -5,8 +5,8 @@ canonical:
   path: config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.json
   format: json
   json_is_yaml_1_2_compatible: true
-  canonical_json_sha256: dd3e83858ba14be91d3fe6841ba74ffa0e59edce5108310bb8db2ef083f5b981
-  register_fingerprint: fec8a7f5baf3c801aae943079ee443fd30dda6d4e0274ee628b712e218d40a5a
+  canonical_json_sha256: 4acece147940911f6527e5257acc2f92a95bab4790685d2c77b3bcabb1109062
+  register_fingerprint: 772823d0bc0401ec4adfc82dddb7c70f023c74bc506695366fca4fd9453833a7
 schema:
   path: config/parameter-control/v1/CDB_PARAMETER_CONTROL_POLICY.schema.json
 source:

--- a/core/replay/binance_window_bank_adapter.py
+++ b/core/replay/binance_window_bank_adapter.py
@@ -26,6 +26,12 @@ from tools.market_data.development_window_selector import (
     DevelopmentSelectionError,
     resolve_window_candles_path,
 )
+from tools.market_data.historical_common import (
+    HistoricalProbeError,
+    dq_report_from_dataset_spec,
+    enforce_dq_content_binding,
+    load_dq_report_sidecar,
+)
 
 BATCH_A_WINDOW_BANK_ROOT = "artifacts/market_data/window_bank/binance/spot/BTCUSDT/1m"
 
@@ -160,6 +166,33 @@ def load_window_candles_jsonl(candles_path: Path) -> list[dict[str, Any]]:
     return candles
 
 
+def _enforce_window_dq_content_binding(
+    *,
+    window_id: str,
+    meta: Mapping[str, Any],
+    candles: Sequence[Mapping[str, Any]],
+    candles_path: Path,
+) -> None:
+    """Fail-closed CDB-050 bind when the window claims a DQ verdict."""
+    dq_report = dq_report_from_dataset_spec(meta)
+    if dq_report is None:
+        # Spec does not claim a DQ verdict — not a DQ consumer for this load.
+        return
+    evidence = load_dq_report_sidecar(candles_path.parent / "quality_report.json")
+    try:
+        enforce_dq_content_binding(
+            report=dq_report,
+            candles=candles,
+            evidence=evidence,
+        )
+    except HistoricalProbeError as exc:
+        raise BinanceWindowBankAdapterError(
+            f"window {window_id!r} DQ content binding failed"
+            + (f" [{exc.code}]" if getattr(exc, "code", None) else "")
+            + f": {exc}"
+        ) from exc
+
+
 def load_binance_window_dataset(
     window_id: str,
     *,
@@ -174,6 +207,10 @@ def load_binance_window_dataset(
     must include the warmup prefix before ``start_ts_ms``. Window-bank JSON
     metadata that stores the series-first timestamp as ``start_ts_ms`` is
     rebound to the live start when ``warmup_candles > 0``.
+
+    CDB-050: when ``data_quality_verdict`` is present on the window spec, the
+    loaded candle content must match the bound ``content_fingerprint`` before
+    the dataset is returned to any consumer.
     """
     ref = resolve_window_bank_paths(
         window_id,
@@ -225,6 +262,14 @@ def load_binance_window_dataset(
             f"window {window_id!r} missing warmup prefix: expected first candle "
             f"ts_ms={live_start - warmup * 60_000}, got {series_first}"
         )
+
+    # CDB-050 consumer bind: before provider load / return.
+    _enforce_window_dq_content_binding(
+        window_id=window_id,
+        meta=meta,
+        candles=candles,
+        candles_path=candles_path,
+    )
 
     dataset_spec = DatasetSpec(
         symbol=str(meta["symbol"]),

--- a/knowledge/logs/sessions/2026-08-04-4336-cdb050-consumer-binding.md
+++ b/knowledge/logs/sessions/2026-08-04-4336-cdb050-consumer-binding.md
@@ -1,0 +1,27 @@
+# Session 2026-08-04 — CDB-050 DQ consumer-binding Forward-Fix (#4336)
+
+## Status
+`DONE_CDB050_CONSUMER_BINDING_ADDED_TO_BATCH_PR`
+
+## Brain Evidence
+- brain_source: repo-only
+- brain_status: not-used
+- context_brain_attempted: true
+- context_brain_used: false
+- context_available: false
+- context_tool_status: available
+- context_trust_level: none
+- records_found: none
+- repo_fallback_used: true
+- repo_fallback_reason: insufficient_evidence
+
+## Base
+- origin/main: `655e7059a3caeb7d554d16a027898d707d3fb5bb`
+- Worktree: `D:\Dev\Workspaces\Repos\cdb-wt-4336-cdb050`
+- Branch: `batch/validation-research-issue-4336-cdb050`
+- Head: `b4c575a72e4c2364b29dd0b2d24673279aa60b30`
+- PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/4339
+
+## Boundaries
+- No merge, no cdb-local-ci, no campaign, LR NO-GO
+- CDB-051/052 untouched; CDB-049 regression only

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -64,7 +64,7 @@ import sys
 from dataclasses import dataclass
 from datetime import timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping, Sequence
 
 from core.replay.batch_a_strategy_registry import (
     BATCH_A_STRATEGY_REGISTRY,
@@ -147,6 +147,11 @@ from core.replay.replay_report_builder import (
 )
 from core.utils.clock import utcnow
 from core.utils.postgres_client import create_postgres_connection
+from tools.market_data.historical_common import (
+    HistoricalProbeError,
+    enforce_dq_content_binding,
+    load_dq_report_sidecar,
+)
 from services.validation.replay_reporter import ReplayReporter, ReplayReporterError
 from scripts.profitability.run_momentum_capture_pipeline_3166 import (
     WARMUP_CANDLES as MOMENTUM_WARMUP_CANDLES,
@@ -739,6 +744,31 @@ def _build_provenance_config_snapshot(
     }
 
 
+def _enforce_replay_dq_sidecar_binding(
+    *,
+    candles_path: Path,
+    candles: Sequence[Mapping[str, Any]],
+) -> None:
+    """CDB-050: if a quality_report.json sidecar exists, bind before replay.
+
+    Absence of a sidecar means this load path does not consume a DQ verdict
+    and is therefore not a CDB-050 DQ consumer for that run.
+    """
+    sidecar = candles_path if candles_path.is_dir() else candles_path.parent
+    report = load_dq_report_sidecar(sidecar / "quality_report.json")
+    if report is None:
+        return
+    try:
+        enforce_dq_content_binding(report=report, candles=candles)
+    except HistoricalProbeError as exc:
+        code = getattr(exc, "code", None)
+        raise ReplayRunnerError(
+            "DQ content binding failed for file dataset"
+            + (f" [{code}]" if code else "")
+            + f": {exc}"
+        ) from exc
+
+
 def _load_dataset_result(
     config: ARVPReplayConfig,
     *,
@@ -790,6 +820,9 @@ def _load_dataset_result(
             enforce_exact_window(candles, spec, str(input_path))
         except DatasetLoadError as exc:
             raise ReplayRunnerError(str(exc)) from exc
+
+        # CDB-050: bind DQ sidecar (if present) to independently loaded content.
+        _enforce_replay_dq_sidecar_binding(candles_path=input_path, candles=candles)
 
         # Request identity follows the *final* windowed spec (not temp start/end=0).
         # Content identity is the loaded candle series (propagate or recompute).

--- a/tests/fixtures/arvp/sensitivity/experiment_manifest_valid_v1.json
+++ b/tests/fixtures/arvp/sensitivity/experiment_manifest_valid_v1.json
@@ -119,7 +119,7 @@
   "manifest_fingerprint": "9efd7cbe8490a8f809181adb704c4a286e752273d1e0db77a2ae18a2f6b82256",
   "parameter_control": {
     "policy_schema_version": "cdb.parameter_control_policy.register.v1",
-    "register_fingerprint": "fec8a7f5baf3c801aae943079ee443fd30dda6d4e0274ee628b712e218d40a5a"
+    "register_fingerprint": "772823d0bc0401ec4adfc82dddb7c70f023c74bc506695366fca4fd9453833a7"
   },
   "parameter_families": [
     {

--- a/tests/unit/arvp/test_campaign_provenance_closure_cdb4336.py
+++ b/tests/unit/arvp/test_campaign_provenance_closure_cdb4336.py
@@ -53,7 +53,9 @@ def test_campaign_provenance_ready_cdb049_to_052(tmp_path_factory, repo_root=Non
     ]
     enforce_exact_window(candles, spec, "file:closure")
 
-    # CDB-050
+    # CDB-050 — independent content fingerprint (never copy from report object)
+    from tools.market_data.historical_common import content_fingerprint_for_normalized
+
     rows = [
         NormalizedCandle(
             ts_ms=_BASE + i * 60_000,
@@ -79,7 +81,8 @@ def test_campaign_provenance_ready_cdb049_to_052(tmp_path_factory, repo_root=Non
         step_ms=60_000,
         source_hash="e" * 64,
     )
-    assert_dq_content_binding(report, content_fingerprint=report["content_fingerprint"])
+    independent_fp = content_fingerprint_for_normalized(rows)
+    assert_dq_content_binding(report, content_fingerprint=independent_fp)
 
     # CDB-051
     assert (

--- a/tests/unit/market_data/test_binance_stress_rebuild.py
+++ b/tests/unit/market_data/test_binance_stress_rebuild.py
@@ -91,7 +91,17 @@ def test_select_stress_chunk_rejects_then_picks_next_deterministically() -> None
 @pytest.mark.unit
 def test_build_stress_windows_single_month_no_gap(tmp_path: Path) -> None:
     month = "2020-01"
-    enriched = tmp_path / "artifacts" / "market_data" / "enriched" / "binance" / "spot" / "BTCUSDT" / "1m" / month
+    enriched = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "enriched"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+        / month
+    )
     enriched.mkdir(parents=True)
     candles = _contiguous_block(1_578_441_600_000, 20_000)
     (enriched / "candles.jsonl").write_text(
@@ -101,7 +111,13 @@ def test_build_stress_windows_single_month_no_gap(tmp_path: Path) -> None:
     manifest = {
         "months": [{"month": month, "quality_verdict": "STRICT_COMPLETE"}],
     }
-    manifest_path = tmp_path / "artifacts" / "market_data" / "manifests" / "binance_btcusdt_1m_full_import.json"
+    manifest_path = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "manifests"
+        / "binance_btcusdt_1m_full_import.json"
+    )
     manifest_path.parent.mkdir(parents=True)
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
@@ -116,7 +132,17 @@ def test_build_stress_windows_single_month_no_gap(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_extract_stress_window_candles_no_interpolation(tmp_path: Path) -> None:
     month = "2020-01"
-    enriched = tmp_path / "artifacts" / "market_data" / "enriched" / "binance" / "spot" / "BTCUSDT" / "1m" / month
+    enriched = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "enriched"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+        / month
+    )
     enriched.mkdir(parents=True)
     candles = _contiguous_block(0, 20)
     (enriched / "candles.jsonl").write_text(
@@ -138,14 +164,33 @@ def test_extract_stress_window_candles_no_interpolation(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_rebuild_stress_v2_writes_new_fingerprints(tmp_path: Path) -> None:
     month = "2020-01"
-    enriched = tmp_path / "artifacts" / "market_data" / "enriched" / "binance" / "spot" / "BTCUSDT" / "1m" / month
+    enriched = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "enriched"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+        / month
+    )
     enriched.mkdir(parents=True)
     candles = _contiguous_block(1_578_441_600_000, 20_000)
     (enriched / "candles.jsonl").write_text(
         "\n".join(json.dumps(c) for c in candles),
         encoding="utf-8",
     )
-    bank_root = tmp_path / "artifacts" / "market_data" / "window_bank" / "binance" / "spot" / "BTCUSDT" / "1m"
+    bank_root = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "window_bank"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+    )
     old_id = "binance_1m_stress_max_drawdown"
     old_dir = bank_root / old_id
     old_dir.mkdir(parents=True)
@@ -162,7 +207,13 @@ def test_rebuild_stress_v2_writes_new_fingerprints(tmp_path: Path) -> None:
         "months": [{"month": month, "quality_verdict": "STRICT_COMPLETE"}],
         "source_sha": "abc123",
     }
-    manifest_path = tmp_path / "artifacts" / "market_data" / "manifests" / "binance_btcusdt_1m_full_import.json"
+    manifest_path = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "manifests"
+        / "binance_btcusdt_1m_full_import.json"
+    )
     manifest_path.parent.mkdir(parents=True)
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
@@ -203,7 +254,16 @@ def test_rebuild_stress_v2_writes_new_fingerprints(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_stress_rerun_manifest_schedules_exactly_six_jobs(tmp_path: Path) -> None:
-    bank_root = tmp_path / "artifacts" / "market_data" / "window_bank" / "binance" / "spot" / "BTCUSDT" / "1m"
+    bank_root = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "window_bank"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+    )
     for idx, wid in enumerate(
         ("binance_1m_stress_max_drawdown_v2", "binance_1m_stress_max_volatility_v2")
     ):
@@ -233,7 +293,13 @@ def test_stress_rerun_manifest_schedules_exactly_six_jobs(tmp_path: Path) -> Non
         }
         (d / "dataset_spec.json").write_text(json.dumps(spec), encoding="utf-8")
 
-    import_path = tmp_path / "artifacts" / "market_data" / "manifests" / "binance_btcusdt_1m_full_import.json"
+    import_path = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "manifests"
+        / "binance_btcusdt_1m_full_import.json"
+    )
     import_path.parent.mkdir(parents=True)
     import_path.write_text(json.dumps({"source_sha": "deadbeef"}), encoding="utf-8")
 
@@ -261,14 +327,33 @@ def test_assert_no_legacy_market_data_path_rejects_e_drive() -> None:
 @pytest.mark.unit
 def test_rebuild_stress_v2_skips_when_existing_valid(tmp_path: Path) -> None:
     month = "2021-05"
-    enriched = tmp_path / "artifacts" / "market_data" / "enriched" / "binance" / "spot" / "BTCUSDT" / "1m" / month
+    enriched = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "enriched"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+        / month
+    )
     enriched.mkdir(parents=True)
     candles = _contiguous_block(1_620_885_600_000, 20_000)
     (enriched / "candles.jsonl").write_text(
         "\n".join(json.dumps(c) for c in candles),
         encoding="utf-8",
     )
-    bank_root = tmp_path / "artifacts" / "market_data" / "window_bank" / "binance" / "spot" / "BTCUSDT" / "1m"
+    bank_root = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "window_bank"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
+    )
     for wid, start in (
         ("binance_1m_stress_max_drawdown_v2", 1_620_885_600_000),
         ("binance_1m_stress_max_volatility_v2", 1_621_339_200_000),
@@ -279,11 +364,17 @@ def test_rebuild_stress_v2_skips_when_existing_valid(tmp_path: Path) -> None:
         cp = d / "candles.jsonl"
         cp.write_text("\n".join(json.dumps(c) for c in chunk), encoding="utf-8")
         fp = wb.sha256_file(cp)
+        from tools.market_data.historical_common import (
+            content_fingerprint_for_candle_rows,
+        )
+
+        content_fp = content_fingerprint_for_candle_rows(chunk)
         spec = {
             "dataset_id": wid,
             "window_id": wid,
             "fingerprint": fp,
             "candles_sha256": fp,
+            "content_fingerprint": content_fp,
             "file_path": str(cp.resolve()).replace("\\", "/"),
             "symbol": "BTCUSDT",
             "timeframe": "1m",
@@ -298,10 +389,18 @@ def test_rebuild_stress_v2_skips_when_existing_valid(tmp_path: Path) -> None:
         }
         (d / "dataset_spec.json").write_text(json.dumps(spec), encoding="utf-8")
 
-    import_path = tmp_path / "artifacts" / "market_data" / "manifests" / "binance_btcusdt_1m_full_import.json"
+    import_path = (
+        tmp_path
+        / "artifacts"
+        / "market_data"
+        / "manifests"
+        / "binance_btcusdt_1m_full_import.json"
+    )
     import_path.parent.mkdir(parents=True)
     import_path.write_text(
-        json.dumps({"months": [{"month": month, "quality_verdict": "STRICT_COMPLETE"}]}),
+        json.dumps(
+            {"months": [{"month": month, "quality_verdict": "STRICT_COMPLETE"}]}
+        ),
         encoding="utf-8",
     )
     (bank_root / "window_bank_manifest.json").write_text("{}", encoding="utf-8")

--- a/tests/unit/market_data/test_dq_content_binding_cdb050.py
+++ b/tests/unit/market_data/test_dq_content_binding_cdb050.py
@@ -1,15 +1,24 @@
-"""CDB-050 DQ verdict binding to content identity."""
+"""CDB-050 DQ verdict binding to content identity — non-tautological matrix."""
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import pytest
 
 from tools.market_data.historical_common import (
+    DQ_CONTENT_FINGERPRINT_MISMATCH,
+    DQ_CONTENT_FINGERPRINT_MISSING,
+    DQ_EVIDENCE_CONTENT_MISMATCH,
     HistoricalProbeError,
     NormalizedCandle,
     assert_dq_content_binding,
     build_quality_report,
+    content_fingerprint_for_candle_rows,
     content_fingerprint_for_normalized,
+    dq_report_from_dataset_spec,
+    enforce_dq_content_binding,
 )
 
 pytestmark = pytest.mark.unit
@@ -17,7 +26,7 @@ pytestmark = pytest.mark.unit
 _BASE = 1_700_000_000_000
 
 
-def _candles(n: int = 3) -> list[NormalizedCandle]:
+def _candles(n: int = 3, *, close0: str = "100.5") -> list[NormalizedCandle]:
     out: list[NormalizedCandle] = []
     for i in range(n):
         out.append(
@@ -26,7 +35,7 @@ def _candles(n: int = 3) -> list[NormalizedCandle]:
                 open="100.0",
                 high="101.0",
                 low="99.0",
-                close="100.5",
+                close=close0 if i == 0 else "100.5",
                 volume="1.0",
                 quote_volume=None,
                 trade_count=None,
@@ -40,38 +49,201 @@ def _candles(n: int = 3) -> list[NormalizedCandle]:
     return out
 
 
-def test_cdb050_dq_verdict_binds_content_fingerprint() -> None:
-    candles = _candles()
-    report = build_quality_report(
+def _rows(candles: list[NormalizedCandle]) -> list[dict]:
+    return [
+        {
+            "ts_ms": c.ts_ms,
+            "open": c.open,
+            "high": c.high,
+            "low": c.low,
+            "close": c.close,
+            "volume": c.volume,
+        }
+        for c in candles
+    ]
+
+
+def _report_for(candles: list[NormalizedCandle]) -> dict:
+    return build_quality_report(
         candles,
         start_ts_ms=_BASE,
-        end_ts_ms=_BASE + 120_000,
+        end_ts_ms=_BASE + (len(candles) - 1) * 60_000,
         step_ms=60_000,
         source_hash="e" * 64,
     )
+
+
+# --- Positive ---
+
+
+def test_cdb050_dq_verdict_binds_content_fingerprint() -> None:
+    candles = _candles()
+    report = _report_for(candles)
     expected = content_fingerprint_for_normalized(candles)
     assert report["content_fingerprint"] == expected
     assert report["content_binding_schema"] == "cdb.dq_content_binding.v1"
     assert_dq_content_binding(report, content_fingerprint=expected)
 
 
+def test_cdb050_triple_match_verdict_evidence_dataset() -> None:
+    candles = _candles()
+    report = _report_for(candles)
+    evidence = {
+        "content_fingerprint": content_fingerprint_for_normalized(candles),
+        "evidence_links": ["docs/runbooks/example.md"],
+    }
+    bound = enforce_dq_content_binding(
+        report=report, candles=candles, evidence=evidence
+    )
+    assert bound == report["content_fingerprint"]
+
+
+def test_cdb050_identical_repeat_is_deterministic() -> None:
+    candles = _candles()
+    report = _report_for(candles)
+    a = enforce_dq_content_binding(report=report, candles=candles)
+    b = enforce_dq_content_binding(report=report, candles=list(candles))
+    assert a == b
+
+
+def test_cdb050_nonsemantic_evidence_links_do_not_change_binding() -> None:
+    candles = _candles()
+    report = _report_for(candles)
+    evidence_a = {
+        "content_fingerprint": report["content_fingerprint"],
+        "evidence_links": ["a.md"],
+    }
+    evidence_b = {
+        "content_fingerprint": report["content_fingerprint"],
+        "evidence_links": ["b.md", "c.md"],
+    }
+    assert enforce_dq_content_binding(
+        report=report, candles=candles, evidence=evidence_a
+    ) == enforce_dq_content_binding(report=report, candles=candles, evidence=evidence_b)
+
+
+# --- Negative ---
+
+
 def test_cdb050_changed_content_makes_verdict_stale() -> None:
     candles = _candles()
-    report = build_quality_report(
-        candles,
-        start_ts_ms=_BASE,
-        end_ts_ms=_BASE + 120_000,
-        step_ms=60_000,
-        source_hash="e" * 64,
+    report = _report_for(candles)
+    altered = _candles(close0="999.0")
+    new_fp = content_fingerprint_for_normalized(altered)
+    with pytest.raises(HistoricalProbeError) as exc:
+        assert_dq_content_binding(report, content_fingerprint=new_fp)
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISMATCH
+
+
+def test_cdb050_same_request_fingerprint_cannot_override_content_mismatch() -> None:
+    """Request-FP equality must not sanitize a content mismatch (CDB-050)."""
+    candles_a = _candles(close0="100.5")
+    candles_b = _candles(close0="200.5")
+    report = _report_for(candles_a)
+    # Same synthetic "request" token for both — must still fail on content.
+    request_fp = "r" * 64
+    assert request_fp  # present, but irrelevant to binding
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(report=report, candles=candles_b)
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISMATCH
+
+
+def test_cdb050_same_window_id_cannot_override_content_mismatch() -> None:
+    candles_a = _candles(close0="100.5")
+    candles_b = _candles(close0="300.5")
+    report = _report_for(candles_a)
+    report_with_window = {**report, "window_id": "binance_1m_month_2021_01"}
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(
+            report={**report_with_window, "window_id": "binance_1m_month_2021_01"},
+            candles=candles_b,
+        )
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISMATCH
+
+
+def test_cdb050_same_filepath_changed_candles_mismatch(tmp_path: Path) -> None:
+    candles_a = _candles(close0="100.5")
+    candles_b = _candles(close0="400.5")
+    path = tmp_path / "candles.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(r) for r in _rows(candles_a)) + "\n", encoding="utf-8"
     )
-    altered = _candles()
-    altered[0] = NormalizedCandle(
-        ts_ms=altered[0].ts_ms,
-        open="999.0",
-        high=altered[0].high,
-        low=altered[0].low,
-        close=altered[0].close,
-        volume=altered[0].volume,
+    report = _report_for(candles_a)
+    # Same path string stamped into report metadata must not override content.
+    report = {**report, "file_path": str(path)}
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(report=report, candles=candles_b)
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISMATCH
+
+
+def test_cdb050_missing_binding_blocks() -> None:
+    with pytest.raises(HistoricalProbeError) as exc:
+        assert_dq_content_binding(
+            {"verdict": "STRICT_COMPLETE"}, content_fingerprint="a" * 64
+        )
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISSING
+
+
+def test_cdb050_evidence_missing_content_fingerprint() -> None:
+    candles = _candles()
+    report = _report_for(candles)
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(
+            report=report,
+            candles=candles,
+            evidence={"verdict": "STRICT_COMPLETE"},
+        )
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISSING
+
+
+def test_cdb050_verdict_matches_evidence_but_not_dataset() -> None:
+    candles_a = _candles(close0="100.5")
+    candles_b = _candles(close0="500.5")
+    report = _report_for(candles_a)
+    evidence = {"content_fingerprint": report["content_fingerprint"]}
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(report=report, candles=candles_b, evidence=evidence)
+    assert exc.value.code in {
+        DQ_CONTENT_FINGERPRINT_MISMATCH,
+        DQ_EVIDENCE_CONTENT_MISMATCH,
+    }
+
+
+def test_cdb050_verdict_matches_dataset_evidence_differs() -> None:
+    candles = _candles()
+    report = _report_for(candles)
+    evidence = {"content_fingerprint": "0" * 64}
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(report=report, candles=candles, evidence=evidence)
+    assert exc.value.code == DQ_EVIDENCE_CONTENT_MISMATCH
+
+
+def test_cdb050_stale_evidence_after_candle_change() -> None:
+    candles = _candles(close0="100.5")
+    report = _report_for(candles)
+    evidence = {"content_fingerprint": report["content_fingerprint"]}
+    altered = _candles(close0="600.5")
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(report=report, candles=altered, evidence=evidence)
+    assert exc.value.code in {
+        DQ_CONTENT_FINGERPRINT_MISMATCH,
+        DQ_EVIDENCE_CONTENT_MISMATCH,
+    }
+
+
+def test_cdb050_warmup_content_change_breaks_binding() -> None:
+    """Warmup rows participate in canonical content identity."""
+    full = _candles(n=5, close0="100.5")
+    report = _report_for(full)
+    # Change only the first (warmup) candle close.
+    mutated = _candles(n=5, close0="100.5")
+    mutated[0] = NormalizedCandle(
+        ts_ms=mutated[0].ts_ms,
+        open=mutated[0].open,
+        high=mutated[0].high,
+        low=mutated[0].low,
+        close="777.0",
+        volume=mutated[0].volume,
         quote_volume=None,
         trade_count=None,
         symbol="BTCUSDT",
@@ -80,14 +252,26 @@ def test_cdb050_changed_content_makes_verdict_stale() -> None:
         source_type="test",
         source_file_sha256="d" * 64,
     )
-    new_fp = content_fingerprint_for_normalized(altered)
-    with pytest.raises(HistoricalProbeError, match="stale or mismatched"):
-        assert_dq_content_binding(report, content_fingerprint=new_fp)
+    assert content_fingerprint_for_normalized(
+        full
+    ) != content_fingerprint_for_normalized(mutated)
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(report=report, candles=mutated)
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISMATCH
+
+
+def test_cdb050_request_content_confusion_rejected() -> None:
+    candles = _candles()
+    report = _report_for(candles)
+    # Passing request fingerprint as content must fail closed.
+    with pytest.raises(HistoricalProbeError) as exc:
+        assert_dq_content_binding(report, content_fingerprint="r" * 64)
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISMATCH
 
 
 def test_cdb050_request_hash_alone_insufficient_mismatch_param() -> None:
     candles = _candles()
-    with pytest.raises(HistoricalProbeError, match="does not match"):
+    with pytest.raises(HistoricalProbeError) as exc:
         build_quality_report(
             candles,
             start_ts_ms=_BASE,
@@ -96,10 +280,212 @@ def test_cdb050_request_hash_alone_insufficient_mismatch_param() -> None:
             source_hash="e" * 64,
             content_fingerprint="0" * 64,
         )
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISMATCH
 
 
-def test_cdb050_missing_binding_blocks() -> None:
-    with pytest.raises(HistoricalProbeError, match="missing content_fingerprint"):
+def test_cdb050_empty_actual_fingerprint_missing() -> None:
+    with pytest.raises(HistoricalProbeError) as exc:
         assert_dq_content_binding(
-            {"verdict": "STRICT_COMPLETE"}, content_fingerprint="a" * 64
+            {"content_fingerprint": "a" * 64}, content_fingerprint="  "
         )
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISSING
+
+
+def test_cdb050_dq_report_from_spec_requires_verdict() -> None:
+    assert dq_report_from_dataset_spec({"window_id": "x"}) is None
+    report = dq_report_from_dataset_spec(
+        {
+            "data_quality_verdict": "STRICT_COMPLETE",
+            "content_fingerprint": "a" * 64,
+        }
+    )
+    assert report is not None
+    assert report["verdict"] == "STRICT_COMPLETE"
+    assert report["content_fingerprint"] == "a" * 64
+
+
+def test_cdb050_spec_without_content_fp_fails_on_enforce() -> None:
+    candles = _candles()
+    report = dq_report_from_dataset_spec({"data_quality_verdict": "STRICT_COMPLETE"})
+    assert report is not None
+    with pytest.raises(HistoricalProbeError) as exc:
+        enforce_dq_content_binding(report=report, candles=candles)
+    assert exc.value.code == DQ_CONTENT_FINGERPRINT_MISSING
+
+
+def test_cdb050_row_fingerprint_matches_normalized() -> None:
+    candles = _candles()
+    assert content_fingerprint_for_normalized(
+        candles
+    ) == content_fingerprint_for_candle_rows(_rows(candles))
+
+
+def test_cdb050_consumer_window_bank_materialize_binding(tmp_path: Path) -> None:
+    from tools.market_data.binance_window_bank import WindowSpec, _write_window_dataset
+
+    candles = [
+        {
+            "ts_ms": _BASE + i * 60_000,
+            "open": "1",
+            "high": "1",
+            "low": "1",
+            "close": "1",
+            "volume": "1",
+            "regime_id": 0,
+        }
+        for i in range(5)
+    ]
+    window = WindowSpec(
+        window_id="cdb050_test_window",
+        start_ts_ms=_BASE,
+        end_ts_ms=_BASE + 4 * 60_000,
+        candle_count=5,
+        dataset_fingerprint="",
+        regime_distribution={"0": {"count": 5}},
+        source_months=("2021-01",),
+        overlap_class="monthly",
+        evidence_class="controlled_lab_evidence",
+        purpose="development",
+        quality_verdict="STRICT_COMPLETE",
+        candles_path="",
+        spec_path="",
+    )
+    # Redirect IMPORT layout under tmp via writing under artifacts path of tmp.
+    # _write_window_dataset uses repo_root / artifacts / ...
+    spec_path = _write_window_dataset(tmp_path, window, candles)
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    assert "content_fingerprint" in spec
+    expected = content_fingerprint_for_candle_rows(candles)
+    assert spec["content_fingerprint"] == expected
+    enforce_dq_content_binding(
+        report=dq_report_from_dataset_spec(spec),  # type: ignore[arg-type]
+        candles=candles,
+    )
+
+
+def test_cdb050_adapter_rejects_stale_content_fp(tmp_path: Path) -> None:
+    from core.replay.binance_window_bank_adapter import (
+        BinanceWindowBankAdapterError,
+        load_binance_window_dataset,
+    )
+
+    window_id = "cdb050_stale"
+    root = tmp_path / window_id
+    root.mkdir()
+    candles = [
+        {
+            "ts_ms": _BASE + i * 60_000,
+            "open": "1",
+            "high": "1",
+            "low": "1",
+            "close": "1",
+            "volume": "1",
+            "regime_id": 0,
+        }
+        for i in range(5)
+    ]
+    (root / "candles.jsonl").write_text(
+        "\n".join(json.dumps(c) for c in candles) + "\n", encoding="utf-8"
+    )
+    (root / "dataset_spec.json").write_text(
+        json.dumps(
+            {
+                "window_id": window_id,
+                "symbol": "BTCUSDT",
+                "timeframe": "1m",
+                "start_ts_ms": candles[0]["ts_ms"],
+                "end_ts_ms": candles[-1]["ts_ms"],
+                "file_path": str(root / "candles.jsonl"),
+                "data_quality_verdict": "STRICT_COMPLETE",
+                "content_fingerprint": "0" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(BinanceWindowBankAdapterError, match="DQ content binding"):
+        load_binance_window_dataset(
+            window_id,
+            warmup_candles=1,
+            repo_root=tmp_path,
+            window_bank_root=tmp_path,
+        )
+
+
+def test_cdb050_runner_file_sidecar_mismatch(tmp_path: Path) -> None:
+    from services.validation.strategy_replay_runner import (
+        ARVPReplayConfig,
+        ReplayRunnerError,
+        _load_dataset_result,
+    )
+
+    candles = [
+        {
+            "ts_ms": _BASE + i * 60_000,
+            "open": "1",
+            "high": "1",
+            "low": "1",
+            "close": "1",
+            "volume": "1",
+        }
+        for i in range(5)
+    ]
+    path = tmp_path / "candles.jsonl"
+    path.write_text("\n".join(json.dumps(c) for c in candles) + "\n", encoding="utf-8")
+    (tmp_path / "quality_report.json").write_text(
+        json.dumps(
+            {
+                "verdict": "STRICT_COMPLETE",
+                "content_fingerprint": "0" * 64,
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = ARVPReplayConfig(
+        dataset_source="file",
+        input_candles_file=str(path),
+        output_directory=str(tmp_path / "out"),
+        entry_lookback_minutes=1,
+        exit_lookback_minutes=1,
+    )
+    with pytest.raises(ReplayRunnerError, match="DQ content binding"):
+        _load_dataset_result(config, warmup_count=1)
+
+
+def test_cdb050_runner_file_sidecar_pass(tmp_path: Path) -> None:
+    from services.validation.strategy_replay_runner import (
+        ARVPReplayConfig,
+        _load_dataset_result,
+    )
+
+    candles = [
+        {
+            "ts_ms": _BASE + i * 60_000,
+            "open": "1",
+            "high": "1",
+            "low": "1",
+            "close": "1",
+            "volume": "1",
+        }
+        for i in range(5)
+    ]
+    path = tmp_path / "candles.jsonl"
+    path.write_text("\n".join(json.dumps(c) for c in candles) + "\n", encoding="utf-8")
+    live_fp = content_fingerprint_for_candle_rows(candles)
+    (tmp_path / "quality_report.json").write_text(
+        json.dumps(
+            {
+                "verdict": "STRICT_COMPLETE",
+                "content_fingerprint": live_fp,
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = ARVPReplayConfig(
+        dataset_source="file",
+        input_candles_file=str(path),
+        output_directory=str(tmp_path / "out"),
+        entry_lookback_minutes=1,
+        exit_lookback_minutes=1,
+    )
+    result = _load_dataset_result(config, warmup_count=1)
+    assert result.content_fingerprint == live_fp

--- a/tools/market_data/binance_full_archive_import.py
+++ b/tools/market_data/binance_full_archive_import.py
@@ -37,6 +37,11 @@ from tools.market_data.historical_common import (
     ONE_MINUTE_MS,
     HistoricalProbeError,
     HttpFetcher,
+    assert_dq_content_binding,
+    content_fingerprint_for_candle_rows,
+    content_fingerprint_for_normalized,
+    enforce_dq_content_binding,
+    load_dq_report_sidecar,
     month_bounds,
     parse_year_month,
     sha256_file,
@@ -421,7 +426,22 @@ def _load_cached_month_record(repo_root: Path, month: str) -> MonthImportRecord 
     quality_path = norm / "quality_report.json"
     if not quality_path.exists():
         return None
-    quality = json.loads(quality_path.read_text(encoding="utf-8"))
+    quality = load_dq_report_sidecar(quality_path)
+    if quality is None:
+        return None
+    candles_path = norm / "candles.jsonl"
+    if not candles_path.exists():
+        raise HistoricalProbeError(
+            f"Cached month {month} has quality_report.json but missing candles.jsonl"
+        )
+    # CDB-050: reuse is only valid when the stored DQ verdict still binds to
+    # the on-disk candle content (independent recompute — no self-compare).
+    candle_rows: list[dict[str, Any]] = []
+    with candles_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if line.strip():
+                candle_rows.append(json.loads(line))
+    enforce_dq_content_binding(report=quality, candles=candle_rows)
     raw_zip = _raw_dir(repo_root, month)
     zip_files = list(raw_zip.glob("BTCUSDT-1m-*.zip"))
     record = MonthImportRecord(
@@ -432,7 +452,7 @@ def _load_cached_month_record(repo_root: Path, month: str) -> MonthImportRecord 
         regime_status="complete",
         quality_verdict=str(quality.get("verdict", "SOURCE_INVALID")),
         local_raw_path=str(zip_files[0]).replace("\\", "/") if zip_files else None,
-        local_normalized_path=str(norm / "candles.jsonl").replace("\\", "/"),
+        local_normalized_path=str(candles_path).replace("\\", "/"),
         local_enriched_path=str(
             (_enriched_dir(repo_root, month) / "candles.jsonl")
         ).replace("\\", "/"),
@@ -447,6 +467,14 @@ def _load_cached_month_record(repo_root: Path, month: str) -> MonthImportRecord 
             fp = spec.get("fingerprint") or spec.get("candles_sha256")
             if isinstance(fp, str):
                 record.normalized_hash = fp
+            content_fp = spec.get("content_fingerprint")
+            if isinstance(content_fp, str) and content_fp.strip():
+                assert_dq_content_binding(
+                    {"content_fingerprint": content_fp},
+                    content_fingerprint=content_fingerprint_for_candle_rows(
+                        candle_rows
+                    ),
+                )
         if not record.normalized_hash:
             record.normalized_hash = hash_jsonl_file(Path(record.local_normalized_path))
     if record.local_enriched_path and Path(record.local_enriched_path).exists():
@@ -619,8 +647,11 @@ def _import_single_month(
         source_hash=file_hash,
         second_parse_hash=file_hash,
     )
+    # CDB-050: expected FP derived independently from the live candle series.
+    independent_content_fp = content_fingerprint_for_normalized(candles)
     assert_dq_content_binding(
-        quality, content_fingerprint=quality["content_fingerprint"]
+        quality,
+        content_fingerprint=independent_content_fp,
     )
     del candles
     write_json(norm_dir / "quality_report.json", quality)
@@ -641,6 +672,7 @@ def _import_single_month(
             ),
             "fingerprint": file_hash,
             "candles_sha256": file_hash,
+            "content_fingerprint": independent_content_fp,
             "month": month,
         },
     )

--- a/tools/market_data/binance_historical_probe.py
+++ b/tools/market_data/binance_historical_probe.py
@@ -38,6 +38,7 @@ from tools.market_data.historical_common import (
     arvp_load_smoke,
     assert_dq_content_binding,
     build_quality_report,
+    content_fingerprint_for_normalized,
     detect_timestamp_unit,
     decimal_str,
     extract_zip_csv,
@@ -555,8 +556,10 @@ def run_probe(
         source_hash=norm_hash,
         second_parse_hash=second_parse_hash,
     )
+    # CDB-050: expected FP must be derived independently of the report object.
     assert_dq_content_binding(
-        quality, content_fingerprint=quality["content_fingerprint"]
+        quality,
+        content_fingerprint=content_fingerprint_for_normalized(candles),
     )
 
     normalized_dir = (

--- a/tools/market_data/binance_window_bank.py
+++ b/tools/market_data/binance_window_bank.py
@@ -2,6 +2,7 @@
 
 Cross-venue research windows only — not MEXC same-venue evidence.
 """
+
 # ruff: noqa: E402
 
 from __future__ import annotations
@@ -31,6 +32,9 @@ from tools.market_data.binance_full_archive_import import (
 from tools.market_data.historical_common import (
     ONE_MINUTE_MS,
     HistoricalProbeError,
+    content_fingerprint_for_candle_rows,
+    dq_report_from_dataset_spec,
+    enforce_dq_content_binding,
     month_bounds,
     parse_year_month,
     sha256_file,
@@ -46,9 +50,7 @@ EXCLUDED_VERDICTS = frozenset(
 OVERLAP_CLASSES = frozenset(
     {"monthly", "quarterly", "yearly", "stress", "smoke", "pilot"}
 )
-PURPOSES = frozenset(
-    {"development", "validation", "out_of_sample", "stress"}
-)
+PURPOSES = frozenset({"development", "validation", "out_of_sample", "stress"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,7 +96,14 @@ def resolve_build_months(repo_root: Path = IMPORT_REPO) -> list[str]:
     manifest = load_import_manifest(repo_root)
     by_month = {str(entry["month"]): entry for entry in manifest.get("months") or []}
     enriched_base = (
-        repo_root / "artifacts" / "market_data" / "enriched" / "binance" / "spot" / "BTCUSDT" / "1m"
+        repo_root
+        / "artifacts"
+        / "market_data"
+        / "enriched"
+        / "binance"
+        / "spot"
+        / "BTCUSDT"
+        / "1m"
     )
     months: list[str] = []
     if enriched_base.is_dir():
@@ -118,8 +127,14 @@ def resolve_build_months(repo_root: Path = IMPORT_REPO) -> list[str]:
     return strict_complete_months(manifest)
 
 
-def _load_month_candles(repo_root: Path, month: str, *, enriched: bool = True) -> list[dict[str, Any]]:
-    base = _enriched_dir(repo_root, month) if enriched else _normalized_dir(repo_root, month)
+def _load_month_candles(
+    repo_root: Path, month: str, *, enriched: bool = True
+) -> list[dict[str, Any]]:
+    base = (
+        _enriched_dir(repo_root, month)
+        if enriched
+        else _normalized_dir(repo_root, month)
+    )
     path = base / "candles.jsonl"
     if not path.exists():
         raise HistoricalProbeError(f"Missing candles: {path}")
@@ -267,7 +282,9 @@ def _month_candle_bounds(
     return int(candles[0]["ts_ms"]), int(candles[-1]["ts_ms"]), len(candles), contiguous
 
 
-def _cross_month_segments(months: Sequence[str], repo_root: Path) -> list[tuple[str, ...]]:
+def _cross_month_segments(
+    months: Sequence[str], repo_root: Path
+) -> list[tuple[str, ...]]:
     """Group consecutive months whose boundary timestamps are contiguous."""
     ordered = sorted(months)
     if not ordered:
@@ -332,12 +349,22 @@ def _update_metric_best(
             value = _window_metrics(chunk)[metric_field]
             current = best.get(metric_key)
             if current is None:
-                best[metric_key] = (value, int(chunk[0]["ts_ms"]), chunk, segment_months)
+                best[metric_key] = (
+                    value,
+                    int(chunk[0]["ts_ms"]),
+                    chunk,
+                    segment_months,
+                )
                 continue
             cur_val, cur_start, _, _ = current
             better = value > cur_val if reverse else value < cur_val
             if better or (value == cur_val and int(chunk[0]["ts_ms"]) < cur_start):
-                best[metric_key] = (value, int(chunk[0]["ts_ms"]), chunk, segment_months)
+                best[metric_key] = (
+                    value,
+                    int(chunk[0]["ts_ms"]),
+                    chunk,
+                    segment_months,
+                )
 
 
 def _window_metrics(chunk: Sequence[dict[str, Any]]) -> dict[str, float]:
@@ -453,6 +480,8 @@ def _write_window_dataset(
         for row in candles:
             handle.write(json.dumps(row, ensure_ascii=False) + "\n")
     fingerprint = sha256_file(jsonl_path)
+    # CDB-050: content identity of the written series (independent of file SHA).
+    content_fp = content_fingerprint_for_candle_rows(candles)
     spec = {
         "schema_version": "dataset_spec.v2",
         "dataset_id": window.window_id,
@@ -470,6 +499,7 @@ def _write_window_dataset(
         "timeframe": "1m",
         "fingerprint": fingerprint,
         "candles_sha256": fingerprint,
+        "content_fingerprint": content_fp,
         "data_quality_verdict": window.quality_verdict,
         "regime_enriched": True,
         "overlap_class": window.overlap_class,
@@ -488,6 +518,11 @@ def _write_window_dataset(
         "lr_status": "NO-GO",
         "issue": "#3990",
     }
+    # Bind the stamped DQ verdict to the written content before accepting the
+    # window as STRICT/usable for downstream consumers.
+    dq_report = dq_report_from_dataset_spec(spec)
+    if dq_report is not None:
+        enforce_dq_content_binding(report=dq_report, candles=candles)
     spec_path = window_dir / "dataset_spec.json"
     write_json(spec_path, spec)
     return spec_path
@@ -685,7 +720,9 @@ def build_stress_windows(
         _value, start_ts, chunk, _segment = entry
         if reject.get(wid_base) == start_ts:
             # pick next-best deterministically within already ranked scan
-            candidates: list[tuple[float, int, list[dict[str, Any]], tuple[str, ...]]] = []
+            candidates: list[
+                tuple[float, int, list[dict[str, Any]], tuple[str, ...]]
+            ] = []
             for segment in _cross_month_segments(months, repo_root):
                 segment_candles = _load_segment_candles(repo_root, segment)
                 for island in _contiguous_islands(segment_candles):
@@ -705,9 +742,7 @@ def build_stress_windows(
                         candidates.append(
                             (metric, int(subchunk[0]["ts_ms"]), subchunk, segment)
                         )
-            candidates = [
-                c for c in candidates if c[1] != reject.get(wid_base, -1)
-            ]
+            candidates = [c for c in candidates if c[1] != reject.get(wid_base, -1)]
             if not candidates:
                 continue
             if metric_key in {"min_vol", "max_downtrend"}:
@@ -940,6 +975,13 @@ def verify_stress_v2_window(
 
     if spec.get("data_quality_verdict") != "STRICT_COMPLETE":
         raise HistoricalProbeError(f"{window_id}: quality verdict not STRICT_COMPLETE")
+    # CDB-050: file SHA alone is insufficient — bind DQ content identity.
+    dq_report = dq_report_from_dataset_spec(spec)
+    if dq_report is None:
+        raise HistoricalProbeError(
+            f"{window_id}: missing data_quality_verdict for DQ content binding"
+        )
+    enforce_dq_content_binding(report=dq_report, candles=candles)
     if spec.get("venue") != "binance":
         raise HistoricalProbeError(f"{window_id}: venue must be binance")
     if spec.get("evidence_subclass") != "historical_cross_venue_research":
@@ -1348,7 +1390,9 @@ def merge_stress_v2_into_campaign(
     from tools.arvp_vacation.queue_store import QUEUE_STATE_FILENAME
     from tools.arvp_vacation.summary import write_summary
 
-    orig_state_path = (repo_root / original_campaign_dir).resolve() / QUEUE_STATE_FILENAME
+    orig_state_path = (
+        repo_root / original_campaign_dir
+    ).resolve() / QUEUE_STATE_FILENAME
     rerun_state_path = (repo_root / rerun_campaign_dir).resolve() / QUEUE_STATE_FILENAME
     rerun_rel = (
         rerun_campaign_dir.as_posix()
@@ -1364,7 +1408,9 @@ def merge_stress_v2_into_campaign(
     rerun_state = json.loads(rerun_state_path.read_text(encoding="utf-8"))
 
     orig_jobs = list(orig_state.get("jobs") or [])
-    base_jobs = [j for j in orig_jobs if isinstance(j, dict) and not _is_stress_v2_job(j)]
+    base_jobs = [
+        j for j in orig_jobs if isinstance(j, dict) and not _is_stress_v2_job(j)
+    ]
     rerun_jobs = [j for j in rerun_state.get("jobs") or [] if isinstance(j, dict)]
     if len(rerun_jobs) != 6:
         raise HistoricalProbeError(
@@ -1410,7 +1456,10 @@ def merge_stress_v2_into_campaign(
     }
     write_json(orig_state_path, merged_state)
 
-    manifest_path = repo_root / "artifacts/arvp_vacation/manifests/binance_historical_campaign_3990.yaml"
+    manifest_path = (
+        repo_root
+        / "artifacts/arvp_vacation/manifests/binance_historical_campaign_3990.yaml"
+    )
     manifest = load_manifest(manifest_path)
     write_summary(manifest, merged_state, repo_root)
 
@@ -1470,10 +1519,7 @@ def build_vacation_manifest(
 
     if smoke_only:
         payload["dataset_roots"] = [
-            str(
-                Path(bank_root)
-                / "binance_1m_month_2026_06"
-            ).replace("\\", "/")
+            str(Path(bank_root) / "binance_1m_month_2026_06").replace("\\", "/")
         ]
     elif pilot_only:
         pilot_ids = []
@@ -1562,7 +1608,9 @@ def main() -> int:
 
         if args.merge_stress_v2:
             if not args.original_campaign_dir or not args.rerun_campaign_dir:
-                parser.error("--merge-stress-v2 requires --original-campaign-dir and --rerun-campaign-dir")
+                parser.error(
+                    "--merge-stress-v2 requires --original-campaign-dir and --rerun-campaign-dir"
+                )
             merge_result = merge_stress_v2_into_campaign(
                 original_campaign_dir=Path(args.original_campaign_dir),
                 rerun_campaign_dir=Path(args.rerun_campaign_dir),
@@ -1596,8 +1644,21 @@ def main() -> int:
                     / "BTCUSDT"
                     / "1m"
                 ).replace("\\", "/"),
-                "windows": json.loads(
-                    (
+                "windows": (
+                    json.loads(
+                        (
+                            REPO_ROOT
+                            / "artifacts"
+                            / "market_data"
+                            / "window_bank"
+                            / "binance"
+                            / "spot"
+                            / "BTCUSDT"
+                            / "1m"
+                            / "window_bank_manifest.json"
+                        ).read_text(encoding="utf-8")
+                    ).get("windows", [])
+                    if (
                         REPO_ROOT
                         / "artifacts"
                         / "market_data"
@@ -1607,20 +1668,9 @@ def main() -> int:
                         / "BTCUSDT"
                         / "1m"
                         / "window_bank_manifest.json"
-                    ).read_text(encoding="utf-8")
-                ).get("windows", [])
-                if (
-                    REPO_ROOT
-                    / "artifacts"
-                    / "market_data"
-                    / "window_bank"
-                    / "binance"
-                    / "spot"
-                    / "BTCUSDT"
-                    / "1m"
-                    / "window_bank_manifest.json"
-                ).exists()
-                else [],
+                    ).exists()
+                    else []
+                ),
             }
             path = build_vacation_manifest(
                 bank_stub,
@@ -1631,12 +1681,16 @@ def main() -> int:
             return 0
 
         if args.run_campaign:
-            mpath = Path(args.manifest_path) if args.manifest_path else (
-                REPO_ROOT
-                / "artifacts"
-                / "arvp_vacation"
-                / "manifests"
-                / "binance_historical_campaign_3990.yaml"
+            mpath = (
+                Path(args.manifest_path)
+                if args.manifest_path
+                else (
+                    REPO_ROOT
+                    / "artifacts"
+                    / "arvp_vacation"
+                    / "manifests"
+                    / "binance_historical_campaign_3990.yaml"
+                )
             )
             result = run_vacation_campaign(mpath)
             print(json.dumps(result, indent=2))

--- a/tools/market_data/historical_common.py
+++ b/tools/market_data/historical_common.py
@@ -43,8 +43,22 @@ QUALITY_VERDICTS = frozenset(
 )
 
 
+# CDB-050 machine-readable DQ content-binding error codes.
+DQ_CONTENT_FINGERPRINT_MISSING = "DQ_CONTENT_FINGERPRINT_MISSING"
+DQ_CONTENT_FINGERPRINT_MISMATCH = "DQ_CONTENT_FINGERPRINT_MISMATCH"
+DQ_EVIDENCE_CONTENT_MISMATCH = "DQ_EVIDENCE_CONTENT_MISMATCH"
+
+
 class HistoricalProbeError(ValueError):
-    """Fail-closed historical probe error."""
+    """Fail-closed historical probe error.
+
+    Optional ``code`` carries a stable machine-readable CDB-050 binding class
+    when the failure is a DQ content-identity violation.
+    """
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 @dataclass(frozen=True, slots=True)
@@ -453,26 +467,155 @@ def content_fingerprint_for_normalized(
     return compute_content_fingerprint(rows)
 
 
+def content_fingerprint_for_candle_rows(
+    candles: Sequence[Mapping[str, Any]],
+) -> str:
+    """Content identity for mapping candle rows (CDB-050 consumer path)."""
+    return compute_content_fingerprint(candles)
+
+
+def _extract_content_fingerprint(payload: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(payload, Mapping):
+        return None
+    raw = payload.get("content_fingerprint")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
 def assert_dq_content_binding(
     report: Mapping[str, Any],
     *,
     content_fingerprint: str,
+    evidence: Mapping[str, Any] | None = None,
 ) -> None:
-    """Fail-closed: DQ verdict must bind to the actual content identity (CDB-050)."""
+    """Fail-closed: DQ verdict must bind to the actual content identity (CDB-050).
+
+    ``content_fingerprint`` MUST be derived independently from the dataset the
+    consumer is about to use — never copied from ``report`` or ``evidence``.
+    Optional ``evidence`` (e.g. sidecar quality evidence) must agree with both
+    the verdict and the live content identity.
+    """
     if not isinstance(content_fingerprint, str) or not content_fingerprint.strip():
         raise HistoricalProbeError(
-            "DQ content binding requires a non-empty content_fingerprint"
+            "DQ content binding requires a non-empty content_fingerprint",
+            code=DQ_CONTENT_FINGERPRINT_MISSING,
         )
-    bound = report.get("content_fingerprint")
-    if not isinstance(bound, str) or not bound.strip():
+    actual = content_fingerprint.strip()
+    bound = _extract_content_fingerprint(report)
+    if bound is None:
         raise HistoricalProbeError(
-            "DQ verdict missing content_fingerprint binding; not applicable"
+            "DQ verdict missing content_fingerprint binding; not applicable",
+            code=DQ_CONTENT_FINGERPRINT_MISSING,
         )
-    if bound != content_fingerprint:
+    if bound != actual:
         raise HistoricalProbeError(
             "DQ verdict content_fingerprint is stale or mismatched; "
-            "verdict is not applicable to this dataset content"
+            "verdict is not applicable to this dataset content",
+            code=DQ_CONTENT_FINGERPRINT_MISMATCH,
         )
+    if evidence is not None:
+        evidence_fp = _extract_content_fingerprint(evidence)
+        if evidence_fp is None:
+            raise HistoricalProbeError(
+                "DQ evidence missing content_fingerprint binding; not applicable",
+                code=DQ_CONTENT_FINGERPRINT_MISSING,
+            )
+        if evidence_fp != bound or evidence_fp != actual:
+            raise HistoricalProbeError(
+                "DQ evidence content_fingerprint disagrees with verdict or "
+                "current dataset content",
+                code=DQ_EVIDENCE_CONTENT_MISMATCH,
+            )
+
+
+def enforce_dq_content_binding(
+    *,
+    report: Mapping[str, Any],
+    content_fingerprint: str | None = None,
+    candles: Sequence[NormalizedCandle] | Sequence[Mapping[str, Any]] | None = None,
+    evidence: Mapping[str, Any] | None = None,
+) -> str:
+    """Single fail-closed CDB-050 enforcement point for all DQ consumers.
+
+    Prefer passing ``candles`` so the actual content fingerprint is computed
+    independently of the verdict/evidence objects. A precomputed fingerprint
+    is accepted only when the caller derived it from a separate source.
+    """
+    if content_fingerprint is not None and candles is not None:
+        # Still allow both; candles win as the independent actual identity.
+        if candles and isinstance(candles[0], NormalizedCandle):
+            actual = content_fingerprint_for_normalized(
+                candles  # type: ignore[arg-type]
+            )
+        else:
+            actual = content_fingerprint_for_candle_rows(
+                candles  # type: ignore[arg-type]
+            )
+        if content_fingerprint.strip() != actual:
+            # Caller-supplied fingerprint disagreed with candle-derived actual:
+            # treat as mismatch against the live dataset (not a rewrite).
+            raise HistoricalProbeError(
+                "provided content_fingerprint does not match examined candle content",
+                code=DQ_CONTENT_FINGERPRINT_MISMATCH,
+            )
+    elif candles is not None:
+        if candles and isinstance(candles[0], NormalizedCandle):
+            actual = content_fingerprint_for_normalized(
+                candles  # type: ignore[arg-type]
+            )
+        elif candles:
+            actual = content_fingerprint_for_candle_rows(
+                candles  # type: ignore[arg-type]
+            )
+        else:
+            actual = content_fingerprint_for_candle_rows([])
+    elif content_fingerprint is not None:
+        actual = content_fingerprint
+    else:
+        raise HistoricalProbeError(
+            "DQ content binding requires candles or content_fingerprint",
+            code=DQ_CONTENT_FINGERPRINT_MISSING,
+        )
+    assert_dq_content_binding(report, content_fingerprint=actual, evidence=evidence)
+    return actual
+
+
+def load_dq_report_sidecar(path: Path) -> dict[str, Any] | None:
+    """Load a ``quality_report.json`` sidecar if present; else ``None``."""
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise HistoricalProbeError(
+            f"Failed to load DQ quality report sidecar: {path}: {exc}",
+            code=DQ_CONTENT_FINGERPRINT_MISSING,
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise HistoricalProbeError(
+            f"DQ quality report sidecar is not an object: {path}",
+            code=DQ_CONTENT_FINGERPRINT_MISSING,
+        )
+    return dict(payload)
+
+
+def dq_report_from_dataset_spec(spec: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Build a minimal DQ verdict mapping from a window/dataset spec.
+
+    Returns ``None`` when the spec does not claim a DQ verdict (consumer is
+    then not a DQ consumer for CDB-050 purposes).
+    """
+    verdict = spec.get("data_quality_verdict")
+    if verdict is None or (isinstance(verdict, str) and not verdict.strip()):
+        return None
+    report: dict[str, Any] = {
+        "verdict": str(verdict).strip(),
+    }
+    fp = _extract_content_fingerprint(spec)
+    if fp is not None:
+        report["content_fingerprint"] = fp
+    return report
 
 
 def build_quality_report(
@@ -494,7 +637,8 @@ def build_quality_report(
     computed_content_fp = content_fingerprint_for_normalized(candles)
     if content_fingerprint is not None and content_fingerprint != computed_content_fp:
         raise HistoricalProbeError(
-            "provided content_fingerprint does not match examined candle content"
+            "provided content_fingerprint does not match examined candle content",
+            code=DQ_CONTENT_FINGERPRINT_MISMATCH,
         )
     dupes = detect_duplicates(candles)
     gaps = detect_gaps(


### PR DESCRIPTION
## Summary

**CDB-050-only** Forward-Fix after Post-Merge-Audit of PR #4338 / main `655e7059`.

- Enforce DQ verdict binding to independently derived `content_fingerprint` on real consumers:
  - Strategy Replay Runner (file sidecar `quality_report.json`)
  - Window-Bank materialize + adapter load + stress verify
  - Binance historical probe / full-archive build + cached-month reuse
- Shared fail-closed API: `enforce_dq_content_binding` / `assert_dq_content_binding` with codes
  `DQ_CONTENT_FINGERPRINT_MISSING`, `DQ_CONTENT_FINGERPRINT_MISMATCH`, `DQ_EVIDENCE_CONTENT_MISMATCH`
- Non-tautological negative/positive test matrix
- Parameter-control CDB-050 corrected from overclaimed `CLOSED_CORRECTNESS` to `CORRECTNESS_FIX_ONLY` (still blocked by #4336 until merge)

### Explicitly NOT in this PR
- CDB-049 already accepted on main (regression covered only)
- CDB-051 / CDB-052 remain open residuals
- No sensitivity campaign / Stage-A/B / OOS / Stress campaign runs
- No `cdb-local-ci` publish, no merge, no issue close
- LR remains **NO-GO**

Refs #4336

## Delivered
- Consumer-binding call chains for Runner and Window-Bank
- Probe non-tautological asserts + cache reuse rebind
- Register evidence paths for CDB-050 only

## Validation
- `pytest` targeted: DQ binding, window adapter, dataset identity (#4335), runner fingerprint wrap, stress rebuild, parameter-control, provenance closure — **60 passed**
- `ruff check` on touched files — PASS
- `black --check` (after format) — PASS
- `gitleaks detect` on commit range — no leaks
- `python -m tools.validate_parameter_control_policy` — PASS

## Non-goals / Remaining uncertainty
- CDB-051 integrity/gap/ooo/runtime parity
- CDB-052 rankability / stale-manifest
- Full Fast-CI / merge gate
- Campaign correctness / profitability claims

## Test plan
- [x] Non-tautological CDB-050 unit matrix
- [x] Window-Bank adapter stale-FP rejection
- [x] Runner file sidecar mismatch/pass
- [x] CDB-049 / #4335 fingerprint regression
- [x] Parameter-control validator
- [ ] Hosted advisory checks (informational only; not merge gate)