### PR TITLE
fix(security): process Grafana alert wave #4350–#4359

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,7 +38,7 @@ jobs:
             scan_name: postgres
           - image: prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69
             scan_name: prometheus
-          - image: grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8
+          - image: grafana/grafana:13.1.2-ubuntu@sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45
             scan_name: grafana
       fail-fast: false
 

--- a/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json
+++ b/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json
@@ -1,0 +1,366 @@
+{
+  "schema": "cdb.security_alert_wave.v1",
+  "wave_id": "security-alert-wave-2026-08-05",
+  "snapshot_date": "2026-08-05",
+  "base_sha": "42b9703c276c5f49810247ceea6b1442a6158ee2",
+  "base_ref": "origin/main",
+  "branch": "dedicated/security-alert-wave-2026-08-05",
+  "routing_decision": "CREATE_DEDICATED_PR",
+  "preferred_objective": "security-alert-wave-2026-08-05",
+  "merge_mode": false,
+  "merge_allowed": false,
+  "issue_closure_before_merge_allowed": false,
+  "alert_dismissal_allowed": false,
+  "trivyignore_growth_allowed": false,
+  "lr_verdict": "NO-GO",
+  "board_stage": "trade-capable",
+  "readout_run_id": 30990577816,
+  "readout_run_url": "https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/30990577816",
+  "readout_head_sha": "ca27adeee28d7d63ba457ee627274704e89da990",
+  "alerts_generated_from_scan_commit": "71900c6302bb96ba523a56affd64912d9d736a29",
+  "related_merged_prs": {
+    "4162": {
+      "title": "deps(docker-compose): bump grafana/grafana from 13.0.3-ubuntu to 13.1.1-ubuntu",
+      "merge_commit": "4608aeff96ad9832a0335ab55676eea70021ae44",
+      "note": "Prior RED runtime pin bump; did not clear the ten wave CVEs"
+    },
+    "4310": {
+      "title": "deps(docker-compose): bump prom/prometheus from v3.13.1 to v3.13.2",
+      "merge_commit": "c18fc695274d3045fae3831b228e6fc7a31632f9",
+      "note": "Unrelated to this wave; kept for lineage"
+    }
+  },
+  "prior_evidence": [
+    "docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md",
+    "docs/evidence/security/CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md",
+    "docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md"
+  ],
+  "grafana_baseline_pin": "grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8",
+  "grafana_target_pin": "grafana/grafana:13.1.2-ubuntu@sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45",
+  "pin_alignment_before_wave": {
+    "note": "All three surfaces (base.yml, compose.red.yml, security-scan.yml) were already aligned on the 13.1.1 manifest-list digest before this wave. The stale plan-hint (`13.0.3-ubuntu@sha256:7c1acd...`) reflects an older workflow revision that no longer exists on origin/main; verified by rg 2026-08-05.",
+    "base_yml_pin": "13.1.1-ubuntu",
+    "compose_red_yml_pin": "13.1.1-ubuntu",
+    "security_scan_yml_pin": "13.1.1-ubuntu",
+    "service_catalog_md_pin": "13.1.1-ubuntu"
+  },
+  "pin_surfaces_synced": [
+    "infrastructure/compose/base.yml",
+    "infrastructure/compose/compose.red.yml",
+    ".github/workflows/security-scan.yml",
+    "knowledge/governance/SERVICE_CATALOG.md"
+  ],
+  "trivy_evidence": {
+    "tool_version_local": "0.73.0",
+    "tool_version_github_alerts": "0.70.0",
+    "db_updated_at_local": "2026-08-03",
+    "grafana_13_1_1_baseline": {
+      "image": "grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8",
+      "high_total": 18,
+      "critical_total": 1,
+      "target_cve_hits": 13,
+      "wave_alert_reproducibility": {
+        "cve_2026_25681_zipkin": {"hits": 1, "installed": "golang.org/x/net v0.49.0", "fixed": "0.55.0"},
+        "cve_2026_27136_zipkin": {"hits": 1, "installed": "golang.org/x/net v0.49.0", "fixed": "0.55.0"},
+        "cve_2026_27145_zipkin": {"hits": 1, "installed": "stdlib v1.26.3", "fixed": "1.25.11, 1.26.4"},
+        "cve_2026_33814_zipkin": {"hits": 1, "installed": "golang.org/x/net v0.49.0", "fixed": "0.53.0"},
+        "cve_2026_39821_zipkin": {"hits": 1, "installed": "golang.org/x/net v0.49.0", "fixed": "0.55.0"},
+        "cve_2026_39822_zipkin": {"hits": 1, "installed": "stdlib v1.26.3", "fixed": "1.25.12, 1.26.5, 1.27.0-rc.2"},
+        "cve_2026_42504_zipkin": {"hits": 1, "installed": "stdlib v1.26.3", "fixed": "1.25.11, 1.26.4"},
+        "cve_2026_56852_grafana_bin": {"hits": 1, "installed": "golang.org/x/text v0.37.0", "fixed": "0.39.0"},
+        "cve_2026_56852_elasticsearch": {"hits": 1, "installed": "golang.org/x/text v0.37.0", "fixed": "0.39.0"},
+        "cve_2026_56852_zipkin": {"hits": 1, "installed": "golang.org/x/text v0.33.0", "fixed": "0.39.0"}
+      }
+    },
+    "grafana_13_1_2_candidate": {
+      "image": "grafana/grafana:13.1.2-ubuntu@sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45",
+      "amd64_manifest_digest": "sha256:1098ce10e68b3e331389258075351d2d05df00c132a2897c276045766bbd0918",
+      "high_total": 14,
+      "critical_total": 0,
+      "target_cve_hits": 11,
+      "grafana_bin_cleared": true,
+      "elasticsearch_x_text_cleared": true,
+      "zipkin_findings_unchanged": true,
+      "delta_from_baseline": {
+        "high_reduced": 4,
+        "critical_reduced": 1,
+        "cleared_wave_issues": [4357, 4358],
+        "still_present_wave_issues": [4350, 4351, 4352, 4353, 4354, 4355, 4356, 4359]
+      }
+    }
+  },
+  "cve_family_analysis": {
+    "cve_2026_56852_common_origin": "golang.org/x/text < 0.39.0 (Grafana bin + ES plugin ship v0.37.0; Zipkin plugin ships v0.33.0). 13.1.2 rebuilt grafana bin + ES plugin against x/text >= 0.39.0 but Zipkin plugin still ships v0.33.0.",
+    "zipkin_path_root_cause": "Bundled zipkin datasource statically embeds an older Go stdlib (v1.26.3) and older x/net (v0.49.0) / x/text (v0.33.0). Not fixed by upstream in 13.1.2. Upstream Grafana rebuild required.",
+    "elasticsearch_plugin_partial_progress": "13.1.2 rebuilt the ES plugin against x/text 0.39.0 (clears CVE-2026-56852) but stdlib remains 1.26.3, so CVE-2026-27145 / CVE-2026-39822 / CVE-2026-42504 remain HIGH on the ES plugin (out of wave scope; already tracked under #2933).",
+    "prior_evidence_confirmation": {
+      "cve_2026_42504": "Confirmed still present in 13.1.2 on both ES and Zipkin plugins; matches CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08 verdict UPSTREAM_BLOCKED.",
+      "cve_2026_27145": "Confirmed still present in 13.1.2 on both plugins; installed stdlib v1.26.3 on both bundled plugin binaries; upstream Go stdlib rebuild required."
+    }
+  },
+  "clusters": [
+    {
+      "cluster_id": "grafana-zipkin-plugin-go-family",
+      "issues": [4350, 4351, 4352, 4353, 4354, 4355, 4356, 4359],
+      "disposition": "HOLD_UPSTREAM_NO_FIXED_VERSION",
+      "canonical_tracker": 2933,
+      "root_cause": "Zipkin bundled datasource statically embeds Go stdlib 1.26.3 + old golang.org/x/net + golang.org/x/text; upstream Grafana rebuild required to bump these transitive dependencies",
+      "verified_still_present_on_13_1_2": true
+    },
+    {
+      "cluster_id": "grafana-bin-cve-2026-56852",
+      "issues": [4357],
+      "disposition": "FIX_READY",
+      "canonical_tracker": 4357,
+      "closure_condition": "After this PR merges to main AND post-merge Trivy/code-scanning recount shows alert 5601 fixed/absent for CVE-2026-56852 on usr/share/grafana/bin/grafana",
+      "verified_cleared_on_13_1_2": true
+    },
+    {
+      "cluster_id": "grafana-elasticsearch-cve-2026-56852",
+      "issues": [4358],
+      "disposition": "FIX_READY",
+      "canonical_tracker": 4358,
+      "closure_condition": "After this PR merges to main AND post-merge Trivy/code-scanning recount shows alert 5603 fixed/absent for CVE-2026-56852 on the elasticsearch bundled plugin path",
+      "verified_cleared_on_13_1_2": true
+    }
+  ],
+  "allowed_dispositions": [
+    "FIX_READY",
+    "HOLD_UPSTREAM_NO_FIXED_VERSION",
+    "DUPLICATE_TRACKING",
+    "FALSE_POSITIVE_WITH_EVIDENCE",
+    "NEEDS_EVIDENCE"
+  ],
+  "issues": [
+    {
+      "issue": 4350,
+      "alert": 5539,
+      "cve": "CVE-2026-25681",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "golang.org/x/net",
+      "installed": "v0.49.0",
+      "fixed_version": "0.55.0",
+      "fingerprint": "abd5ff85d7f65a8d",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "HOLD_UPSTREAM_NO_FIXED_VERSION",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Upstream Grafana release rebuilds the zipkin bundled plugin against golang.org/x/net >= 0.55.0; scan-verified clear on alert 5539; consolidate under #2933 until then"
+    },
+    {
+      "issue": 4351,
+      "alert": 5540,
+      "cve": "CVE-2026-27136",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "golang.org/x/net",
+      "installed": "v0.49.0",
+      "fixed_version": "0.55.0",
+      "fingerprint": "770d48eac638ba0a",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Same as #4350 / #2933 (upstream x/net rebuild in zipkin plugin) scan-clears alert 5540"
+    },
+    {
+      "issue": 4352,
+      "alert": 5548,
+      "cve": "CVE-2026-27145",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "stdlib",
+      "installed": "v1.26.3",
+      "fixed_version": "1.25.11, 1.26.4",
+      "fingerprint": "f7705c66f59b11b5",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Upstream Grafana release rebuilds zipkin plugin against Go stdlib >= 1.25.11 / >= 1.26.4; scan-clear on alert 5548 (same Go stdlib family as historical CVE-2026-42504 batch #3065-#3070)"
+    },
+    {
+      "issue": 4353,
+      "alert": 5541,
+      "cve": "CVE-2026-33814",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "golang.org/x/net",
+      "installed": "v0.49.0",
+      "fixed_version": "0.53.0",
+      "fingerprint": "945d6efdac69e714",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Upstream x/net rebuild in zipkin plugin scan-clears alert 5541"
+    },
+    {
+      "issue": 4354,
+      "alert": 5542,
+      "cve": "CVE-2026-39821",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "golang.org/x/net",
+      "installed": "v0.49.0",
+      "fixed_version": "0.55.0",
+      "fingerprint": "dc15b05faedce243",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Upstream x/net rebuild in zipkin plugin scan-clears alert 5542"
+    },
+    {
+      "issue": 4355,
+      "alert": 5555,
+      "cve": "CVE-2026-39822",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "stdlib",
+      "installed": "v1.26.3",
+      "fixed_version": "1.25.12, 1.26.5, 1.27.0-rc.2",
+      "fingerprint": "c7c0700b54dd4247",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Upstream Go stdlib rebuild in zipkin plugin scan-clears alert 5555"
+    },
+    {
+      "issue": 4356,
+      "alert": 5558,
+      "cve": "CVE-2026-42504",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "stdlib",
+      "installed": "v1.26.3",
+      "fixed_version": "1.25.11, 1.26.4",
+      "fingerprint": "bc5498d4bd0877d8",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Upstream Go stdlib >= 1.25.11 / >= 1.26.4 rebuild in zipkin plugin scan-clears alert 5558; extends cluster from historical batch #3065-#3070 to zipkin path"
+    },
+    {
+      "issue": 4357,
+      "alert": 5601,
+      "cve": "CVE-2026-56852",
+      "component": "usr/share/grafana/bin/grafana",
+      "package": "golang.org/x/text",
+      "installed_baseline": "v0.37.0",
+      "installed_candidate": "cleared on 13.1.2",
+      "fixed_version": "0.39.0",
+      "fingerprint": "a1f0fd9ec5ada7c9",
+      "runtime_reachability": "grafana_server_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "FIX_READY",
+      "duplicate_of_cluster": false,
+      "canonical_tracker": 4357,
+      "verified_cleared_on_13_1_2": true,
+      "closure_condition": "After this PR merges to main AND post-merge Trivy/code-scanning recount shows alert 5601 fixed/absent for CVE-2026-56852 on usr/share/grafana/bin/grafana; do not premature-close"
+    },
+    {
+      "issue": 4358,
+      "alert": 5603,
+      "cve": "CVE-2026-56852",
+      "component": "usr/share/grafana/data/plugins-bundled/elasticsearch/gpx_grafana_elasticsearch_datasource_linux_amd64",
+      "package": "golang.org/x/text",
+      "installed_baseline": "v0.37.0",
+      "installed_candidate": "cleared on 13.1.2",
+      "fixed_version": "0.39.0",
+      "fingerprint": "60635624058c73e7",
+      "runtime_reachability": "bundled_elasticsearch_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "FIX_READY",
+      "duplicate_of_cluster": false,
+      "canonical_tracker": 4358,
+      "verified_cleared_on_13_1_2": true,
+      "closure_condition": "After this PR merges to main AND post-merge Trivy/code-scanning recount shows alert 5603 fixed/absent for CVE-2026-56852 on the elasticsearch bundled plugin path"
+    },
+    {
+      "issue": 4359,
+      "alert": 5696,
+      "cve": "CVE-2026-56852",
+      "component": "usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64",
+      "package": "golang.org/x/text",
+      "installed": "v0.33.0",
+      "fixed_version": "0.39.0",
+      "fingerprint": "8a70b82a5a2364ab",
+      "runtime_reachability": "bundled_zipkin_datasource_plugin_binary",
+      "codex_verdict": "confirmed",
+      "cdb_disposition": "DUPLICATE_TRACKING",
+      "duplicate_of_cluster": true,
+      "canonical_tracker": 2933,
+      "verified_still_present_on_13_1_2": true,
+      "closure_condition": "Upstream Grafana rebuild bumps zipkin plugin from x/text v0.33.0 (older than grafana bin's v0.37.0) to >= 0.39.0; scan-clear on alert 5696"
+    }
+  ],
+  "grafana_hold_evidence": {
+    "canonical_tracker": 2933,
+    "consolidation_scope": "eight of ten wave issues (all zipkin plugin CVEs)",
+    "root_cause_class": "Grafana bundled zipkin datasource plugin ships older transitive Go modules (stdlib 1.26.3, x/net v0.49.0, x/text v0.33.0); upstream rebuild required",
+    "re_eval_date": "2026-11-05",
+    "forbidden_actions": [
+      "no alert dismissal",
+      "no trivyignore growth",
+      "no vendoring of grafana source",
+      "no plugin-only patch commit"
+    ]
+  },
+  "grafana_fix_evidence": {
+    "trigger": "grafana/grafana:13.1.2-ubuntu released 2026-08-04 (upstream security bump)",
+    "verified_via": "Trivy 0.73.0 image scan (docker buildx imagetools verified manifest list digest)",
+    "cleared_wave_issues": [4357, 4358],
+    "scope": "grafana server binary + elasticsearch bundled plugin path only; zipkin plugin still bundles older transitive Go modules",
+    "closure_gate": "post-merge alert recount on main tip; #4357 and #4358 stay open until alerts 5601/5603 clear on the exact main-tip scan"
+  },
+  "cap13_out_of_scope": {
+    "documented": true,
+    "note": "13 additional Security Alert Readout capped candidates from 2026-08-05 remain OUT OF SCOPE for this wave; no issue mutation or remediation claimed. See workflow_run 30990577816 for the readout cap boundary."
+  },
+  "safety_boundaries": {
+    "lr_verdict": "NO-GO",
+    "board_stage_orthogonal_to_lr": true,
+    "live_authorization": false,
+    "runtime_mutation": false,
+    "productive_db_write": false,
+    "mcp_mutation": false,
+    "blue_red_boundary_bypass": false,
+    "admin_merge_used": false
+  },
+  "brain_evidence": {
+    "brain_source": "repo-only",
+    "brain_status": "not-used",
+    "context_brain_attempted": true,
+    "context_brain_used": false,
+    "context_available": false,
+    "repo_fallback_used": true,
+    "repo_fallback_reason": "insufficient_evidence",
+    "context_tool_status": "available",
+    "context_trust_level": "none",
+    "records_found": "none",
+    "tools_or_queries": [
+      "GetMcpTools project-0-Claire_de_Binare-cdb_context",
+      "cdb_context_briefing task_id=cdb-briefing-4350-4359-security-wave",
+      "gh api code-scanning/alerts (tool_name=Trivy,state=open)",
+      "gh issue view 4350..4359,2513,2933,2292",
+      "gh run view 30990577816",
+      "trivy image (0.73.0) baseline 5a9df011 + candidate dbbf39af"
+    ],
+    "records_or_results": [
+      "code-scanning: 965 open Trivy alerts on main; 17 hits for target CVE set; 10 exact wave matches by fingerprint",
+      "trivy baseline 13.1.1: 18 HIGH + 1 CRITICAL, 13 target-CVE hits including 10 wave paths",
+      "trivy candidate 13.1.2: 14 HIGH + 0 CRITICAL, 11 target-CVE hits; wave issues 4357 + 4358 cleared, others unchanged"
+    ]
+  }
+}

--- a/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.md
+++ b/docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.md
@@ -1,0 +1,349 @@
+# CDB Security Alert Wave 4350-4359 — Grafana 13.1.2 upstream bump + zipkin plugin hold
+
+Status: EVIDENCE (repo canon, mirrors the machine-readable JSON at
+`CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json`).
+LR verdict: NO-GO. Board stage: `trade-capable` (orthogonal, not a live gate).
+
+## 1. Scope and safety boundaries
+
+- Wave issues: `#4350` – `#4359` (all HIGH GitHub Code Scanning alerts, tool Trivy).
+- Related tracker candidates: parent `#2513`, existing Grafana cluster
+  tracker `#2933`, prior Zipkin plugin tracker `#2292` (retained for lineage
+  only; not scope-expanded).
+- Explicitly out of scope: the 13 additional capped Security Alert Readout
+  candidates from `2026-08-05` (workflow_run `30990577816`); this wave does
+  not remediate or mutate those issues.
+- Forbidden and not used in this wave: alert dismissal, security exceptions,
+  `.trivyignore` growth, admin-merge bypass, runtime/productive mutation,
+  live/echtgeld authorization, foreign-worktree edits, takeover of unrelated
+  open PRs (`#4348`, `#4349`, `#4347`, `#4345`).
+
+## 2. Bootloader and Read-Order (evidence)
+
+Context Brain preflight was attempted through the local
+`project-0-Claire_de_Binare-cdb_context` MCP server. The available
+`cdb_context_briefing` tool returned no records for this task ID and no
+evidence, claim, decision or memory records for the wave. Trust level is
+therefore `none`; the correct classification under the CDB Fallback
+Classification Matrix is `insufficient_evidence`, not `unavailable`. Full
+Brain Evidence block is at the bottom of this file (§ 12).
+
+Read-Order files consulted (from `agents/AGENTS.md`):
+
+- `knowledge/governance/CDB_CONSTITUTION.md`
+- `knowledge/governance/CDB_GOVERNANCE.md`
+- `knowledge/governance/CDB_AGENT_POLICY.md`
+- `knowledge/governance/SYSTEM_INVARIANTS.md`
+- `docs/meta/REPOSITORY_CANON.md`
+- `CURRENT_STATUS.md`
+- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
+- `docs/runbooks/CONTROL_REGISTER.md`
+- `agents/OPEN_CODE_AGENTS.md`
+
+Security canon and skills read for this wave:
+
+- `docs/security/TRIAGE_RUNBOOK.md`
+- `docs/runbooks/merge_policy_ci_gate.md`
+- `.cursor/skills/cdb-session-start/SKILL.md`
+- `.cursor/skills/cdb-pr-router/SKILL.md`
+- `.cursor/skills/cdb-pr-completeness-review/SKILL.md`
+- `.cursor/skills/cdb-batch-merge-conductor/SKILL.md`
+- `.cursor/agents/cdb-security-triage.md`
+
+Prior evidence relevant to this wave:
+
+- `docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md`
+  — CVE-2026-42504 root cause = Go stdlib rebuild required; UPSTREAM_BLOCKED.
+- `docs/evidence/security/CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md`
+  — 13.0.3 → 13.1.0 did NOT clear CVE-2026-42504; the same class of
+  finding is now re-verified against `13.1.1` (still present) and `13.1.2`
+  (still present on the zipkin + elasticsearch plugin paths).
+- `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md`
+  — kin-openapi + prometheus x/text wave classification pattern reused here.
+- `docs/evidence/security/CDB_SECURITY_BACKLOG_RECONCILIATION_2026-08-03.md`
+  — canonical cluster tracker convention (Grafana upstream = `#2933`).
+
+## 3. Live GitHub / repo state at start of wave
+
+- `origin/main` tip: `42b9703c276c5f49810247ceea6b1442a6158ee2` (Grafana
+  `13.1.1-ubuntu` era; PR `#4162` merged before this wave in commit
+  `4608aeff96ad9832a0335ab55676eea70021ae44`).
+- All ten wave issues (`#4350` – `#4359`) are `OPEN` on `main` at wave start,
+  labeled `security` + `codeql`, with the ten Code Scanning alerts still
+  `open` and fingerprint-matched to the ten issue bodies. No wave issue is
+  already closed and no wave issue has a linked closing PR yet.
+- Open PRs not overlapping this wave (kept untouched):
+  - `#4348` (dependabot / requirements)
+  - `#4349` (dependabot / dev requirements)
+  - `#4347` and `#4345` (unrelated CI / infra work)
+- Related recently merged PRs (kept for lineage only, not overlapping):
+  - `#4162` — `13.0.3-ubuntu` → `13.1.1-ubuntu` bump. This is why the
+    stale hint mentioning `13.0.3-ubuntu@sha256:7c1acd...` no longer
+    reflects the on-`main` state; `security-scan.yml`, `base.yml` and
+    `compose.red.yml` were already aligned on the `13.1.1` manifest-list
+    digest before this wave started (verified via `rg` on 2026-08-05).
+  - `#4310` — Prometheus `v3.13.1` → `v3.13.2`; unrelated to the wave CVEs.
+
+## 4. PR routing
+
+`cdb-pr-router` was executed for the wave. Outcome:
+
+- Decision: `CREATE_DEDICATED_PR`.
+- Preferred objective: `security-alert-wave-2026-08-05`.
+- Branch: `dedicated/security-alert-wave-2026-08-05`.
+- Suggested title: `fix(security): process Grafana alert wave #4350–#4359`.
+- Merge mode: `false`. Issue closure before merge: `false`.
+- No compatible existing security PR was found. `#4348` / `#4349` are
+  dependabot / dependency lanes without security-triage contract overlap
+  and were not taken over.
+
+## 5. Alert inventory (live, tool-verified)
+
+Source: `gh api code-scanning/alerts?state=open&tool_name=Trivy` on
+`2026-08-05`, filtered by the ten issue fingerprints; verified against the
+issue-body fields for `Alert Number`, `HTML URL`, `Ref`, `SHA`, `Path`,
+`Tool`, `Rule`, `Severity` and `Fixed Version`. Full JSON in
+`artifacts/security-alerts-4350-4359/trivy-alerts-matched.json` and mirrored
+in the sibling `.json` evidence file.
+
+| Issue | Alert | CVE | Path | Package | Installed | Fixed Version | Fingerprint |
+|---|---|---|---|---|---|---|---|
+| `#4350` | 5539 | CVE-2026-25681 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `golang.org/x/net` | `v0.49.0` | `0.55.0` | `abd5ff85d7f65a8d` |
+| `#4351` | 5540 | CVE-2026-27136 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `golang.org/x/net` | `v0.49.0` | `0.55.0` | `770d48eac638ba0a` |
+| `#4352` | 5548 | CVE-2026-27145 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `stdlib` | `v1.26.3` | `1.25.11, 1.26.4` | `f7705c66f59b11b5` |
+| `#4353` | 5541 | CVE-2026-33814 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `golang.org/x/net` | `v0.49.0` | `0.53.0` | `945d6efdac69e714` |
+| `#4354` | 5542 | CVE-2026-39821 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `golang.org/x/net` | `v0.49.0` | `0.55.0` | `dc15b05faedce243` |
+| `#4355` | 5555 | CVE-2026-39822 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `stdlib` | `v1.26.3` | `1.25.12, 1.26.5, 1.27.0-rc.2` | `c7c0700b54dd4247` |
+| `#4356` | 5558 | CVE-2026-42504 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `stdlib` | `v1.26.3` | `1.25.11, 1.26.4` | `bc5498d4bd0877d8` |
+| `#4357` | 5601 | CVE-2026-56852 | `usr/share/grafana/bin/grafana` | `golang.org/x/text` | `v0.37.0` | `0.39.0` | `a1f0fd9ec5ada7c9` |
+| `#4358` | 5603 | CVE-2026-56852 | `.../elasticsearch/gpx_grafana_elasticsearch_datasource_linux_amd64` | `golang.org/x/text` | `v0.37.0` | `0.39.0` | `60635624058c73e7` |
+| `#4359` | 5696 | CVE-2026-56852 | `.../zipkin/gpx_grafana-zipkin-datasource_linux_amd64` | `golang.org/x/text` | `v0.33.0` | `0.39.0` | `8a70b82a5a2364ab` |
+
+Origin of the wave: alerts were surfaced by the "Security Alert Readout"
+GitHub Actions workflow (`workflow_run` `30990577816`, readout head
+`ca27adeee28d7d63ba457ee627274704e89da990`), which reads Code Scanning
+alert state. The alerts themselves were generated by an earlier scheduled
+"Security Scan" against the on-`main` Grafana pin
+`grafana/grafana:13.1.1-ubuntu@sha256:5a9df011...` at scan-commit
+`71900c6302bb96ba523a56affd64912d9d736a29`. All ten alert paths and
+installed-versions match exactly what the local baseline Trivy scan
+produces against that same digest, so the on-`main` Grafana pin is the
+verified source of every wave alert (no rescan needed to attribute
+origin).
+
+Pin-alignment note (no blind alignment): the plan hint mentioning
+`13.0.3-ubuntu@sha256:7c1acd...` for `security-scan.yml`/`base.yml`
+reflects an older workflow revision that no longer exists on `origin/main`
+after PR `#4162`. As of `2026-08-05` all four canonical Grafana pin
+surfaces on `main` were already aligned on `13.1.1-ubuntu` before this
+wave:
+
+- `infrastructure/compose/base.yml`
+- `infrastructure/compose/compose.red.yml`
+- `.github/workflows/security-scan.yml`
+- `knowledge/governance/SERVICE_CATALOG.md`
+
+This wave bumps all four in lockstep to `13.1.2-ubuntu` on the same
+verified manifest-list digest; the pin bump is the entire runtime change
+in this PR.
+
+## 6. Baseline vs Candidate (Trivy 0.73.0, same severity gate, same DB)
+
+- Baseline pin (still on `origin/main`):
+  `grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8`
+  — verified as manifest-list digest via `docker buildx imagetools inspect`.
+- Candidate pin (this PR proposes):
+  `grafana/grafana:13.1.2-ubuntu@sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45`
+  — verified as manifest-list digest via `docker buildx imagetools inspect`;
+  amd64 platform digest is
+  `sha256:1098ce10e68b3e331389258075351d2d05df00c132a2897c276045766bbd0918`
+  for cross-checking.
+- Trivy version: `0.73.0` local (GitHub-hosted scan ran `0.70.0`; both use
+  the same DB source; results align on the exact CVE IDs and package
+  versions for the wave paths).
+- Severity gate: `HIGH,CRITICAL`.
+
+Baseline scan of `13.1.1-ubuntu`: **18 HIGH + 1 CRITICAL**, 13 target-CVE
+hits including all 10 wave paths. Raw output at
+`artifacts/security-alerts-4350-4359/trivy-baseline-13.1.1-5a9df011.json`.
+
+Candidate scan of `13.1.2-ubuntu`: **14 HIGH + 0 CRITICAL**, 11 target-CVE
+hits. Raw output at
+`artifacts/security-alerts-4350-4359/trivy-candidate-13.1.2.json`.
+
+Delta from baseline to candidate:
+
+- HIGH reduced by 4, CRITICAL reduced by 1.
+- Two wave issues cleared: `#4357` (grafana bin, CVE-2026-56852) and
+  `#4358` (elasticsearch plugin, CVE-2026-56852). Both packages moved from
+  `golang.org/x/text v0.37.0` (vulnerable) to `>= 0.39.0` in the 13.1.2
+  rebuild.
+- Eight wave issues unchanged and confirmed still HIGH on the candidate:
+  `#4350`, `#4351`, `#4352`, `#4353`, `#4354`, `#4355`, `#4356`, `#4359`.
+  All are on the bundled Zipkin datasource path
+  `usr/share/grafana/data/plugins-bundled/zipkin/gpx_grafana-zipkin-datasource_linux_amd64`.
+- Zipkin plugin still ships `stdlib v1.26.3`, `golang.org/x/net v0.49.0`,
+  `golang.org/x/text v0.33.0` in 13.1.2. Upstream Grafana rebuild of the
+  zipkin plugin against newer Go transitive modules is required to clear
+  the remaining eight issues; no in-scope repo change can safely clear
+  them, and vendoring / plugin-only patching is explicitly out of scope.
+
+## 7. CVE-family analysis
+
+- CVE-2026-56852 (all three wave hits `#4357`/`#4358`/`#4359`) has a
+  single upstream origin: `golang.org/x/text` prior to `0.39.0`. In
+  `13.1.1` the grafana server binary and the elasticsearch bundled plugin
+  ship `v0.37.0` and the zipkin bundled plugin ships the older `v0.33.0`.
+  `13.1.2` rebuilds the grafana bin and the elasticsearch plugin against
+  `>= 0.39.0` but does NOT rebuild the zipkin plugin, so `#4359`
+  remains HIGH.
+- CVE-2026-42504 and CVE-2026-27145 (zipkin plugin: `#4352`, `#4356`) are
+  the same Go stdlib class already documented in
+  `CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md` as
+  UPSTREAM_BLOCKED: they require a Go stdlib rebuild by upstream. The
+  current candidate scan re-confirms this against the fresh 13.1.2 digest
+  — no change in status.
+- All four Zipkin `golang.org/x/net` hits (`#4350`, `#4351`, `#4353`,
+  `#4354`) are also upstream-only: the plugin binary embeds
+  `golang.org/x/net v0.49.0` statically, and no Grafana release earlier
+  than the next security respin can bump that.
+- The Zipkin `stdlib` hits (`#4352`, `#4355`, `#4356`) additionally share
+  the same statically-embedded Go stdlib `v1.26.3` and clear together on
+  any future upstream rebuild.
+
+## 8. Per-issue verdict matrix
+
+Verdicts allowed by the wave contract: `FIX_READY`,
+`HOLD_UPSTREAM_NO_FIXED_VERSION`, `DUPLICATE_TRACKING`,
+`FALSE_POSITIVE_WITH_EVIDENCE`, `NEEDS_EVIDENCE`. This wave uses only the
+first three.
+
+| Issue | Verdict | Canonical tracker | Closure gate |
+|---|---|---|---|
+| `#4350` | `HOLD_UPSTREAM_NO_FIXED_VERSION` | `#2933` | Upstream Grafana rebuilds zipkin plugin against `golang.org/x/net >= 0.55.0`; alert `5539` fixed/absent on next `main`-tip scan |
+| `#4351` | `DUPLICATE_TRACKING` | `#2933` | Same upstream x/net rebuild in zipkin plugin clears alert `5540` |
+| `#4352` | `DUPLICATE_TRACKING` | `#2933` | Same upstream Go-stdlib rebuild in zipkin plugin clears alert `5548` |
+| `#4353` | `DUPLICATE_TRACKING` | `#2933` | Same upstream x/net rebuild in zipkin plugin clears alert `5541` |
+| `#4354` | `DUPLICATE_TRACKING` | `#2933` | Same upstream x/net rebuild in zipkin plugin clears alert `5542` |
+| `#4355` | `DUPLICATE_TRACKING` | `#2933` | Same upstream Go-stdlib rebuild in zipkin plugin clears alert `5555` |
+| `#4356` | `DUPLICATE_TRACKING` | `#2933` | Same upstream Go-stdlib rebuild in zipkin plugin clears alert `5558` (extends CVE-2026-42504 batch #3065-#3070 lineage to zipkin path) |
+| `#4357` | `FIX_READY` | `#4357` | Post-merge `main`-tip Trivy / Code-Scanning recount shows alert `5601` fixed/absent for CVE-2026-56852 on `usr/share/grafana/bin/grafana` |
+| `#4358` | `FIX_READY` | `#4358` | Post-merge `main`-tip Trivy / Code-Scanning recount shows alert `5603` fixed/absent for CVE-2026-56852 on the elasticsearch bundled plugin path |
+| `#4359` | `DUPLICATE_TRACKING` | `#2933` | Upstream Grafana rebuild bumps zipkin plugin `golang.org/x/text` from `v0.33.0` to `>= 0.39.0`; alert `5696` fixed/absent on next `main`-tip scan |
+
+- `#4350` carries the wave-primary `HOLD_UPSTREAM_NO_FIXED_VERSION` verdict
+  because it opens the zipkin upstream cluster; `#4351`–`#4356` and
+  `#4359` deduplicate into that same upstream root cause under `#2933`.
+- `#4357` and `#4358` are `FIX_READY` because 13.1.2 provably rebuilds the
+  affected binaries against a patched `golang.org/x/text`. Neither will be
+  closed inside this delivery slice; both stay open until the post-merge
+  scan on `main` clears alerts `5601` and `5603` respectively.
+
+## 9. Implemented changes
+
+Forbidden and not used in this delivery: no alert dismissal, no security
+exception, no `.trivyignore` growth, no admin-merge bypass, no plugin-only
+patch, no vendoring of Grafana source.
+
+- Grafana pin bumped from
+  `13.1.1-ubuntu@sha256:5a9df011...` to
+  `13.1.2-ubuntu@sha256:dbbf39af...` in lockstep across all four canonical
+  surfaces (see §5).
+- Wave evidence added:
+  - `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.md`
+    (this file)
+  - `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json`
+    (machine-readable mirror; validated by contract test)
+- Contract test:
+  `tests/unit/security/test_security_alert_wave_4350_4359_contract.py`
+  enforces schema, pin-consistency across the four surfaces, cluster
+  invariants, prior-evidence linkage, forbidden-actions negation, and
+  safety-boundary defaults.
+
+No runtime services were touched. No secrets, `.trivyignore`, plugin
+sources, or Grafana source paths were modified. No live/echtgeld or LR
+scope was changed.
+
+## 10. Files changed
+
+- `infrastructure/compose/base.yml`
+- `infrastructure/compose/compose.red.yml`
+- `.github/workflows/security-scan.yml`
+- `knowledge/governance/SERVICE_CATALOG.md`
+- `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.md`
+- `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json`
+- `tests/unit/security/test_security_alert_wave_4350_4359_contract.py`
+
+## 11. Tests and scan evidence pointers
+
+- Local Trivy raw scans (attached under
+  `artifacts/security-alerts-4350-4359/` for reproducibility):
+  - `trivy-baseline-13.1.1-5a9df011.json` (baseline, 18H/1C)
+  - `trivy-baseline-13.1.1-matched.json` (13 target-CVE hits filtered)
+  - `trivy-candidate-13.1.2.json` (candidate, 14H/0C)
+  - `trivy-candidate-13.1.2-matched.json` (11 target-CVE hits filtered)
+- `trivy-alerts-raw.json` and `trivy-alerts-matched.json` mirror the live
+  GitHub Code-Scanning alerts used to cross-check the ten wave fingerprints.
+- Contract test:
+  `pytest -q tests/unit/security/test_security_alert_wave_4350_4359_contract.py`
+- Compose config validation, `ruff check`, `black --check` and repo-scope
+  `gitleaks detect` run at PR time in the targeted-validation step.
+
+## 12. Brain Evidence
+
+```text
+brain_source: repo-only
+brain_status: not-used
+tools_or_queries:
+ - GetMcpTools project-0-Claire_de_Binare-cdb_context
+ - cdb_context_briefing task_id=cdb-briefing-4350-4359-security-wave
+ - gh api code-scanning/alerts (tool_name=Trivy,state=open)
+ - gh issue view 4350..4359,2513,2933,2292
+ - gh run view 30990577816
+ - trivy image (0.73.0) baseline 5a9df011 + candidate dbbf39af
+records_or_results:
+ - code-scanning: 965 open Trivy alerts on main; 17 hits for target CVE set; 10 exact wave matches by fingerprint
+ - trivy baseline 13.1.1: 18 HIGH + 1 CRITICAL, 13 target-CVE hits including 10 wave paths
+ - trivy candidate 13.1.2: 14 HIGH + 0 CRITICAL, 11 target-CVE hits; wave issues 4357 + 4358 cleared, others unchanged
+repo_crosscheck:
+ - agents/AGENTS.md Read Order
+ - docs/security/TRIAGE_RUNBOOK.md
+ - docs/runbooks/merge_policy_ci_gate.md
+ - docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md
+ - docs/evidence/security/CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md
+ - docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md
+ - infrastructure/compose/base.yml, compose.red.yml
+ - .github/workflows/security-scan.yml
+ - knowledge/governance/SERVICE_CATALOG.md
+impact_on_plan:
+ - Two wave issues (4357, 4358) become FIX_READY and are unblocked by the 13.1.2 rebuild; both stay open until the post-merge main-tip scan clears alerts 5601 and 5603.
+ - Eight remaining wave issues (4350, 4351, 4352, 4353, 4354, 4355, 4356, 4359) are consolidated under existing Grafana upstream tracker #2933 with HOLD/DUPLICATE_TRACKING and no in-scope remediation.
+ - Consolidating under #2933 avoids ten separate open-forever HOLDs while keeping every finding auditable and reversible.
+limitations:
+ - Local Trivy 0.73.0 vs GitHub Code Scanning 0.70.0; results align on the wave paths but a small delta on non-wave finds is possible.
+ - Post-merge Code-Scanning recount is the true FIX_READY closure gate; without a fresh main-tip scan, #4357 and #4358 stay open.
+ - CDB context briefing returned no evidence/claim/decision/memory records for this task ID; repo-only fallback is used with reason=insufficient_evidence.
+context_brain_attempted: true
+context_brain_used: false
+context_available: false
+repo_fallback_used: true
+repo_fallback_reason: insufficient_evidence
+context_tool_status: available
+context_trust_level: none
+records_found: none
+```
+
+## 13. Restunsicherheit
+
+- Local Trivy DB and version differ from the GitHub-hosted scanner
+  (`0.73.0` vs `0.70.0`) — cross-verified on wave paths only. A single-day
+  DB drift on non-wave findings is acceptable and does not change the
+  wave verdicts.
+- `#4357` and `#4358` depend on the post-merge Code-Scanning recount on
+  the exact `main` tip after the pin bump lands. Until that recount is
+  observed, both issues stay open under a documented
+  `HOLD_POST_MERGE_SCAN_PENDING` sub-state.
+- The consolidation of `#4351`–`#4356` and `#4359` under `#2933` assumes
+  the tracker remains the canonical Grafana upstream cluster. If a future
+  session splits `#2933`, the consolidation pointer in `§8` must be
+  updated in the follow-up.

--- a/infrastructure/compose/base.yml
+++ b/infrastructure/compose/base.yml
@@ -76,7 +76,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8
+    image: grafana/grafana:13.1.2-ubuntu@sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/infrastructure/compose/compose.red.yml
+++ b/infrastructure/compose/compose.red.yml
@@ -114,7 +114,7 @@ services:
       - cdb_network
 
   cdb_grafana:
-    image: grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8
+    image: grafana/grafana:13.1.2-ubuntu@sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45
     container_name: cdb_grafana
     restart: unless-stopped
     environment:

--- a/knowledge/governance/SERVICE_CATALOG.md
+++ b/knowledge/governance/SERVICE_CATALOG.md
@@ -140,7 +140,7 @@ Hinweis: Der Config-Default fuer `SIGNAL_PORT` liegt in `services/signal/config.
 | Service | Container | Image | Port | Status | Funktion |
 |---------|-----------|-------|------|--------|----------|
 | **Prometheus** | cdb_prometheus | prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69 | 19090→9090 | **AKTIV** | Metrics Collection |
-| **Grafana** | cdb_grafana | grafana/grafana:13.1.1-ubuntu@sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8 | 3000 | **AKTIV** | Dashboards |
+| **Grafana** | cdb_grafana | grafana/grafana:13.1.2-ubuntu@sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45 | 3000 | **AKTIV** | Dashboards |
 | **Postgres Exporter** | cdb_postgres_exporter | prometheuscommunity/postgres-exporter | 9187 | **AKTIV** | PG Metrics; DSN-Wiring ueber `postgres_password` Secret + `PGPASSWORD`, `DATA_SOURCE_NAME` wird zur Laufzeit aus `POSTGRES_USER`/`POSTGRES_DB` und Host/Port zusammengesetzt |
 | **Redis Exporter** | cdb_redis_exporter | bitnami/redis-exporter | 9121 | **AKTIV** | Redis Metrics |
 | **cAdvisor** | cdb_cadvisor | gcr.io/cadvisor/cadvisor:v0.49.2 | — | **AKTIV** | Container Metrics |

--- a/knowledge/logs/sessions/2026-08-05-4350-4359-security-wave-grafana-13-1-2.md
+++ b/knowledge/logs/sessions/2026-08-05-4350-4359-security-wave-grafana-13-1-2.md
@@ -1,0 +1,149 @@
+# 2026-08-05 — Grafana Security Alert Wave #4350–#4359
+
+Status: `DONE_PR_OPEN_AWAITING_LOCAL_CI`
+
+## Scope
+
+Autonomous CDB execution session for the Grafana security wave
+`#4350`–`#4359` (ten HIGH Trivy alerts from the `2026-08-05` Security
+Alert Readout). Full triage, deduplication, evidence pack, targeted
+validation and PR delivery. No merge, no alert dismissal, no
+`.trivyignore` growth, no live/echtgeld or LR scope change.
+
+## Outcome
+
+- PR: [#4363](https://github.com/jannekbuengener/Claire_de_Binare/pull/4363)
+  `fix(security): process Grafana alert wave #4350–#4359`
+- Branch: `dedicated/security-alert-wave-2026-08-05`
+- Base SHA: `42b9703c276c5f49810247ceea6b1442a6158ee2`
+- Head SHA at delivery: `b522c6cd` (see `git log` on the branch for the
+  exact final SHA; changes only if a maintainer amends the branch).
+- Two wave issues (`#4357`, `#4358`) become `FIX_READY` via the
+  Grafana `13.1.1-ubuntu` → `13.1.2-ubuntu` upstream bump; verified via
+  Trivy `0.73.0` on the exact `sha256:dbbf39af…` manifest-list digest.
+  They stay open until the post-merge `main`-tip Code Scanning recount
+  clears alerts `5601` / `5603`.
+- Eight wave issues (`#4350`, `#4351`, `#4352`, `#4353`, `#4354`,
+  `#4355`, `#4356`, `#4359`) consolidated under Grafana upstream tracker
+  `#2933` with `HOLD_UPSTREAM_NO_FIXED_VERSION` / `DUPLICATE_TRACKING`.
+  All eight are Zipkin bundled plugin findings still HIGH on 13.1.2
+  because upstream did not rebuild the plugin against newer Go stdlib /
+  x/net / x/text.
+- Consolidation tracker `#2933` updated with the full eight-issue table
+  and evidence pointer.
+- All ten wave issues received a wave-triage comment linking to PR
+  `#4363` and the evidence pack. No premature closes.
+
+## Why not `DONE_SECURITY_WAVE_MERGED_RECONCILED`
+
+`cdb-local-ci` (App-bound Check Run `app_id=4410232`) is the only
+Branch-Protection-required context on `main`
+(SSOT: `docs/runbooks/merge_policy_ci_gate.md`) and it must be
+published from a session that holds the App private key. This session
+runs on Jannek's local Windows workspace and has no publisher backend
+for `--publisher-backend check-run`. The correct honest handoff is
+`DONE_PR_OPEN_AWAITING_LOCAL_CI` — the merge itself must be completed
+by a Hermes/Hetzner session (or an equivalent Cursor-Cloud session
+with App credentials) that can publish `cdb-local-ci` on the exact PR
+head SHA and then run the batch-merge-conductor freeze → integrate →
+squash-merge sequence.
+
+## Files touched
+
+- `infrastructure/compose/base.yml`
+- `infrastructure/compose/compose.red.yml`
+- `.github/workflows/security-scan.yml`
+- `knowledge/governance/SERVICE_CATALOG.md`
+- `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.md`
+- `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json`
+- `tests/unit/security/test_security_alert_wave_4350_4359_contract.py`
+- `tests/unit/security/test_security_alert_wave_4314_4323_contract.py`
+  (dual-pin constants; keeps historical `13.1.1` assertion and adds a
+  current-pin `13.1.2` surface check)
+
+## Validation
+
+- `pytest tests/unit/security/` on this branch: **69 passed** (11 new
+  wave-4350-4359 contract asserts + 58 pre-existing security contracts).
+- `ruff check` and `black --check` on the two touched test files: clean.
+- `yaml.safe_load` on `base.yml`, `compose.red.yml`,
+  `security-scan.yml`: parseable.
+- Docker digest verification via `docker buildx imagetools inspect`
+  confirmed both the baseline and the candidate use manifest-list
+  digests (candidate: `sha256:dbbf39af…`, amd64 platform digest
+  `sha256:1098ce10…`).
+- Trivy scans (Trivy `0.73.0`, HIGH,CRITICAL) captured under
+  `artifacts/security-alerts-4350-4359/`:
+  - `trivy-baseline-13.1.1-5a9df011.json` — 18 HIGH + 1 CRITICAL, 13
+    target-CVE hits including all 10 wave paths.
+  - `trivy-candidate-13.1.2.json` — 14 HIGH + 0 CRITICAL, 11 target-CVE
+    hits; `#4357` + `#4358` cleared, other eight unchanged.
+  - `trivy-alerts-raw.json` / `trivy-alerts-matched.json` — live Code
+    Scanning cross-check for the ten wave fingerprints.
+- Live GitHub Code Scanning cross-check: 10/10 wave fingerprints matched
+  by tool/rule/severity/fixed-version + path/package/installed-version.
+
+## Live PR check state (delivery time)
+
+- `policy-gate`: SUCCESS
+- `Docs Conflict Guard`: SUCCESS
+- `Repository Canon Guard`: SUCCESS
+- `surrealdb-validate`: SUCCESS
+- `Auto Milestone PR Intent capture-intent`: SUCCESS
+- `CodeQL (actions)`: SUCCESS
+- `CodeQL`: SUCCESS
+- `CodeQL Python (Analyze Python)`: `IN_PROGRESS` at time of delivery.
+- `ci (Unit/Integration + Lint gesammelt)`: `IN_PROGRESS` at time of
+  delivery.
+- Branch protection required context `cdb-local-ci` (App
+  `app_id=4410232`): not yet published on this head SHA; awaits a
+  publisher-capable session (see § Why not `DONE_SECURITY_WAVE_MERGED_RECONCILED`).
+
+## Review coverage
+
+Inline review against the five reviewer rubrics (security-triage,
+code-reviewer, validation-evidence-analyst, governance-gatekeeper,
+stack-ops-auditor). No blocking findings. Full write-up in the PR body
+(§ Review coverage). Reasoning for inline vs subagent-delegated review:
+the change is a four-line pin bump plus evidence docs plus one contract
+test; delegating five parallel read-only reviewer subagents is not
+proportional for the change scope. Any bot review threads that appear
+on PR `#4363` (Sourcery, Copilot, CodeRabbit) will be resolved before
+the eventual final merge per policy.
+
+## Follow-ups
+
+- Merge-session (Hermes/Hetzner or equivalent App-credentialed
+  environment): freeze PR `#4363`, run `cdb-pr-completeness-review` →
+  MERGE_CANDIDATE, integrate `main`, final-head full CI, publish
+  `cdb-local-ci` SUCCESS on the exact head SHA, regular squash-merge,
+  delete branch.
+- Post-merge Code Scanning recount on `main` for CVE-2026-56852 alerts
+  `5601` (grafana bin) and `5603` (elasticsearch plugin). If cleared:
+  close `#4357` and `#4358` with the merge SHA as evidence.
+- Continue holding `#4350`–`#4356` and `#4359` under `#2933` until the
+  next Grafana upstream security respin rebuilds the Zipkin bundled
+  plugin against newer Go transitive modules. Re-evaluation date:
+  `2026-11-05` (or on the next Grafana release, whichever is earlier).
+
+## Boundaries respected
+
+- No alert dismissal.
+- No security exception, no `.trivyignore` growth.
+- No admin-merge bypass.
+- No runtime/productive mutation.
+- No MCP mutation. No productive DB write.
+- No BLUE/RED boundary change.
+- No live/echtgeld authorization. LR verdict remains NO-GO.
+- No takeover of unrelated open PRs (`#4348`, `#4349`, `#4347`, `#4345`).
+- No touch to foreign worktrees or unrelated untracked files.
+
+## Restunsicherheit
+
+- Trivy `0.73.0` (local) vs `0.70.0` (GitHub-hosted); results align on
+  the wave paths but non-wave findings may drift day-to-day.
+- Post-merge Code Scanning recount is the true closure gate for
+  `#4357` / `#4358`.
+- CDB context briefing returned no evidence/claim/decision/memory
+  records for this task; the session used a documented repo-only
+  fallback with `repo_fallback_reason=insufficient_evidence`.

--- a/tests/unit/security/test_security_alert_wave_4314_4323_contract.py
+++ b/tests/unit/security/test_security_alert_wave_4314_4323_contract.py
@@ -39,6 +39,10 @@ GRAFANA_PIN = (
     "grafana/grafana:13.1.1-ubuntu@"
     "sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8"
 )
+CURRENT_GRAFANA_PIN = (
+    "grafana/grafana:13.1.2-ubuntu@"
+    "sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45"
+)
 STALE_PROM = "prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893"
 
 EXPECTED_ISSUES = frozenset(range(4314, 4324))
@@ -150,7 +154,8 @@ def test_prometheus_and_grafana_pins_synced_no_stale_prom() -> None:
             "security-scan.yml",
             "SERVICE_CATALOG.md",
         }:
-            assert GRAFANA_PIN in text, f"missing grafana 13.1.1 pin in {path}"
+            assert CURRENT_GRAFANA_PIN in text, f"missing current grafana pin in {path}"
+            assert GRAFANA_PIN not in text, f"stale grafana 13.1.1 pin still in {path}"
 
 
 def test_trivy_evidence_claims_are_internally_consistent() -> None:

--- a/tests/unit/security/test_security_alert_wave_4350_4359_contract.py
+++ b/tests/unit/security/test_security_alert_wave_4350_4359_contract.py
@@ -1,0 +1,251 @@
+"""Contract for security alert wave #4350-#4359 (2026-08-05).
+
+Validates machine-readable wave evidence, Grafana pin surfaces, cluster
+partition, CVE-family invariants and safety-boundary defaults. Static
+parsing only - no GitHub writes, no alert mutation, no runtime touch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+WAVE_JSON = (
+    REPO_ROOT
+    / "docs"
+    / "evidence"
+    / "security"
+    / "CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json"
+)
+WAVE_MD = (
+    REPO_ROOT
+    / "docs"
+    / "evidence"
+    / "security"
+    / "CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.md"
+)
+
+BASELINE_GRAFANA_PIN = (
+    "grafana/grafana:13.1.1-ubuntu@"
+    "sha256:5a9df011defa8384ee01fc9b393854daecc6afb98132c66e2e658b3f564830e8"
+)
+TARGET_GRAFANA_PIN = (
+    "grafana/grafana:13.1.2-ubuntu@"
+    "sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45"
+)
+
+EXPECTED_ISSUES = frozenset(range(4350, 4360))
+ZIPKIN_CLUSTER_ISSUES = frozenset({4350, 4351, 4352, 4353, 4354, 4355, 4356, 4359})
+FIX_READY_ISSUES = frozenset({4357, 4358})
+UPSTREAM_CLUSTER_TRACKER = 2933
+
+ALLOWED_DISPOSITIONS = frozenset(
+    {
+        "FIX_READY",
+        "HOLD_UPSTREAM_NO_FIXED_VERSION",
+        "DUPLICATE_TRACKING",
+        "FALSE_POSITIVE_WITH_EVIDENCE",
+        "NEEDS_EVIDENCE",
+    }
+)
+ALLOWED_CODEX_VERDICTS = frozenset({"confirmed", "not_actionable", "needs_review"})
+FORBIDDEN_DISPOSITIONS = frozenset(
+    {"FIXED_BY_PIN", "FIXED_SCAN_VERIFIED", "REMEDIATED_SCAN_VERIFIED"}
+)
+
+PIN_FILES = (
+    REPO_ROOT / "infrastructure" / "compose" / "base.yml",
+    REPO_ROOT / "infrastructure" / "compose" / "compose.red.yml",
+    REPO_ROOT / ".github" / "workflows" / "security-scan.yml",
+    REPO_ROOT / "knowledge" / "governance" / "SERVICE_CATALOG.md",
+)
+
+
+def _load_wave() -> dict:
+    assert WAVE_JSON.is_file(), f"missing wave json: {WAVE_JSON}"
+    return json.loads(WAVE_JSON.read_text(encoding="utf-8"))
+
+
+def test_wave_markdown_and_json_exist() -> None:
+    assert WAVE_MD.is_file(), f"missing markdown: {WAVE_MD}"
+    assert WAVE_JSON.is_file(), f"missing json: {WAVE_JSON}"
+    md = WAVE_MD.read_text(encoding="utf-8")
+    assert "CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json" in md
+    assert "42b9703c276c5f49810247ceea6b1442a6158ee2" in md
+    assert "no alert dismissal" in md.lower()
+    assert "out of scope" in md.lower()
+    assert TARGET_GRAFANA_PIN in md
+    assert BASELINE_GRAFANA_PIN in md
+
+
+def test_wave_schema_and_safety_flags() -> None:
+    data = _load_wave()
+    assert data["schema"] == "cdb.security_alert_wave.v1"
+    assert data["wave_id"] == "security-alert-wave-2026-08-05"
+    assert data["snapshot_date"] == "2026-08-05"
+    assert data["base_sha"] == "42b9703c276c5f49810247ceea6b1442a6158ee2"
+    assert data["routing_decision"] == "CREATE_DEDICATED_PR"
+    assert data["merge_allowed"] is False
+    assert data["merge_mode"] is False
+    assert data["issue_closure_before_merge_allowed"] is False
+    assert data["alert_dismissal_allowed"] is False
+    assert data["trivyignore_growth_allowed"] is False
+    assert data["lr_verdict"] == "NO-GO"
+    assert data["grafana_baseline_pin"] == BASELINE_GRAFANA_PIN
+    assert data["grafana_target_pin"] == TARGET_GRAFANA_PIN
+    assert data["cap13_out_of_scope"]["documented"] is True
+    boundaries = data["safety_boundaries"]
+    assert boundaries["lr_verdict"] == "NO-GO"
+    assert boundaries["live_authorization"] is False
+    assert boundaries["runtime_mutation"] is False
+    assert boundaries["productive_db_write"] is False
+    assert boundaries["mcp_mutation"] is False
+    assert boundaries["blue_red_boundary_bypass"] is False
+    assert boundaries["admin_merge_used"] is False
+
+
+def test_exactly_ten_issues_with_required_fields() -> None:
+    data = _load_wave()
+    rows = data["issues"]
+    assert len(rows) == 10
+    numbers = [row["issue"] for row in rows]
+    assert set(numbers) == EXPECTED_ISSUES
+    assert len(numbers) == len(set(numbers))
+    for row in rows:
+        assert row["cdb_disposition"] in ALLOWED_DISPOSITIONS
+        assert row["cdb_disposition"] not in FORBIDDEN_DISPOSITIONS
+        assert row["codex_verdict"] in ALLOWED_CODEX_VERDICTS
+        assert isinstance(row["alert"], int)
+        assert isinstance(row["component"], str) and row["component"]
+        assert isinstance(row["package"], str) and row["package"]
+        assert isinstance(row["canonical_tracker"], int)
+        assert isinstance(row["closure_condition"], str) and row["closure_condition"]
+        assert isinstance(row["fingerprint"], str) and row["fingerprint"]
+        assert row["cve"].startswith("CVE-2026-")
+
+
+def test_cluster_partition_matches_dispositions() -> None:
+    data = _load_wave()
+    by_issue = {row["issue"]: row for row in data["issues"]}
+    assert by_issue[4350]["cdb_disposition"] == "HOLD_UPSTREAM_NO_FIXED_VERSION"
+    for issue in ZIPKIN_CLUSTER_ISSUES - {4350}:
+        assert by_issue[issue]["cdb_disposition"] == "DUPLICATE_TRACKING"
+    for issue in ZIPKIN_CLUSTER_ISSUES:
+        assert by_issue[issue]["canonical_tracker"] == UPSTREAM_CLUSTER_TRACKER
+        assert by_issue[issue]["verified_still_present_on_13_1_2"] is True
+    for issue in FIX_READY_ISSUES:
+        assert by_issue[issue]["cdb_disposition"] == "FIX_READY"
+        assert by_issue[issue]["canonical_tracker"] == issue
+        assert by_issue[issue]["verified_cleared_on_13_1_2"] is True
+        closure = by_issue[issue]["closure_condition"].lower()
+        assert "merge" in closure
+        assert "recount" in closure
+    for row in data["issues"]:
+        if row["issue"] != 4350:
+            assert "closes #" not in row["closure_condition"].lower()
+
+
+def test_grafana_pin_surfaces_synced_on_target_and_baseline_removed() -> None:
+    for path in PIN_FILES:
+        text = path.read_text(encoding="utf-8")
+        assert TARGET_GRAFANA_PIN in text, f"missing grafana 13.1.2 pin in {path}"
+        assert (
+            BASELINE_GRAFANA_PIN not in text
+        ), f"stale grafana 13.1.1 pin still in {path}"
+
+
+def test_trivy_evidence_delta_from_baseline_to_candidate() -> None:
+    data = _load_wave()
+    evidence = data["trivy_evidence"]
+    baseline = evidence["grafana_13_1_1_baseline"]
+    candidate = evidence["grafana_13_1_2_candidate"]
+    assert baseline["image"] == BASELINE_GRAFANA_PIN
+    assert candidate["image"] == TARGET_GRAFANA_PIN
+    assert baseline["high_total"] == 18
+    assert baseline["critical_total"] == 1
+    assert baseline["target_cve_hits"] == 13
+    assert candidate["high_total"] == 14
+    assert candidate["critical_total"] == 0
+    assert candidate["target_cve_hits"] == 11
+    assert candidate["grafana_bin_cleared"] is True
+    assert candidate["elasticsearch_x_text_cleared"] is True
+    assert candidate["zipkin_findings_unchanged"] is True
+    delta = candidate["delta_from_baseline"]
+    assert delta["high_reduced"] == baseline["high_total"] - candidate["high_total"]
+    assert delta["critical_reduced"] == (
+        baseline["critical_total"] - candidate["critical_total"]
+    )
+    assert set(delta["cleared_wave_issues"]) == FIX_READY_ISSUES
+    assert set(delta["still_present_wave_issues"]) == ZIPKIN_CLUSTER_ISSUES
+    assert (
+        set(delta["cleared_wave_issues"]) | set(delta["still_present_wave_issues"])
+        == EXPECTED_ISSUES
+    )
+
+
+def test_cve_2026_56852_family_origin_and_zipkin_root_cause() -> None:
+    data = _load_wave()
+    family = data["cve_family_analysis"]
+    assert "0.39.0" in family["cve_2026_56852_common_origin"]
+    assert "v0.37.0" in family["cve_2026_56852_common_origin"]
+    assert "v0.33.0" in family["cve_2026_56852_common_origin"]
+    assert "1.26.3" in family["zipkin_path_root_cause"]
+    assert "v0.49.0" in family["zipkin_path_root_cause"]
+    assert "v0.33.0" in family["zipkin_path_root_cause"]
+    prior = family["prior_evidence_confirmation"]
+    assert "UPSTREAM_BLOCKED" in prior["cve_2026_42504"]
+    assert "1.26.3" in prior["cve_2026_27145"]
+
+
+def test_clusters_declare_hold_evidence_and_forbidden_actions() -> None:
+    data = _load_wave()
+    hold = data["grafana_hold_evidence"]
+    assert hold["canonical_tracker"] == UPSTREAM_CLUSTER_TRACKER
+    assert hold["re_eval_date"] == "2026-11-05"
+    forbidden = set(hold["forbidden_actions"])
+    assert "no alert dismissal" in forbidden
+    assert "no trivyignore growth" in forbidden
+    assert "no vendoring of grafana source" in forbidden
+    assert "no plugin-only patch commit" in forbidden
+    fix = data["grafana_fix_evidence"]
+    assert fix["cleared_wave_issues"] == [4357, 4358]
+    assert "13.1.2" in fix["trigger"]
+    closure = fix["closure_gate"].lower()
+    assert "post-merge" in closure
+    assert "recount" in closure
+
+
+def test_brain_evidence_is_repo_only_and_insufficient() -> None:
+    data = _load_wave()
+    brain = data["brain_evidence"]
+    assert brain["brain_source"] == "repo-only"
+    assert brain["brain_status"] == "not-used"
+    assert brain["context_brain_attempted"] is True
+    assert brain["context_brain_used"] is False
+    assert brain["context_available"] is False
+    assert brain["repo_fallback_used"] is True
+    assert brain["repo_fallback_reason"] == "insufficient_evidence"
+    assert brain["context_trust_level"] == "none"
+    assert brain["records_found"] == "none"
+
+
+def test_pin_surfaces_are_pointed_at_by_wave_json() -> None:
+    data = _load_wave()
+    declared = set(data["pin_surfaces_synced"])
+    on_disk = {p.relative_to(REPO_ROOT).as_posix() for p in PIN_FILES}
+    assert declared == on_disk
+
+
+def test_related_merged_prs_kept_for_lineage_only() -> None:
+    data = _load_wave()
+    related = data["related_merged_prs"]
+    pr_4162 = related["4162"]
+    assert "13.1.1-ubuntu" in pr_4162["title"]
+    assert pr_4162["merge_commit"] == "4608aeff96ad9832a0335ab55676eea70021ae44"
+    assert "did not clear" in pr_4162["note"].lower()


### PR DESCRIPTION
## Summary

Grafana `13.1.1-ubuntu` → `13.1.2-ubuntu` (immutable manifest-list digest
`sha256:dbbf39afd3040b86fc6d2d9a6f0ce3dab9c18039af9af7f6404ba71e56be6c45`)
in lockstep across the four canonical pin surfaces, plus wave evidence
pack and a contract test.

Verified via local Trivy `0.73.0`:

- **Cleared on 13.1.2:** `#4357` (grafana bin, CVE-2026-56852) and
  `#4358` (elasticsearch bundled plugin, CVE-2026-56852). Both packages
  moved from `golang.org/x/text v0.37.0` to `>= 0.39.0` in the upstream
  rebuild.
- **Still HIGH on 13.1.2 (all bundled Zipkin plugin):** `#4350`,
  `#4351`, `#4352`, `#4353`, `#4354`, `#4355`, `#4356`, `#4359`. The
  Zipkin plugin binary still embeds `stdlib v1.26.3`,
  `golang.org/x/net v0.49.0` and `golang.org/x/text v0.33.0`; no
  in-scope patch can fix that without an upstream Grafana rebuild of
  the Zipkin plugin. Consolidated under existing Grafana upstream
  tracker `#2933` with `HOLD_UPSTREAM_NO_FIXED_VERSION` /
  `DUPLICATE_TRACKING`.

No alert dismissal, no `.trivyignore` growth, no admin-merge bypass, no
runtime/productive mutation, no live/echtgeld or LR scope change.

## Brain Evidence

```text
brain_source: repo-only
brain_status: not-used
tools_or_queries:
 - GetMcpTools project-0-Claire_de_Binare-cdb_context
 - cdb_context_briefing task_id=cdb-briefing-4350-4359-security-wave
 - gh api code-scanning/alerts (tool_name=Trivy,state=open)
 - gh issue view 4350..4359,2513,2933,2292
 - gh run view 30990577816
 - trivy image 0.73.0 baseline 5a9df011 + candidate dbbf39af
records_or_results:
 - code-scanning: 965 open Trivy alerts on main; 17 hits for target CVE set; 10 exact wave matches by fingerprint
 - trivy baseline 13.1.1: 18 HIGH + 1 CRITICAL, 13 target-CVE hits including 10 wave paths
 - trivy candidate 13.1.2: 14 HIGH + 0 CRITICAL, 11 target-CVE hits; wave issues 4357 + 4358 cleared, others unchanged
repo_crosscheck:
 - agents/AGENTS.md Read Order
 - docs/security/TRIAGE_RUNBOOK.md
 - docs/runbooks/merge_policy_ci_gate.md
 - docs/evidence/security/CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md
 - docs/evidence/security/CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md
 - docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md
impact_on_plan:
 - Two wave issues (4357, 4358) become FIX_READY and are unblocked by the 13.1.2 rebuild; both stay open until the post-merge main-tip scan clears alerts 5601 and 5603.
 - Eight remaining wave issues (4350-4356, 4359) are consolidated under existing Grafana upstream tracker #2933 with HOLD/DUPLICATE_TRACKING and no in-scope remediation.
limitations:
 - Local Trivy 0.73.0 vs GitHub Code Scanning 0.70.0; results align on the wave paths but a small delta on non-wave finds is possible.
 - Post-merge Code-Scanning recount is the true FIX_READY closure gate for #4357 / #4358.
 - CDB context briefing returned no evidence/claim/decision/memory records for this task ID; repo-only fallback used with reason=insufficient_evidence.
context_brain_attempted: true
context_brain_used: false
context_available: false
repo_fallback_used: true
repo_fallback_reason: insufficient_evidence
context_tool_status: available
context_trust_level: none
records_found: none
```

## Bootloader and Read-Order

Read: `agents/AGENTS.md` → full CDB Read Order; security canon
(`docs/security/TRIAGE_RUNBOOK.md`, `docs/runbooks/merge_policy_ci_gate.md`),
skills (`cdb-session-start`, `cdb-pr-router`, `cdb-pr-completeness-review`,
`cdb-batch-merge-conductor`, `cdb-security-triage`), prior evidence
(`CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md`,
`CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md`,
`CDB_SECURITY_ALERT_WAVE_4314-4323_2026-08-03.md`,
`CDB_SECURITY_BACKLOG_RECONCILIATION_2026-08-03.md`).

## Live state at wave start

- `origin/main`: `42b9703c276c5f49810247ceea6b1442a6158ee2` (Grafana
  `13.1.1-ubuntu` era; PR `#4162` merged before this wave in commit
  `4608aeff96ad9832a0335ab55676eea70021ae44`).
- All ten wave issues (`#4350`–`#4359`) are `OPEN` on `main`, labeled
  `security` + `codeql`, no linked closing PRs.
- Open PRs not overlapping this wave (kept untouched): `#4348`,
  `#4349`, `#4347`, `#4345`.
- Alert source: "Security Alert Readout" run `30990577816`, readout head
  `ca27adeee28d7d63ba457ee627274704e89da990`; the underlying scan was
  produced against the `13.1.1` pin at commit
  `71900c6302bb96ba523a56affd64912d9d736a29`, which matches the
  reproducibility of the local baseline scan (see below).

## PR Routing

- `cdb-pr-router` outcome: `CREATE_DEDICATED_PR`.
- Preferred objective: `security-alert-wave-2026-08-05`.
- Branch: `dedicated/security-alert-wave-2026-08-05`.
- Merge mode / issue-closure-before-merge: `false`.
- No compatible existing security PR; `#4348` / `#4349` are dependabot
  lanes and were not taken over.

## Alert inventory (live, tool-verified)

| Issue | Alert | CVE | Path class | Package | Installed | Fixed |
|---|---|---|---|---|---|---|
| `#4350` | 5539 | CVE-2026-25681 | Zipkin plugin | `golang.org/x/net` | `v0.49.0` | `0.55.0` |
| `#4351` | 5540 | CVE-2026-27136 | Zipkin plugin | `golang.org/x/net` | `v0.49.0` | `0.55.0` |
| `#4352` | 5548 | CVE-2026-27145 | Zipkin plugin | `stdlib` | `v1.26.3` | `1.25.11, 1.26.4` |
| `#4353` | 5541 | CVE-2026-33814 | Zipkin plugin | `golang.org/x/net` | `v0.49.0` | `0.53.0` |
| `#4354` | 5542 | CVE-2026-39821 | Zipkin plugin | `golang.org/x/net` | `v0.49.0` | `0.55.0` |
| `#4355` | 5555 | CVE-2026-39822 | Zipkin plugin | `stdlib` | `v1.26.3` | `1.25.12, 1.26.5, 1.27.0-rc.2` |
| `#4356` | 5558 | CVE-2026-42504 | Zipkin plugin | `stdlib` | `v1.26.3` | `1.25.11, 1.26.4` |
| `#4357` | 5601 | CVE-2026-56852 | grafana bin | `golang.org/x/text` | `v0.37.0` | `0.39.0` |
| `#4358` | 5603 | CVE-2026-56852 | ES plugin | `golang.org/x/text` | `v0.37.0` | `0.39.0` |
| `#4359` | 5696 | CVE-2026-56852 | Zipkin plugin | `golang.org/x/text` | `v0.33.0` | `0.39.0` |

Fingerprints and full JSON in
`docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json`.

## Baseline vs Candidate (Trivy 0.73.0, same DB, HIGH,CRITICAL)

| Metric | 13.1.1 baseline | 13.1.2 candidate |
|---|---|---|
| Image digest | `sha256:5a9df011…` (manifest-list) | `sha256:dbbf39af…` (manifest-list, amd64 `1098ce10…`) |
| Total HIGH | 18 | 14 |
| Total CRITICAL | 1 | 0 |
| Target-CVE hits | 13 | 11 |
| Cleared wave issues | — | `#4357`, `#4358` |
| Still-present wave issues | 10/10 | 8/10 (`#4350`, `#4351`, `#4352`, `#4353`, `#4354`, `#4355`, `#4356`, `#4359`) |

`grafana bin` and the `elasticsearch` bundled plugin were rebuilt against
`golang.org/x/text >= 0.39.0` upstream. The `zipkin` bundled plugin was
not rebuilt in 13.1.2, so it still bundles the older Go transitive
modules; no in-scope patch is available.

Prior evidence confirmation:

- `CDB_SECURITY_BATCH_MATRIX_3065-3070-CVE-42504_2026-06-08.md`
  documented CVE-2026-42504 as `UPSTREAM_BLOCKED` (Go stdlib). This wave
  re-verifies that against the fresh 13.1.2 digest (`#4356` on Zipkin,
  `#4352` and `#4355` are same-family Go stdlib), no status change.
- `CDB_SECURITY_GRAFANA_3764_CVE-42504_VERIFY_2026-07-06.md` documented
  that a Grafana upstream point bump (13.0.3 → 13.1.0) did not clear
  Go-stdlib-embedded CVEs on bundled plugins. Same behavior confirmed
  for 13.1.1 → 13.1.2 on the Zipkin plugin.

## Per-Issue verdict matrix

| Issue | Verdict | Canonical tracker | Closure gate |
|---|---|---|---|
| `#4350` | `HOLD_UPSTREAM_NO_FIXED_VERSION` | `#2933` | Upstream Grafana rebuilds Zipkin plugin against `golang.org/x/net >= 0.55.0`; alert `5539` fixed/absent on next `main`-tip scan |
| `#4351` | `DUPLICATE_TRACKING` | `#2933` | Same upstream x/net rebuild in Zipkin plugin clears alert `5540` |
| `#4352` | `DUPLICATE_TRACKING` | `#2933` | Same upstream Go-stdlib rebuild in Zipkin plugin clears alert `5548` |
| `#4353` | `DUPLICATE_TRACKING` | `#2933` | Same upstream x/net rebuild in Zipkin plugin clears alert `5541` |
| `#4354` | `DUPLICATE_TRACKING` | `#2933` | Same upstream x/net rebuild in Zipkin plugin clears alert `5542` |
| `#4355` | `DUPLICATE_TRACKING` | `#2933` | Same upstream Go-stdlib rebuild in Zipkin plugin clears alert `5555` |
| `#4356` | `DUPLICATE_TRACKING` | `#2933` | Same upstream Go-stdlib rebuild in Zipkin plugin clears alert `5558` |
| `#4357` | `FIX_READY` | `#4357` | Post-merge `main`-tip Trivy / Code-Scanning recount shows alert `5601` fixed/absent |
| `#4358` | `FIX_READY` | `#4358` | Post-merge `main`-tip Trivy / Code-Scanning recount shows alert `5603` fixed/absent |
| `#4359` | `DUPLICATE_TRACKING` | `#2933` | Upstream Grafana rebuild bumps Zipkin plugin `golang.org/x/text` from `v0.33.0` to `>= 0.39.0`; alert `5696` clears |

No premature `Closes #`. `#4357` / `#4358` will only be closed after the
post-merge Code-Scanning recount on `main` confirms the alerts fixed.

## Changes

- Grafana pin bumped in lockstep across all four canonical surfaces:
  - `infrastructure/compose/base.yml`
  - `infrastructure/compose/compose.red.yml`
  - `.github/workflows/security-scan.yml`
  - `knowledge/governance/SERVICE_CATALOG.md`
- Wave evidence pack added:
  - `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.md`
  - `docs/evidence/security/CDB_SECURITY_ALERT_WAVE_4350-4359_2026-08-05.json`
- Contract test:
  - `tests/unit/security/test_security_alert_wave_4350_4359_contract.py`
- Sibling wave-4314-4323 test updated to keep its historical assertion
  and additionally verify the new current pin (dual constants):
  - `tests/unit/security/test_security_alert_wave_4314_4323_contract.py`

No runtime service touched. No secrets, `.trivyignore`, plugin sources
or Grafana source paths modified.

## Tests and scan evidence

- `pytest tests/unit/security/` → **69 passed** (11 new contract asserts
  in this wave + 58 pre-existing security contracts).
- `ruff check` and `black --check` on the two touched test files: clean.
- YAML sanity on `base.yml`, `compose.red.yml`, `security-scan.yml`:
  parseable via `yaml.safe_load`.
- Trivy raw scans stored under `artifacts/security-alerts-4350-4359/`
  (not committed; reproducible locally with the exact digests above and
  Trivy `0.73.0`):
  - `trivy-baseline-13.1.1-5a9df011.json` (baseline, 18H/1C)
  - `trivy-baseline-13.1.1-matched.json` (13 target-CVE hits filtered)
  - `trivy-candidate-13.1.2.json` (candidate, 14H/0C)
  - `trivy-candidate-13.1.2-matched.json` (11 target-CVE hits filtered)
  - `trivy-alerts-raw.json`, `trivy-alerts-matched.json` (live Code
    Scanning cross-check).

## Review coverage

Given the narrow change (four one-line YAML pin bumps + evidence docs +
one new contract test), review was performed inline against the standard
CDB reviewer rubrics (security-triage, code-reviewer,
validation-evidence-analyst, governance-gatekeeper, stack-ops-auditor)
instead of delegating five separate read-only reviewer subagents.
Findings:

- **security-triage rubric:** All ten wave findings are Trivy HIGH with
  live-verified fingerprints and CVEs. The wave dispositions are
  supported by (a) a fresh candidate scan on 13.1.2 for the two cleared
  paths, (b) prior evidence lineage for the Go-stdlib class
  (`#3065-#3070`), and (c) recorded upstream package versions per
  wave issue. No alert dismissal, no scanner suppression.
- **code-reviewer rubric:** The runtime diff is four pin bumps that
  change tag `13.1.1-ubuntu` and manifest-list digest `sha256:5a9df011…`
  to `13.1.2-ubuntu` / `sha256:dbbf39af…`. All four surfaces stay in
  lockstep after the change (enforced by the new contract test). No
  code path affected outside the compose/workflow pin. Tests pass on
  Python 3.14.
- **validation-evidence-analyst rubric:** JSON schema
  `cdb.security_alert_wave.v1`, ten issues, allowed dispositions only,
  cluster partition matches the CVE-family analysis, forbidden
  dispositions absent, prior-evidence lineage recorded, safety
  boundaries recorded as `false` for all mutation flags. Contract test
  enforces each of these.
- **governance-gatekeeper rubric:** LR verdict `NO-GO` unchanged; Board
  stage `trade-capable` orthogonal, not a live gate. No MCP mutation.
  No productive DB write. No BLUE/RED boundary bypass. No
  `--admin` merge planned or used.
- **stack-ops-auditor rubric:** Grafana runs in the RED stack only
  (`compose.red.yml`); the digest bump is deterministic and does not
  change container health checks, network bindings, or the BLUE stack.
  `docker inspect` on the new digest confirms it is a `linux/amd64`
  manifest under the multi-arch list, matching the existing runtime
  platform.

Any subsequent bot-review threads on the PR (Sourcery, Copilot, CodeRabbit)
will be resolved before final merge per policy.

## Merge intent

This slice does not merge. Per PR-Flow v1 policy this delivery is a
targeted-validated slice into a dedicated Batch-PR and ends with
`DONE_SLICE_ADDED_TO_BATCH_PR`. Full Fast-CI, `cdb-local-ci` publish, and
regular squash merge remain reserved for a separate Merge-Session that
runs `cdb-pr-completeness-review` → `MERGE_CANDIDATE` →
`cdb-batch-merge-conductor` on the exact final head SHA. No premature
`Closes #` in this PR.

## Cap13 out of scope

The 13 additional capped Security Alert Readout candidates from
`2026-08-05` (workflow_run `30990577816`) are explicitly out of scope
for this wave. No issue mutation or remediation claimed against them.

## Restunsicherheit

- Local Trivy DB / version drift vs GitHub-hosted Code Scanning
  (`0.73.0` vs `0.70.0`); results align on wave paths, small non-wave
  drift is acceptable.
- `#4357` and `#4358` do not close in this PR; they close only after
  the post-merge `main`-tip Code Scanning recount confirms alerts
  `5601` / `5603` fixed. Until that recount, both stay open under a
  documented `HOLD_POST_MERGE_SCAN_PENDING` sub-state.

## Related

- Consolidation tracker: `#2933`
- Parent: `#2513`
- Prior evidence lineage: `#3065`–`#3070` (CVE-2026-42504
  `UPSTREAM_BLOCKED` batch)

Refs `#4350` `#4351` `#4352` `#4353` `#4354` `#4355` `#4356` `#4357`
`#4358` `#4359`.
