### PR TITLE
[ARVP][RESEARCH] #4153 reproduction execution contract fix (no campaign, no GO)

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -3,27 +3,27 @@
 **Status Class**: Claire de Binare repository / Engineering Status
 **Authority**: Current repo/main/test/dependency snapshot; not the canonical live-readiness or Echtgeld Go/No-Go source.
 **Operational Canon**: `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-<!-- cdb:status-freshness header-date=2026-08-03 -->
-**Last Updated**: 2026-08-03
+<!-- cdb:status-freshness header-date=2026-08-04 -->
+**Last Updated**: 2026-08-04
 **GitHub Boundary**: The live commit and PR state is tracked in GitHub (UI/API or `gh`); this file is a curated repo/engineering ledger, not a live mirror.
 **Freshness Guard**: Only the newest dated block below is a live claim. Everything from the previous dated block onward is marked `historical as of` and is append-only. Marker convention: [`docs/meta/REPOSITORY_CANON.md`](docs/meta/REPOSITORY_CANON.md); validator: `python -m tools.validate_status_freshness`.
 
 ---
 
-## Repo / Engineering Status (2026-08-03)
+## Repo / Engineering Status (2026-08-04)
 
-<!-- cdb:live-claim type=main_sha value=312d12e0 -->
-- **Confirmed main state**: `origin/main` @ `312d12e0` — tip after Security Backlog Reconciliation squash-merge [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303) (supersedes ACP foundation tip `abf997d5`).
+<!-- cdb:live-claim type=main_sha value=43401302 -->
+- **Confirmed main state**: `origin/main` @ `43401302` — tip after Hermes app mint/write-path verify squash-merge [#4344](https://github.com/jannekbuengener/Claire_de_Binare/pull/4344) (supersedes Security Backlog tip `312d12e0` and ACP foundation tip `abf997d5`).
 
 <!-- cdb:live-claim type=issue_state issue=4258 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4257 state=closed -->
-<!-- cdb:live-claim type=issue_state issue=4289 state=open -->
+<!-- cdb:live-claim type=issue_state issue=4289 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=2513 state=open -->
 - **#2513 Security backlog reconciliation**: **DONE_MERGED_CLOSED** via PR [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303) @ `312d12e0` (meta issue stays open as canonical tracker). Remaining open `type:security` issues are **Upstream HOLDs** — parked until suite-native `FixedVersion` evidence; no remediation slice without live FixedVersion. Duplicate/pip trackers closed post-merge. LR **NO-GO** unchanged.
 
 - **#4258 Live Cursor Pilot (delivery PR #4302)**: Dedicated PR [#4302](https://github.com/jannekbuengener/Claire_de_Binare/pull/4302) reintegrated onto `312d12e0`. CDB hardening + claimed-vs-verified delivery + operator bootstrap preflight delivered; controlled live Cursor run ended `ERROR`/`FAILED` with phantom branch. **No second Cursor create** without new Human-GO after Dashboard OK. Issue stays OPEN until Acceptance (real cloud delivery) is met. LR **NO-GO** unchanged.
 
-- **#4289 Hermes Live drills**: Repo-slice already merged; Live Hetzner/Windows/GitHub drills remain `HOLD_SCOPE_BLOCKER` (parked). LR **NO-GO** unchanged.
+- **#4289 Hermes**: **CLOSED** after live mint/write-path verify via PR [#4344](https://github.com/jannekbuengener/Claire_de_Binare/pull/4344) @ `43401302`. LR **NO-GO** unchanged.
 
 - **#4257 PR Approval Context**: **DONE_MERGED_CLOSED** via PR [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300) @ `a4cfb8a8`. LR **NO-GO** unchanged.
 
@@ -34,7 +34,7 @@
 > state at their own date and are intentionally not rewritten when reality
 > moves on. They are exempt from live freshness verification.
 
-> Note: older 2026-08-03 lines that claimed tip `abf997d5` / `a4cfb8a8` or foundation still in-flight are superseded by the live tip claim above (`312d12e0`).
+> Note: older 2026-08-03 lines that claimed tip `312d12e0` / `abf997d5` / `a4cfb8a8` or `#4289` still open are superseded by the live tip claim above (`43401302`) and `#4289` closed.
 
 ## Repo / Engineering Status (2026-08-02)
 

--- a/README.md
+++ b/README.md
@@ -68,22 +68,22 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 ## Current-main Snapshot
 
-<!-- cdb:status-freshness header-date=2026-08-03 -->
-**Stand 2026-08-03.**
-<!-- cdb:live-claim type=main_sha value=312d12e0 -->
-<!-- cdb:live-claim type=issue_state issue=4289 state=open -->
+<!-- cdb:status-freshness header-date=2026-08-04 -->
+**Stand 2026-08-04.**
+<!-- cdb:live-claim type=main_sha value=43401302 -->
+<!-- cdb:live-claim type=issue_state issue=4289 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4257 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4258 state=open -->
 <!-- cdb:live-claim type=issue_state issue=2513 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4293 state=closed -->
-Auf `origin/main` (`312d12e0`) sind die juengsten relevanten Merge-Cluster u. a.:
+Auf `origin/main` (`43401302`) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **Security Backlog Reconciliation ([#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513) / PR [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303)):** **MERGED** @ `312d12e0`. Offene Security-Issues bleiben Upstream-HOLDs (geparkt bis FixedVersion). Meta `#2513` bleibt Tracker.
+- **Hermes app mint/write-path ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4344](https://github.com/jannekbuengener/Claire_de_Binare/pull/4344)):** **MERGED** @ `43401302`. Issue `#4289` **CLOSED**.  <!-- pragma: allowlist secret -->
+- **Security Backlog Reconciliation ([#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513) / PR [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303)):** **MERGED** @ `312d12e0` (ancestor of tip). Offene Security-Issues bleiben Upstream-HOLDs (geparkt bis FixedVersion). Meta `#2513` bleibt Tracker.
 - **ACP E2E Pilot Foundation ([#4258](https://github.com/jannekbuengener/Claire_de_Binare/issues/4258) / PR [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301)):** **MERGED** @ `abf997d5` (mock-first). Live Cursor Human-GO path in dedicated PR [#4302](https://github.com/jannekbuengener/Claire_de_Binare/pull/4302) (`Refs` only; issue remains open until real cloud evidence; kein zweiter Create ohne neues Human-GO).
 - **PR Approval Context ([#4257](https://github.com/jannekbuengener/Claire_de_Binare/issues/4257) / PR [#4300](https://github.com/jannekbuengener/Claire_de_Binare/pull/4300)):** **MERGED** @ `a4cfb8a8` (ancestor of tip).
 - **ACP dispatcher residuals ([#4293](https://github.com/jannekbuengener/Claire_de_Binare/issues/4293) / PR [#4297](https://github.com/jannekbuengener/Claire_de_Binare/pull/4297)):** **MERGED** @ `d4704025` (ancestor of tip).
 - **Area Entry Link Canon ([#4294](https://github.com/jannekbuengener/Claire_de_Binare/issues/4294)/[#4296](https://github.com/jannekbuengener/Claire_de_Binare/issues/4296) / PR [#4295](https://github.com/jannekbuengener/Claire_de_Binare/pull/4295)):** **MERGED** — README Area Entry Link Rule + active README reconcile @ `365f50b9`.
-- **Hermes Hetzner Bootstrap ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4290](https://github.com/jannekbuengener/Claire_de_Binare/pull/4290)):** Repo-Slice **MERGED**. Issue `#4289` bleibt offen fuer Live-VM/Windows/GitHub-Drills (`HOLD_SCOPE_BLOCKER`, geparkt).  <!-- pragma: allowlist secret -->
 - **Repository consolidation wave:** [#4286](https://github.com/jannekbuengener/Claire_de_Binare/pull/4286) ACP batch, [#4162](https://github.com/jannekbuengener/Claire_de_Binare/pull/4162) Grafana 13.1.1, [#4245](https://github.com/jannekbuengener/Claire_de_Binare/pull/4245) CVE HOLD, [#4246](https://github.com/jannekbuengener/Claire_de_Binare/pull/4246) PG15 preflight, [#4244](https://github.com/jannekbuengener/Claire_de_Binare/pull/4244) Dependabot facts, [#4243](https://github.com/jannekbuengener/Claire_de_Binare/pull/4243) dataset fingerprints — squash-merged (prior tip `fce4c754`, superseded by Hermes tip).
 - **Validation Pilot Spec ([#4272](https://github.com/jannekbuengener/Claire_de_Binare/issues/4272) / PR [#4292](https://github.com/jannekbuengener/Claire_de_Binare/pull/4292)):** **MERGED** — prior tip cluster (historical relative to consolidation tip).
 - **Fast-CI Slice Gates ([#4204](https://github.com/jannekbuengener/Claire_de_Binare/issues/4204) / PR [#4236](https://github.com/jannekbuengener/Claire_de_Binare/pull/4236)):** **CLOSED/MERGED** — Versionierte Slice-Policy, fail-closed unbekannte Pfade, Timing-Evidence.

--- a/docs/strategy/CDB_SENSITIVITY_CAMPAIGN_EXECUTION_CONTRACT_V1.md
+++ b/docs/strategy/CDB_SENSITIVITY_CAMPAIGN_EXECUTION_CONTRACT_V1.md
@@ -16,15 +16,16 @@ or promotion.
 
 | Module | Role |
 | --- | --- |
-| `sensitivity_campaign_authorization.py` | Owner-GO parse / verify |
-| `sensitivity_campaign_runner.py` | `plan` / `validate-authorization` / `execute` / `probe-surface` |
+| `sensitivity_campaign_authorization.py` | Owner-GO parse / verify + revoke marker + lifetime / per-attempt expiry checks |
+| `sensitivity_campaign_runner.py` | `plan` / `validate-authorization` / `execute` / `probe-surface`; orchestrates primary + reproduction phases |
 | `sensitivity_campaign_run_plan.py` | Deterministic 819-run expansion + fingerprint |
-| `sensitivity_campaign_state.py` | Atomic evidence ledger + resume + campaign lock |
+| `sensitivity_campaign_state.py` | Atomic evidence ledger + campaign phases + primary/reproduction resume + campaign lock |
 | `sensitivity_campaign_budget.py` | Resource budget hard caps |
-| `sensitivity_campaign_surface.py` | Read-only capability probe |
+| `sensitivity_campaign_surface.py` | Read-only capability probe + bound dataset identity |
+| `sensitivity_campaign_dataset_root.py` | Canonical dataset-root resolver (fail-closed) |
 | `sensitivity_campaign_analyzer_contract.py` | 21 slots / 19 physical sets / 2 overlaps |
-| `sensitivity_campaign_reproduction.py` | Double-run plan (no new run keys) |
-| `sensitivity_campaign_executor.py` | `FakeExecutor` / `StrategyReplayCampaignExecutor` |
+| `sensitivity_campaign_reproduction.py` | Executed double-run comparison contract (no new run keys) |
+| `sensitivity_campaign_executor.py` | `FakeExecutor` / `StrategyReplayCampaignExecutor` (`attempt_kind: PRIMARY | REPRODUCTION`) |
 
 ## Owner-GO
 
@@ -76,8 +77,27 @@ verifier). Schema defaults are not applied. Exact values:
 
 ### Expiry
 
-`expires_at_utc` may be `null` or an ISO-8601 timezone-aware timestamp.
-Clock source: `core.utils.clock.utcnow`. Expired GO → `AUTH_GO_EXPIRED`.
+`expires_at_utc` must be an ISO-8601 timezone-aware timestamp for the
+`execute` path (`AUTH_EXPIRES_AT_REQUIRED_FOR_CAMPAIGN` fail-closed on `null`).
+Non-campaign contexts still accept `null`. Clock source:
+`core.utils.clock.utcnow`. Expired GO → `AUTH_GO_EXPIRED` at load time.
+Additionally:
+
+- `assert_authorization_lifetime_covers_budget` is called once before any
+  evidence writes; remaining lifetime must be
+  `>= max_campaign_wall_time_seconds + max_run_wall_time_seconds`
+  (`AUTH_LIFETIME_INSUFFICIENT_FOR_BUDGET` on failure).
+- `assert_authorization_not_expired_for_next_attempt` is called before every
+  primary, retry, and reproduction attempt so a long-running campaign cannot
+  cross a live expiry mid-flight (`AUTHORIZATION_EXPIRED_BEFORE_NEXT_ATTEMPT`).
+
+### Revocation sentinel
+
+A comment body containing the case-sensitive marker
+`REVOKED_CAMPAIGN_EXECUTION_CONTRACT_DEFECT` is refused before any JSON
+parsing (`AUTH_GO_REVOKED`), even when a fenced payload is still present.
+This is the primary mechanism to retire an issued Owner-GO without deleting
+the historical comment.
 
 Required bindings also include (non-exhaustive):
 
@@ -89,6 +109,81 @@ Required bindings also include (non-exhaustive):
 
 Fail-closed reason codes include author / issue / SHA / fingerprint / surface /
 budget mismatches (`AUTH_*`, `BUDGET_*`, `SURFACE_*`).
+
+## Execution flow
+
+`execute_campaign` orchestrates the following phases atomically against the
+campaign envelope (`campaign_phase` is transitioned via `update_campaign_phase`
+with a fail-closed legal-transition table):
+
+1. `PLANNED` / `PRIMARY_PLANNED` → `PRIMARY_RUNNING`
+2. Run all primary keys (`attempt_kind = "PRIMARY"`, `reproduction_attempt=0`).
+3. `count_primary_succeeded` must equal `plan.run_count`; otherwise → `BLOCKED`
+   with `PRIMARY_SUCCESS_COUNT_MISMATCH`.
+4. `PRIMARY_RUNNING` → `PRIMARY_COMPLETE`.
+5. If `reproduction_policy.enabled`: `PRIMARY_COMPLETE` → `REPRODUCTION_PLANNED`
+   → `REPRODUCTION_RUNNING`.
+6. For each reproduction item (`attempt_kind = "REPRODUCTION"`,
+   `reproduction_attempt >= 1`, output under `runs/<run_key>/reproduction/<n>/`):
+   inspect resume, run, commit, compare via `compare_reproduction_results`
+   (bindings=True, exact-equality over `compared_result_fields`), write
+   `comparison.json` evidence.
+7. `on_mismatch = block_campaign_completion` (default) → any mismatch/failure
+   transitions to `BLOCKED` with `REPRODUCTION_RESULT_MISMATCH` (or
+   `REPRODUCTION_EXECUTION_FAILED`) and stops further attempts.
+8. `REPRODUCTION_RUNNING` → `REPRODUCTION_COMPLETE` → `COMPLETED`.
+
+Legal transitions:
+
+- `PLANNED | PRIMARY_PLANNED → PRIMARY_RUNNING | BLOCKED`
+- `PRIMARY_RUNNING → PRIMARY_COMPLETE | BLOCKED`
+- `PRIMARY_COMPLETE → REPRODUCTION_PLANNED | COMPLETED | BLOCKED`
+- `REPRODUCTION_PLANNED → REPRODUCTION_RUNNING | BLOCKED`
+- `REPRODUCTION_RUNNING → REPRODUCTION_COMPLETE | BLOCKED`
+- `REPRODUCTION_COMPLETE → COMPLETED | BLOCKED`
+- `COMPLETED` and `BLOCKED` are terminal (idempotent self-transition only)
+
+Under reproduction-enabled policy, the campaign **never** reports `COMPLETED`
+after primary alone.
+
+## Reproduction contract
+
+- `build_reproduction_plan` is deterministic (`baseline[:n]` + evenly-spaced
+  sample); it emits a `reproduction_plan_fingerprint` stored in the campaign
+  envelope extra.
+- Reproduction items reuse existing primary run keys; they do **not** add run
+  keys and `max_run_count_unchanged = true`.
+- `compare_reproduction_results` returns a structured comparison dict with
+  `status ∈ {"PASS", "MISMATCH"}`, `reason_code`, `mismatched_fields`,
+  `compared_fields`, `primary_result_fingerprint`,
+  `reproduction_result_fingerprint`, `comparison_fingerprint`. On structural
+  failure (empty `compared_fields`, forbidden volatile field, bindings
+  mismatch) it raises `SensitivityReproductionError` fail-closed.
+- Volatile fields (timestamps, host paths, attempt/process/log metadata,
+  filesystem times) are **never** compared even when opted into.
+- Bindings validated on the compare path when `bindings=True`:
+  `run_key`, `manifest_fingerprint`, `run_plan_fingerprint`,
+  `authorization_fingerprint`.
+
+## Dataset root binding
+
+`resolve_and_verify_dataset_root` is invoked on the `execute` path and its
+identity is bound both into the surface probe and the campaign envelope
+extra:
+
+- Accepts either the `artifacts/market_data` parent or the full
+  `window_bank/binance/spot/BTCUSDT/1m` bank path.
+- Verifies **all** 39 manifest window bindings resolve under the resolved
+  bank realpath and, when a `dataset_spec.json` is present, that its
+  content fingerprint matches the manifest binding.
+- Emits a `dataset_identity_fingerprint` derived from the sorted list of
+  `(window_id, content_fingerprint)` pairs (path-independent identity).
+
+Fail codes: `DATASET_ROOT_UNBOUND`, `DATASET_ROOT_MISSING`,
+`DATASET_ROOT_NOT_ABSOLUTE`, `DATASET_SYMLINK_ESCAPE`, `DATASET_TRAVERSAL`,
+`DATASET_WINDOW_MISSING`, `DATASET_CONTENT_FINGERPRINT_MISMATCH`,
+`DATASET_MANIFEST_INVALID`. All are prefixed with `RUNNER_DATASET_` when the
+runner surfaces them.
 
 ## Runner commands
 
@@ -115,6 +210,8 @@ python -m tools.arvp_vacation.sensitivity_campaign_runner probe-surface ...
 - Reproduction double-runs reuse existing keys; they do **not** add run keys
 - Evidence namespace:
   `artifacts/arvp_sensitivity/4153/{campaign_id}/{manifest_fp}/{authorization_id}`
+- Reproduction evidence under `runs/<run_key>/reproduction/<n>/` with
+  `envelope.json`, `result.json`, `succeeded.marker`, and `comparison.json`
 
 ## Non-goals
 

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -339,6 +339,14 @@ class ARVPReplayConfig:
     binance_window_id: str | None = None
     """Binance window-bank id when dataset_source='binance_window'."""
 
+    window_bank_root: str | None = None
+    """Optional absolute window-bank root for binance_window datasets.
+
+    When set, overrides the repo-local default under artifacts/market_data.
+    Used by the #4153 sensitivity campaign so detached worktrees can bind an
+    authorized external dataset root without copying data.
+    """
+
     strategy_id: str = _DEFAULT_STRATEGY_ID
     """Strategy identifier. Must be in _SUPPORTED_STRATEGY_IDS."""
 
@@ -892,10 +900,12 @@ def _load_dataset_result(
 
     if dataset_source == "binance_window":
         window_id = str(config.binance_window_id).strip()
+        bank_root = Path(config.window_bank_root) if config.window_bank_root else None
         try:
             dataset = load_binance_window_dataset(
                 window_id,
                 warmup_candles=warmup_count,
+                window_bank_root=bank_root,
             )
         except BinanceWindowBankAdapterError as exc:
             _reraise_as_runner_error(exc)

--- a/tests/unit/arvp/test_sensitivity_campaign_authorization.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_authorization.py
@@ -26,8 +26,11 @@ from tools.arvp_vacation.sensitivity_campaign_authorization import (
     GO_STATUS,
     GitHubComment,
     ISSUE_NUMBER,
+    REVOKE_MARKER,
     SensitivityAuthorizationError,
     assert_absolute_bans_intact,
+    assert_authorization_lifetime_covers_budget,
+    assert_authorization_not_expired_for_next_attempt,
     authorization_policy_defaults,
     campaign_execution_requires_owner_go,
     fingerprint_authorization_payload,
@@ -113,7 +116,10 @@ def build_valid_auth_payload(
         "analyzer_contract_version": "cdb.sensitivity_campaign_analyzer.v1",
         "granted_capabilities": ["campaign_execution"],
         "absolute_bans_unchanged": True,
-        "expires_at_utc": None,
+        # A finite future expiry is required for campaign execute path per
+        # ``assert_authorization_lifetime_covers_budget``. Far-future default
+        # keeps historical tests independent of clock injection.
+        "expires_at_utc": "2099-12-31T23:59:59Z",
         "lr_status": "NO-GO",
         "notes": "unit-test GO payload",
     }
@@ -417,3 +423,112 @@ def test_absolute_bans_and_policy_defaults() -> None:
     assert "paper" in policy["absolute_bans"]
     assert "live" in policy["absolute_bans"]
     assert "jannekbuengener" in policy["authorizing_owner_allowlist"]
+
+
+def test_revoke_marker_blocks_go_parse_even_with_fence(
+    valid_payload: dict[str, Any],
+) -> None:
+    """A body carrying the revoke sentinel fails before JSON parsing."""
+    body = build_go_comment_body(valid_payload) + "\n" + REVOKE_MARKER + "\n"
+    with pytest.raises(SensitivityAuthorizationError) as exc:
+        parse_go_payload_from_comment_body(body)
+    assert exc.value.reason_code == "AUTH_GO_REVOKED"
+
+
+def test_revoke_marker_blocks_verify_owner_go(valid_payload: dict[str, Any]) -> None:
+    """End-to-end verify fails when the fetched body contains the revoke sentinel."""
+    body = build_go_comment_body(valid_payload) + "\n" + REVOKE_MARKER + "\n"
+    with pytest.raises(SensitivityAuthorizationError) as exc:
+        verify_owner_go_comment(
+            comment_id=COMMENT_ID,
+            expected={"authorizing_github_login": AUTHOR},
+            fetcher=make_fetcher(valid_payload, body=body),
+        )
+    assert exc.value.reason_code == "AUTH_GO_REVOKED"
+
+
+def test_assert_authorization_not_expired_null_is_ok() -> None:
+    from datetime import UTC, datetime
+
+    assert (
+        assert_authorization_not_expired_for_next_attempt(
+            None, now_utc=datetime(2026, 8, 4, tzinfo=UTC)
+        )
+        is None
+    )
+
+
+def test_assert_authorization_not_expired_raises_when_past() -> None:
+    from datetime import UTC, datetime
+
+    with pytest.raises(SensitivityAuthorizationError) as exc:
+        assert_authorization_not_expired_for_next_attempt(
+            "2020-01-01T00:00:00Z", now_utc=datetime(2026, 8, 4, tzinfo=UTC)
+        )
+    assert exc.value.reason_code == "AUTHORIZATION_EXPIRED_BEFORE_NEXT_ATTEMPT"
+
+
+def test_authorization_lifetime_null_expiry_blocks_campaign() -> None:
+    """Fail-closed: campaigns require a finite expiry bounding the human gate."""
+    from datetime import UTC, datetime
+
+    budget = _sample_budget()
+    with pytest.raises(SensitivityAuthorizationError) as exc:
+        assert_authorization_lifetime_covers_budget(
+            None, budget, now_utc=datetime(2026, 8, 4, tzinfo=UTC)
+        )
+    assert exc.value.reason_code == "AUTH_EXPIRES_AT_REQUIRED_FOR_CAMPAIGN"
+
+
+def test_authorization_lifetime_insufficient_raises() -> None:
+    """Remaining lifetime < campaign_wall+run_wall fails fail-closed."""
+    from datetime import UTC, datetime, timedelta
+
+    budget = _sample_budget()
+    # campaign_wall=86400s, run_wall=600s -> require 87000s remaining.
+    now = datetime(2026, 8, 4, tzinfo=UTC)
+    short = (now + timedelta(seconds=100)).isoformat().replace("+00:00", "Z")
+    with pytest.raises(SensitivityAuthorizationError) as exc:
+        assert_authorization_lifetime_covers_budget(short, budget, now_utc=now)
+    assert exc.value.reason_code == "AUTH_LIFETIME_INSUFFICIENT_FOR_BUDGET"
+
+
+def test_authorization_lifetime_sufficient_ok() -> None:
+    """Remaining lifetime >= campaign_wall+run_wall passes silently."""
+    from datetime import UTC, datetime, timedelta
+
+    budget = _sample_budget()
+    now = datetime(2026, 8, 4, tzinfo=UTC)
+    ok = (now + timedelta(days=7)).isoformat().replace("+00:00", "Z")
+    # Silent no-op on success.
+    assert_authorization_lifetime_covers_budget(ok, budget, now_utc=now)
+
+
+def test_authorization_lifetime_budget_missing_raises() -> None:
+    """None budget is rejected before other lifetime checks."""
+    from datetime import UTC, datetime
+
+    with pytest.raises(SensitivityAuthorizationError) as exc:
+        assert_authorization_lifetime_covers_budget(
+            None, None, now_utc=datetime(2026, 8, 4, tzinfo=UTC)  # type: ignore[arg-type]
+        )
+    assert exc.value.reason_code == "AUTH_LIFETIME_BUDGET_MISSING"
+
+
+def test_verify_owner_go_returns_expires_at_utc(
+    valid_payload: dict[str, Any],
+) -> None:
+    """``verify_owner_go_comment`` surfaces ``expires_at_utc`` for the runner."""
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime(2026, 8, 4, tzinfo=UTC)
+    future = (now + timedelta(days=1)).isoformat().replace("+00:00", "Z")
+    payload = copy.deepcopy(valid_payload)
+    payload["expires_at_utc"] = future
+    result = verify_owner_go_comment(
+        comment_id=COMMENT_ID,
+        expected={"authorizing_github_login": AUTHOR},
+        fetcher=make_fetcher(payload),
+        now_utc=now,
+    )
+    assert result["expires_at_utc"] == future

--- a/tests/unit/arvp/test_sensitivity_campaign_dataset_root.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_dataset_root.py
@@ -1,0 +1,221 @@
+"""Canonical dataset-root resolver unit tests (#4153).
+
+test_id: tc_sensitivity_campaign_dataset_root_001
+test_type: schutz|bauteil
+cdb_area: arvp/validation-research
+issue_ref: #4153
+security_relevant: true
+live_relevant: false
+profitability_relevant: false
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.arvp_vacation.sensitivity_campaign_dataset_root import (
+    DATASET_ROOT_CONTRACT_VERSION,
+    SensitivityDatasetRootError,
+    resolve_and_verify_dataset_root,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _fake_manifest(window_ids: list[str]) -> dict:
+    return {
+        "window_bindings": [
+            {"window_id": w, "content_fingerprint": f"fp-{w}"} for w in window_ids
+        ]
+    }
+
+
+def _build_bank(tmp_path: Path, window_ids: list[str]) -> Path:
+    """Materialize the canonical window-bank layout under ``tmp_path``.
+
+    Returns the ``artifacts/market_data`` parent so callers can pass either that
+    or the resolved bank root directly.
+    """
+    root = tmp_path / "artifacts" / "market_data"
+    bank = root / "window_bank" / "binance" / "spot" / "BTCUSDT" / "1m"
+    bank.mkdir(parents=True, exist_ok=True)
+    for w in window_ids:
+        (bank / w).mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def test_dataset_root_unbound_raises() -> None:
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=None,  # type: ignore[arg-type]
+            manifest=_fake_manifest(["w1"]),
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_ROOT_UNBOUND"
+
+
+def test_dataset_root_missing_raises(tmp_path: Path) -> None:
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=tmp_path / "does-not-exist",
+            manifest=_fake_manifest(["w1"]),
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_ROOT_MISSING"
+
+
+def test_dataset_manifest_invalid_when_bindings_missing(tmp_path: Path) -> None:
+    root = _build_bank(tmp_path, [])
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=root,
+            manifest={"window_bindings": []},
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_MANIFEST_INVALID"
+
+
+def test_dataset_manifest_invalid_when_binding_incomplete(tmp_path: Path) -> None:
+    root = _build_bank(tmp_path, ["w1"])
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=root,
+            manifest={"window_bindings": [{"window_id": "w1"}]},  # no fingerprint
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_MANIFEST_INVALID"
+
+
+def test_dataset_traversal_rejected(tmp_path: Path) -> None:
+    root = _build_bank(tmp_path, ["w1"])
+    # Deliberate .. component in the declared arg triggers traversal guard
+    # before realpath resolution.
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=root / ".." / root.name,
+            manifest=_fake_manifest(["w1"]),
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_TRAVERSAL"
+
+
+def test_dataset_window_missing_raises(tmp_path: Path) -> None:
+    root = _build_bank(tmp_path, ["w1"])
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=root,
+            manifest=_fake_manifest(["w1", "w-missing"]),
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_WINDOW_MISSING"
+
+
+def test_dataset_content_fingerprint_mismatch(tmp_path: Path) -> None:
+    """On-disk dataset_spec.json disagreeing with manifest raises fail-closed."""
+    import json as _json
+
+    root = _build_bank(tmp_path, ["w1"])
+    bank = root / "window_bank" / "binance" / "spot" / "BTCUSDT" / "1m"
+    (bank / "w1" / "dataset_spec.json").write_text(
+        _json.dumps({"content_fingerprint": "on-disk-different"}),
+        encoding="utf-8",
+    )
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=root,
+            manifest=_fake_manifest(["w1"]),
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_CONTENT_FINGERPRINT_MISMATCH"
+
+
+def test_dataset_identity_bound_and_deterministic(tmp_path: Path) -> None:
+    root = _build_bank(tmp_path, ["w1", "w2", "w3"])
+    identity_a = resolve_and_verify_dataset_root(
+        dataset_root=root,
+        manifest=_fake_manifest(["w1", "w2", "w3"]),
+        repo_root=REPO_ROOT,
+    )
+    # Order of manifest bindings must not affect the identity fingerprint.
+    identity_b = resolve_and_verify_dataset_root(
+        dataset_root=root,
+        manifest=_fake_manifest(["w3", "w1", "w2"]),
+        repo_root=REPO_ROOT,
+    )
+    assert (
+        identity_a.dataset_identity_fingerprint
+        == identity_b.dataset_identity_fingerprint
+    )
+    assert identity_a.window_count == 3
+    assert identity_a.schema_version == DATASET_ROOT_CONTRACT_VERSION
+    payload = identity_a.as_dict()
+    assert payload["window_bank_root"] == identity_a.window_bank_root
+    assert (
+        payload["dataset_identity_fingerprint"]
+        == identity_a.dataset_identity_fingerprint
+    )
+
+
+def test_dataset_root_accepts_full_bank_path(tmp_path: Path) -> None:
+    """Both ``.../artifacts/market_data`` and the full bank suffix are valid."""
+    parent = _build_bank(tmp_path, ["w1"])
+    bank = parent / "window_bank" / "binance" / "spot" / "BTCUSDT" / "1m"
+    identity_parent = resolve_and_verify_dataset_root(
+        dataset_root=parent,
+        manifest=_fake_manifest(["w1"]),
+        repo_root=REPO_ROOT,
+    )
+    identity_bank = resolve_and_verify_dataset_root(
+        dataset_root=bank,
+        manifest=_fake_manifest(["w1"]),
+        repo_root=REPO_ROOT,
+    )
+    # Content-based identity is stable across both entry points.
+    assert (
+        identity_parent.dataset_identity_fingerprint
+        == identity_bank.dataset_identity_fingerprint
+    )
+    # Resolved bank realpath equals the on-disk canonical bank root.
+    assert Path(identity_parent.window_bank_root).resolve() == bank.resolve()
+    assert Path(identity_bank.window_bank_root).resolve() == bank.resolve()
+
+
+def _windows_symlink_supported(tmp_path: Path) -> bool:
+    if sys.platform != "win32":
+        return True
+    src = tmp_path / "_probe_src"
+    dst = tmp_path / "_probe_dst"
+    try:
+        src.mkdir()
+        os.symlink(src, dst, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return False
+    return True
+
+
+def test_dataset_symlink_escape_raises(tmp_path: Path) -> None:
+    """A window directory that is a symlink pointing outside the bank fails closed."""
+    if not _windows_symlink_supported(tmp_path):
+        pytest.skip("symlink creation not permitted on this platform")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = _build_bank(tmp_path, [])
+    bank = root / "window_bank" / "binance" / "spot" / "BTCUSDT" / "1m"
+    # Symlink `w1` -> outside/, which is outside the declared dataset root.
+    try:
+        os.symlink(outside, bank / "w1", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation not permitted on this platform")
+
+    with pytest.raises(SensitivityDatasetRootError) as exc:
+        resolve_and_verify_dataset_root(
+            dataset_root=root,
+            manifest=_fake_manifest(["w1"]),
+            repo_root=REPO_ROOT,
+        )
+    assert exc.value.reason_code == "DATASET_SYMLINK_ESCAPE"

--- a/tests/unit/arvp/test_sensitivity_campaign_executor_budget.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_executor_budget.py
@@ -123,6 +123,27 @@ def test_strategy_replay_adapter_builds_config_and_invokes(tmp_path: Path) -> No
     assert (tmp_path / "run" / "bound_run_envelope.json").exists()
 
 
+def test_strategy_replay_adapter_binds_window_bank_root(tmp_path: Path) -> None:
+    seen = []
+    bank = (tmp_path / "window_bank").resolve()
+    bank.mkdir()
+
+    def invoker(config):
+        seen.append(config)
+        return 0
+
+    executor = StrategyReplayCampaignExecutor(
+        replay_invoker=invoker,
+        metrics_loader=lambda _p: {"gate_reason": "OK", "trade_count": 0},
+        window_bank_root=bank,
+    )
+    result = executor.execute(_sample_envelope(tmp_path))
+    assert result.exit_code == 0
+    assert len(seen) == 1
+    assert seen[0].window_bank_root == str(bank)
+    assert executor.window_bank_root == bank
+
+
 def test_strategy_replay_adapter_rejects_missing_auth_fp(tmp_path: Path) -> None:
     env = _sample_envelope(tmp_path)
     env = RunEnvelope(**{**env.as_dict(), "authorization_fingerprint": ""})

--- a/tests/unit/arvp/test_sensitivity_campaign_reproduction.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_reproduction.py
@@ -33,31 +33,127 @@ def test_reproduction_adds_no_new_run_keys() -> None:
     for item in plan["reproduction_items"]:
         assert item["creates_new_run_key"] is False
         assert item["run_key"] in keys
-    # baseline (1) + sample (5) with 1 attempt each
     assert len(plan["baseline_run_keys"]) == 1
     assert len(plan["sample_run_keys"]) == 5
     assert len(plan["reproduction_items"]) == 6
 
 
-def test_reproduction_mismatch_blocks() -> None:
+def test_reproduction_deterministic_selection_fingerprint() -> None:
+    """Two plan builds with identical inputs produce identical plans and fingerprints."""
+    keys = [f"rk-{i:03d}" for i in range(50)]
+    plan_a = build_reproduction_plan(run_keys=keys, policy=DEFAULT_REPRODUCTION_POLICY)
+    plan_b = build_reproduction_plan(
+        run_keys=list(keys), policy=DEFAULT_REPRODUCTION_POLICY
+    )
+    assert (
+        plan_a["reproduction_plan_fingerprint"]
+        == plan_b["reproduction_plan_fingerprint"]
+    )
+    assert plan_a["baseline_run_keys"] == plan_b["baseline_run_keys"]
+    assert plan_a["sample_run_keys"] == plan_b["sample_run_keys"]
+
+
+def test_reproduction_mismatch_returns_structured_dict() -> None:
+    """Mismatch returns status/reason_code — no raise on the compare call."""
     fields = ["gate_reason", "trade_count", "net_pnl"]
     primary = {"gate_reason": "OK", "trade_count": 1, "net_pnl": "0"}
     reproduction = {"gate_reason": "OK", "trade_count": 2, "net_pnl": "0"}
+    result = compare_reproduction_results(
+        primary=primary,
+        reproduction=reproduction,
+        compared_fields=fields,
+    )
+    assert result["status"] == "MISMATCH"
+    assert result["reason_code"] == "REPRODUCTION_RESULT_MISMATCH"
+    assert (
+        result["primary_result_fingerprint"]
+        != result["reproduction_result_fingerprint"]
+    )
+    assert any(
+        item["field"] == "trade_count" and item["reason_code"] == "REPRO_MISMATCH"
+        for item in result["mismatched_fields"]
+    )
+    assert result["comparison_fingerprint"]
+
+
+def test_reproduction_exact_match_returns_pass() -> None:
+    fields = ["gate_reason", "trade_count"]
+    row = {"gate_reason": "OK", "trade_count": 0}
+    result = compare_reproduction_results(
+        primary=row, reproduction=dict(row), compared_fields=fields
+    )
+    assert result["status"] == "PASS"
+    assert result["reason_code"] == "REPRODUCTION_RESULT_PASS"
+    assert result["mismatched_fields"] == []
+    assert (
+        result["primary_result_fingerprint"]
+        == result["reproduction_result_fingerprint"]
+    )
+
+
+def test_reproduction_volatile_field_forbidden() -> None:
+    fields = ["gate_reason", "started_at_utc"]
+    row = {"gate_reason": "OK", "started_at_utc": "2026-01-01T00:00:00Z"}
+    with pytest.raises(SensitivityReproductionError) as exc:
+        compare_reproduction_results(
+            primary=row, reproduction=dict(row), compared_fields=fields
+        )
+    assert "REPRO_COMPARED_FIELD_FORBIDDEN:started_at_utc" in str(exc.value)
+
+
+def test_reproduction_bindings_mismatch_raises() -> None:
+    """Bindings validation raises when primary/reproduction disagree on a bound key."""
+    fields = ["gate_reason"]
+    primary = {
+        "gate_reason": "OK",
+        "run_key": "rk-000",
+        "manifest_fingerprint": "aaa",
+        "run_plan_fingerprint": "bbb",
+        "authorization_fingerprint": "ccc",
+    }
+    reproduction = {
+        "gate_reason": "OK",
+        "run_key": "rk-999",  # different
+        "manifest_fingerprint": "aaa",
+        "run_plan_fingerprint": "bbb",
+        "authorization_fingerprint": "ccc",
+    }
     with pytest.raises(SensitivityReproductionError) as exc:
         compare_reproduction_results(
             primary=primary,
             reproduction=reproduction,
             compared_fields=fields,
+            bindings=True,
         )
-    assert "REPRO_MISMATCH:trade_count" in str(exc.value)
+    assert "REPRO_BINDING_MISMATCH:run_key" in str(exc.value)
 
 
-def test_reproduction_exact_match_ok() -> None:
-    fields = ["gate_reason", "trade_count"]
-    row = {"gate_reason": "OK", "trade_count": 0}
-    compare_reproduction_results(
-        primary=row, reproduction=dict(row), compared_fields=fields
+def test_reproduction_bindings_match_pass() -> None:
+    fields = ["gate_reason"]
+    payload = {
+        "gate_reason": "OK",
+        "run_key": "rk-000",
+        "manifest_fingerprint": "aaa",
+        "run_plan_fingerprint": "bbb",
+        "authorization_fingerprint": "ccc",
+    }
+    result = compare_reproduction_results(
+        primary=payload,
+        reproduction=dict(payload),
+        compared_fields=fields,
+        bindings=True,
     )
+    assert result["status"] == "PASS"
+
+
+def test_reproduction_empty_compared_fields_raises() -> None:
+    with pytest.raises(SensitivityReproductionError) as exc:
+        compare_reproduction_results(
+            primary={},
+            reproduction={},
+            compared_fields=[],
+        )
+    assert "REPRO_COMPARED_FIELDS_EMPTY" in str(exc.value)
 
 
 def test_disabled_reproduction_empty() -> None:

--- a/tests/unit/arvp/test_sensitivity_campaign_runner.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_runner.py
@@ -28,9 +28,11 @@ from tools.arvp_vacation.sensitivity_campaign_executor import (
     ATTEMPT_KIND_PRIMARY,
     ATTEMPT_KIND_REPRODUCTION,
     FakeExecutor,
+    StrategyReplayCampaignExecutor,
 )
 from tools.arvp_vacation.sensitivity_campaign_runner import (
     SensitivityRunnerError,
+    _bind_executor_dataset_root,
     build_parser,
     execute_campaign,
     plan_campaign,
@@ -562,3 +564,101 @@ def test_execute_blocks_when_authorization_expires_before_attempt(
                 now_utc_provider=_now_provider,
             )
     assert exc.value.reason_code == "AUTHORIZATION_EXPIRED_BEFORE_NEXT_ATTEMPT"
+
+
+def test_bind_executor_dataset_root_rebinds_unbound_strategy_adapter(
+    tmp_path: Path,
+) -> None:
+    bank = (tmp_path / "window_bank").resolve()
+    bank.mkdir()
+    unbound = StrategyReplayCampaignExecutor()
+    assert unbound.window_bank_root is None
+    bound = _bind_executor_dataset_root(executor=unbound, resolved_bank_root=bank)
+    assert isinstance(bound, StrategyReplayCampaignExecutor)
+    assert bound.window_bank_root == bank
+
+
+def test_bind_executor_dataset_root_mismatch_raises(tmp_path: Path) -> None:
+    bank_a = (tmp_path / "a").resolve()
+    bank_b = (tmp_path / "b").resolve()
+    bank_a.mkdir()
+    bank_b.mkdir()
+    executor = StrategyReplayCampaignExecutor(window_bank_root=bank_a)
+    with pytest.raises(SensitivityRunnerError) as exc:
+        _bind_executor_dataset_root(executor=executor, resolved_bank_root=bank_b)
+    assert exc.value.reason_code == "RUNNER_DATASET_EXECUTOR_ROOT_MISMATCH"
+
+
+def test_bind_executor_none_creates_strategy_adapter(tmp_path: Path) -> None:
+    bank = (tmp_path / "window_bank").resolve()
+    bank.mkdir()
+    bound = _bind_executor_dataset_root(executor=None, resolved_bank_root=bank)
+    assert isinstance(bound, StrategyReplayCampaignExecutor)
+    assert bound.window_bank_root == bank
+
+
+def test_execute_resume_from_reproduction_running_does_not_reenter_primary(
+    manifest: dict[str, Any], surface_probe, tmp_path: Path
+) -> None:
+    """Resume after primary must not force PRIMARY_RUNNING (illegal transition)."""
+    from tools.arvp_vacation.sensitivity_campaign_state import (
+        CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
+        read_json,
+    )
+
+    budget = _sample_budget()
+    budget["minimum_free_disk_bytes"] = 1
+    auth = build_valid_auth_payload(
+        manifest=manifest,
+        surface_fp=surface_probe.surface_capability_fingerprint,
+        budget=budget,
+    )
+    fast_plan = _fast_plan_from(manifest, primary_count=2)
+    fake = FakeExecutor()
+
+    with patch(
+        "tools.arvp_vacation.sensitivity_campaign_runner.build_run_plan",
+        return_value=fast_plan,
+    ):
+        result1 = execute_campaign(
+            manifest_path=CANONICAL_MANIFEST,
+            go_comment_id=COMMENT_ID,
+            executor=fake,
+            repo_root=REPO_ROOT,
+            artifacts_base=tmp_path,
+            main_sha=MAIN_SHA,
+            authorizing_github_login=AUTHOR,
+            surface_id=SURFACE_ID,
+            surface_capability_fingerprint=surface_probe.surface_capability_fingerprint,
+            resource_budget=budget,
+            fetcher=make_fetcher(auth),
+            stream=io.StringIO(),
+        )
+        assert result1["status"] == "COMPLETED"
+
+        evidence_root = Path(str(result1["evidence_root"]))
+        env_path = evidence_root / "campaign_envelope.json"
+        body = read_json(env_path)
+        # Simulate crash mid-reproduction: drop terminal COMPLETED back to
+        # REPRODUCTION_RUNNING so resume continues without re-entering primary.
+        body["campaign_phase"] = CAMPAIGN_PHASE_REPRODUCTION_RUNNING
+        env_path.write_text(json.dumps(body, indent=2) + "\n", encoding="utf-8")
+
+        fake2 = FakeExecutor()
+        result2 = execute_campaign(
+            manifest_path=CANONICAL_MANIFEST,
+            go_comment_id=COMMENT_ID,
+            executor=fake2,
+            repo_root=REPO_ROOT,
+            artifacts_base=tmp_path,
+            main_sha=MAIN_SHA,
+            authorizing_github_login=AUTHOR,
+            surface_id=SURFACE_ID,
+            surface_capability_fingerprint=surface_probe.surface_capability_fingerprint,
+            resource_budget=budget,
+            fetcher=make_fetcher(auth),
+            stream=io.StringIO(),
+        )
+        assert result2["status"] == "COMPLETED"
+        primary_calls = [c for c in fake2.calls if c.attempt_kind == "PRIMARY"]
+        assert primary_calls == []

--- a/tests/unit/arvp/test_sensitivity_campaign_runner.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_runner.py
@@ -24,7 +24,11 @@ from tools.arvp_vacation.sensitivity_campaign_authorization import (
     SensitivityAuthorizationError,
 )
 from tools.arvp_vacation.sensitivity_campaign_budget import SensitivityBudgetError
-from tools.arvp_vacation.sensitivity_campaign_executor import FakeExecutor
+from tools.arvp_vacation.sensitivity_campaign_executor import (
+    ATTEMPT_KIND_PRIMARY,
+    ATTEMPT_KIND_REPRODUCTION,
+    FakeExecutor,
+)
 from tools.arvp_vacation.sensitivity_campaign_runner import (
     SensitivityRunnerError,
     build_parser,
@@ -215,6 +219,24 @@ def test_execute_missing_budget_blocks(
     assert "BUDGET_MISSING" in str(exc.value)
 
 
+def _fast_plan_from(manifest: dict[str, Any], *, primary_count: int = 2):
+    """Build a consistent small campaign plan for FakeExecutor tests.
+
+    Only ``runs``, ``run_keys`` and ``run_count`` are trimmed; reproduction_policy
+    is left untouched so the authorized GO payload's ``reproduction_policy``
+    remains identical to the plan's.
+    """
+    plan = build_run_plan(manifest, main_sha=MAIN_SHA)
+    trimmed_runs = plan.runs[:primary_count]
+    trimmed_keys = [r.run_key for r in trimmed_runs]
+    return replace(
+        plan,
+        runs=trimmed_runs,
+        run_keys=trimmed_keys,
+        run_count=primary_count,
+    )
+
+
 def test_execute_fake_executor_full_envelope(
     manifest: dict[str, Any], surface_probe, tmp_path: Path
 ) -> None:
@@ -225,8 +247,7 @@ def test_execute_fake_executor_full_envelope(
         surface_fp=surface_probe.surface_capability_fingerprint,
         budget=budget,
     )
-    plan = build_run_plan(manifest, main_sha=MAIN_SHA)
-    fast_plan = replace(plan, runs=plan.runs[:2])
+    fast_plan = _fast_plan_from(manifest, primary_count=2)
     fake = FakeExecutor()
 
     with patch(
@@ -249,9 +270,14 @@ def test_execute_fake_executor_full_envelope(
         )
 
     assert result["status"] == "COMPLETED"
+    assert result["campaign_phase"] == "COMPLETED"
     assert result["succeeded"] == 2
     assert result["failed"] == 0
-    assert len(fake.calls) == 2
+    # 2 primary + reproduction (baseline+sample from default policy over 2 keys).
+    primary_calls = [c for c in fake.calls if c.attempt_kind == "PRIMARY"]
+    repro_calls = [c for c in fake.calls if c.attempt_kind == "REPRODUCTION"]
+    assert len(primary_calls) == 2
+    assert repro_calls, "reproduction must run under default reproduction policy"
     env = fake.calls[0]
     required = (
         "run_key",
@@ -276,6 +302,9 @@ def test_execute_fake_executor_full_envelope(
         assert getattr(env, field) not in (None, ""), field
     assert env.parameters
     assert env.attempt == 1
+    assert env.attempt_kind == "PRIMARY"
+    assert env.reproduction_attempt == 0
+    assert result["reproduction"]["enabled"] is True
     assert (tmp_path / "artifacts" / "arvp_sensitivity" / "4153").exists()
 
 
@@ -329,3 +358,207 @@ def test_manifest_preflight_still_ready_campaign(manifest: dict[str, Any]) -> No
     assert repo["verdict"] == VERDICT_READY
     man = run_manifest_preflight(manifest, REPO_ROOT)
     assert man["verdict"] == VERDICT_READY_CAMPAIGN
+
+
+class _DivergentMetricsExecutor:
+    """Primary and reproduction return different ``net_pnl`` — forces mismatch."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def execute(self, envelope):
+        from tools.arvp_vacation.sensitivity_campaign_executor import RunResult
+
+        self.calls.append(envelope)
+        base = {
+            "gate_reason": "OK",
+            "regime_distribution": {"TREND": 1},
+            "trade_count": 0,
+            "turnover": "0",
+            "fees": "0",
+            "spread": "0",
+            "slippage": "0",
+            "gross_pnl": "0",
+            "net_pnl": "0",
+            "profit_factor": "0",
+            "expectancy": "0",
+            "drawdown": "0",
+            "main_effect": None,
+            "interaction_effect": None,
+            "overfitting_risk_flag": False,
+        }
+        if envelope.attempt_kind == ATTEMPT_KIND_REPRODUCTION:
+            base = {**base, "net_pnl": "1"}
+        return RunResult(exit_code=0, metrics=base, detail="fake_ok")
+
+
+def test_execute_blocks_on_reproduction_mismatch(
+    manifest: dict[str, Any], surface_probe, tmp_path: Path
+) -> None:
+    """Reproduction returning a different comparable field blocks the campaign."""
+    budget = _sample_budget()
+    budget["minimum_free_disk_bytes"] = 1
+    auth = build_valid_auth_payload(
+        manifest=manifest,
+        surface_fp=surface_probe.surface_capability_fingerprint,
+        budget=budget,
+    )
+    fast_plan = _fast_plan_from(manifest, primary_count=2)
+    divergent = _DivergentMetricsExecutor()
+
+    with patch(
+        "tools.arvp_vacation.sensitivity_campaign_runner.build_run_plan",
+        return_value=fast_plan,
+    ):
+        result = execute_campaign(
+            manifest_path=CANONICAL_MANIFEST,
+            go_comment_id=COMMENT_ID,
+            executor=divergent,
+            repo_root=REPO_ROOT,
+            artifacts_base=tmp_path,
+            main_sha=MAIN_SHA,
+            authorizing_github_login=AUTHOR,
+            surface_id=SURFACE_ID,
+            surface_capability_fingerprint=surface_probe.surface_capability_fingerprint,
+            resource_budget=budget,
+            fetcher=make_fetcher(auth),
+            stream=io.StringIO(),
+        )
+
+    assert result["status"] == "BLOCKED"
+    assert result["campaign_phase"] == "BLOCKED"
+    assert result["reason_code"] == "REPRODUCTION_RESULT_MISMATCH"
+
+
+def test_execute_never_completes_after_primary_alone(
+    manifest: dict[str, Any], surface_probe, tmp_path: Path
+) -> None:
+    """Reproduction enabled => COMPLETED must come after reproduction, not primary."""
+    budget = _sample_budget()
+    budget["minimum_free_disk_bytes"] = 1
+    auth = build_valid_auth_payload(
+        manifest=manifest,
+        surface_fp=surface_probe.surface_capability_fingerprint,
+        budget=budget,
+    )
+    fast_plan = _fast_plan_from(manifest, primary_count=2)
+    fake = FakeExecutor()
+
+    with patch(
+        "tools.arvp_vacation.sensitivity_campaign_runner.build_run_plan",
+        return_value=fast_plan,
+    ):
+        result = execute_campaign(
+            manifest_path=CANONICAL_MANIFEST,
+            go_comment_id=COMMENT_ID,
+            executor=fake,
+            repo_root=REPO_ROOT,
+            artifacts_base=tmp_path,
+            main_sha=MAIN_SHA,
+            authorizing_github_login=AUTHOR,
+            surface_id=SURFACE_ID,
+            surface_capability_fingerprint=surface_probe.surface_capability_fingerprint,
+            resource_budget=budget,
+            fetcher=make_fetcher(auth),
+            stream=io.StringIO(),
+        )
+    assert result["status"] == "COMPLETED"
+    assert result["reproduction"]["enabled"] is True
+    assert result["reproduction"]["phase_outcome"] == "REPRODUCTION_COMPLETE"
+    # Reproduction was actually executed under FakeExecutor.
+    assert any(c.attempt_kind == ATTEMPT_KIND_REPRODUCTION for c in fake.calls)
+
+
+def test_execute_blocks_when_auth_lifetime_insufficient(
+    manifest: dict[str, Any], surface_probe, tmp_path: Path
+) -> None:
+    """Live GO with too-short expires_at vs budget is refused fail-closed."""
+    from datetime import UTC, datetime, timedelta
+
+    budget = _sample_budget()
+    budget["minimum_free_disk_bytes"] = 1
+    # Set expires_at only 5 minutes in the future — remaining <
+    # max_campaign_wall_time_seconds (86400) + max_run_wall_time_seconds (600).
+    now = datetime(2026, 8, 4, tzinfo=UTC)
+    tight = (now + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+    auth = build_valid_auth_payload(
+        manifest=manifest,
+        surface_fp=surface_probe.surface_capability_fingerprint,
+        budget=budget,
+        expires_at_utc=tight,
+    )
+
+    with pytest.raises(SensitivityAuthorizationError) as exc:
+        execute_campaign(
+            manifest_path=CANONICAL_MANIFEST,
+            go_comment_id=COMMENT_ID,
+            executor=FakeExecutor(),
+            repo_root=REPO_ROOT,
+            artifacts_base=tmp_path,
+            main_sha=MAIN_SHA,
+            authorizing_github_login=AUTHOR,
+            surface_id=SURFACE_ID,
+            surface_capability_fingerprint=surface_probe.surface_capability_fingerprint,
+            resource_budget=budget,
+            fetcher=make_fetcher(auth),
+            stream=io.StringIO(),
+            now_utc_provider=lambda: now,
+        )
+    assert exc.value.reason_code == "AUTH_LIFETIME_INSUFFICIENT_FOR_BUDGET"
+
+
+def test_execute_blocks_when_authorization_expires_before_attempt(
+    manifest: dict[str, Any], surface_probe, tmp_path: Path
+) -> None:
+    """Pre-attempt expiry gate blocks the first primary run when time has passed."""
+    from datetime import UTC, datetime, timedelta
+
+    budget = _sample_budget()
+    budget["minimum_free_disk_bytes"] = 1
+
+    lifetime_start = datetime(2026, 8, 4, 0, 0, tzinfo=UTC)
+    # Expiry far enough in the future to satisfy lifetime coverage but still
+    # before the per-attempt clock jump below.
+    expires_at = (
+        (lifetime_start + timedelta(days=30)).isoformat().replace("+00:00", "Z")
+    )
+    auth = build_valid_auth_payload(
+        manifest=manifest,
+        surface_fp=surface_probe.surface_capability_fingerprint,
+        budget=budget,
+        expires_at_utc=expires_at,
+    )
+    fast_plan = _fast_plan_from(manifest, primary_count=2)
+
+    # Two lifetime clock calls at start, then jump past expiry for the
+    # per-attempt guard.
+    calls = {"n": 0}
+
+    def _now_provider():
+        i = calls["n"]
+        calls["n"] += 1
+        if i < 2:
+            return lifetime_start  # verify + lifetime check
+        return lifetime_start + timedelta(days=60)  # past expiry
+
+    with patch(
+        "tools.arvp_vacation.sensitivity_campaign_runner.build_run_plan",
+        return_value=fast_plan,
+    ):
+        with pytest.raises(SensitivityAuthorizationError) as exc:
+            execute_campaign(
+                manifest_path=CANONICAL_MANIFEST,
+                go_comment_id=COMMENT_ID,
+                executor=FakeExecutor(),
+                repo_root=REPO_ROOT,
+                artifacts_base=tmp_path,
+                main_sha=MAIN_SHA,
+                authorizing_github_login=AUTHOR,
+                surface_id=SURFACE_ID,
+                surface_capability_fingerprint=surface_probe.surface_capability_fingerprint,
+                resource_budget=budget,
+                fetcher=make_fetcher(auth),
+                stream=io.StringIO(),
+                now_utc_provider=_now_provider,
+            )
+    assert exc.value.reason_code == "AUTHORIZATION_EXPIRED_BEFORE_NEXT_ATTEMPT"

--- a/tests/unit/arvp/test_sensitivity_campaign_state.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_state.py
@@ -294,6 +294,17 @@ def test_reproduction_resume_success_skips(tmp_path: Path) -> None:
         envelope={"run_key": "rk1", "reproduction_attempt": 1},
         result={"gate_reason": "OK", "trade_count": 0},
     )
+    write_comparison_evidence(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        comparison={
+            "status": "PASS",
+            "reason_code": "REPRODUCTION_EXACT_MATCH",
+            "mismatched_fields": [],
+            "comparison_fingerprint": "e" * 64,
+        },
+    )
     assert reproduction_completion_marker_path(root, "rk1", 1).exists()
     action = inspect_reproduction_for_resume(
         root,
@@ -304,6 +315,76 @@ def test_reproduction_resume_success_skips(tmp_path: Path) -> None:
         retry_failed=True,
     )
     assert action == "skip"
+
+
+def test_reproduction_resume_success_without_comparison_blocks(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    commit_successful_reproduction_result(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        attempt=1,
+        envelope={"run_key": "rk1", "reproduction_attempt": 1},
+        result={"gate_reason": "OK", "trade_count": 0},
+    )
+    with pytest.raises(SensitivityStateError) as exc:
+        inspect_reproduction_for_resume(
+            root,
+            run_key="rk1",
+            reproduction_attempt=1,
+            bindings=BINDINGS,
+            max_attempts=3,
+            retry_failed=True,
+        )
+    assert "STATE_REPRO_COMPARISON_MISSING" in str(exc.value)
+
+
+def test_reproduction_resume_running_with_pass_comparison_finalizes(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "ns"
+    write_reproduction_envelope(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        status="RUNNING",
+        attempt=1,
+        envelope={"run_key": "rk1", "reproduction_attempt": 1},
+    )
+    from tools.arvp_vacation.sensitivity_campaign_state import (
+        persist_reproduction_result,
+    )
+
+    persist_reproduction_result(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        result={"gate_reason": "OK", "trade_count": 0},
+    )
+    write_comparison_evidence(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        comparison={
+            "status": "PASS",
+            "reason_code": "REPRODUCTION_EXACT_MATCH",
+            "mismatched_fields": [],
+            "comparison_fingerprint": "e" * 64,
+        },
+    )
+    action = inspect_reproduction_for_resume(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        max_attempts=3,
+        retry_failed=True,
+    )
+    assert action == "finalize"
 
 
 def test_reproduction_resume_partial_blocks(tmp_path: Path) -> None:

--- a/tests/unit/arvp/test_sensitivity_campaign_state.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_state.py
@@ -16,12 +16,32 @@ from pathlib import Path
 import pytest
 
 from tools.arvp_vacation.sensitivity_campaign_state import (
+    CAMPAIGN_PHASES,
+    CAMPAIGN_PHASE_BLOCKED,
+    CAMPAIGN_PHASE_COMPLETED,
+    CAMPAIGN_PHASE_PRIMARY_COMPLETE,
+    CAMPAIGN_PHASE_PRIMARY_RUNNING,
+    CAMPAIGN_PHASE_REPRODUCTION_COMPLETE,
+    CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
+    CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
     CampaignBindings,
     SensitivityStateError,
     assert_namespace_startable,
+    commit_successful_reproduction_result,
     commit_successful_result,
+    count_primary_succeeded,
+    inspect_reproduction_for_resume,
     inspect_run_for_resume,
+    read_campaign_phase,
+    reproduction_comparison_path,
+    reproduction_completion_marker_path,
+    reproduction_dir,
+    reproduction_envelope_path,
+    reproduction_result_path,
+    update_campaign_phase,
     write_campaign_envelope,
+    write_comparison_evidence,
+    write_reproduction_envelope,
     write_run_envelope,
 )
 
@@ -166,3 +186,262 @@ def test_fresh_namespace(tmp_path: Path) -> None:
     assert assert_namespace_startable(root, bindings=BINDINGS, allow_resume=True) == (
         "fresh"
     )
+
+
+def test_campaign_phases_frozenset_membership() -> None:
+    for expected in (
+        "PRIMARY_PLANNED",
+        "PRIMARY_RUNNING",
+        "PRIMARY_COMPLETE",
+        "REPRODUCTION_PLANNED",
+        "REPRODUCTION_RUNNING",
+        "REPRODUCTION_COMPLETE",
+        "COMPLETED",
+        "BLOCKED",
+    ):
+        assert expected in CAMPAIGN_PHASES
+
+
+def test_update_campaign_phase_happy_transition_sequence(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    assert read_campaign_phase(root) == "PLANNED"
+
+    update_campaign_phase(root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_PRIMARY_RUNNING)
+    assert read_campaign_phase(root) == "PRIMARY_RUNNING"
+    update_campaign_phase(
+        root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_PRIMARY_COMPLETE
+    )
+    update_campaign_phase(
+        root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_REPRODUCTION_PLANNED
+    )
+    update_campaign_phase(
+        root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_REPRODUCTION_RUNNING
+    )
+    update_campaign_phase(
+        root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_REPRODUCTION_COMPLETE
+    )
+    update_campaign_phase(root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_COMPLETED)
+    assert read_campaign_phase(root) == "COMPLETED"
+
+
+def test_update_campaign_phase_illegal_transition_raises(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    # PLANNED -> COMPLETED is illegal (must go via PRIMARY_RUNNING).
+    with pytest.raises(SensitivityStateError) as exc:
+        update_campaign_phase(root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_COMPLETED)
+    assert "STATE_PHASE_ILLEGAL_TRANSITION" in str(exc.value)
+
+
+def test_update_campaign_phase_terminal_stays(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    update_campaign_phase(root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_BLOCKED)
+    # Terminal BLOCKED cannot transition further.
+    with pytest.raises(SensitivityStateError) as exc:
+        update_campaign_phase(root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_COMPLETED)
+    assert "STATE_PHASE_ILLEGAL_TRANSITION" in str(exc.value)
+    # Idempotent stay is allowed.
+    update_campaign_phase(root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_BLOCKED)
+    assert read_campaign_phase(root) == "BLOCKED"
+
+
+def test_update_campaign_phase_binding_mismatch(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    other = CampaignBindings(
+        campaign_id=BINDINGS.campaign_id,
+        manifest_fingerprint="f" * 64,
+        run_plan_fingerprint=BINDINGS.run_plan_fingerprint,
+        authorization_fingerprint=BINDINGS.authorization_fingerprint,
+        execution_sha=BINDINGS.execution_sha,
+        main_sha=BINDINGS.main_sha,
+    )
+    with pytest.raises(SensitivityStateError) as exc:
+        update_campaign_phase(
+            root, bindings=other, phase=CAMPAIGN_PHASE_PRIMARY_RUNNING
+        )
+    assert "STATE_BINDING_MISMATCH" in str(exc.value)
+
+
+def test_update_campaign_phase_unknown_raises(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    with pytest.raises(SensitivityStateError) as exc:
+        update_campaign_phase(root, bindings=BINDINGS, phase="BOGUS_PHASE")
+    assert "STATE_PHASE_UNKNOWN" in str(exc.value)
+
+
+def test_update_campaign_phase_missing_envelope(tmp_path: Path) -> None:
+    root = tmp_path / "unknown"
+    with pytest.raises(SensitivityStateError) as exc:
+        update_campaign_phase(
+            root, bindings=BINDINGS, phase=CAMPAIGN_PHASE_PRIMARY_RUNNING
+        )
+    assert "STATE_PHASE_ENVELOPE_MISSING" in str(exc.value)
+
+
+def test_reproduction_resume_success_skips(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    commit_successful_reproduction_result(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        attempt=1,
+        envelope={"run_key": "rk1", "reproduction_attempt": 1},
+        result={"gate_reason": "OK", "trade_count": 0},
+    )
+    assert reproduction_completion_marker_path(root, "rk1", 1).exists()
+    action = inspect_reproduction_for_resume(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        max_attempts=3,
+        retry_failed=True,
+    )
+    assert action == "skip"
+
+
+def test_reproduction_resume_partial_blocks(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_reproduction_envelope(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        status="SUCCEEDED",
+        attempt=1,
+        envelope={"run_key": "rk1", "reproduction_attempt": 1},
+        exit_code=0,
+        result_fingerprint="d" * 64,
+    )
+    with pytest.raises(SensitivityStateError) as exc:
+        inspect_reproduction_for_resume(
+            root,
+            run_key="rk1",
+            reproduction_attempt=1,
+            bindings=BINDINGS,
+            max_attempts=3,
+            retry_failed=True,
+        )
+    assert "STATE_REPRO_PARTIAL_SUCCESS_BLOCKED" in str(exc.value)
+
+
+def test_reproduction_resume_running_blocks(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_reproduction_envelope(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        status="RUNNING",
+        attempt=1,
+        envelope={"run_key": "rk1", "reproduction_attempt": 1},
+    )
+    with pytest.raises(SensitivityStateError) as exc:
+        inspect_reproduction_for_resume(
+            root,
+            run_key="rk1",
+            reproduction_attempt=1,
+            bindings=BINDINGS,
+            max_attempts=3,
+            retry_failed=True,
+        )
+    assert "STATE_REPRO_RUNNING_WITHOUT_COMPLETION" in str(exc.value)
+
+
+def test_reproduction_resume_retry_limit(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_reproduction_envelope(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        bindings=BINDINGS,
+        status="FAILED",
+        attempt=2,
+        envelope={"run_key": "rk1", "reproduction_attempt": 1},
+        exit_code=1,
+    )
+    with pytest.raises(SensitivityStateError) as exc:
+        inspect_reproduction_for_resume(
+            root,
+            run_key="rk1",
+            reproduction_attempt=1,
+            bindings=BINDINGS,
+            max_attempts=2,
+            retry_failed=True,
+        )
+    assert "STATE_REPRO_RETRY_LIMIT_EXCEEDED" in str(exc.value)
+
+
+def test_reproduction_dir_layout(tmp_path: Path) -> None:
+    d = reproduction_dir(tmp_path, "rk1", 1)
+    assert d.parts[-3:] == ("rk1", "reproduction", "1")
+    env = reproduction_envelope_path(tmp_path, "rk1", 1)
+    assert env.name == "run_envelope.json"
+    assert env.parent == d
+    res = reproduction_result_path(tmp_path, "rk1", 1)
+    assert res.name == "result.json"
+    cmp_path = reproduction_comparison_path(tmp_path, "rk1", 1)
+    assert cmp_path.name == "comparison.json"
+
+
+def test_write_comparison_evidence_writes_body(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    cmp_path = write_comparison_evidence(
+        root,
+        run_key="rk1",
+        reproduction_attempt=1,
+        comparison={
+            "status": "PASS",
+            "reason_code": "REPRODUCTION_RESULT_PASS",
+            "compared_fields": ["gate_reason"],
+        },
+    )
+    import json
+
+    payload = json.loads(cmp_path.read_text(encoding="utf-8"))
+    assert payload["run_key"] == "rk1"
+    assert payload["reproduction_attempt"] == 1
+    assert payload["comparison"]["status"] == "PASS"
+
+
+def test_count_primary_succeeded_counts_only_bound_successes(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=2)
+    commit_successful_result(
+        root,
+        run_key="rk1",
+        bindings=BINDINGS,
+        attempt=1,
+        envelope={"run_key": "rk1"},
+        result={"gate_reason": "OK", "trade_count": 0},
+    )
+    # rk2 is planned but not yet committed → count only counts rk1.
+    n = count_primary_succeeded(
+        root, bindings=BINDINGS, expected_run_keys=["rk1", "rk2"]
+    )
+    assert n == 1
+
+
+def test_count_primary_succeeded_partial_blocks(tmp_path: Path) -> None:
+    root = tmp_path / "ns"
+    write_run_envelope(
+        root,
+        run_key="rk1",
+        bindings=BINDINGS,
+        status="SUCCEEDED",
+        attempt=1,
+        envelope={"run_key": "rk1"},
+        exit_code=0,
+        result_fingerprint="d" * 64,
+    )
+    # No completion marker / result → treated as partial → fail-closed.
+    with pytest.raises(SensitivityStateError) as exc:
+        count_primary_succeeded(root, bindings=BINDINGS, expected_run_keys=["rk1"])
+    assert "STATE_PARTIAL_SUCCESS_BLOCKED" in str(exc.value)

--- a/tools/arvp_vacation/sensitivity_campaign_authorization.py
+++ b/tools/arvp_vacation/sensitivity_campaign_authorization.py
@@ -40,6 +40,11 @@ AUTHORIZING_OWNER_ALLOWLIST = frozenset({"jannekbuengener"})
 GO_FENCE_START = "```cdb.sensitivity_campaign_execution_authorization.v1"
 GO_FENCE_END = "```"
 
+# Sentinel marker documenting an explicit revocation of the fenced GO block by
+# the authorizing owner. Presence anywhere in the comment body (case-sensitive)
+# fails the parse fail-closed even if a fenced block is still present.
+REVOKE_MARKER = "REVOKED_CAMPAIGN_EXECUTION_CONTRACT_DEFECT"
+
 ABSOLUTE_BAN_KEYS = frozenset(
     {
         "campaign_execution_auto_start",
@@ -174,33 +179,105 @@ def validate_authorization_payload(
     _assert_expires_at_valid(payload.get("expires_at_utc"), now_utc=now_utc)
 
 
+def _parse_expires_at(raw: Any) -> datetime | None:
+    """Parse ``expires_at_utc``. Returns None when null; raises on malformed input."""
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw.strip():
+        raise SensitivityAuthorizationError("AUTH_EXPIRES_AT_INVALID", "non-string")
+    value = raw.strip()
+    try:
+        if value.endswith("Z"):
+            exp = datetime.fromisoformat(value[:-1] + "+00:00")
+        else:
+            exp = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SensitivityAuthorizationError(
+            "AUTH_EXPIRES_AT_INVALID", str(exc)
+        ) from exc
+    if exp.tzinfo is None:
+        raise SensitivityAuthorizationError("AUTH_EXPIRES_AT_NOT_TIMEZONE_AWARE", value)
+    return exp
+
+
 def _assert_expires_at_valid(
     expires_at_utc: Any,
     *,
     now_utc: datetime | None = None,
 ) -> None:
     """Clock source: core.utils.clock.utcnow unless injected for tests."""
-    if expires_at_utc is None:
+    exp = _parse_expires_at(expires_at_utc)
+    if exp is None:
         return
-    if not isinstance(expires_at_utc, str) or not expires_at_utc.strip():
-        raise SensitivityAuthorizationError("AUTH_EXPIRES_AT_INVALID", "non-string")
-    raw = expires_at_utc.strip()
-    try:
-        if raw.endswith("Z"):
-            exp = datetime.fromisoformat(raw[:-1] + "+00:00")
-        else:
-            exp = datetime.fromisoformat(raw)
-    except ValueError as exc:
-        raise SensitivityAuthorizationError(
-            "AUTH_EXPIRES_AT_INVALID", str(exc)
-        ) from exc
-    if exp.tzinfo is None:
-        raise SensitivityAuthorizationError("AUTH_EXPIRES_AT_NOT_TIMEZONE_AWARE", raw)
     now = now_utc if now_utc is not None else cdb_utcnow()
     if now.tzinfo is None:
         now = now.replace(tzinfo=UTC)
     if now.astimezone(UTC) >= exp.astimezone(UTC):
-        raise SensitivityAuthorizationError("AUTH_GO_EXPIRED", raw)
+        raise SensitivityAuthorizationError("AUTH_GO_EXPIRED", str(expires_at_utc))
+
+
+def assert_authorization_not_expired_for_next_attempt(
+    expires_at_utc: Any,
+    *,
+    now_utc: datetime | None = None,
+) -> None:
+    """Fail-closed pre-attempt gate: refuse to start a new run when expired.
+
+    Called before every primary / retry / reproduction attempt so a long-running
+    campaign cannot cross a live expiry mid-flight. ``null`` expiry is allowed.
+    """
+    exp = _parse_expires_at(expires_at_utc)
+    if exp is None:
+        return
+    now = now_utc if now_utc is not None else cdb_utcnow()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    if now.astimezone(UTC) >= exp.astimezone(UTC):
+        raise SensitivityAuthorizationError(
+            "AUTHORIZATION_EXPIRED_BEFORE_NEXT_ATTEMPT",
+            str(expires_at_utc),
+        )
+
+
+def assert_authorization_lifetime_covers_budget(
+    expires_at_utc: Any,
+    resource_budget: Mapping[str, Any],
+    *,
+    now_utc: datetime | None = None,
+) -> None:
+    """Assert remaining GO lifetime >= campaign_wall + run_wall seconds.
+
+    A campaign whose GO expiry cannot cover the configured budget is refused
+    fail-closed before any side effects. ``null`` expiry is refused for a
+    campaign path (finite lifetime required to bound the human gate).
+    """
+    if resource_budget is None:
+        raise SensitivityAuthorizationError("AUTH_LIFETIME_BUDGET_MISSING")
+    body = dict(resource_budget)
+    try:
+        campaign_wall = int(body["max_campaign_wall_time_seconds"])
+        run_wall = int(body["max_run_wall_time_seconds"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise SensitivityAuthorizationError(
+            "AUTH_LIFETIME_BUDGET_INVALID", str(exc)
+        ) from exc
+    required = campaign_wall + run_wall
+    if expires_at_utc is None:
+        raise SensitivityAuthorizationError(
+            "AUTH_EXPIRES_AT_REQUIRED_FOR_CAMPAIGN",
+            "finite expires_at_utc required to bound campaign execution",
+        )
+    exp = _parse_expires_at(expires_at_utc)
+    assert exp is not None  # narrows for type checker; None handled above
+    now = now_utc if now_utc is not None else cdb_utcnow()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    remaining = int((exp.astimezone(UTC) - now.astimezone(UTC)).total_seconds())
+    if remaining < required:
+        raise SensitivityAuthorizationError(
+            "AUTH_LIFETIME_INSUFFICIENT_FOR_BUDGET",
+            f"remaining={remaining}s required={required}s",
+        )
 
 
 def fingerprint_authorization_payload(payload: Mapping[str, Any]) -> str:
@@ -214,12 +291,22 @@ def fingerprint_authorization_payload(payload: Mapping[str, Any]) -> str:
 
 
 def parse_go_payload_from_comment_body(body: str) -> dict[str, Any]:
-    """Extract exactly one fenced authorization JSON block from a comment body."""
+    """Extract exactly one fenced authorization JSON block from a comment body.
+
+    A body containing the explicit revocation sentinel is rejected fail-closed
+    before any JSON parsing.
+    """
+    raw = body or ""
+    if REVOKE_MARKER in raw:
+        raise SensitivityAuthorizationError(
+            "AUTH_GO_REVOKED",
+            "comment body carries REVOKED_CAMPAIGN_EXECUTION_CONTRACT_DEFECT sentinel",
+        )
     pattern = re.compile(
         r"```cdb\.sensitivity_campaign_execution_authorization\.v1\s*\n" r"(.*?)\n```",
         re.DOTALL,
     )
-    matches = pattern.findall(body or "")
+    matches = pattern.findall(raw)
     if not matches:
         raise SensitivityAuthorizationError(
             "AUTH_GO_BLOCK_MISSING",
@@ -470,6 +557,7 @@ def verify_owner_go_comment(
         "github_comment_id": comment_id,
         "authorizing_github_login": live_author,
         "comment_updated_at": comment.updated_at,
+        "expires_at_utc": payload.get("expires_at_utc"),
         "reason_code": "AUTH_GO_VALID",
         "clock_source": "core.utils.clock.utcnow",
     }

--- a/tools/arvp_vacation/sensitivity_campaign_dataset_root.py
+++ b/tools/arvp_vacation/sensitivity_campaign_dataset_root.py
@@ -1,0 +1,243 @@
+"""Canonical dataset-root resolver for #4153 sensitivity campaign execution.
+
+Resolves and verifies the dataset root supplied at ``execute`` time against the
+manifest window bindings. Emits a stable identity dict that is bound into the
+execution-surface fingerprint and the campaign envelope.
+
+Fail-closed reason codes:
+    DATASET_ROOT_UNBOUND
+        No dataset root supplied to execute path.
+    DATASET_ROOT_MISSING
+        Resolved path does not exist on disk.
+    DATASET_ROOT_NOT_ABSOLUTE
+        Resolved path is not absolute after realpath resolution.
+    DATASET_SYMLINK_ESCAPE
+        Resolved path escapes the declared root via symlink or parent-of-symlink.
+    DATASET_TRAVERSAL
+        Traversal marker (``..``) present in the declared root argument.
+    DATASET_WINDOW_MISSING
+        A manifest window binding does not resolve under the window-bank layout.
+    DATASET_CONTENT_FINGERPRINT_MISMATCH
+        On-disk content fingerprint disagrees with the manifest binding.
+    DATASET_MANIFEST_INVALID
+        Manifest missing / malformed window_bindings.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePath
+from typing import Any, Mapping
+
+from core.replay.canonical_json import canonical_hash
+
+DATASET_ROOT_CONTRACT_VERSION = "cdb.sensitivity_campaign_dataset_root.v1"
+
+WINDOW_BANK_SUFFIX = PurePath("window_bank/binance/spot/BTCUSDT/1m")
+
+
+class SensitivityDatasetRootError(ValueError):
+    """Fail-closed dataset-root resolver error."""
+
+    def __init__(self, reason_code: str, detail: str = "") -> None:
+        self.reason_code = reason_code
+        message = reason_code if not detail else f"{reason_code}: {detail}"
+        super().__init__(message)
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetRootIdentity:
+    window_bank_root: str
+    window_count: int
+    content_fingerprints_hash: str
+    dataset_identity_fingerprint: str
+    schema_version: str = DATASET_ROOT_CONTRACT_VERSION
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "window_bank_root": self.window_bank_root,
+            "window_count": int(self.window_count),
+            "content_fingerprints_hash": self.content_fingerprints_hash,
+            "dataset_identity_fingerprint": self.dataset_identity_fingerprint,
+        }
+
+
+def _reject_traversal_component(raw: Path) -> None:
+    """Reject any ``..`` component in the declared path before resolving."""
+    parts = PurePath(str(raw)).parts
+    if any(p == ".." for p in parts):
+        raise SensitivityDatasetRootError(
+            "DATASET_TRAVERSAL", f"path contains parent traversal: {raw}"
+        )
+
+
+def _resolve_realpath(path: Path) -> Path:
+    """Resolve ``..``-free absolute realpath, distinguishing missing from escape."""
+    try:
+        resolved = Path(os.path.realpath(str(path)))
+    except OSError as exc:
+        raise SensitivityDatasetRootError(
+            "DATASET_ROOT_MISSING", f"{path}: {exc}"
+        ) from exc
+    return resolved
+
+
+def _pick_window_bank_root(dataset_root: Path, repo_root: Path) -> Path:
+    """Return the resolved absolute window-bank root under the declared root.
+
+    Accepts either the parent ``artifacts/market_data`` (with a
+    ``window_bank/binance/spot/BTCUSDT/1m`` child) or a path that already ends
+    in the canonical window-bank suffix.
+    """
+    _reject_traversal_component(dataset_root)
+
+    resolved = _resolve_realpath(dataset_root)
+    if not resolved.is_absolute():
+        raise SensitivityDatasetRootError("DATASET_ROOT_NOT_ABSOLUTE", str(resolved))
+    if not resolved.exists():
+        raise SensitivityDatasetRootError("DATASET_ROOT_MISSING", str(resolved))
+
+    resolved_suffix = PurePath(*resolved.parts[-len(WINDOW_BANK_SUFFIX.parts) :])
+    candidates: list[Path] = []
+    child = resolved / WINDOW_BANK_SUFFIX
+    if child.exists():
+        candidates.append(child)
+    if resolved_suffix.as_posix() == WINDOW_BANK_SUFFIX.as_posix():
+        candidates.append(resolved)
+    if not candidates:
+        raise SensitivityDatasetRootError(
+            "DATASET_ROOT_MISSING",
+            f"neither {child} nor a canonical window-bank suffix under {resolved}",
+        )
+
+    bank = _resolve_realpath(candidates[0])
+    if not bank.is_absolute():
+        raise SensitivityDatasetRootError("DATASET_ROOT_NOT_ABSOLUTE", str(bank))
+    # Reject symlink escapes: the bank realpath must live under the declared
+    # dataset-root realpath.
+    try:
+        bank.relative_to(resolved)
+    except ValueError as exc:
+        # Accept the case where the caller passed the bank itself (equal path).
+        if bank != resolved:
+            raise SensitivityDatasetRootError(
+                "DATASET_SYMLINK_ESCAPE",
+                f"resolved bank {bank} escapes declared root {resolved}",
+            ) from exc
+    _ = repo_root  # reserved for future repo-relative binding
+    return bank
+
+
+def _load_window_content_fingerprint(bank_root: Path, window_id: str) -> str | None:
+    """Read on-disk ``dataset_spec.json`` and return its content_fingerprint."""
+    window_dir = bank_root / window_id
+    if not window_dir.exists():
+        return None
+    spec = window_dir / "dataset_spec.json"
+    if not spec.exists():
+        return None
+    try:
+        import json
+
+        payload = json.loads(spec.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    # dataset_spec content_fingerprint keys as observed in the bank layout.
+    for key in ("content_fingerprint", "candles_content_fingerprint", "fingerprint"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def resolve_and_verify_dataset_root(
+    *,
+    dataset_root: Path,
+    manifest: Mapping[str, Any],
+    repo_root: Path,
+) -> DatasetRootIdentity:
+    """Resolve the dataset root and verify all manifest bindings.
+
+    Returns a :class:`DatasetRootIdentity` with a stable, path-independent
+    ``dataset_identity_fingerprint`` derived from the sorted list of
+    ``(window_id, content_fingerprint)`` pairs.
+    """
+    if dataset_root is None:
+        raise SensitivityDatasetRootError(
+            "DATASET_ROOT_UNBOUND", "execute path requires --dataset-root"
+        )
+    bindings = manifest.get("window_bindings")
+    if not isinstance(bindings, list) or not bindings:
+        raise SensitivityDatasetRootError(
+            "DATASET_MANIFEST_INVALID", "manifest.window_bindings missing or empty"
+        )
+
+    bank_root = _pick_window_bank_root(Path(dataset_root), Path(repo_root))
+
+    pairs: list[tuple[str, str]] = []
+    for binding in bindings:
+        if not isinstance(binding, Mapping):
+            raise SensitivityDatasetRootError(
+                "DATASET_MANIFEST_INVALID",
+                "window_bindings must be a list of objects",
+            )
+        window_id = str(binding.get("window_id") or "")
+        expected_fp = str(binding.get("content_fingerprint") or "")
+        if not window_id or not expected_fp:
+            raise SensitivityDatasetRootError(
+                "DATASET_MANIFEST_INVALID",
+                f"window binding missing window_id/content_fingerprint: {binding!r}",
+            )
+        window_dir = bank_root / window_id
+        if not window_dir.exists():
+            raise SensitivityDatasetRootError(
+                "DATASET_WINDOW_MISSING",
+                f"{window_id!r} not present under {bank_root}",
+            )
+        # Guard symlink escape on the window dir itself.
+        try:
+            _resolve_realpath(window_dir).relative_to(bank_root)
+        except ValueError as exc:
+            raise SensitivityDatasetRootError(
+                "DATASET_SYMLINK_ESCAPE",
+                f"window {window_id!r} escapes bank root",
+            ) from exc
+        actual_fp = _load_window_content_fingerprint(bank_root, window_id)
+        if actual_fp is not None and actual_fp != expected_fp:
+            raise SensitivityDatasetRootError(
+                "DATASET_CONTENT_FINGERPRINT_MISMATCH",
+                (
+                    f"window {window_id!r}: on-disk {actual_fp!r} != "
+                    f"manifest {expected_fp!r}"
+                ),
+            )
+        # When the on-disk spec does not expose a content fingerprint we bind
+        # the manifest value; this matches the current window-bank layout where
+        # the manifest is the SSOT for content identity.
+        pairs.append((window_id, expected_fp))
+
+    pairs_sorted = sorted(pairs, key=lambda entry: entry[0])
+    fingerprints_hash = canonical_hash(
+        {
+            "pairs": [
+                {"window_id": w, "content_fingerprint": fp} for w, fp in pairs_sorted
+            ]
+        }
+    )
+    identity_body = {
+        "schema_version": DATASET_ROOT_CONTRACT_VERSION,
+        "window_count": len(pairs_sorted),
+        "content_fingerprints_hash": fingerprints_hash,
+    }
+    identity_fp = canonical_hash(identity_body)
+
+    return DatasetRootIdentity(
+        window_bank_root=str(bank_root),
+        window_count=len(pairs_sorted),
+        content_fingerprints_hash=fingerprints_hash,
+        dataset_identity_fingerprint=identity_fp,
+    )

--- a/tools/arvp_vacation/sensitivity_campaign_executor.py
+++ b/tools/arvp_vacation/sensitivity_campaign_executor.py
@@ -20,6 +20,10 @@ DEFAULT_ADAPTER_ID = "primary_breakout_runner_v1"
 DEFAULT_SYMBOL = "BTCUSDT"
 DEFAULT_SPEEDUP = "instant"
 
+ATTEMPT_KIND_PRIMARY = "PRIMARY"
+ATTEMPT_KIND_REPRODUCTION = "REPRODUCTION"
+ALLOWED_ATTEMPT_KINDS = frozenset({ATTEMPT_KIND_PRIMARY, ATTEMPT_KIND_REPRODUCTION})
+
 
 @dataclass(frozen=True, slots=True)
 class RunEnvelope:
@@ -42,6 +46,7 @@ class RunEnvelope:
     authorization_fingerprint: str
     attempt: int = 1
     reproduction_attempt: int = 0
+    attempt_kind: str = ATTEMPT_KIND_PRIMARY
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -66,6 +71,7 @@ class RunEnvelope:
             "authorization_fingerprint": self.authorization_fingerprint,
             "attempt": self.attempt,
             "reproduction_attempt": self.reproduction_attempt,
+            "attempt_kind": self.attempt_kind,
         }
 
 
@@ -203,6 +209,11 @@ class StrategyReplayCampaignExecutor:
     ``dataset_source=binance_window`` and envelope parameters. Does not touch
     paper supervisors, exchange APIs, or order paths.
 
+    An optional ``window_bank_root`` (aka ``dataset_root``) may be supplied so
+    the underlying binance window-bank adapter resolves data under the given
+    root. When set, the value is stored and made available for downstream
+    invocations; the executor never mutates dataset files.
+
     Execution remains blocked upstream without a live-verified Owner-GO.
     """
 
@@ -214,14 +225,27 @@ class StrategyReplayCampaignExecutor:
         adapter_id: str = DEFAULT_ADAPTER_ID,
         symbol: str = DEFAULT_SYMBOL,
         speedup_profile: str = DEFAULT_SPEEDUP,
+        window_bank_root: Path | None = None,
+        dataset_root: Path | None = None,
     ) -> None:
         self._replay_invoker = replay_invoker
         self._metrics_loader = metrics_loader or _default_metrics_loader
         self._adapter_id = adapter_id
         self._symbol = symbol
         self._speedup_profile = speedup_profile
+        # ``dataset_root`` is accepted as an alias for backward-compatibility
+        # with runner call sites that resolve a dataset root from the manifest
+        # and hand the derived window-bank path down.
+        resolved_bank = window_bank_root or dataset_root
+        self._window_bank_root: Path | None = (
+            Path(resolved_bank) if resolved_bank is not None else None
+        )
         self.calls: list[RunEnvelope] = []
         self.last_config: Any | None = None
+
+    @property
+    def window_bank_root(self) -> Path | None:
+        return self._window_bank_root
 
     def _resolve_invoker(self) -> ReplayInvoker:
         if self._replay_invoker is not None:
@@ -263,9 +287,15 @@ class StrategyReplayCampaignExecutor:
             json.dumps(envelope.as_dict(), indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
+        bank_root = (
+            str(self._window_bank_root.resolve())
+            if self._window_bank_root is not None
+            else None
+        )
         return ARVPReplayConfig(
             dataset_source="binance_window",
             binance_window_id=str(envelope.window_id),
+            window_bank_root=bank_root,
             strategy_id=str(envelope.strategy_id),
             adapter_id=self._adapter_id,
             symbol=self._symbol,

--- a/tools/arvp_vacation/sensitivity_campaign_reproduction.py
+++ b/tools/arvp_vacation/sensitivity_campaign_reproduction.py
@@ -1,4 +1,18 @@
-"""Reproduction / double-run contract for #4153 (plan only; not executed here)."""
+"""Reproduction / double-run contract for #4153.
+
+Executed by the campaign runner: reproduction items are bound run replays of
+existing primary run keys, compared in-place against the primary result. No new
+run keys, no widening of the run count.
+
+Comparison semantics:
+- ``compare_reproduction_results`` compares only ``compared_fields`` after a
+  fail-closed canonical normalization. Volatile fields (timestamps, host paths,
+  attempt/process/log metadata, filesystem times, etc.) are never compared
+  unless explicitly opted in via ``compared_fields``.
+- Bindings (``run_key``, ``manifest_fingerprint``, ``run_plan_fingerprint``,
+  ``authorization_fingerprint``) are asserted between primary and reproduction
+  when provided; foreign primary results fail closed.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +21,49 @@ from typing import Any, Mapping, Sequence
 from core.replay.canonical_json import canonical_hash
 
 REPRODUCTION_CONTRACT_VERSION = "cdb.sensitivity_campaign_reproduction.v1"
+
+# Fields that must never be compared implicitly, even if the primary result
+# happens to persist them. Volatile / host-local by definition.
+_VOLATILE_FIELDS = frozenset(
+    {
+        "attempt",
+        "attempt_id",
+        "process_id",
+        "pid",
+        "hostname",
+        "host",
+        "runtime_seconds",
+        "runtime_ms",
+        "wall_time_seconds",
+        "wall_time_ms",
+        "started_at_utc",
+        "ended_at_utc",
+        "completed_at_utc",
+        "created_at_utc",
+        "updated_at_utc",
+        "timestamp",
+        "log_path",
+        "log_file",
+        "log_filename",
+        "output_dir",
+        "output_directory",
+        "artifact_path",
+        "workspace",
+        "cwd",
+        "filesystem_mtime",
+        "filesystem_ctime",
+        "filesystem_atime",
+    }
+)
+
+# Bindings that must be structurally identical between primary and reproduction
+# when the caller opts into bindings validation.
+_REQUIRED_BINDING_FIELDS = (
+    "run_key",
+    "manifest_fingerprint",
+    "run_plan_fingerprint",
+    "authorization_fingerprint",
+)
 
 
 class SensitivityReproductionError(ValueError):
@@ -42,7 +99,6 @@ def build_reproduction_plan(
     if baseline_run_keys is None:
         baseline_run_keys = keys[:baseline_n]
     if sample_run_keys is None:
-        # Deterministic sample: evenly spaced keys excluding baseline set.
         remaining = [k for k in keys if k not in set(baseline_run_keys)]
         if sample_n == 0 or not remaining:
             sample_run_keys = []
@@ -62,6 +118,7 @@ def build_reproduction_plan(
         )
 
     items = []
+    baseline_set = set(baseline_run_keys)
     for run_key in list(baseline_run_keys) + list(sample_run_keys):
         if run_key not in keys:
             raise SensitivityReproductionError(f"REPRO_UNKNOWN_RUN_KEY:{run_key}")
@@ -71,7 +128,7 @@ def build_reproduction_plan(
                     "run_key": run_key,
                     "reproduction_attempt": attempt,
                     "creates_new_run_key": False,
-                    "role": "baseline" if run_key in baseline_run_keys else "sample",
+                    "role": "baseline" if run_key in baseline_set else "sample",
                 }
             )
 
@@ -92,15 +149,107 @@ def build_reproduction_plan(
     return plan
 
 
+def _project_compared(
+    result: Mapping[str, Any], compared_fields: Sequence[str]
+) -> dict[str, Any]:
+    """Project the compared fields with canonical normalization."""
+    projected: dict[str, Any] = {}
+    for field in compared_fields:
+        if field in _VOLATILE_FIELDS:
+            raise SensitivityReproductionError(
+                f"REPRO_COMPARED_FIELD_FORBIDDEN:{field}"
+            )
+        projected[field] = result.get(field)
+    return projected
+
+
+def _assert_bindings_match(
+    *,
+    primary: Mapping[str, Any],
+    reproduction: Mapping[str, Any],
+    required: Sequence[str],
+) -> None:
+    for field in required:
+        p_val = primary.get(field)
+        r_val = reproduction.get(field)
+        # A binding key that is only present on one side (or is empty on both) is
+        # only compared when at least one side provides a non-empty value.
+        if p_val in (None, "") and r_val in (None, ""):
+            continue
+        if p_val != r_val:
+            raise SensitivityReproductionError(
+                f"REPRO_BINDING_MISMATCH:{field}:"
+                f"primary={p_val!r} reproduction={r_val!r}"
+            )
+
+
 def compare_reproduction_results(
     *,
     primary: Mapping[str, Any],
     reproduction: Mapping[str, Any],
     compared_fields: Sequence[str],
-) -> None:
+    bindings: bool = False,
+    required_bindings: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Compare primary vs reproduction result under exact-equality semantics.
+
+    Returns a structured comparison dict. On mismatch: ``status="MISMATCH"``
+    and ``reason_code="REPRODUCTION_RESULT_MISMATCH"``. Structural failures
+    (missing bindings on both sides, forbidden compared fields) raise
+    :class:`SensitivityReproductionError` fail-closed.
+    """
+    if not compared_fields:
+        raise SensitivityReproductionError("REPRO_COMPARED_FIELDS_EMPTY")
+
+    if bindings:
+        required = tuple(required_bindings or _REQUIRED_BINDING_FIELDS)
+        _assert_bindings_match(
+            primary=primary,
+            reproduction=reproduction,
+            required=required,
+        )
+
+    primary_projected = _project_compared(primary, compared_fields)
+    repro_projected = _project_compared(reproduction, compared_fields)
+
+    primary_fp = canonical_hash(primary_projected)
+    repro_fp = canonical_hash(repro_projected)
+
+    mismatched: list[dict[str, Any]] = []
     for field in compared_fields:
-        if primary.get(field) != reproduction.get(field):
-            raise SensitivityReproductionError(
-                f"REPRO_MISMATCH:{field}:"
-                f"{primary.get(field)!r}!={reproduction.get(field)!r}"
+        p_val = primary_projected.get(field)
+        r_val = repro_projected.get(field)
+        if p_val != r_val:
+            mismatched.append(
+                {
+                    "field": field,
+                    "primary": p_val,
+                    "reproduction": r_val,
+                    "reason_code": "REPRO_MISMATCH",
+                }
             )
+
+    body = {
+        "schema_version": REPRODUCTION_CONTRACT_VERSION,
+        "compared_fields": list(compared_fields),
+        "primary_result_fingerprint": primary_fp,
+        "reproduction_result_fingerprint": repro_fp,
+        "mismatched_fields": mismatched,
+    }
+    if mismatched:
+        body["status"] = "MISMATCH"
+        body["reason_code"] = "REPRODUCTION_RESULT_MISMATCH"
+    else:
+        body["status"] = "PASS"
+        body["reason_code"] = "REPRODUCTION_RESULT_PASS"
+
+    body["comparison_fingerprint"] = canonical_hash(
+        {
+            "compared_fields": list(compared_fields),
+            "primary_result_fingerprint": primary_fp,
+            "reproduction_result_fingerprint": repro_fp,
+            "mismatched_fields": mismatched,
+            "status": body["status"],
+        }
+    )
+    return body

--- a/tools/arvp_vacation/sensitivity_campaign_runner.py
+++ b/tools/arvp_vacation/sensitivity_campaign_runner.py
@@ -79,7 +79,9 @@ from tools.arvp_vacation.sensitivity_campaign_state import (
     CAMPAIGN_ENVELOPE_NAME,
     CAMPAIGN_PHASE_BLOCKED,
     CAMPAIGN_PHASE_COMPLETED,
+    CAMPAIGN_PHASE_PLANNED,
     CAMPAIGN_PHASE_PRIMARY_COMPLETE,
+    CAMPAIGN_PHASE_PRIMARY_PLANNED,
     CAMPAIGN_PHASE_PRIMARY_RUNNING,
     CAMPAIGN_PHASE_REPRODUCTION_COMPLETE,
     CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
@@ -94,6 +96,8 @@ from tools.arvp_vacation.sensitivity_campaign_state import (
     evidence_root_for,
     inspect_reproduction_for_resume,
     inspect_run_for_resume,
+    persist_reproduction_result,
+    read_campaign_phase,
     read_json,
     release_campaign_lock,
     reproduction_dir,
@@ -124,6 +128,41 @@ class SensitivityRunnerError(ValueError):
     def __init__(self, reason_code: str, detail: str = "") -> None:
         self.reason_code = reason_code
         super().__init__(reason_code if not detail else f"{reason_code}: {detail}")
+
+
+def _bind_executor_dataset_root(
+    *,
+    executor: CampaignRunExecutor | None,
+    resolved_bank_root: Path | None,
+) -> CampaignRunExecutor:
+    """Ensure the production replay adapter consumes the verified dataset root.
+
+    CLI historically constructed ``StrategyReplayCampaignExecutor()`` before
+    ``dataset_root`` resolution; without rebinding, surface identity would
+    reflect the external root while replays still used the repo-local bank.
+    """
+    if executor is None:
+        return StrategyReplayCampaignExecutor(window_bank_root=resolved_bank_root)
+    if resolved_bank_root is None:
+        return executor
+    if isinstance(executor, StrategyReplayCampaignExecutor):
+        existing = executor.window_bank_root
+        if existing is None:
+            return StrategyReplayCampaignExecutor(
+                replay_invoker=executor._replay_invoker,
+                metrics_loader=executor._metrics_loader,
+                adapter_id=executor._adapter_id,
+                symbol=executor._symbol,
+                speedup_profile=executor._speedup_profile,
+                window_bank_root=resolved_bank_root,
+            )
+        if Path(existing).resolve() != Path(resolved_bank_root).resolve():
+            raise SensitivityRunnerError(
+                "RUNNER_DATASET_EXECUTOR_ROOT_MISMATCH",
+                f"executor={existing} verified={resolved_bank_root}",
+            )
+        return executor
+    return executor
 
 
 def _git_head_sha(repo_root: Path) -> str:
@@ -536,6 +575,29 @@ def _run_reproduction_loop(
             repro_skipped += 1
             continue
 
+        if action == "finalize":
+            # Crash window after PASS comparison, before success marker.
+            env_path = (
+                reproduction_dir(evidence_root, run_key, repro_attempt)
+                / "run_envelope.json"
+            )
+            prev = json.loads(env_path.read_text(encoding="utf-8"))
+            repro_result_body = read_json(
+                reproduction_dir(evidence_root, run_key, repro_attempt) / "result.json"
+            )
+            commit_successful_reproduction_result(
+                evidence_root,
+                run_key=run_key,
+                reproduction_attempt=repro_attempt,
+                bindings=bindings,
+                attempt=int(prev.get("attempt") or 1),
+                envelope=dict(prev.get("envelope") or {}),
+                result=dict(repro_result_body.get("result") or {}),
+                exit_code=0,
+            )
+            repro_succeeded += 1
+            continue
+
         # Pre-attempt expiry gate.
         assert_authorization_not_expired_for_next_attempt(
             auth_expiry, now_utc=now_utc_provider()
@@ -609,15 +671,13 @@ def _run_reproduction_loop(
                 }
             continue
 
-        commit_successful_reproduction_result(
+        # Persist result while still RUNNING; SUCCEEDED only after PASS comparison.
+        persist_reproduction_result(
             evidence_root,
             run_key=run_key,
             reproduction_attempt=repro_attempt,
             bindings=bindings,
-            attempt=attempt,
-            envelope=envelope.as_dict(),
             result=result.metrics,
-            exit_code=0,
         )
 
         # Load primary and compare, with bindings validation.
@@ -658,6 +718,16 @@ def _run_reproduction_loop(
         )
 
         if comparison["status"] == "MISMATCH":
+            write_reproduction_envelope(
+                evidence_root,
+                run_key=run_key,
+                reproduction_attempt=repro_attempt,
+                bindings=bindings,
+                status="FAILED",
+                attempt=attempt,
+                envelope=envelope.as_dict(),
+                exit_code=0,
+            )
             mismatches.append(
                 {
                     "run_key": run_key,
@@ -675,8 +745,19 @@ def _run_reproduction_loop(
                     "skipped": repro_skipped,
                     "mismatches": mismatches,
                 }
-        else:
-            repro_succeeded += 1
+            continue
+
+        commit_successful_reproduction_result(
+            evidence_root,
+            run_key=run_key,
+            reproduction_attempt=repro_attempt,
+            bindings=bindings,
+            attempt=attempt,
+            envelope=envelope.as_dict(),
+            result=result.metrics,
+            exit_code=0,
+        )
+        repro_succeeded += 1
 
     return {
         "phase_outcome": "REPRODUCTION_COMPLETE",
@@ -792,10 +873,9 @@ def execute_campaign(
             ) from exc
         resolved_bank_root = Path(dataset_identity.window_bank_root)
 
-    active_executor = (
-        executor
-        if executor is not None
-        else (StrategyReplayCampaignExecutor(window_bank_root=resolved_bank_root))
+    active_executor = _bind_executor_dataset_root(
+        executor=executor,
+        resolved_bank_root=resolved_bank_root,
     )
 
     probe = probe_execution_surface(
@@ -922,116 +1002,38 @@ def execute_campaign(
             extra=envelope_extra,
         )
 
-        # Enter primary phase.
-        update_campaign_phase(
-            evidence_root,
-            bindings=bindings,
-            phase=CAMPAIGN_PHASE_PRIMARY_RUNNING,
-        )
-
-        primary_outcome = _run_primary_loop(
-            plan=plan,
-            evidence_root=evidence_root,
-            bindings=bindings,
-            budget=budget,
-            active_executor=active_executor,
-            manifest=manifest,
-            auth_fp=auth_fp,
-            sha=sha,
-            auth_expiry=auth_expiry,
-            now_utc_provider=now_provider,
-        )
-        primary_succeeded = int(primary_outcome.get("succeeded", 0))
-        primary_failed = int(primary_outcome.get("failed", 0))
-        primary_skipped = int(primary_outcome.get("skipped", 0))
-
-        if primary_outcome["phase_outcome"] == "BLOCKED":
-            update_campaign_phase(
-                evidence_root,
-                bindings=bindings,
-                phase=CAMPAIGN_PHASE_BLOCKED,
-                extra={"blocked_reason": primary_outcome.get("reason_code")},
-            )
+        current_phase = read_campaign_phase(evidence_root)
+        if current_phase in {CAMPAIGN_PHASE_COMPLETED, CAMPAIGN_PHASE_BLOCKED}:
             payload = {
                 "command": "execute",
-                "status": "BLOCKED",
-                "reason_code": str(primary_outcome.get("reason_code")),
-                "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
-                "succeeded": primary_succeeded,
-                "failed": primary_failed,
-                "skipped": primary_skipped,
+                "status": current_phase,
+                "campaign_phase": current_phase,
+                "reason_code": f"RUNNER_ALREADY_{current_phase}",
                 "lr_status": "NO-GO",
             }
             _emit(payload, out)
             return payload
 
-        # All primary attempts must have SUCCEEDED before we move forward.
-        confirmed_primary = count_primary_succeeded(
-            evidence_root,
-            bindings=bindings,
-            expected_run_keys=list(plan.run_keys),
-        )
-        if confirmed_primary != plan.run_count:
-            update_campaign_phase(
-                evidence_root,
-                bindings=bindings,
-                phase=CAMPAIGN_PHASE_BLOCKED,
-                extra={
-                    "blocked_reason": "PRIMARY_SUCCESS_COUNT_MISMATCH",
-                    "expected_run_count": plan.run_count,
-                    "confirmed_primary": confirmed_primary,
-                },
-            )
-            payload = {
-                "command": "execute",
-                "status": "BLOCKED",
-                "reason_code": "PRIMARY_SUCCESS_COUNT_MISMATCH",
-                "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
-                "succeeded": primary_succeeded,
-                "failed": primary_failed,
-                "skipped": primary_skipped,
-                "confirmed_primary": confirmed_primary,
-                "lr_status": "NO-GO",
-            }
-            _emit(payload, out)
-            return payload
+        primary_succeeded = 0
+        primary_failed = 0
+        primary_skipped = 0
+        run_primary = current_phase in {
+            CAMPAIGN_PHASE_PLANNED,
+            CAMPAIGN_PHASE_PRIMARY_PLANNED,
+            CAMPAIGN_PHASE_PRIMARY_RUNNING,
+        }
 
-        update_campaign_phase(
-            evidence_root,
-            bindings=bindings,
-            phase=CAMPAIGN_PHASE_PRIMARY_COMPLETE,
-        )
+        if run_primary:
+            # Fresh start or mid-primary resume — never re-enter from later phases.
+            if current_phase != CAMPAIGN_PHASE_PRIMARY_RUNNING:
+                update_campaign_phase(
+                    evidence_root,
+                    bindings=bindings,
+                    phase=CAMPAIGN_PHASE_PRIMARY_RUNNING,
+                )
 
-        reproduction_enabled = bool(plan.reproduction_policy.get("enabled"))
-        reproduction_summary: dict[str, Any] = {"enabled": reproduction_enabled}
-
-        if reproduction_enabled:
-            update_campaign_phase(
-                evidence_root,
-                bindings=bindings,
-                phase=CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
-            )
-            reproduction_plan = build_reproduction_plan(
-                run_keys=list(plan.run_keys),
-                policy=plan.reproduction_policy,
-            )
-            update_campaign_phase(
-                evidence_root,
-                bindings=bindings,
-                phase=CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
-                extra={
-                    "reproduction_plan_fingerprint": reproduction_plan.get(
-                        "reproduction_plan_fingerprint"
-                    ),
-                    "reproduction_item_count": len(
-                        reproduction_plan.get("reproduction_items", [])
-                    ),
-                },
-            )
-
-            repro_outcome = _run_reproduction_loop(
+            primary_outcome = _run_primary_loop(
                 plan=plan,
-                reproduction_plan=reproduction_plan,
                 evidence_root=evidence_root,
                 bindings=bindings,
                 budget=budget,
@@ -1042,31 +1044,55 @@ def execute_campaign(
                 auth_expiry=auth_expiry,
                 now_utc_provider=now_provider,
             )
-            reproduction_summary.update(repro_outcome)
+            primary_succeeded = int(primary_outcome.get("succeeded", 0))
+            primary_failed = int(primary_outcome.get("failed", 0))
+            primary_skipped = int(primary_outcome.get("skipped", 0))
 
-            if repro_outcome["phase_outcome"] == "BLOCKED":
+            if primary_outcome["phase_outcome"] == "BLOCKED":
+                update_campaign_phase(
+                    evidence_root,
+                    bindings=bindings,
+                    phase=CAMPAIGN_PHASE_BLOCKED,
+                    extra={"blocked_reason": primary_outcome.get("reason_code")},
+                )
+                payload = {
+                    "command": "execute",
+                    "status": "BLOCKED",
+                    "reason_code": str(primary_outcome.get("reason_code")),
+                    "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
+                    "succeeded": primary_succeeded,
+                    "failed": primary_failed,
+                    "skipped": primary_skipped,
+                    "lr_status": "NO-GO",
+                }
+                _emit(payload, out)
+                return payload
+
+            confirmed_primary = count_primary_succeeded(
+                evidence_root,
+                bindings=bindings,
+                expected_run_keys=list(plan.run_keys),
+            )
+            if confirmed_primary != plan.run_count:
                 update_campaign_phase(
                     evidence_root,
                     bindings=bindings,
                     phase=CAMPAIGN_PHASE_BLOCKED,
                     extra={
-                        "blocked_reason": repro_outcome.get("reason_code"),
-                        "reproduction_mismatches": repro_outcome.get("mismatches"),
+                        "blocked_reason": "PRIMARY_SUCCESS_COUNT_MISMATCH",
+                        "expected_run_count": plan.run_count,
+                        "confirmed_primary": confirmed_primary,
                     },
                 )
                 payload = {
                     "command": "execute",
                     "status": "BLOCKED",
-                    "reason_code": str(repro_outcome.get("reason_code")),
+                    "reason_code": "PRIMARY_SUCCESS_COUNT_MISMATCH",
                     "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
                     "succeeded": primary_succeeded,
                     "failed": primary_failed,
                     "skipped": primary_skipped,
-                    "reproduction": reproduction_summary,
-                    "run_count": plan.run_count,
-                    "evidence_root": str(evidence_root),
-                    "authorization_fingerprint": auth_fp,
-                    "run_plan_fingerprint": plan.run_plan_fingerprint,
+                    "confirmed_primary": confirmed_primary,
                     "lr_status": "NO-GO",
                 }
                 _emit(payload, out)
@@ -1075,8 +1101,142 @@ def execute_campaign(
             update_campaign_phase(
                 evidence_root,
                 bindings=bindings,
-                phase=CAMPAIGN_PHASE_REPRODUCTION_COMPLETE,
+                phase=CAMPAIGN_PHASE_PRIMARY_COMPLETE,
             )
+        else:
+            # Resume past primary: require a complete primary ledger.
+            confirmed_primary = count_primary_succeeded(
+                evidence_root,
+                bindings=bindings,
+                expected_run_keys=list(plan.run_keys),
+            )
+            if confirmed_primary != plan.run_count:
+                update_campaign_phase(
+                    evidence_root,
+                    bindings=bindings,
+                    phase=CAMPAIGN_PHASE_BLOCKED,
+                    extra={
+                        "blocked_reason": "PRIMARY_SUCCESS_COUNT_MISMATCH",
+                        "expected_run_count": plan.run_count,
+                        "confirmed_primary": confirmed_primary,
+                    },
+                )
+                payload = {
+                    "command": "execute",
+                    "status": "BLOCKED",
+                    "reason_code": "PRIMARY_SUCCESS_COUNT_MISMATCH",
+                    "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
+                    "confirmed_primary": confirmed_primary,
+                    "lr_status": "NO-GO",
+                }
+                _emit(payload, out)
+                return payload
+            primary_succeeded = confirmed_primary
+
+        reproduction_enabled = bool(plan.reproduction_policy.get("enabled"))
+        reproduction_summary: dict[str, Any] = {"enabled": reproduction_enabled}
+        current_phase = read_campaign_phase(evidence_root)
+
+        if reproduction_enabled:
+            if current_phase == CAMPAIGN_PHASE_REPRODUCTION_COMPLETE:
+                reproduction_summary["phase_outcome"] = "REPRODUCTION_COMPLETE"
+                reproduction_summary["resumed_complete"] = True
+            else:
+                if current_phase == CAMPAIGN_PHASE_PRIMARY_COMPLETE:
+                    update_campaign_phase(
+                        evidence_root,
+                        bindings=bindings,
+                        phase=CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
+                    )
+                    current_phase = CAMPAIGN_PHASE_REPRODUCTION_PLANNED
+
+                reproduction_plan = build_reproduction_plan(
+                    run_keys=list(plan.run_keys),
+                    policy=plan.reproduction_policy,
+                )
+                if current_phase == CAMPAIGN_PHASE_REPRODUCTION_PLANNED:
+                    update_campaign_phase(
+                        evidence_root,
+                        bindings=bindings,
+                        phase=CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
+                        extra={
+                            "reproduction_plan_fingerprint": reproduction_plan.get(
+                                "reproduction_plan_fingerprint"
+                            ),
+                            "reproduction_item_count": len(
+                                reproduction_plan.get("reproduction_items", [])
+                            ),
+                        },
+                    )
+                elif current_phase == CAMPAIGN_PHASE_REPRODUCTION_RUNNING:
+                    # Idempotent resume into reproduction.
+                    update_campaign_phase(
+                        evidence_root,
+                        bindings=bindings,
+                        phase=CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
+                        extra={
+                            "reproduction_plan_fingerprint": reproduction_plan.get(
+                                "reproduction_plan_fingerprint"
+                            ),
+                            "reproduction_item_count": len(
+                                reproduction_plan.get("reproduction_items", [])
+                            ),
+                        },
+                    )
+                else:
+                    raise SensitivityRunnerError(
+                        "RUNNER_PHASE_UNSUPPORTED_RESUME",
+                        current_phase,
+                    )
+
+                repro_outcome = _run_reproduction_loop(
+                    plan=plan,
+                    reproduction_plan=reproduction_plan,
+                    evidence_root=evidence_root,
+                    bindings=bindings,
+                    budget=budget,
+                    active_executor=active_executor,
+                    manifest=manifest,
+                    auth_fp=auth_fp,
+                    sha=sha,
+                    auth_expiry=auth_expiry,
+                    now_utc_provider=now_provider,
+                )
+                reproduction_summary.update(repro_outcome)
+
+                if repro_outcome["phase_outcome"] == "BLOCKED":
+                    update_campaign_phase(
+                        evidence_root,
+                        bindings=bindings,
+                        phase=CAMPAIGN_PHASE_BLOCKED,
+                        extra={
+                            "blocked_reason": repro_outcome.get("reason_code"),
+                            "reproduction_mismatches": repro_outcome.get("mismatches"),
+                        },
+                    )
+                    payload = {
+                        "command": "execute",
+                        "status": "BLOCKED",
+                        "reason_code": str(repro_outcome.get("reason_code")),
+                        "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
+                        "succeeded": primary_succeeded,
+                        "failed": primary_failed,
+                        "skipped": primary_skipped,
+                        "reproduction": reproduction_summary,
+                        "run_count": plan.run_count,
+                        "evidence_root": str(evidence_root),
+                        "authorization_fingerprint": auth_fp,
+                        "run_plan_fingerprint": plan.run_plan_fingerprint,
+                        "lr_status": "NO-GO",
+                    }
+                    _emit(payload, out)
+                    return payload
+
+                update_campaign_phase(
+                    evidence_root,
+                    bindings=bindings,
+                    phase=CAMPAIGN_PHASE_REPRODUCTION_COMPLETE,
+                )
 
         update_campaign_phase(
             evidence_root,
@@ -1217,7 +1377,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             execute_campaign(
                 manifest_path=args.manifest,
                 go_comment_id=args.go_comment_id,
-                executor=StrategyReplayCampaignExecutor(),
+                executor=None,
                 repository=args.repository,
                 authorizing_github_login=args.authorizing_github_login,
                 surface_id=args.surface_id,

--- a/tools/arvp_vacation/sensitivity_campaign_runner.py
+++ b/tools/arvp_vacation/sensitivity_campaign_runner.py
@@ -33,6 +33,8 @@ from tools.arvp_vacation.sensitivity_campaign_authorization import (
     SensitivityAuthorizationError,
     assert_absolute_bans_intact,
     assert_author_in_owner_allowlist,
+    assert_authorization_lifetime_covers_budget,
+    assert_authorization_not_expired_for_next_attempt,
     campaign_execution_requires_owner_go,
     verify_owner_go_comment,
 )
@@ -42,7 +44,14 @@ from tools.arvp_vacation.sensitivity_campaign_budget import (
     assert_failure_thresholds,
     validate_resource_budget,
 )
+from tools.arvp_vacation.sensitivity_campaign_dataset_root import (
+    DatasetRootIdentity,
+    SensitivityDatasetRootError,
+    resolve_and_verify_dataset_root,
+)
 from tools.arvp_vacation.sensitivity_campaign_executor import (
+    ATTEMPT_KIND_PRIMARY,
+    ATTEMPT_KIND_REPRODUCTION,
     CampaignRunExecutor,
     RunEnvelope,
     StrategyReplayCampaignExecutor,
@@ -58,25 +67,42 @@ from tools.arvp_vacation.sensitivity_campaign_preflight import (
     run_repo_preflight,
 )
 from tools.arvp_vacation.sensitivity_campaign_reproduction import (
+    SensitivityReproductionError,
     build_reproduction_plan,
+    compare_reproduction_results,
 )
 from tools.arvp_vacation.sensitivity_campaign_run_plan import (
     EVIDENCE_NAMESPACE_ROOT,
     build_run_plan,
 )
 from tools.arvp_vacation.sensitivity_campaign_state import (
+    CAMPAIGN_ENVELOPE_NAME,
+    CAMPAIGN_PHASE_BLOCKED,
+    CAMPAIGN_PHASE_COMPLETED,
+    CAMPAIGN_PHASE_PRIMARY_COMPLETE,
+    CAMPAIGN_PHASE_PRIMARY_RUNNING,
+    CAMPAIGN_PHASE_REPRODUCTION_COMPLETE,
+    CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
+    CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
     CampaignBindings,
     SensitivityStateError,
     acquire_campaign_lock,
     assert_namespace_startable,
+    commit_successful_reproduction_result,
     commit_successful_result,
+    count_primary_succeeded,
     evidence_root_for,
+    inspect_reproduction_for_resume,
     inspect_run_for_resume,
     read_json,
     release_campaign_lock,
+    reproduction_dir,
+    result_path,
+    update_campaign_phase,
     write_campaign_envelope,
+    write_comparison_evidence,
+    write_reproduction_envelope,
     write_run_envelope,
-    CAMPAIGN_ENVELOPE_NAME,
 )
 from tools.arvp_vacation.sensitivity_campaign_surface import (
     SensitivitySurfaceError,
@@ -85,7 +111,6 @@ from tools.arvp_vacation.sensitivity_campaign_surface import (
 )
 from tools.arvp_vacation.sensitivity_experiment_manifest import (
     SensitivityManifestError,
-    fingerprint_manifest,
     load_manifest,
     validate_manifest,
 )
@@ -316,6 +341,352 @@ def validate_authorization_command(
     return payload
 
 
+def _load_primary_result(evidence_root: Path, run_key: str) -> dict[str, Any]:
+    """Load the persisted primary result for a run key.
+
+    Fail-closed if the marker/result is missing (partial success would already
+    have been rejected during ``count_primary_succeeded``).
+    """
+    rpath = result_path(evidence_root, run_key)
+    if not rpath.exists():
+        raise SensitivityRunnerError("RUNNER_PRIMARY_RESULT_MISSING", f"{rpath}")
+    body = read_json(rpath)
+    if not isinstance(body.get("result"), Mapping):
+        raise SensitivityRunnerError("RUNNER_PRIMARY_RESULT_MALFORMED", str(rpath))
+    return dict(body["result"])
+
+
+def _run_primary_loop(
+    *,
+    plan: Any,
+    evidence_root: Path,
+    bindings: CampaignBindings,
+    budget: Mapping[str, Any],
+    active_executor: CampaignRunExecutor,
+    manifest: Mapping[str, Any],
+    auth_fp: str,
+    sha: str,
+    auth_expiry: Any,
+    now_utc_provider: Any,
+) -> dict[str, Any]:
+    consecutive_failures = 0
+    total_failures = 0
+    succeeded = 0
+    skipped = 0
+    failed = 0
+    eff_fp = str(manifest.get("effective_config_snapshot_fingerprint") or "")
+
+    for planned in plan.runs:
+        try:
+            action = inspect_run_for_resume(
+                evidence_root,
+                run_key=planned.run_key,
+                bindings=bindings,
+                max_attempts=int(budget["max_attempts_per_run"]),
+                retry_failed=bool(plan.resume_policy.get("retry_failed")),
+            )
+        except SensitivityStateError as exc:
+            raise SensitivityRunnerError("RUNNER_RESUME_BLOCKED", str(exc)) from exc
+
+        if action == "skip":
+            skipped += 1
+            continue
+
+        # Pre-attempt authorization expiry gate.
+        assert_authorization_not_expired_for_next_attempt(
+            auth_expiry, now_utc=now_utc_provider()
+        )
+
+        attempt = 1
+        env_path = evidence_root / "runs" / planned.run_key / "run_envelope.json"
+        if env_path.exists() and action == "retry":
+            prev = json.loads(env_path.read_text(encoding="utf-8"))
+            attempt = int(prev.get("attempt") or 0) + 1
+
+        envelope = RunEnvelope(
+            run_key=planned.run_key,
+            campaign_id=plan.campaign_id,
+            manifest_fingerprint=plan.manifest_fingerprint,
+            execution_sha=sha,
+            window_id=planned.window_id,
+            strategy_id=planned.strategy_id,
+            parameters=dict(planned.param_set),
+            slot_id=planned.slot_id,
+            phase=planned.phase,
+            label=planned.label,
+            physical_parameter_set_fingerprint=(
+                planned.physical_parameter_set_fingerprint
+            ),
+            effective_config_fingerprint=eff_fp,
+            dataset_content_fingerprint=_window_content_fp(manifest, planned.window_id),
+            seed=_seed_for(plan.campaign_id, planned.window_id, planned.slot_id),
+            output_dir=str(evidence_root / "runs" / planned.run_key),
+            run_plan_fingerprint=plan.run_plan_fingerprint,
+            authorization_fingerprint=auth_fp,
+            attempt=attempt,
+            reproduction_attempt=0,
+            attempt_kind=ATTEMPT_KIND_PRIMARY,
+        )
+        write_run_envelope(
+            evidence_root,
+            run_key=planned.run_key,
+            bindings=bindings,
+            status="RUNNING",
+            attempt=attempt,
+            envelope=envelope.as_dict(),
+        )
+        result = active_executor.execute(envelope)
+        if result.exit_code != 0:
+            failed += 1
+            consecutive_failures += 1
+            total_failures += 1
+            write_run_envelope(
+                evidence_root,
+                run_key=planned.run_key,
+                bindings=bindings,
+                status="FAILED",
+                attempt=attempt,
+                envelope=envelope.as_dict(),
+                exit_code=result.exit_code,
+            )
+            try:
+                assert_failure_thresholds(
+                    budget=budget,
+                    consecutive_failures=consecutive_failures,
+                    total_failures=total_failures,
+                )
+            except SensitivityBudgetError as exc:
+                return {
+                    "phase_outcome": "BLOCKED",
+                    "reason_code": str(exc),
+                    "succeeded": succeeded,
+                    "failed": failed,
+                    "skipped": skipped,
+                }
+            continue
+
+        consecutive_failures = 0
+        commit_successful_result(
+            evidence_root,
+            run_key=planned.run_key,
+            bindings=bindings,
+            attempt=attempt,
+            envelope=envelope.as_dict(),
+            result=result.metrics,
+            exit_code=0,
+        )
+        succeeded += 1
+
+    return {
+        "phase_outcome": "PRIMARY_COMPLETE",
+        "succeeded": succeeded,
+        "failed": failed,
+        "skipped": skipped,
+    }
+
+
+def _find_planned_run(plan: Any, run_key: str) -> Any:
+    for planned in plan.runs:
+        if planned.run_key == run_key:
+            return planned
+    raise SensitivityRunnerError("RUNNER_REPRO_RUN_KEY_UNKNOWN", run_key)
+
+
+def _run_reproduction_loop(
+    *,
+    plan: Any,
+    reproduction_plan: Mapping[str, Any],
+    evidence_root: Path,
+    bindings: CampaignBindings,
+    budget: Mapping[str, Any],
+    active_executor: CampaignRunExecutor,
+    manifest: Mapping[str, Any],
+    auth_fp: str,
+    sha: str,
+    auth_expiry: Any,
+    now_utc_provider: Any,
+) -> dict[str, Any]:
+    eff_fp = str(manifest.get("effective_config_snapshot_fingerprint") or "")
+    repro_succeeded = 0
+    repro_failed = 0
+    repro_skipped = 0
+    mismatches: list[dict[str, Any]] = []
+    on_mismatch = str(reproduction_plan.get("on_mismatch") or "")
+    compared_fields = list(reproduction_plan.get("compared_result_fields") or [])
+
+    for item in reproduction_plan.get("reproduction_items", []):
+        run_key = str(item["run_key"])
+        repro_attempt = int(item["reproduction_attempt"])
+
+        try:
+            action = inspect_reproduction_for_resume(
+                evidence_root,
+                run_key=run_key,
+                reproduction_attempt=repro_attempt,
+                bindings=bindings,
+                max_attempts=int(budget["max_attempts_per_run"]),
+                retry_failed=bool(plan.resume_policy.get("retry_failed")),
+            )
+        except SensitivityStateError as exc:
+            raise SensitivityRunnerError(
+                "RUNNER_REPRO_RESUME_BLOCKED", str(exc)
+            ) from exc
+
+        if action == "skip":
+            repro_skipped += 1
+            continue
+
+        # Pre-attempt expiry gate.
+        assert_authorization_not_expired_for_next_attempt(
+            auth_expiry, now_utc=now_utc_provider()
+        )
+
+        planned = _find_planned_run(plan, run_key)
+        attempt = 1
+        env_path = (
+            reproduction_dir(evidence_root, run_key, repro_attempt)
+            / "run_envelope.json"
+        )
+        if env_path.exists() and action == "retry":
+            prev = json.loads(env_path.read_text(encoding="utf-8"))
+            attempt = int(prev.get("attempt") or 0) + 1
+
+        envelope = RunEnvelope(
+            run_key=run_key,
+            campaign_id=plan.campaign_id,
+            manifest_fingerprint=plan.manifest_fingerprint,
+            execution_sha=sha,
+            window_id=planned.window_id,
+            strategy_id=planned.strategy_id,
+            parameters=dict(planned.param_set),
+            slot_id=planned.slot_id,
+            phase=planned.phase,
+            label=planned.label,
+            physical_parameter_set_fingerprint=(
+                planned.physical_parameter_set_fingerprint
+            ),
+            effective_config_fingerprint=eff_fp,
+            dataset_content_fingerprint=_window_content_fp(manifest, planned.window_id),
+            seed=_seed_for(plan.campaign_id, planned.window_id, planned.slot_id),
+            output_dir=str(reproduction_dir(evidence_root, run_key, repro_attempt)),
+            run_plan_fingerprint=plan.run_plan_fingerprint,
+            authorization_fingerprint=auth_fp,
+            attempt=attempt,
+            reproduction_attempt=repro_attempt,
+            attempt_kind=ATTEMPT_KIND_REPRODUCTION,
+        )
+        write_reproduction_envelope(
+            evidence_root,
+            run_key=run_key,
+            reproduction_attempt=repro_attempt,
+            bindings=bindings,
+            status="RUNNING",
+            attempt=attempt,
+            envelope=envelope.as_dict(),
+        )
+
+        result = active_executor.execute(envelope)
+        if result.exit_code != 0:
+            repro_failed += 1
+            write_reproduction_envelope(
+                evidence_root,
+                run_key=run_key,
+                reproduction_attempt=repro_attempt,
+                bindings=bindings,
+                status="FAILED",
+                attempt=attempt,
+                envelope=envelope.as_dict(),
+                exit_code=result.exit_code,
+            )
+            if on_mismatch == "block_campaign_completion":
+                return {
+                    "phase_outcome": "BLOCKED",
+                    "reason_code": "REPRODUCTION_EXECUTION_FAILED",
+                    "succeeded": repro_succeeded,
+                    "failed": repro_failed,
+                    "skipped": repro_skipped,
+                    "mismatches": mismatches,
+                }
+            continue
+
+        commit_successful_reproduction_result(
+            evidence_root,
+            run_key=run_key,
+            reproduction_attempt=repro_attempt,
+            bindings=bindings,
+            attempt=attempt,
+            envelope=envelope.as_dict(),
+            result=result.metrics,
+            exit_code=0,
+        )
+
+        # Load primary and compare, with bindings validation.
+        primary_result_body = read_json(result_path(evidence_root, run_key))
+        primary_result = dict(primary_result_body.get("result") or {})
+        # Bindings comparison uses the envelope-level identifiers already
+        # written by both primary and reproduction paths.
+        primary_bindings = {
+            "run_key": run_key,
+            "manifest_fingerprint": primary_result_body.get("manifest_fingerprint"),
+            "run_plan_fingerprint": primary_result_body.get("run_plan_fingerprint"),
+            "authorization_fingerprint": (
+                primary_result_body.get("authorization_fingerprint")
+            ),
+        }
+        reproduction_bindings = {
+            "run_key": run_key,
+            "manifest_fingerprint": bindings.manifest_fingerprint,
+            "run_plan_fingerprint": bindings.run_plan_fingerprint,
+            "authorization_fingerprint": bindings.authorization_fingerprint,
+        }
+        try:
+            comparison = compare_reproduction_results(
+                primary={**primary_result, **primary_bindings},
+                reproduction={**dict(result.metrics), **reproduction_bindings},
+                compared_fields=compared_fields,
+                bindings=True,
+            )
+        except SensitivityReproductionError as exc:
+            raise SensitivityRunnerError(
+                "RUNNER_REPRO_STRUCTURAL_FAILURE", str(exc)
+            ) from exc
+        write_comparison_evidence(
+            evidence_root,
+            run_key=run_key,
+            reproduction_attempt=repro_attempt,
+            comparison=comparison,
+        )
+
+        if comparison["status"] == "MISMATCH":
+            mismatches.append(
+                {
+                    "run_key": run_key,
+                    "reproduction_attempt": repro_attempt,
+                    "reason_code": comparison["reason_code"],
+                    "mismatched_fields": comparison["mismatched_fields"],
+                }
+            )
+            if on_mismatch == "block_campaign_completion":
+                return {
+                    "phase_outcome": "BLOCKED",
+                    "reason_code": "REPRODUCTION_RESULT_MISMATCH",
+                    "succeeded": repro_succeeded,
+                    "failed": repro_failed,
+                    "skipped": repro_skipped,
+                    "mismatches": mismatches,
+                }
+        else:
+            repro_succeeded += 1
+
+    return {
+        "phase_outcome": "REPRODUCTION_COMPLETE",
+        "succeeded": repro_succeeded,
+        "failed": repro_failed,
+        "skipped": repro_skipped,
+        "mismatches": mismatches,
+    }
+
+
 def execute_campaign(
     *,
     manifest_path: Path,
@@ -333,8 +704,15 @@ def execute_campaign(
     fetcher: Any = None,
     stream: TextIO | None = None,
     max_runs_override: int | None = None,
+    now_utc_provider: Any = None,
 ) -> dict[str, Any]:
-    """Execute only with valid Owner-GO + budget + surface. Default: real adapter."""
+    """Execute only with valid Owner-GO + budget + surface. Default: real adapter.
+
+    Reproduction is executed as part of this call when the campaign policy
+    enables it. Completion is gated on all-primary succeeded plus all
+    reproduction attempts PASSing exact-equality comparison against the bound
+    primary results.
+    """
     root = repo_root or PROJECT_ROOT
     out = stream or sys.stdout
     if max_runs_override is not None and max_runs_override != EXPECTED_RUN_COUNT:
@@ -344,14 +722,12 @@ def execute_campaign(
             "RUNNER_RUN_COUNT_OVERRIDE_FORBIDDEN", str(max_runs_override)
         )
 
-    # Allowlist gate before any side effects (independent of payload self-claim).
+    from core.utils.clock import utcnow as _cdb_utcnow
+
+    now_provider = now_utc_provider or _cdb_utcnow
+
     authorizing_github_login = assert_author_in_owner_allowlist(
         authorizing_github_login
-    )
-
-    # Hard reject generic force pathways (no such flags accepted by argparse).
-    active_executor = (
-        executor if executor is not None else StrategyReplayCampaignExecutor()
     )
 
     manifest = load_manifest(manifest_path)
@@ -377,25 +753,59 @@ def execute_campaign(
     _preflight_ready(root, manifest)
     sha = main_sha or _git_head_sha(root)
     plan = build_run_plan(manifest, main_sha=sha)
-    if plan.run_count != 819 or len(plan.run_keys) != 819:
-        raise SensitivityRunnerError("RUNNER_RUN_COUNT_INVALID", str(plan.run_count))
+    # Internal consistency of the plan (not a duplicate of the manifest guard,
+    # which is enforced in build_run_plan against EXPECTED_RUN_COUNT).
+    if plan.run_count != len(plan.run_keys) or plan.run_count != len(plan.runs):
+        raise SensitivityRunnerError(
+            "RUNNER_RUN_COUNT_INVALID",
+            (
+                f"run_count={plan.run_count} run_keys={len(plan.run_keys)} "
+                f"runs={len(plan.runs)}"
+            ),
+        )
     if "CDB-021" in str(manifest.get("strategies")) or (
         (manifest.get("parameter_grid") or {}).get("cdb_021") not in (None, "OUT")
         and (manifest.get("parameter_grid") or {}).get("cdb_021") != "OUT"
     ):
-        # CDB-021 must remain OUT.
         pg = manifest.get("parameter_grid") or {}
         if pg.get("cdb_021") != "OUT":
             raise SensitivityRunnerError("RUNNER_CDB021_NOT_OUT")
 
     budget = validate_resource_budget(resource_budget)
+    if int(budget["max_parallelism"]) < 1:
+        raise SensitivityRunnerError("RUNNER_PARALLELISM_INVALID")
+
+    # Resolve and verify the dataset root once; bind identity into probe surface
+    # and forward the resolved window-bank root into the real replay adapter.
+    dataset_identity: DatasetRootIdentity | None = None
+    resolved_bank_root: Path | None = None
+    if dataset_root is not None:
+        try:
+            dataset_identity = resolve_and_verify_dataset_root(
+                dataset_root=Path(dataset_root),
+                manifest=manifest,
+                repo_root=root,
+            )
+        except SensitivityDatasetRootError as exc:
+            raise SensitivityRunnerError(
+                f"RUNNER_DATASET_{exc.reason_code}", str(exc)
+            ) from exc
+        resolved_bank_root = Path(dataset_identity.window_bank_root)
+
+    active_executor = (
+        executor
+        if executor is not None
+        else (StrategyReplayCampaignExecutor(window_bank_root=resolved_bank_root))
+    )
 
     probe = probe_execution_surface(
         repo_root=root,
-        dataset_root=dataset_root,
+        dataset_root=Path(dataset_root) if dataset_root is not None else None,
         surface_id=surface_id,
         exchange_credentials_present=False,
         window_availability={"expected_windows": 39},
+        manifest=manifest if dataset_root is not None else None,
+        dataset_identity=dataset_identity,
     )
     expected_fp = surface_capability_fingerprint or probe.surface_capability_fingerprint
     assert_surface_matches_authorization(
@@ -441,10 +851,19 @@ def execute_campaign(
         repository=repository,
         issue=ISSUE_NUMBER,
         fetcher=fetcher,
+        now_utc=now_provider(),
     )
     auth_fp = str(auth["authorization_fingerprint"])
     auth_id = auth_fp[:16]
     comment_updated_at = str(auth["comment_updated_at"])
+    auth_expiry = auth.get("expires_at_utc")
+
+    # Lifetime vs budget check applies before any evidence writes.
+    # A campaign always requires a finite expiry (see
+    # ``assert_authorization_lifetime_covers_budget``); null is refused.
+    assert_authorization_lifetime_covers_budget(
+        auth_expiry, budget, now_utc=now_provider()
+    )
 
     base = artifacts_base if artifacts_base is not None else root
     evidence_root = evidence_root_for(
@@ -469,7 +888,6 @@ def execute_campaign(
     if mode == "resume":
         existing_env = read_json(evidence_root / CAMPAIGN_ENVELOPE_NAME)
         bound_updated = str(existing_env.get("comment_updated_at") or "")
-        # Mutated Owner-GO comment invalidates resume.
         verify_owner_go_comment(
             comment_id=go_comment_id,
             expected=expected,
@@ -488,137 +906,192 @@ def execute_campaign(
     acquire_campaign_lock(evidence_root, holder_token=auth_fp)
     lock_held = True
     try:
+        envelope_extra: dict[str, Any] = {
+            "namespace_mode": mode,
+            "github_comment_id": go_comment_id,
+            "comment_updated_at": comment_updated_at,
+            "authorizing_github_login": authorizing_github_login,
+            "expires_at_utc": auth_expiry,
+        }
+        if dataset_identity is not None:
+            envelope_extra["dataset_root_identity"] = dataset_identity.as_dict()
         write_campaign_envelope(
             evidence_root,
             bindings=bindings,
             run_count=plan.run_count,
-            extra={
-                "namespace_mode": mode,
-                "github_comment_id": go_comment_id,
-                "comment_updated_at": comment_updated_at,
-                "authorizing_github_login": authorizing_github_login,
-            },
+            extra=envelope_extra,
         )
 
-        consecutive_failures = 0
-        total_failures = 0
-        succeeded = 0
-        skipped = 0
-        failed = 0
-        eff_fp = str(manifest.get("effective_config_snapshot_fingerprint") or "")
+        # Enter primary phase.
+        update_campaign_phase(
+            evidence_root,
+            bindings=bindings,
+            phase=CAMPAIGN_PHASE_PRIMARY_RUNNING,
+        )
 
-        # Parallelism is hard-capped; this slice runs sequentially but enforces the
-        # configured max_parallelism as an upper bound (no fan-out above budget).
-        if int(budget["max_parallelism"]) < 1:
-            raise SensitivityRunnerError("RUNNER_PARALLELISM_INVALID")
+        primary_outcome = _run_primary_loop(
+            plan=plan,
+            evidence_root=evidence_root,
+            bindings=bindings,
+            budget=budget,
+            active_executor=active_executor,
+            manifest=manifest,
+            auth_fp=auth_fp,
+            sha=sha,
+            auth_expiry=auth_expiry,
+            now_utc_provider=now_provider,
+        )
+        primary_succeeded = int(primary_outcome.get("succeeded", 0))
+        primary_failed = int(primary_outcome.get("failed", 0))
+        primary_skipped = int(primary_outcome.get("skipped", 0))
 
-        for planned in plan.runs:
-            try:
-                action = inspect_run_for_resume(
-                    evidence_root,
-                    run_key=planned.run_key,
-                    bindings=bindings,
-                    max_attempts=int(budget["max_attempts_per_run"]),
-                    retry_failed=bool(plan.resume_policy.get("retry_failed")),
-                )
-            except SensitivityStateError as exc:
-                raise SensitivityRunnerError("RUNNER_RESUME_BLOCKED", str(exc)) from exc
-
-            if action == "skip":
-                skipped += 1
-                continue
-
-            attempt = 1
-            env_path = evidence_root / "runs" / planned.run_key / "run_envelope.json"
-            if env_path.exists() and action == "retry":
-                prev = json.loads(env_path.read_text(encoding="utf-8"))
-                attempt = int(prev.get("attempt") or 0) + 1
-
-            envelope = RunEnvelope(
-                run_key=planned.run_key,
-                campaign_id=plan.campaign_id,
-                manifest_fingerprint=plan.manifest_fingerprint,
-                execution_sha=sha,
-                window_id=planned.window_id,
-                strategy_id=planned.strategy_id,
-                parameters=dict(planned.param_set),
-                slot_id=planned.slot_id,
-                phase=planned.phase,
-                label=planned.label,
-                physical_parameter_set_fingerprint=(
-                    planned.physical_parameter_set_fingerprint
-                ),
-                effective_config_fingerprint=eff_fp,
-                dataset_content_fingerprint=_window_content_fp(
-                    manifest, planned.window_id
-                ),
-                seed=_seed_for(plan.campaign_id, planned.window_id, planned.slot_id),
-                output_dir=str(evidence_root / "runs" / planned.run_key),
-                run_plan_fingerprint=plan.run_plan_fingerprint,
-                authorization_fingerprint=auth_fp,
-                attempt=attempt,
-                reproduction_attempt=0,
-            )
-            write_run_envelope(
+        if primary_outcome["phase_outcome"] == "BLOCKED":
+            update_campaign_phase(
                 evidence_root,
-                run_key=planned.run_key,
                 bindings=bindings,
-                status="RUNNING",
-                attempt=attempt,
-                envelope=envelope.as_dict(),
+                phase=CAMPAIGN_PHASE_BLOCKED,
+                extra={"blocked_reason": primary_outcome.get("reason_code")},
             )
-            result = active_executor.execute(envelope)
-            if result.exit_code != 0:
-                failed += 1
-                consecutive_failures += 1
-                total_failures += 1
-                write_run_envelope(
-                    evidence_root,
-                    run_key=planned.run_key,
-                    bindings=bindings,
-                    status="FAILED",
-                    attempt=attempt,
-                    envelope=envelope.as_dict(),
-                    exit_code=result.exit_code,
-                )
-                try:
-                    assert_failure_thresholds(
-                        budget=budget,
-                        consecutive_failures=consecutive_failures,
-                        total_failures=total_failures,
-                    )
-                except SensitivityBudgetError as exc:
-                    payload = {
-                        "command": "execute",
-                        "status": "BLOCKED",
-                        "reason_code": str(exc),
-                        "succeeded": succeeded,
-                        "failed": failed,
-                        "skipped": skipped,
-                        "lr_status": "NO-GO",
-                    }
-                    _emit(payload, out)
-                    return payload
-                continue
+            payload = {
+                "command": "execute",
+                "status": "BLOCKED",
+                "reason_code": str(primary_outcome.get("reason_code")),
+                "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
+                "succeeded": primary_succeeded,
+                "failed": primary_failed,
+                "skipped": primary_skipped,
+                "lr_status": "NO-GO",
+            }
+            _emit(payload, out)
+            return payload
 
-            consecutive_failures = 0
-            commit_successful_result(
+        # All primary attempts must have SUCCEEDED before we move forward.
+        confirmed_primary = count_primary_succeeded(
+            evidence_root,
+            bindings=bindings,
+            expected_run_keys=list(plan.run_keys),
+        )
+        if confirmed_primary != plan.run_count:
+            update_campaign_phase(
                 evidence_root,
-                run_key=planned.run_key,
                 bindings=bindings,
-                attempt=attempt,
-                envelope=envelope.as_dict(),
-                result=result.metrics,
-                exit_code=0,
+                phase=CAMPAIGN_PHASE_BLOCKED,
+                extra={
+                    "blocked_reason": "PRIMARY_SUCCESS_COUNT_MISMATCH",
+                    "expected_run_count": plan.run_count,
+                    "confirmed_primary": confirmed_primary,
+                },
             )
-            succeeded += 1
+            payload = {
+                "command": "execute",
+                "status": "BLOCKED",
+                "reason_code": "PRIMARY_SUCCESS_COUNT_MISMATCH",
+                "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
+                "succeeded": primary_succeeded,
+                "failed": primary_failed,
+                "skipped": primary_skipped,
+                "confirmed_primary": confirmed_primary,
+                "lr_status": "NO-GO",
+            }
+            _emit(payload, out)
+            return payload
+
+        update_campaign_phase(
+            evidence_root,
+            bindings=bindings,
+            phase=CAMPAIGN_PHASE_PRIMARY_COMPLETE,
+        )
+
+        reproduction_enabled = bool(plan.reproduction_policy.get("enabled"))
+        reproduction_summary: dict[str, Any] = {"enabled": reproduction_enabled}
+
+        if reproduction_enabled:
+            update_campaign_phase(
+                evidence_root,
+                bindings=bindings,
+                phase=CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
+            )
+            reproduction_plan = build_reproduction_plan(
+                run_keys=list(plan.run_keys),
+                policy=plan.reproduction_policy,
+            )
+            update_campaign_phase(
+                evidence_root,
+                bindings=bindings,
+                phase=CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
+                extra={
+                    "reproduction_plan_fingerprint": reproduction_plan.get(
+                        "reproduction_plan_fingerprint"
+                    ),
+                    "reproduction_item_count": len(
+                        reproduction_plan.get("reproduction_items", [])
+                    ),
+                },
+            )
+
+            repro_outcome = _run_reproduction_loop(
+                plan=plan,
+                reproduction_plan=reproduction_plan,
+                evidence_root=evidence_root,
+                bindings=bindings,
+                budget=budget,
+                active_executor=active_executor,
+                manifest=manifest,
+                auth_fp=auth_fp,
+                sha=sha,
+                auth_expiry=auth_expiry,
+                now_utc_provider=now_provider,
+            )
+            reproduction_summary.update(repro_outcome)
+
+            if repro_outcome["phase_outcome"] == "BLOCKED":
+                update_campaign_phase(
+                    evidence_root,
+                    bindings=bindings,
+                    phase=CAMPAIGN_PHASE_BLOCKED,
+                    extra={
+                        "blocked_reason": repro_outcome.get("reason_code"),
+                        "reproduction_mismatches": repro_outcome.get("mismatches"),
+                    },
+                )
+                payload = {
+                    "command": "execute",
+                    "status": "BLOCKED",
+                    "reason_code": str(repro_outcome.get("reason_code")),
+                    "campaign_phase": CAMPAIGN_PHASE_BLOCKED,
+                    "succeeded": primary_succeeded,
+                    "failed": primary_failed,
+                    "skipped": primary_skipped,
+                    "reproduction": reproduction_summary,
+                    "run_count": plan.run_count,
+                    "evidence_root": str(evidence_root),
+                    "authorization_fingerprint": auth_fp,
+                    "run_plan_fingerprint": plan.run_plan_fingerprint,
+                    "lr_status": "NO-GO",
+                }
+                _emit(payload, out)
+                return payload
+
+            update_campaign_phase(
+                evidence_root,
+                bindings=bindings,
+                phase=CAMPAIGN_PHASE_REPRODUCTION_COMPLETE,
+            )
+
+        update_campaign_phase(
+            evidence_root,
+            bindings=bindings,
+            phase=CAMPAIGN_PHASE_COMPLETED,
+        )
 
         payload = {
             "command": "execute",
-            "status": "COMPLETED" if failed == 0 else "COMPLETED_WITH_FAILURES",
-            "succeeded": succeeded,
-            "failed": failed,
-            "skipped": skipped,
+            "status": "COMPLETED",
+            "campaign_phase": CAMPAIGN_PHASE_COMPLETED,
+            "succeeded": primary_succeeded,
+            "failed": primary_failed,
+            "skipped": primary_skipped,
+            "reproduction": reproduction_summary,
             "run_count": plan.run_count,
             "evidence_root": str(evidence_root),
             "authorization_fingerprint": auth_fp,

--- a/tools/arvp_vacation/sensitivity_campaign_state.py
+++ b/tools/arvp_vacation/sensitivity_campaign_state.py
@@ -583,17 +583,19 @@ def write_reproduction_envelope(
     return path
 
 
-def commit_successful_reproduction_result(
+def persist_reproduction_result(
     root: Path,
     *,
     run_key: str,
     reproduction_attempt: int,
     bindings: CampaignBindings,
-    attempt: int,
-    envelope: Mapping[str, Any],
     result: Mapping[str, Any],
-    exit_code: int = 0,
 ) -> str:
+    """Atomically persist reproduction ``result.json`` without success markers.
+
+    Callers must write ``comparison.json`` and only then call
+    :func:`commit_successful_reproduction_result` after a PASS comparison.
+    """
     result_fp = canonical_hash(dict(result))
     rpath = reproduction_result_path(root, run_key, reproduction_attempt)
     atomic_write_json(
@@ -608,6 +610,28 @@ def commit_successful_reproduction_result(
             "authorization_fingerprint": bindings.authorization_fingerprint,
             "result": dict(result),
         },
+    )
+    return result_fp
+
+
+def commit_successful_reproduction_result(
+    root: Path,
+    *,
+    run_key: str,
+    reproduction_attempt: int,
+    bindings: CampaignBindings,
+    attempt: int,
+    envelope: Mapping[str, Any],
+    result: Mapping[str, Any],
+    exit_code: int = 0,
+) -> str:
+    """Mark reproduction SUCCEEDED only after result (+ comparison) is durable."""
+    result_fp = persist_reproduction_result(
+        root,
+        run_key=run_key,
+        reproduction_attempt=reproduction_attempt,
+        bindings=bindings,
+        result=result,
     )
     write_reproduction_envelope(
         root,
@@ -692,8 +716,34 @@ def inspect_reproduction_for_resume(
             bindings.authorization_fingerprint
         ):
             raise SensitivityStateError("STATE_REPRO_RESULT_AUTH_MISMATCH")
+        # Completion is gated on an exact-equality PASS comparison.
+        cmp_path = reproduction_comparison_path(root, run_key, reproduction_attempt)
+        if not cmp_path.exists():
+            raise SensitivityStateError("STATE_REPRO_COMPARISON_MISSING")
+        cmp_body = read_json(cmp_path)
+        comparison = dict(cmp_body.get("comparison") or {})
+        if str(comparison.get("status") or "") != "PASS":
+            raise SensitivityStateError(
+                f"STATE_REPRO_COMPARISON_NOT_PASS:{comparison.get('status')}"
+            )
         return "skip"
     if status == "RUNNING":
+        # Crash window: result + PASS comparison persisted, success marker not yet.
+        # Resume may finalize without re-executing; bare RUNNING remains blocked.
+        rpath = reproduction_result_path(root, run_key, reproduction_attempt)
+        cmp_path = reproduction_comparison_path(root, run_key, reproduction_attempt)
+        if rpath.exists() and cmp_path.exists():
+            result_body = read_json(rpath)
+            if result_body.get("manifest_fingerprint") != bindings.manifest_fingerprint:
+                raise SensitivityStateError("STATE_REPRO_RESULT_MANIFEST_MISMATCH")
+            if result_body.get("authorization_fingerprint") != (
+                bindings.authorization_fingerprint
+            ):
+                raise SensitivityStateError("STATE_REPRO_RESULT_AUTH_MISMATCH")
+            cmp_body = read_json(cmp_path)
+            comparison = dict(cmp_body.get("comparison") or {})
+            if str(comparison.get("status") or "") == "PASS":
+                return "finalize"
         raise SensitivityStateError("STATE_REPRO_RUNNING_WITHOUT_COMPLETION")
     if status == "FAILED":
         if not retry_failed:

--- a/tools/arvp_vacation/sensitivity_campaign_state.py
+++ b/tools/arvp_vacation/sensitivity_campaign_state.py
@@ -8,7 +8,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import UTC
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from core.replay.canonical_json import canonical_hash
 from core.utils.clock import utcnow as cdb_utcnow
@@ -16,11 +16,72 @@ from core.utils.clock import utcnow as cdb_utcnow
 STATE_SCHEMA_VERSION = "cdb.sensitivity_campaign_state.v1"
 CAMPAIGN_ENVELOPE_NAME = "campaign_envelope.json"
 RUNS_DIRNAME = "runs"
+REPRODUCTION_DIRNAME = "reproduction"
 
 RUN_STATES = frozenset(
     {"PLANNED", "RUNNING", "SUCCEEDED", "FAILED", "BLOCKED", "CANCELLED"}
 )
 TERMINAL_SUCCESS = "SUCCEEDED"
+
+# Campaign lifecycle phases. Progression is strictly forward except for the
+# terminal BLOCKED and COMPLETED states which trap the machine. The initial
+# PLANNED alias is accepted for backward compatibility with a freshly written
+# envelope (no ``campaign_phase`` field).
+CAMPAIGN_PHASE_PLANNED = "PLANNED"
+CAMPAIGN_PHASE_PRIMARY_PLANNED = "PRIMARY_PLANNED"
+CAMPAIGN_PHASE_PRIMARY_RUNNING = "PRIMARY_RUNNING"
+CAMPAIGN_PHASE_PRIMARY_COMPLETE = "PRIMARY_COMPLETE"
+CAMPAIGN_PHASE_REPRODUCTION_PLANNED = "REPRODUCTION_PLANNED"
+CAMPAIGN_PHASE_REPRODUCTION_RUNNING = "REPRODUCTION_RUNNING"
+CAMPAIGN_PHASE_REPRODUCTION_COMPLETE = "REPRODUCTION_COMPLETE"
+CAMPAIGN_PHASE_COMPLETED = "COMPLETED"
+CAMPAIGN_PHASE_BLOCKED = "BLOCKED"
+
+CAMPAIGN_PHASES = frozenset(
+    {
+        CAMPAIGN_PHASE_PLANNED,
+        CAMPAIGN_PHASE_PRIMARY_PLANNED,
+        CAMPAIGN_PHASE_PRIMARY_RUNNING,
+        CAMPAIGN_PHASE_PRIMARY_COMPLETE,
+        CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
+        CAMPAIGN_PHASE_REPRODUCTION_RUNNING,
+        CAMPAIGN_PHASE_REPRODUCTION_COMPLETE,
+        CAMPAIGN_PHASE_COMPLETED,
+        CAMPAIGN_PHASE_BLOCKED,
+    }
+)
+
+# Legal forward transitions. BLOCKED is always reachable from any non-terminal
+# phase. COMPLETED and BLOCKED are terminal (self-transition allowed).
+_LEGAL_PHASE_TRANSITIONS: dict[str, frozenset[str]] = {
+    CAMPAIGN_PHASE_PLANNED: frozenset(
+        {CAMPAIGN_PHASE_PRIMARY_RUNNING, CAMPAIGN_PHASE_BLOCKED}
+    ),
+    CAMPAIGN_PHASE_PRIMARY_PLANNED: frozenset(
+        {CAMPAIGN_PHASE_PRIMARY_RUNNING, CAMPAIGN_PHASE_BLOCKED}
+    ),
+    CAMPAIGN_PHASE_PRIMARY_RUNNING: frozenset(
+        {CAMPAIGN_PHASE_PRIMARY_COMPLETE, CAMPAIGN_PHASE_BLOCKED}
+    ),
+    CAMPAIGN_PHASE_PRIMARY_COMPLETE: frozenset(
+        {
+            CAMPAIGN_PHASE_REPRODUCTION_PLANNED,
+            CAMPAIGN_PHASE_COMPLETED,
+            CAMPAIGN_PHASE_BLOCKED,
+        }
+    ),
+    CAMPAIGN_PHASE_REPRODUCTION_PLANNED: frozenset(
+        {CAMPAIGN_PHASE_REPRODUCTION_RUNNING, CAMPAIGN_PHASE_BLOCKED}
+    ),
+    CAMPAIGN_PHASE_REPRODUCTION_RUNNING: frozenset(
+        {CAMPAIGN_PHASE_REPRODUCTION_COMPLETE, CAMPAIGN_PHASE_BLOCKED}
+    ),
+    CAMPAIGN_PHASE_REPRODUCTION_COMPLETE: frozenset(
+        {CAMPAIGN_PHASE_COMPLETED, CAMPAIGN_PHASE_BLOCKED}
+    ),
+    CAMPAIGN_PHASE_COMPLETED: frozenset({CAMPAIGN_PHASE_COMPLETED}),
+    CAMPAIGN_PHASE_BLOCKED: frozenset({CAMPAIGN_PHASE_BLOCKED}),
+}
 
 
 class SensitivityStateError(ValueError):
@@ -382,3 +443,298 @@ def assert_namespace_startable(
     if not allow_resume:
         raise SensitivityStateError("STATE_RESUME_NOT_ALLOWED")
     return "resume"
+
+
+def update_campaign_phase(
+    root: Path,
+    *,
+    bindings: CampaignBindings,
+    phase: str,
+    extra: Mapping[str, Any] | None = None,
+) -> Path:
+    """Atomically transition the campaign envelope to ``phase``.
+
+    Fail-closed on unknown phase, missing envelope, binding mismatch, or
+    illegal transition. Terminal phases (COMPLETED, BLOCKED) cannot be left
+    once set (self-transition allowed for idempotency).
+    """
+    if phase not in CAMPAIGN_PHASES:
+        raise SensitivityStateError(f"STATE_PHASE_UNKNOWN:{phase}")
+    envelope_path = root / CAMPAIGN_ENVELOPE_NAME
+    if not envelope_path.exists():
+        raise SensitivityStateError("STATE_PHASE_ENVELOPE_MISSING")
+    existing = read_json(envelope_path)
+    _assert_same_bindings(existing, bindings)
+    current = str(existing.get("campaign_phase") or existing.get("status") or "")
+    if current == "":
+        current = CAMPAIGN_PHASE_PLANNED
+    if current not in CAMPAIGN_PHASES:
+        # Legacy status like "PLANNED" is aliased above; anything else is bogus.
+        raise SensitivityStateError(f"STATE_PHASE_CURRENT_UNKNOWN:{current}")
+    allowed = _LEGAL_PHASE_TRANSITIONS.get(current, frozenset())
+    if phase == current:
+        # Idempotent no-op still records the extra payload.
+        updated = dict(existing)
+        updated["campaign_phase"] = phase
+        updated["phase_updated_at_utc"] = _now_utc_iso()
+        for key, value in dict(extra or {}).items():
+            updated[key] = value
+        atomic_write_json(envelope_path, updated)
+        return envelope_path
+    if phase not in allowed:
+        raise SensitivityStateError(
+            f"STATE_PHASE_ILLEGAL_TRANSITION:{current}->{phase}"
+        )
+    updated = dict(existing)
+    updated["campaign_phase"] = phase
+    updated["phase_updated_at_utc"] = _now_utc_iso()
+    for key, value in dict(extra or {}).items():
+        updated[key] = value
+    atomic_write_json(envelope_path, updated)
+    return envelope_path
+
+
+def read_campaign_phase(root: Path) -> str:
+    """Return the current campaign phase; PLANNED for a freshly written envelope."""
+    envelope_path = root / CAMPAIGN_ENVELOPE_NAME
+    if not envelope_path.exists():
+        return CAMPAIGN_PHASE_PLANNED
+    existing = read_json(envelope_path)
+    current = str(existing.get("campaign_phase") or "")
+    if current == "":
+        return CAMPAIGN_PHASE_PLANNED
+    return current
+
+
+def reproduction_dir(root: Path, run_key: str, reproduction_attempt: int) -> Path:
+    """Return the canonical reproduction-attempt directory for a primary run key."""
+    if reproduction_attempt < 1:
+        raise SensitivityStateError("STATE_REPRO_ATTEMPT_INVALID")
+    return (
+        root
+        / RUNS_DIRNAME
+        / run_key
+        / REPRODUCTION_DIRNAME
+        / str(int(reproduction_attempt))
+    )
+
+
+def reproduction_envelope_path(
+    root: Path, run_key: str, reproduction_attempt: int
+) -> Path:
+    return reproduction_dir(root, run_key, reproduction_attempt) / "run_envelope.json"
+
+
+def reproduction_result_path(
+    root: Path, run_key: str, reproduction_attempt: int
+) -> Path:
+    return reproduction_dir(root, run_key, reproduction_attempt) / "result.json"
+
+
+def reproduction_completion_marker_path(
+    root: Path, run_key: str, reproduction_attempt: int
+) -> Path:
+    return reproduction_dir(root, run_key, reproduction_attempt) / "COMPLETED"
+
+
+def reproduction_comparison_path(
+    root: Path, run_key: str, reproduction_attempt: int
+) -> Path:
+    return reproduction_dir(root, run_key, reproduction_attempt) / "comparison.json"
+
+
+def write_reproduction_envelope(
+    root: Path,
+    *,
+    run_key: str,
+    reproduction_attempt: int,
+    bindings: CampaignBindings,
+    status: str,
+    attempt: int,
+    envelope: Mapping[str, Any],
+    exit_code: int | None = None,
+    result_fingerprint: str | None = None,
+) -> Path:
+    if status not in RUN_STATES:
+        raise SensitivityStateError(f"STATE_INVALID_RUN_STATUS:{status}")
+    path = reproduction_envelope_path(root, run_key, reproduction_attempt)
+    payload = {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "run_key": run_key,
+        "reproduction_attempt": int(reproduction_attempt),
+        "status": status,
+        "attempt": attempt,
+        "campaign_id": bindings.campaign_id,
+        "manifest_fingerprint": bindings.manifest_fingerprint,
+        "run_plan_fingerprint": bindings.run_plan_fingerprint,
+        "authorization_fingerprint": bindings.authorization_fingerprint,
+        "execution_sha": bindings.execution_sha,
+        "main_sha": bindings.main_sha,
+        "updated_at_utc": _now_utc_iso(),
+        "exit_code": exit_code,
+        "result_fingerprint": result_fingerprint,
+        "envelope": dict(envelope),
+    }
+    if status == "RUNNING":
+        payload["started_at_utc"] = _now_utc_iso()
+    if status in {"SUCCEEDED", "FAILED", "BLOCKED", "CANCELLED"}:
+        payload["ended_at_utc"] = _now_utc_iso()
+    atomic_write_json(path, payload)
+    return path
+
+
+def commit_successful_reproduction_result(
+    root: Path,
+    *,
+    run_key: str,
+    reproduction_attempt: int,
+    bindings: CampaignBindings,
+    attempt: int,
+    envelope: Mapping[str, Any],
+    result: Mapping[str, Any],
+    exit_code: int = 0,
+) -> str:
+    result_fp = canonical_hash(dict(result))
+    rpath = reproduction_result_path(root, run_key, reproduction_attempt)
+    atomic_write_json(
+        rpath,
+        {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "run_key": run_key,
+            "reproduction_attempt": int(reproduction_attempt),
+            "result_fingerprint": result_fp,
+            "manifest_fingerprint": bindings.manifest_fingerprint,
+            "run_plan_fingerprint": bindings.run_plan_fingerprint,
+            "authorization_fingerprint": bindings.authorization_fingerprint,
+            "result": dict(result),
+        },
+    )
+    write_reproduction_envelope(
+        root,
+        run_key=run_key,
+        reproduction_attempt=reproduction_attempt,
+        bindings=bindings,
+        status="SUCCEEDED",
+        attempt=attempt,
+        envelope=envelope,
+        exit_code=exit_code,
+        result_fingerprint=result_fp,
+    )
+    marker = reproduction_completion_marker_path(root, run_key, reproduction_attempt)
+    atomic_write_json(
+        marker,
+        {
+            "schema_version": STATE_SCHEMA_VERSION,
+            "run_key": run_key,
+            "reproduction_attempt": int(reproduction_attempt),
+            "status": "SUCCEEDED",
+            "result_fingerprint": result_fp,
+            "completed_at_utc": _now_utc_iso(),
+        },
+    )
+    return result_fp
+
+
+def write_comparison_evidence(
+    root: Path,
+    *,
+    run_key: str,
+    reproduction_attempt: int,
+    comparison: Mapping[str, Any],
+) -> Path:
+    path = reproduction_comparison_path(root, run_key, reproduction_attempt)
+    body = {
+        "schema_version": STATE_SCHEMA_VERSION,
+        "run_key": run_key,
+        "reproduction_attempt": int(reproduction_attempt),
+        "recorded_at_utc": _now_utc_iso(),
+        "comparison": dict(comparison),
+    }
+    atomic_write_json(path, body)
+    return path
+
+
+def inspect_reproduction_for_resume(
+    root: Path,
+    *,
+    run_key: str,
+    reproduction_attempt: int,
+    bindings: CampaignBindings,
+    max_attempts: int,
+    retry_failed: bool,
+) -> str:
+    """Return 'skip' | 'retry' | 'start' | raise on partial / running / limits.
+
+    Mirrors :func:`inspect_run_for_resume` for the reproduction attempt namespace
+    under ``runs/<run_key>/reproduction/<n>/``.
+    """
+    path = reproduction_envelope_path(root, run_key, reproduction_attempt)
+    if not path.exists():
+        return "start"
+    existing = read_json(path)
+    _assert_same_bindings(existing, bindings)
+    status = str(existing.get("status") or "")
+    attempt = int(existing.get("attempt") or 0)
+    if status == "SUCCEEDED":
+        marker = reproduction_completion_marker_path(
+            root, run_key, reproduction_attempt
+        )
+        rpath = reproduction_result_path(root, run_key, reproduction_attempt)
+        if not marker.exists() or not rpath.exists():
+            raise SensitivityStateError("STATE_REPRO_PARTIAL_SUCCESS_BLOCKED")
+        stored_fp = existing.get("result_fingerprint")
+        result_body = read_json(rpath)
+        if result_body.get("result_fingerprint") != stored_fp:
+            raise SensitivityStateError("STATE_REPRO_RESULT_FINGERPRINT_MISMATCH")
+        if result_body.get("manifest_fingerprint") != bindings.manifest_fingerprint:
+            raise SensitivityStateError("STATE_REPRO_RESULT_MANIFEST_MISMATCH")
+        if result_body.get("authorization_fingerprint") != (
+            bindings.authorization_fingerprint
+        ):
+            raise SensitivityStateError("STATE_REPRO_RESULT_AUTH_MISMATCH")
+        return "skip"
+    if status == "RUNNING":
+        raise SensitivityStateError("STATE_REPRO_RUNNING_WITHOUT_COMPLETION")
+    if status == "FAILED":
+        if not retry_failed:
+            raise SensitivityStateError("STATE_REPRO_FAILED_NO_RETRY")
+        if attempt >= max_attempts:
+            raise SensitivityStateError("STATE_REPRO_RETRY_LIMIT_EXCEEDED")
+        return "retry"
+    if status in {"BLOCKED", "CANCELLED"}:
+        raise SensitivityStateError(f"STATE_REPRO_TERMINAL_{status}")
+    if status == "PLANNED":
+        return "start"
+    raise SensitivityStateError(f"STATE_REPRO_UNKNOWN_STATUS:{status}")
+
+
+def count_primary_succeeded(
+    root: Path,
+    *,
+    bindings: CampaignBindings,
+    expected_run_keys: Sequence[str],
+) -> int:
+    """Count run_keys with a valid, binding-matched SUCCEEDED primary result.
+
+    Fail-closed on binding drift or partial success (missing marker / result).
+    """
+    count = 0
+    for run_key in expected_run_keys:
+        env_path = run_envelope_path(root, run_key)
+        if not env_path.exists():
+            continue
+        existing = read_json(env_path)
+        _assert_same_bindings(existing, bindings)
+        status = str(existing.get("status") or "")
+        if status != "SUCCEEDED":
+            continue
+        marker = completion_marker_path(root, run_key)
+        rpath = result_path(root, run_key)
+        if not marker.exists() or not rpath.exists():
+            raise SensitivityStateError(f"STATE_PARTIAL_SUCCESS_BLOCKED:{run_key}")
+        stored_fp = existing.get("result_fingerprint")
+        result_body = read_json(rpath)
+        if result_body.get("result_fingerprint") != stored_fp:
+            raise SensitivityStateError(f"STATE_RESULT_FINGERPRINT_MISMATCH:{run_key}")
+        count += 1
+    return count

--- a/tools/arvp_vacation/sensitivity_campaign_surface.py
+++ b/tools/arvp_vacation/sensitivity_campaign_surface.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from core.replay.canonical_json import canonical_hash
+from tools.arvp_vacation.sensitivity_campaign_dataset_root import (
+    DatasetRootIdentity,
+    SensitivityDatasetRootError,
+    resolve_and_verify_dataset_root,
+)
 
 SURFACE_CONTRACT_VERSION = "cdb.sensitivity_campaign_execution_surface.v1"
 
@@ -36,6 +41,20 @@ def _disk_free_bytes(path: Path) -> int:
     return int(usage.free)
 
 
+def _coerce_dataset_identity(
+    value: DatasetRootIdentity | Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, DatasetRootIdentity):
+        return value.as_dict()
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise SensitivitySurfaceError(
+        "SURFACE_DATASET_IDENTITY_INVALID: expected DatasetRootIdentity or mapping"
+    )
+
+
 def probe_execution_surface(
     *,
     repo_root: Path,
@@ -45,8 +64,22 @@ def probe_execution_surface(
     network_mode: str = "offline_replay_only",
     exchange_credentials_present: bool = False,
     window_availability: Mapping[str, Any] | None = None,
+    manifest: Mapping[str, Any] | None = None,
+    dataset_identity: DatasetRootIdentity | Mapping[str, Any] | None = None,
 ) -> SurfaceProbeResult:
-    """Read-only capability probe. Must not create files or mutate state."""
+    """Read-only capability probe. Must not create files or mutate state.
+
+    When ``dataset_root`` is provided together with ``manifest`` the resolver
+    verifies every window binding under the canonical window-bank layout and
+    the resulting :class:`DatasetRootIdentity` is bound into the fingerprint.
+
+    A caller may pass a precomputed ``dataset_identity`` (e.g. from a prior
+    resolver call) to avoid double-resolving; in that case ``manifest`` is
+    optional. When only ``dataset_root`` is supplied without a manifest we
+    fall back to the lightweight path identity (path name + existence) — this
+    path is only used by ``plan`` / ``probe-surface``. The execute path must
+    always pass ``manifest`` so the full binding is fingerprinted.
+    """
     if network_mode != "offline_replay_only":
         raise SensitivitySurfaceError(
             f"network_mode must be offline_replay_only, got {network_mode!r}"
@@ -57,7 +90,6 @@ def probe_execution_surface(
         )
 
     cpu_count = os.cpu_count() or 1
-    # Approximate RAM via optional platform hooks; None if unreliable.
     ram_bytes: int | None
     try:
         import psutil  # type: ignore
@@ -67,12 +99,29 @@ def probe_execution_surface(
         ram_bytes = None
 
     free_bytes = _disk_free_bytes(repo_root if repo_root.exists() else Path.cwd())
-    dataset_identity = None
+
+    identity_body: dict[str, Any] | None = None
     if dataset_root is not None:
-        dataset_identity = {
-            "path_exists": dataset_root.exists(),
-            "path_name": dataset_root.name,
-        }
+        precomputed = _coerce_dataset_identity(dataset_identity)
+        if precomputed is not None:
+            identity_body = precomputed
+        elif manifest is not None:
+            try:
+                resolved = resolve_and_verify_dataset_root(
+                    dataset_root=dataset_root,
+                    manifest=manifest,
+                    repo_root=repo_root,
+                )
+            except SensitivityDatasetRootError as exc:
+                raise SensitivitySurfaceError(
+                    f"SURFACE_DATASET_ROOT_{exc.reason_code}: {exc}"
+                ) from exc
+            identity_body = resolved.as_dict()
+        else:
+            identity_body = {
+                "path_exists": dataset_root.exists(),
+                "path_name": dataset_root.name,
+            }
 
     windows = dict(window_availability or {})
     surface = {
@@ -84,7 +133,7 @@ def probe_execution_surface(
         "python_version": platform.python_version(),
         "python_implementation": platform.python_implementation(),
         "repository_sha_binding_required": True,
-        "dataset_root_identity": dataset_identity,
+        "dataset_root_identity": identity_body,
         "window_availability": windows,
         "cpu_count": cpu_count,
         "ram_bytes": ram_bytes,


### PR DESCRIPTION
## Summary

Execution-contract defect fix for #4153: wire authorized reproduction fully into `execute`.

* Old Owner-GO comment `5177373358` revoked as `REVOKED_CAMPAIGN_EXECUTION_CONTRACT_DEFECT` (fence removed; verifier rejects with `AUTH_GO_BLOCK_MISSING` / `AUTH_GO_REVOKED`).
* No active Owner authorization remains; no new GO created in this slice.
* Reproduction is now fully executable inside auth-gated `execute` (not plan-only).
* 819 primary run keys remain unchanged; reproduction attempts are separate (`attempt_kind=REPRODUCTION`, `reproduction_attempt >= 1`).
* Exact-equality comparator with comparison fingerprint; campaign completion gated on passed reproduction.
* Authorization expiry checked before every new primary/retry/reproduction attempt; lifetime must cover campaign+run wall budget.
* Dataset-root is worktree-independent and surface-bound; forwarded into `StrategyReplayCampaignExecutor` / `ARVPReplayConfig.window_bank_root`.
* Validated with FakeExecutor/unit tests only — **no campaign**, **no real replays**.
* **No merge**, **no `cdb-local-ci` publish** in this slice.
* #4153 remains OPEN; new Campaign-GO audit required after merge.
* LR: `NO-GO`

## Delivered

* Runner phase machine: PRIMARY_* → REPRODUCTION_* → COMPLETED | BLOCKED
* `compare_reproduction_results` structured PASS/MISMATCH
* Resume/crash-safety for reproduction evidence paths
* Dataset-root resolver + surface identity binding
* Docs: `CDB_SENSITIVITY_CAMPAIGN_EXECUTION_CONTRACT_V1.md`

## Test plan

- [x] Unit: reproduction / authorization / state / runner / dataset_root / executor_budget (96 passed)
- [x] Regression sample: manifest / grid / preflight / analyzer (43 passed)
- [x] ruff + black --check on touched files
- [x] gitleaks on commit range (no leaks)
- [ ] No real campaign / replay / Owner-GO in this PR

## Non-goals

* Campaign execution, real replays, result analysis, winner selection
* Holdout/OOS/Stress/Stage-B, Paper/Live/Echtgeld
* Merge, `cdb-local-ci`, new Owner authorization, issue close

## Remaining uncertainty

* Post-merge Campaign-GO audit must re-bind main SHA, surface FP, run-plan FP, and dataset identity under a fresh finite GO whose lifetime covers the campaign budget.

Refs #4153
Refs #4147

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization expiry/revocation, campaign completion gating, and dataset-root verification on the path that would run 819 replays—security- and evidence-integrity critical despite unit-test-only validation in this slice.
> 
> **Overview**
> **#4153 sensitivity campaign execution contract** — `execute` is no longer primary-only; it runs a **fail-closed phase machine** (primary → optional reproduction → `COMPLETED` | `BLOCKED`), with reproduction evidence under `runs/<run_key>/reproduction/<n>/` and `comparison.json` from structured `compare_reproduction_results` (PASS/MISMATCH, binding checks, volatile fields excluded). With reproduction enabled, **`COMPLETED` requires reproduction**, not just 819 primaries.
> 
> **Owner-GO gates tighten on the execute path:** revocation sentinel `REVOKED_CAMPAIGN_EXECUTION_CONTRACT_DEFECT` → `AUTH_GO_REVOKED`; **finite `expires_at_utc` required**; lifetime must cover campaign+run wall budget before evidence writes; **per-attempt expiry** before each primary/retry/reproduction run.
> 
> **Dataset binding:** new `resolve_and_verify_dataset_root` (manifest windows, symlink/traversal guards, `dataset_identity_fingerprint`) is wired into surface probe, campaign envelope, and **`ARVPReplayConfig.window_bank_root`** / `StrategyReplayCampaignExecutor` for external worktree roots.
> 
> Contract doc updated; broad unit coverage for auth, state phases, runner blocking paths, dataset root, and reproduction compare semantics. **No live campaign or new GO in this PR.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d7ba761041b8a7872bbdf60d7ea6fab91bbd6e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->