### PR TITLE
fix(security): raise aiohttp/cryptography floors for HIGH CVEs

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ flask==3.1.3
 werkzeug>=3.1.8  # Security: CVE fixes
 psycopg2-binary==2.9.12
 requests==2.34.2
-cryptography==49.0.0
+cryptography==50.0.0
 aiohttp>=3.14.3
 python-dateutil==2.8.2
 tabulate==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@
 # Utilities
 # Web Framework
 aiohttp>=3.14.3
-cryptography==49.0.0
+cryptography==50.0.0
 flask==3.1.3
 werkzeug>=3.1.8  # Security: Fix CVEs in Dependabot alerts #339
 psycopg2-binary==2.9.12

--- a/services/execution/requirements.txt
+++ b/services/execution/requirements.txt
@@ -15,10 +15,10 @@ psycopg2-binary==2.9.12
 requests==2.33.0
 
 # Async Support
-aiohttp==3.14.1
+aiohttp==3.14.3
 
 # Crypto & Signing (für MEXC API)
-cryptography==48.0.1
+cryptography==50.0.0
 
 # Environment Variables
 python-dotenv==1.2.2

--- a/tests/unit/security/test_pip_crypto_aiohttp_pin_contract_2026_08_05.py
+++ b/tests/unit/security/test_pip_crypto_aiohttp_pin_contract_2026_08_05.py
@@ -1,0 +1,76 @@
+"""Contract: aiohttp/cryptography pin floors for HIGH CVEs (2026-08-05 campaign).
+
+Guards remediation of:
+- CVE-2026-69244 (aiohttp < 3.14.3)
+- CVE-2026-69247 (cryptography < 50.0.0)
+- CVE-2026-69249 / CVE-2026-69248 (cryptography < 49.0.0; subsumed by 50.0.0)
+
+Static requirements parsing only — no image build, no alert dismissal.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+AIOHTTP_FLOOR = (3, 14, 3)
+CRYPTOGRAPHY_FLOOR = (50, 0, 0)
+
+EXECUTION_REQ = REPO_ROOT / "services" / "execution" / "requirements.txt"
+ROOT_REQ = REPO_ROOT / "requirements.txt"
+DEV_REQ = REPO_ROOT / "requirements-dev.txt"
+
+
+def _parse_eq_pin(text: str, name: str) -> tuple[int, ...]:
+    m = re.search(rf"(?m)^{re.escape(name)}==([0-9]+(?:\.[0-9]+)*)\s*$", text)
+    assert m, f"missing exact pin {name}== in requirements"
+    return tuple(int(p) for p in m.group(1).split("."))
+
+
+def _parse_ge_or_eq_pin(text: str, name: str) -> tuple[int, ...]:
+    m = re.search(
+        rf"(?m)^{re.escape(name)}(?:==|>=)([0-9]+(?:\.[0-9]+)*)\s*$",
+        text,
+    )
+    assert m, f"missing pin {name} in requirements"
+    return tuple(int(p) for p in m.group(1).split("."))
+
+
+def test_execution_aiohttp_meets_high_cve_floor() -> None:
+    text = EXECUTION_REQ.read_text(encoding="utf-8")
+    assert _parse_eq_pin(text, "aiohttp") >= AIOHTTP_FLOOR
+
+
+def test_execution_cryptography_meets_high_cve_floor() -> None:
+    text = EXECUTION_REQ.read_text(encoding="utf-8")
+    assert _parse_eq_pin(text, "cryptography") >= CRYPTOGRAPHY_FLOOR
+
+
+def test_root_and_dev_cryptography_meet_high_cve_floor() -> None:
+    for path in (ROOT_REQ, DEV_REQ):
+        text = path.read_text(encoding="utf-8")
+        assert _parse_ge_or_eq_pin(text, "cryptography") >= CRYPTOGRAPHY_FLOOR
+
+
+def test_root_and_dev_aiohttp_meet_high_cve_floor() -> None:
+    for path in (ROOT_REQ, DEV_REQ):
+        text = path.read_text(encoding="utf-8")
+        assert _parse_ge_or_eq_pin(text, "aiohttp") >= AIOHTTP_FLOOR
+
+
+def test_cves_not_silenced_in_trivyignore() -> None:
+    ignore = REPO_ROOT / ".trivyignore"
+    text = ignore.read_text(encoding="utf-8") if ignore.is_file() else ""
+    for cve in (
+        "CVE-2026-69244",
+        "CVE-2026-69247",
+        "CVE-2026-69248",
+        "CVE-2026-69249",
+    ):
+        assert cve not in text, f"{cve} must not be ignored"


### PR DESCRIPTION
## Summary
- Pin `services/execution` `aiohttp==3.14.3` and `cryptography==50.0.0` to clear Trivy HIGH CVE-2026-69244 / CVE-2026-69247 (and subsumed 69248/69249).
- Align root/`requirements-dev` cryptography floor to `50.0.0`.
- Add static pin contract tests; no `.trivyignore` growth, no alert dismissals.
- Supersedes Dependabot #4348 / #4349 scope for these floors.

## Test plan
- [x] `pytest -q tests/unit/security/test_pip_crypto_aiohttp_pin_contract_2026_08_05.py`
- [ ] Hosted CI green
- [ ] `cdb-local-ci` SUCCESS on exact head
- [ ] Post-merge main tip rescan shows related alerts fixed

Refs #2513