### PR TITLE
[CI][INFRA] Fix Cursor environment build context (.dockerignore vs requirements-dev)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -82,5 +82,8 @@ test_*.py
 pytest.ini
 .coveragerc
 
-# Requirements (install from specific file, not all)
-requirements-dev.txt
+# Do NOT ignore requirements-dev.txt here.
+# `.cursor/environment.json` builds `ci/Dockerfile` with repo-root context; that
+# Dockerfile COPY/installs requirements-dev.txt (toolchain SSOT #4206 / #4360).
+# Service images still COPY only their own requirements.txt — presence in the
+# build context does not install the file.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     && rm -rf /var/lib/apt/lists/*
 
+# COPY sources must remain allowed by the repo-root .dockerignore — this image is
+# also the Cursor Cloud environment build target (`.cursor/environment.json`, #4360).
 COPY requirements.txt requirements-dev.txt requirements-mcp.txt pyproject.toml ./
 RUN python -m pip install --upgrade pip \
     && pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt -r requirements-mcp.txt

--- a/docs/contracts/agent_environment/CDB_AGENT_ENVIRONMENT_V1.md
+++ b/docs/contracts/agent_environment/CDB_AGENT_ENVIRONMENT_V1.md
@@ -20,6 +20,17 @@ bleiben getrennt.
 | Doctor / Preflight | `tools/agent_control/environment/` | Shared gate for dry-run + execute |
 | CLI | `python -m tools.agent_control environment ...` | Validate / offline doctor |
 
+## Build-context invariant (#4360)
+
+`.cursor/environment.json` builds `ci/Dockerfile` with repo-root context (`..`).
+Every local `COPY`/`ADD` source in that Dockerfile MUST exist under the context
+and MUST NOT be excluded by the context-root `.dockerignore`.
+
+In particular, `requirements-dev.txt` is required by `ci/Dockerfile` (toolchain
+SSOT) and must remain visible to the Cursor saved-environment build. Contract
+enforcement: `tools/agent_control/environment/dockerfile_context.py` and
+`tests/unit/infra/test_cursor_environment_dockerfile_context.py`.
+
 ## Governed profile IDs
 
 - `cdb-docs-readonly.v1`

--- a/tests/unit/arvp/test_arvp_vacation_recovery.py
+++ b/tests/unit/arvp/test_arvp_vacation_recovery.py
@@ -16,19 +16,33 @@ from tools.arvp_vacation.queue_store import QUEUE_STATE_FILENAME, read_queue_sta
 from tools.arvp_vacation.summary import write_summary
 
 
-def _write_dataset(root: Path, rel_dir: str, *, dataset_id: str, fingerprint: str) -> None:
+def _write_dataset(
+    root: Path,
+    rel_dir: str,
+    *,
+    dataset_id: str,
+    fingerprint: str,
+    window_index: int = 0,
+) -> None:
+    """Write a lab dataset_spec with a stable unique time window.
+
+    Do not use ``hash(dataset_id)`` for timestamps: PYTHONHASHSEED is randomized
+    per process, so ``% 1000`` windows can collide across datasets and drop jobs
+    in ``discover_datasets`` (CI flake: assert len(jobs) >= 6 saw 5).
+    """
     base = root / rel_dir
     base.mkdir(parents=True, exist_ok=True)
     candles = base / "candles.jsonl"
     candles.write_text('{"ts_ms":1,"open":1,"high":1,"low":1,"close":1,"volume":1}\n')
+    start_ts_ms = 1_000_000 + int(window_index) * 10_000
     spec = {
         "dataset_id": dataset_id,
         "source": "file",
         "file_path": f"{rel_dir}/candles.jsonl".replace("\\", "/"),
         "symbol": "BTCUSDT",
         "fingerprint": fingerprint,
-        "start_ts_ms": 1000 + hash(dataset_id) % 1000,
-        "end_ts_ms": 2000 + hash(dataset_id) % 1000,
+        "start_ts_ms": start_ts_ms,
+        "end_ts_ms": start_ts_ms + 999,
         "evidence_class": "controlled_lab_evidence",
     }
     (base / "dataset_spec.json").write_text(json.dumps(spec), encoding="utf-8")
@@ -87,6 +101,7 @@ def test_recovery_orphan_running_without_double_pass(tmp_path: Path) -> None:
             rel,
             dataset_id=f"w{i}",
             fingerprint=f"{i:064d}",
+            window_index=i,
         )
     manifest_path = tmp_path / "manifest.yaml"
     manifest_path.write_text(_manifest_yaml(roots), encoding="utf-8")
@@ -140,6 +155,7 @@ def test_acceptance_drill_six_jobs_summary(tmp_path: Path) -> None:
             rel,
             dataset_id=f"ds{i}",
             fingerprint=f"{i+10:064d}",
+            window_index=i,
         )
     manifest_path = tmp_path / "manifest.yaml"
     manifest_path.write_text(_manifest_yaml(roots), encoding="utf-8")
@@ -152,7 +168,9 @@ def test_acceptance_drill_six_jobs_summary(tmp_path: Path) -> None:
     manifest = load_manifest(manifest_path)
     write_summary(manifest, state, tmp_path)
     assert len(state["jobs"]) >= 6
-    assert (tmp_path / "artifacts/arvp_vacation/vac_recovery/vacation_summary.json").exists()
+    assert (
+        tmp_path / "artifacts/arvp_vacation/vac_recovery/vacation_summary.json"
+    ).exists()
     assert calls["count"] >= 1
 
 
@@ -164,6 +182,7 @@ def test_recovery_preserves_scenario_group_id(tmp_path: Path) -> None:
             rel,
             dataset_id=f"w{i}",
             fingerprint=f"{i+20:064d}",
+            window_index=i,
         )
     manifest_path = tmp_path / "manifest.yaml"
     manifest_path.write_text(_manifest_yaml(roots), encoding="utf-8")

--- a/tests/unit/infra/test_cursor_environment_dockerfile_context.py
+++ b/tests/unit/infra/test_cursor_environment_dockerfile_context.py
@@ -1,0 +1,113 @@
+"""Contract: Cursor environment Dockerfile COPY sources are in build context (#4360).
+
+test_id: tc_cursor_environment_dockerfile_context_4360
+test_type: contract / bauteil
+cdb_area: infra/ci / agent-control
+rule_ref: .cursor/environment.json build context must include all local COPY/ADD sources
+issue_ref: #4360
+security_relevant: false
+live_relevant: false
+profitability_relevant: false
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.agent_control.environment.dockerfile_context import (
+    assert_cursor_dockerfile_context_ok,
+    check_cursor_dockerfile_context,
+    dockerignore_excludes,
+    parse_local_copy_sources,
+)
+from tools.agent_control.paths import REPO_ROOT
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+
+def test_dockerignore_exact_requirements_dev_match() -> None:
+    excluded, pattern = dockerignore_excludes(
+        "requirements-dev.txt",
+        ["requirements-dev.txt"],
+    )
+    assert excluded is True
+    assert pattern == "requirements-dev.txt"
+
+
+def test_dockerignore_negation_last_match_wins() -> None:
+    excluded, pattern = dockerignore_excludes(
+        "requirements-dev.txt",
+        ["requirements-dev.txt", "!requirements-dev.txt"],
+    )
+    assert excluded is False
+    assert pattern == "!requirements-dev.txt"
+
+
+def test_parse_ci_dockerfile_copy_sources() -> None:
+    text = (
+        "FROM python:3.12-slim-bookworm\n"
+        "COPY requirements.txt requirements-dev.txt "
+        "requirements-mcp.txt pyproject.toml ./\n"
+        "COPY --from=build /venv /venv\n"
+        "ADD https://example.com/x.tgz /tmp/\n"
+    )
+    sources = parse_local_copy_sources(text)
+    assert sources == [
+        ("COPY", "requirements.txt"),
+        ("COPY", "requirements-dev.txt"),
+        ("COPY", "requirements-mcp.txt"),
+        ("COPY", "pyproject.toml"),
+    ]
+
+
+def test_repo_cursor_environment_dockerfile_context_ok() -> None:
+    report = assert_cursor_dockerfile_context_ok(REPO_ROOT)
+    assert report.config_path == ".cursor/environment.json"
+    assert report.dockerfile_path == "ci/Dockerfile"
+    assert report.context_path == "."
+    names = {item.source for item in report.sources}
+    assert "requirements-dev.txt" in names
+    assert all(item.ok for item in report.sources)
+
+
+def test_regression_excluded_requirements_dev_fails(tmp_path: Path) -> None:
+    """Synthetic repo recreates the pre-#4360 failure mode."""
+    root = tmp_path / "repo"
+    cursor = root / ".cursor"
+    cursor.mkdir(parents=True)
+    (root / "ci").mkdir()
+    (root / "requirements.txt").write_text("x\n", encoding="utf-8")
+    (root / "requirements-dev.txt").write_text("y\n", encoding="utf-8")
+    (root / "requirements-mcp.txt").write_text("z\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='t'\n", encoding="utf-8")
+    (root / "ci" / "Dockerfile").write_text(
+        "FROM python:3.12-slim-bookworm\n"
+        "COPY requirements.txt requirements-dev.txt "
+        "requirements-mcp.txt pyproject.toml ./\n",
+        encoding="utf-8",
+    )
+    (root / ".dockerignore").write_text(
+        "# Requirements (install from specific file, not all)\n"
+        "requirements-dev.txt\n",
+        encoding="utf-8",
+    )
+    (cursor / "environment.json").write_text(
+        json.dumps(
+            {
+                "build": {"dockerfile": "../ci/Dockerfile", "context": ".."},
+                "install": "python -m pip install -r requirements-dev.txt",
+                "agentCanUpdateSnapshot": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = check_cursor_dockerfile_context(root)
+    assert report.ok is False
+    failed = {item.source: item for item in report.failures}
+    assert "requirements-dev.txt" in failed
+    assert failed["requirements-dev.txt"].excluded_by_dockerignore is True
+    assert failed["requirements-dev.txt"].matching_pattern == "requirements-dev.txt"

--- a/tools/agent_control/environment/dockerfile_context.py
+++ b/tools/agent_control/environment/dockerfile_context.py
@@ -1,0 +1,310 @@
+"""Cursor environment Dockerfile build-context contract (#4360).
+
+Ensures every local COPY/ADD source in the Dockerfile referenced by
+``.cursor/environment.json`` exists under the configured build context and is
+not excluded by the context-root ``.dockerignore``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from tools.agent_control.environment.codes import (
+    REASON_CONFIG_MISSING,
+    REASON_CONFIG_SCHEMA_INVALID,
+)
+from tools.agent_control.environment.digest import resolve_repo_relative
+from tools.agent_control.errors import DispatchError
+
+DEFAULT_CONFIG_REL = Path(".cursor") / "environment.json"
+
+_COPY_ADD_RE = re.compile(
+    r"^\s*(COPY|ADD)\s+(.+?)\s+(\S+)\s*$",
+    re.IGNORECASE,
+)
+_FROM_FLAG_RE = re.compile(r"^--from=.+$", re.IGNORECASE)
+_CHMOD_CHOWN_RE = re.compile(r"^--(chmod|chown)=.+$", re.IGNORECASE)
+_URL_RE = re.compile(r"^(?:https?|git|ftp)://", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class CopySourceCheck:
+    instruction: str
+    source: str
+    exists: bool
+    excluded_by_dockerignore: bool
+    matching_pattern: str | None
+
+    @property
+    def ok(self) -> bool:
+        return self.exists and not self.excluded_by_dockerignore
+
+
+@dataclass(frozen=True)
+class DockerfileContextReport:
+    config_path: str
+    dockerfile_path: str
+    context_path: str
+    dockerignore_path: str | None
+    sources: tuple[CopySourceCheck, ...]
+
+    @property
+    def ok(self) -> bool:
+        return all(item.ok for item in self.sources)
+
+    @property
+    def failures(self) -> tuple[CopySourceCheck, ...]:
+        return tuple(item for item in self.sources if not item.ok)
+
+
+def load_dockerignore_patterns(dockerignore: Path) -> list[str]:
+    if not dockerignore.is_file():
+        return []
+    patterns: list[str] = []
+    for raw in dockerignore.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        patterns.append(line)
+    return patterns
+
+
+def dockerignore_excludes(
+    rel_path: str,
+    patterns: Sequence[str],
+) -> tuple[bool, str | None]:
+    """Return whether ``rel_path`` is excluded and the last matching pattern."""
+    normalized = rel_path.replace("\\", "/").lstrip("./")
+    excluded = False
+    last_match: str | None = None
+    for raw in patterns:
+        negate = raw.startswith("!")
+        pat = raw[1:] if negate else raw
+        pat = pat.lstrip("/")
+        if not _dockerignore_match(normalized, pat):
+            continue
+        excluded = not negate
+        last_match = raw
+    return excluded, last_match
+
+
+def _dockerignore_match(path: str, pattern: str) -> bool:
+    if pattern.endswith("/"):
+        prefix = pattern.rstrip("/")
+        return path == prefix or path.startswith(prefix + "/")
+    if pattern == path:
+        return True
+    if "**" in pattern:
+        # Conservative fnmatch after collapsing ** to *
+        collapsed = pattern.replace("**/", "").replace("**", "*")
+        return fnmatch(path, collapsed) or fnmatch(path.split("/")[-1], collapsed)
+    if "/" in pattern:
+        return fnmatch(path, pattern)
+    # Basename-only patterns match in any directory (Docker/.gitignore style).
+    return fnmatch(path, pattern) or fnmatch(path.split("/")[-1], pattern)
+
+
+def parse_local_copy_sources(dockerfile_text: str) -> list[tuple[str, str]]:
+    """Yield (instruction, source) for local COPY/ADD sources (not URLs / --from)."""
+    sources: list[tuple[str, str]] = []
+    for raw_line in dockerfile_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = _COPY_ADD_RE.match(line)
+        if not match:
+            continue
+        instruction = match.group(1).upper()
+        mid = match.group(2).strip()
+        # Dest is group(3); sources are everything before it in mid after flags.
+        tokens = _tokenize_dockerfile_args(mid)
+        # Multi-stage COPY --from=... is not a local context source.
+        if any(_FROM_FLAG_RE.match(token) for token in tokens):
+            continue
+        filtered: list[str] = []
+        for token in tokens:
+            if _CHMOD_CHOWN_RE.match(token):
+                continue
+            filtered.append(token)
+        for src in filtered:
+            if src in {".", ".."}:
+                continue
+            if _URL_RE.match(src):
+                continue
+            if src.startswith("--"):
+                continue
+            # Absolute paths are not context-relative sources.
+            if src.startswith("/"):
+                continue
+            sources.append((instruction, src))
+    return sources
+
+
+def _tokenize_dockerfile_args(mid: str) -> list[str]:
+    # JSON-array form: COPY ["a","b","dest"] — regex already excluded dest via last token
+    # of non-JSON form. For JSON, mid may be '["a", "b"]' without dest when dest is last
+    # in full line — handle both.
+    stripped = mid.strip()
+    if stripped.startswith("["):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return stripped.split()
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+        return stripped.split()
+    return stripped.split()
+
+
+def check_cursor_dockerfile_context(
+    repo_root: Path,
+    *,
+    config_path: Path | None = None,
+) -> DockerfileContextReport:
+    """Validate Cursor environment Dockerfile COPY/ADD sources vs .dockerignore."""
+    root = repo_root.resolve()
+    path = (config_path or (root / DEFAULT_CONFIG_REL)).resolve()
+    if not path.is_file():
+        raise DispatchError(
+            REASON_CONFIG_MISSING,
+            f"missing provider environment config: {path}",
+        )
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DispatchError(
+            REASON_CONFIG_SCHEMA_INVALID,
+            f"invalid environment.json: {exc}",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise DispatchError(
+            REASON_CONFIG_SCHEMA_INVALID,
+            "environment.json must be an object",
+        )
+
+    build = payload.get("build") or {}
+    if not isinstance(build, dict):
+        raise DispatchError(
+            REASON_CONFIG_SCHEMA_INVALID,
+            "environment.json build must be an object",
+        )
+    dockerfile_rel = build.get("dockerfile")
+    context_rel = build.get("context", ".")
+    if not isinstance(dockerfile_rel, str) or not dockerfile_rel.strip():
+        raise DispatchError(
+            REASON_CONFIG_SCHEMA_INVALID,
+            "environment.json build.dockerfile is required",
+        )
+    if not isinstance(context_rel, str) or not context_rel.strip():
+        raise DispatchError(
+            REASON_CONFIG_SCHEMA_INVALID,
+            "environment.json build.context is required",
+        )
+
+    base_dir = path.parent
+    dockerfile = resolve_repo_relative(
+        root, base_dir, dockerfile_rel, code=REASON_CONFIG_SCHEMA_INVALID
+    )
+    context = resolve_repo_relative(
+        root, base_dir, context_rel, code=REASON_CONFIG_SCHEMA_INVALID
+    )
+    if not dockerfile.is_file():
+        raise DispatchError(
+            REASON_CONFIG_SCHEMA_INVALID,
+            f"dockerfile not found: {dockerfile_rel}",
+        )
+    if not context.is_dir():
+        raise DispatchError(
+            REASON_CONFIG_SCHEMA_INVALID,
+            f"build context not found: {context_rel}",
+        )
+
+    dockerignore = context / ".dockerignore"
+    patterns = load_dockerignore_patterns(dockerignore)
+    text = dockerfile.read_text(encoding="utf-8")
+    checks: list[CopySourceCheck] = []
+    for instruction, src in parse_local_copy_sources(text):
+        # Sources are relative to the build context for typical Cursor/ci usage.
+        src_norm = src.replace("\\", "/").lstrip("./")
+        abs_src = (context / src_norm).resolve()
+        try:
+            abs_src.relative_to(context.resolve())
+        except ValueError:
+            exists = False
+            excluded = True
+            matching = "path-escape"
+        else:
+            exists = abs_src.exists()
+            excluded, matching = dockerignore_excludes(src_norm, patterns)
+        checks.append(
+            CopySourceCheck(
+                instruction=instruction,
+                source=src_norm,
+                exists=exists,
+                excluded_by_dockerignore=excluded,
+                matching_pattern=matching,
+            )
+        )
+
+    return DockerfileContextReport(
+        config_path=str(path.relative_to(root)).replace("\\", "/"),
+        dockerfile_path=str(dockerfile.relative_to(root)).replace("\\", "/"),
+        context_path=str(context.relative_to(root)).replace("\\", "/") or ".",
+        dockerignore_path=(
+            str(dockerignore.relative_to(root)).replace("\\", "/")
+            if dockerignore.is_file()
+            else None
+        ),
+        sources=tuple(checks),
+    )
+
+
+def assert_cursor_dockerfile_context_ok(
+    repo_root: Path,
+    *,
+    config_path: Path | None = None,
+) -> DockerfileContextReport:
+    report = check_cursor_dockerfile_context(repo_root, config_path=config_path)
+    if report.ok:
+        return report
+    details = "; ".join(
+        f"{item.instruction} {item.source} "
+        f"(exists={item.exists}, excluded={item.excluded_by_dockerignore}, "
+        f"pattern={item.matching_pattern!r})"
+        for item in report.failures
+    )
+    raise DispatchError(
+        REASON_CONFIG_SCHEMA_INVALID,
+        f"cursor Dockerfile build-context contract failed: {details}",
+    )
+
+
+def format_report(report: DockerfileContextReport) -> str:
+    lines = [
+        f"config={report.config_path}",
+        f"dockerfile={report.dockerfile_path}",
+        f"context={report.context_path}",
+        f"dockerignore={report.dockerignore_path or '(none)'}",
+        f"ok={report.ok}",
+    ]
+    for item in report.sources:
+        lines.append(
+            f"  {item.instruction} {item.source}: "
+            f"exists={item.exists} excluded={item.excluded_by_dockerignore} "
+            f"pattern={item.matching_pattern!r} ok={item.ok}"
+        )
+    return "\n".join(lines)
+
+
+def iter_failure_messages(report: DockerfileContextReport) -> Iterable[str]:
+    for item in report.failures:
+        yield (
+            f"{item.instruction} source {item.source!r} "
+            f"exists={item.exists} excluded={item.excluded_by_dockerignore} "
+            f"pattern={item.matching_pattern!r}"
+        )


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: ci-tooling
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: frozen
objective_key: issue-4360
planned_issues: #4360
contract_keys: ci-tooling-v1
risk_flags: none
-->

## Summary

Closes #4360
Refs #4255
Refs #4258

Fix Cursor Cloud saved-environment Dockerfile build failure (.dockerignore vs requirements-dev.txt), plus stabilize ARVP vacation unit flake (hash time-window collisions).

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4360 | SLICE_DELIVERED | 242fafd5d5eb6dcdaa61ed96393f6a6e7c45fa78 | local Fast-CI PASS; hosted CI PASS; contract+vacation tests | none | Live Cursor UI re-save not re-run |

## Validation

- Local Fast-CI: overall PASS merge_evidence=true evidence=ci/artifacts/20260805T172309Z_ae12487f commit=242fafd5d5eb6dcdaa61ed96393f6a6e7c45fa78
- Hosted ci (Unit/Integration + Lint): PASS on tip
- Completeness: MERGE_CANDIDATE (local evidence under reports/pr-acceptance/4361-242fafd5)

## Non-goals

- No --admin merge
- #4153 campaign untouched
