### PR TITLE
chore(security): run security-alert-readout monthly instead of 3x/week

### DIFF
--- a/.github/workflows/security-alert-readout.yml
+++ b/.github/workflows/security-alert-readout.yml
@@ -2,7 +2,8 @@ name: Security Alert Readout
 
 # Generates a machine-readable GitHub security alert readout (code_scanning,
 # dependabot, secret_scanning) and computes a delta against the most recent
-# previous readout.  Runs Mon/Wed/Fri; always available for manual dispatch.
+# previous readout.  Runs monthly (1st of month, 06:15 UTC); always available
+# for manual dispatch.
 #
 # Artifacts-only mode (default): readout and delta are uploaded as GitHub Actions
 # artifacts (retention: 30 days).  No direct commit to main is attempted.
@@ -13,6 +14,11 @@ name: Security Alert Readout
 # failed with GH006 (protected branch — changes must be made via PR).  See
 # fix/security-readout-disable-direct-publish-2289 for details.
 #
+# Schedule history: originally scheduled 3x/week (Mon/Wed/Fri 06:15 UTC).
+# Reduced to monthly cadence after the Grafana security alert wave
+# #4350–#4359 was processed in PR #4363 (merged as ee2a5c81) — the readout
+# cadence should follow triage/backlog pace, not repeat weekly.
+#
 # Refs: #2289 (security alert monitoring epic)
 # Related scripts:
 #   scripts/audit/github_security_quality_readout.py  (read-only fetcher)
@@ -20,9 +26,7 @@ name: Security Alert Readout
 
 on:
   schedule:
-    - cron: "15 6 * * 1"  # Monday   06:15 UTC
-    - cron: "15 6 * * 3"  # Wednesday 06:15 UTC
-    - cron: "15 6 * * 5"  # Friday   06:15 UTC
+    - cron: "15 6 1 * *"  # Monthly on the 1st, 06:15 UTC
   workflow_dispatch:
     inputs:
       publish_mode:

--- a/docs/security/TRIAGE_RUNBOOK.md
+++ b/docs/security/TRIAGE_RUNBOOK.md
@@ -162,7 +162,10 @@ Gruppierung nach:
 ### Zweck
 
 Das Workflow `.github/workflows/security-alert-readout.yml` läuft automatisch
-**Mo / Mi / Fr um 06:15 UTC** und kann jederzeit manuell ausgelöst werden.  
+**am 1. jedes Monats um 06:15 UTC** und kann jederzeit manuell ausgelöst werden.
+Die Kadenz wurde nach der Grafana-Alert-Welle #4350–#4359 (PR #4363, gemergt
+als `ee2a5c81`) von 3x/Woche auf monatlich reduziert — die Readout-Kadenz
+folgt Triage-/Backlog-Rhythmus, nicht Wochentakt.  
 Es kombiniert zwei Read-only-Skripte:
 
 | Skript | Zweck |


### PR DESCRIPTION
## Summary

Reduce the **Security Alert Readout** schedule from **3×/week (Mon/Wed/Fri 06:15 UTC)** to **monthly (1st of month, 06:15 UTC)** after the Grafana security alert wave [#4350–#4359](https://github.com/jannekbuengener/Claire_de_Binare/issues/4350) was processed in [#4363](https://github.com/jannekbuengener/Claire_de_Binare/pull/4363) (merged as `ee2a5c81`).

- **File**: `.github/workflows/security-alert-readout.yml` (workflow "Security Alert Readout", DB ID 274172858)
- **Cron before**: `15 6 * * 1`, `15 6 * * 3`, `15 6 * * 5` (Mon/Wed/Fri 06:15 UTC)
- **Cron after**: `15 6 1 * *` (1st of every month, 06:15 UTC)
- **Uhrzeit** bewusst beibehalten (06:15 UTC / ~08:15 CET / ~09:15 CEST) — nur die Kadenz ändert sich.
- `workflow_dispatch` bleibt jederzeit verfügbar.

### Rationale
- Der Readout ist ein Triage-/Backlog-Signal, kein Runtime-Health-Probe.
- Nach abgeschlossener Wellenverarbeitung existiert kein laufender Wave-Backlog, der Mo/Mi/Fr rechtfertigt.
- Monatliche Kadenz passt zum typischen Grafana/CodeQL/Trivy-Backlog-Rhythmus und reduziert Rauschen auf Epic [#2289](https://github.com/jannekbuengener/Claire_de_Binare/issues/2289) (Ledger-Kommentare) und im `issue-automation`-Live-Pfad (Scheduled-Runs bleiben `LIVE_MODE=true`, laufen nur noch monatlich).

### Live-Evidence
- Letzter Run unter alter Kadenz: [Actions run 30990577816](https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/30990577816) (Workflow "Security Alert Readout", `event=schedule`, `conclusion=success`, `headSha=ca27adee`).
- Origin/main-Head: `de09abbe` (nach `ee2a5c81`/#4363).
- PR-Head-SHA: `ae473c0c`.

### Files changed
- `.github/workflows/security-alert-readout.yml` — 3 Cron-Einträge → 1 monatlicher Cron; Header-Kommentar auf monatliche Kadenz aktualisiert; Schedule-History-Note ergänzt.
- `docs/security/TRIAGE_RUNBOOK.md` §9 (Automated Readout Workflow) — Zweck-Absatz auf "am 1. jedes Monats um 06:15 UTC" umgestellt; Wave-Referenz ergänzt.

### Validation
- `python -c "import yaml; yaml.safe_load(...)"` → YAML valid; `schedule=[{'cron': '15 6 1 * *'}]`; Jobs unverändert (`security-readout`, `persist-via-pr`, `comment-epic`, `issue-automation`).
- `pytest tests/unit/scripts/test_security_workflow_boundary_contract.py tests/unit/scripts/test_scheduled_workflow_cadence_contract.py tests/unit/scripts/test_security_alert_readout_workflow_contract.py` → **51 passed** (1.24s). Insbesondere:
  - `test_security_workflows_declare_schedule_trigger[security-alert-readout.yml-True]` → PASS
  - `test_security_alert_readout_manual_publish_defaults_to_dry_run` → PASS
  - `test_security_alert_readout_scheduled_vs_manual_boundary_is_documented` → PASS
  - `test_manual_issue_automation_live_input_defaults_false` → PASS
  - `test_issue_automation_scheduled_runs_default_to_live_mode` → PASS
- `security-alert-readout.yml` ist **nicht** Teil der `P1_SCHEDULED_WORKFLOW_FILES`-Cadence-Parametrize in `test_scheduled_workflow_cadence_contract.py`; keine Cron-String-Assertion existiert für diesen Workflow.

### Non-goals (explicit)
- **Keine** Scanner-Unterdrückung, kein `.trivyignore`, keine Alert-Dismissals.
- **Keine** Severity-/Policy-Abschwächung; ausschließlich Schedule-Kadenz.
- **Keine** Änderungen an Permissions, `issue-automation`-Cap-Logik, Dedupe-Markern, Publish-Mode-Gating oder `persist_via_pr`-Pfad.
- **Keine** Runtime-/LR-/Live-/Echtgeld-Semantik. LR bleibt `NO-GO`.
- **Keine** Änderung an anderen Security-Workflows (`security-scan.yml` bleibt bimonthly `0 2 1 2,4,6,8,10,12 *`; `trivy.yml`, `gitleaks.yml`, `codeql-python.yml` unverändert).

### Refs
- Wave: [#4350–#4359](https://github.com/jannekbuengener/Claire_de_Binare/issues/4350), resolved in [#4363](https://github.com/jannekbuengener/Claire_de_Binare/pull/4363) (`ee2a5c81`)
- Epic: [#2289](https://github.com/jannekbuengener/Claire_de_Binare/issues/2289) (security alert monitoring)
- Letzter Old-Cadence-Run: [Actions run 30990577816](https://github.com/jannekbuengener/Claire_de_Binare/actions/runs/30990577816)
