### PR TITLE
fix(security): bump setuptools pin floor to 83.0.0

### DIFF
--- a/infrastructure/compose/Dockerfile.test
+++ b/infrastructure/compose/Dockerfile.test
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Fix CVE-2026-23949 (jaraco.context), CVE-2026-24049 (wheel)
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # Copy requirements (all service dependencies for E2E tests)
 COPY requirements.txt /app/

--- a/services/allocation/Dockerfile
+++ b/services/allocation/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # System-Dependencies
 RUN apt-get update && apt-get install -y \

--- a/services/candles/Dockerfile
+++ b/services/candles/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # System-Dependencies
 RUN apt-get update && apt-get install -y \

--- a/services/db_writer/Dockerfile
+++ b/services/db_writer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # Install dependencies
 RUN pip install --no-cache-dir redis psycopg2-binary prometheus-client

--- a/services/execution/Dockerfile
+++ b/services/execution/Dockerfile
@@ -26,7 +26,7 @@ COPY services/execution/requirements.txt ./
 # image path — Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643.
 RUN python -m venv /venv \
     && /venv/bin/pip install --upgrade pip==26.1.2 \
-    && /venv/bin/pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2 \
+    && /venv/bin/pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2 \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
 FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
@@ -48,7 +48,7 @@ RUN apt-get update \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643 (global runtime pip)
 RUN pip install --upgrade pip==26.1.2
 

--- a/services/market/Dockerfile
+++ b/services/market/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 COPY services/market/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/services/regime/Dockerfile
+++ b/services/regime/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # System-Dependencies
 RUN apt-get update && apt-get install -y \

--- a/services/reports/Dockerfile
+++ b/services/reports/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN pip install --upgrade pip==26.1.2
 
 # Fix CVE-2026-23949 (jaraco.context), CVE-2026-24049 (wheel)
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # Install system dependencies (procps for pgrep healthcheck)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/risk/Dockerfile
+++ b/services/risk/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 COPY services/risk/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/services/signal/Dockerfile
+++ b/services/signal/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
 # Python deps
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 COPY services/signal/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/services/ws/Dockerfile
+++ b/services/ws/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
 
 # Security pin (#4095): pip 26.1.2 fixes CVE-2026-8643, supersedes the CVE-2025-8869 pin
 RUN pip install --upgrade pip==26.1.2
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # System dependencies
 RUN apt-get update && apt-get install -y \

--- a/tests/unit/security/test_setuptools_pin_contract_2026_08_05.py
+++ b/tests/unit/security/test_setuptools_pin_contract_2026_08_05.py
@@ -1,11 +1,15 @@
 """Contract: setuptools pin floor CVE-2026-59890 (2026-08-05)."""
+
 from __future__ import annotations
 from pathlib import Path
 import re
 import pytest
+
 pytestmark = [pytest.mark.unit, pytest.mark.contract]
 REPO = Path(__file__).resolve().parents[3]
 FLOOR = (83, 0, 0)
+
+
 def test_dockerfiles_pin_setuptools_at_or_above_floor() -> None:
     bad = []
     for path in REPO.rglob("Dockerfile*"):
@@ -15,6 +19,8 @@ def test_dockerfiles_pin_setuptools_at_or_above_floor() -> None:
             if ver < FLOOR:
                 bad.append((str(path.relative_to(REPO)), m.group(1)))
     assert bad == [], f"setuptools pins below 83.0.0: {bad}"
+
+
 def test_cve_not_in_trivyignore() -> None:
     ignore = REPO / ".trivyignore"
     text = ignore.read_text(encoding="utf-8") if ignore.is_file() else ""

--- a/tests/unit/security/test_setuptools_pin_contract_2026_08_05.py
+++ b/tests/unit/security/test_setuptools_pin_contract_2026_08_05.py
@@ -1,0 +1,21 @@
+"""Contract: setuptools pin floor CVE-2026-59890 (2026-08-05)."""
+from __future__ import annotations
+from pathlib import Path
+import re
+import pytest
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+REPO = Path(__file__).resolve().parents[3]
+FLOOR = (83, 0, 0)
+def test_dockerfiles_pin_setuptools_at_or_above_floor() -> None:
+    bad = []
+    for path in REPO.rglob("Dockerfile*"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for m in re.finditer(r"setuptools==([0-9]+(?:\.[0-9]+)*)", text):
+            ver = tuple(int(p) for p in m.group(1).split("."))
+            if ver < FLOOR:
+                bad.append((str(path.relative_to(REPO)), m.group(1)))
+    assert bad == [], f"setuptools pins below 83.0.0: {bad}"
+def test_cve_not_in_trivyignore() -> None:
+    ignore = REPO / ".trivyignore"
+    text = ignore.read_text(encoding="utf-8") if ignore.is_file() else ""
+    assert "CVE-2026-59890" not in text

--- a/tools/paper_trading/Dockerfile
+++ b/tools/paper_trading/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 RUN pip install --upgrade pip==26.1.2
 
 # Fix CVE-2026-23949 (jaraco.context), CVE-2026-24049 (wheel)
-RUN python -m pip install --no-cache-dir --upgrade setuptools==82.0.0 wheel==0.46.2
+RUN python -m pip install --no-cache-dir --upgrade setuptools==83.0.0 wheel==0.46.2
 
 # Copy requirements first (for layer caching)
 COPY tools/paper_trading/requirements.txt /app/tools/paper_trading/


### PR DESCRIPTION
## Summary
- Bump `setuptools==82.0.0` → `83.0.0` across productive Dockerfiles (CVE-2026-59890 MEDIUM).
- Add static pin contract; no `.trivyignore` growth; no dismissals.

## Test plan
- [x] `pytest -q tests/unit/security/test_setuptools_pin_contract_2026_08_05.py`
- [ ] Hosted CI / `cdb-local-ci` on exact head
- [ ] Post-merge rescan

Refs #2513