### PR TITLE
chore(devenv): Cursor Cloud environment setup + verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,9 +366,14 @@ targets.
 
 - Canonical CI command: `pytest -q -k "not test_mcp_time_server_runtime"` (5126+ tests).
 - `make test-unit` alone fails without MCP deps; use the CI filter or install
-  `requirements-mcp.txt` first.
+ `requirements-mcp.txt` first.
 - Equivalently: `make test` after MCP deps are installed.
 - For coverage: `make test-coverage` (80% threshold)
+- A few unit tests shell out to the `docker` binary (e.g.
+ `test_docker_compose_config_merge_is_valid`) and fail with
+ `FileNotFoundError: 'docker'` when Docker is not installed. This is expected in
+ a no-Docker Cloud session and is not a code regression — skip it or install
+ Docker per the one-time setup above if you need it.
 
 ### Linting
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified a full development environment for the CDB (Claire de Binare) trading system in the Cursor Cloud VM, and ran the core product end-to-end.

This PR itself is docs-only: it adds one non-obvious note to the `## Cursor Cloud Agent environment (remote only)` section of `AGENTS.md`. The environment (venv + dependency refresh) is captured via the Cloud Agent update script, not repo changes.

## What was set up

- Installed system `python3.12-venv` (one-time; `sudo apt-get update` was required first), created `.venv` on Python 3.12.3.
- Installed deps: `pip install -r requirements.txt -r requirements-dev.txt -r requirements-mcp.txt`.
- Update script (dependency refresh on startup) = create `.venv` + `pip upgrade` + install the three requirements files (verified idempotent).

## Verification (agreed scope: full dev readiness)

| Task | Command | Result |
|---|---|---|
| Lint | `ruff check .` | All checks passed |
| Tests | `pytest -q -k "not test_mcp_time_server_runtime"` | 10035 passed, 110 skipped, 1 env-only failure |
| Core demo (hello-world) | `make replay-shadow-run REPLAY_INPUT_CANDLES=...dataset.candles.json` | completed; deterministic replay OK |

The single test failure (`test_docker_compose_config_merge_is_valid`) fails with `FileNotFoundError: 'docker'` because Docker is not installed in the Cloud VM — expected, not a code regression. A second test (`test_acceptance_drill_six_jobs_summary`) passed in isolation (flaky/ordering-dependent). This PR documents the Docker-dependent case in `AGENTS.md`.

## Hello-world evidence (core trading pipeline, offline)

The `replay-shadow-run` deterministically replays the `primary_breakout_v1` strategy over 20,160 BTCUSDT 1m candles and produces real trade decisions + PnL metrics:

- `events_processed=20160`, `decisions_made=44`, `orders_placed=44`, `fills_recorded=22`
- `closed_trades_total=22`, `gross_pnl_quote=2646.81`, `fee_adjusted_profit_factor=1.15`
- `deterministic_replay_ok=True`, `data_integrity_ok=True`, gate=`REVIEW`

[Replay shadow demo output](https://cursor.com/artifacts/c/art-ef75f566-0283-4187-b8a1-28f7379b2768)

## Notes

- Docker BLUE+RED full stack (`make docker-up`) is optional/heavy (Docker not pre-installed; needs a `SECRETS_PATH` dir with mock secrets) and was intentionally not started; the offline replay/shadow path already exercises the core trading logic end-to-end. LR remains NO-GO.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d8c87d1-249a-46ab-a5b0-5734f8fe1519?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d8c87d1-249a-46ab-a5b0-5734f8fe1519&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

