### PR TITLE
[ARVP][CAMPAIGN] #4374 wire authorized hh_hl replay execution

### DIFF
--- a/docs/evidence/arvp_hh_hl_execution_wiring_4374.md
+++ b/docs/evidence/arvp_hh_hl_execution_wiring_4374.md
@@ -41,6 +41,40 @@ Owner Execution-GO (live verify)
 - No Owner-GO post/edit
 - No analyzer / reproduction / Stage-B / paper / live / promotion
 
+## Auth / runtime-gate hardening (PR #4380 follow-up)
+
+Status: `DONE_PR_4380_AUTH_RUNTIME_GATES_HARDENED` candidate evidence.
+
+### Removed public test surfaces
+
+- Removed `--fixture-json` and `--design-go-fixture-json` from
+  `hh_hl_campaign_execute` argparse.
+- Production `_owner_go_fetcher` always resolves to
+  `default_gh_comment_fetcher` unless a private `_test_set_owner_go_fetcher`
+  injection is active (unit tests only).
+- Design-GO receipt resolution uses reference receipt only (no CLI fixture).
+- No env-var / hidden CLI offline bypass.
+
+### Runtime surface gate
+
+- Removed tautological
+  `payload.surface_capability_fingerprint == ctx.surface_capability_fingerprint`
+  self-check (never claimed as current-surface proof).
+- `surface_capability_fingerprint` retained as Owner-authorized historical
+  post-merge surface-receipt binding on `AuthorizationContext`.
+- Fresh free-disk threshold gate:
+  `current free_disk_bytes >= resource_budget.minimum_free_disk_bytes`
+  via `measure_free_disk_bytes` / injectable `_test_set_free_disk_bytes`
+  → `HOLD_EXECUTION_FREE_DISK_BELOW_MINIMUM` before any callable.
+- Live gates remain: execution_sha checkout, provider callable, strategy/
+  adapter via plan rebuild, FINAL run-plan exact, 39 unique keys, dataset
+  aggregate bindings, max_parallelism/in_flight/attempts/max_run_count ==
+  authorized caps.
+
+### Authorization bypass audit verdict
+
+`NO_PRODUCTION_TEST_BYPASS`
+
 ## Next gate (post-merge, separate session)
 
 1. Rebuild FINAL plan + surface receipt on new main SHA

--- a/docs/evidence/arvp_hh_hl_execution_wiring_4374.md
+++ b/docs/evidence/arvp_hh_hl_execution_wiring_4374.md
@@ -75,6 +75,28 @@ Status: `DONE_PR_4380_AUTH_RUNTIME_GATES_HARDENED` candidate evidence.
 
 `NO_PRODUCTION_TEST_BYPASS`
 
+## Per-run runtime gate + state terminalization (PR #4380)
+
+Status: `DONE_PR_4380_RUNTIME_STATE_HARDENED` candidate evidence.
+
+### Per-run free-disk
+
+- Campaign-start free-disk check retained in `_rebuild_bound_plans`.
+- Fresh threshold check in `assert_per_run_pre_dispatch` immediately before
+  every dispatch (before RUNNING + before bound_run_envelope / replay artifacts).
+- Semantics: `current_free >= minimum_free_disk_bytes` (never byte-equality to
+  a past surface receipt).
+- Failure: `HOLD_EXECUTION_FREE_DISK_BELOW_MINIMUM`.
+
+### State terminalization
+
+- `dispatch_run_with_terminalization` persists RUNNING only after pre-dispatch PASS.
+- Controlled provider/safety HOLDs (`CampaignProfileError` / auth / binding /
+  dataset / PB1 / scenario) → terminal `BLOCKED`, then fail-closed re-raise.
+- Non-zero `exit_code` → terminal `FAILED` (failure-budget unchanged).
+- Unexpected exceptions → terminal `FAILED` + `HOLD_EXECUTION_PROVIDER_UNEXPECTED`.
+- `STATE_RUNNING_WITHOUT_COMPLETION` unchanged for real process crashes.
+
 ## Next gate (post-merge, separate session)
 
 1. Rebuild FINAL plan + surface receipt on new main SHA

--- a/docs/evidence/arvp_hh_hl_execution_wiring_4374.md
+++ b/docs/evidence/arvp_hh_hl_execution_wiring_4374.md
@@ -1,0 +1,48 @@
+# hh_hl #4374 — Production Execution Wiring Evidence
+
+Status: WIRING SLICE COMPLETE — production path wired, **0 campaign runs**.
+Scope: Issue #4374 execute-wiring only. No Owner-GO post/edit. LR = **NO-GO**.
+
+## Root cause addressed
+
+1. `resolve_campaign_executor(hh_hl_continuation_replay_v1)` previously returned
+   `HhHlSingleRunReplayProvider` with `single_run_callable=None` →
+   `HOLD_EXECUTION_SINGLE_RUN_CALLABLE_UNSET`.
+2. No AuthorizationContext-bound entry-point propagated to
+   `services.validation.strategy_replay_runner` single-run.
+
+## Production path (WIRED_AND_REACHABLE)
+
+```
+Owner Execution-GO (live verify)
+  → AuthorizationContext
+  → hh_hl_campaign_execute (preflight|execute|status)
+  → hh_hl_campaign_lifecycle (bindings/startable/resume)
+  → HhHlSingleRunReplayProvider (+ AuthorizationContext)
+  → build_production_single_run_callable
+  → ARVPReplayConfig (binance_window / hh_hl / batch_b)
+  → run_arvp_replay_detailed / run_arvp_replay
+  → Batch-B dispatch → run_hh_hl_continuation_backtest
+  → bound run artifacts + state markers
+```
+
+## Delivered files
+
+- `tools/arvp_vacation/hh_hl_single_run_callable.py` — production callable
+- `tools/arvp_vacation/hh_hl_campaign_execute.py` — preflight/execute/status
+- `tools/arvp_vacation/campaign_executor_providers.py` — production wiring
+- `services/validation/strategy_replay_runner.py` — hh_hl binance_window allowlist +
+  `ArvpReplayOutcome` / `run_arvp_replay_detailed`
+- `tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py`
+
+## Explicit non-goals (this slice)
+
+- No campaign execute against live GO `#5213976751` (invalid fence; inert)
+- No Owner-GO post/edit
+- No analyzer / reproduction / Stage-B / paper / live / promotion
+
+## Next gate (post-merge, separate session)
+
+1. Rebuild FINAL plan + surface receipt on new main SHA
+2. Post **new** Owner Execution-GO with correct triple-backtick fence
+3. Supervised `hh_hl_campaign_execute execute` for exact 39 baseline runs

--- a/knowledge/logs/sessions/2026-08-07-4380-auth-runtime-gate-hardening.md
+++ b/knowledge/logs/sessions/2026-08-07-4380-auth-runtime-gate-hardening.md
@@ -1,0 +1,29 @@
+# Session — PR #4380 Auth/Runtime-Gate Hardening (#4374)
+
+Date: 2026-08-07  
+Branch: `batch/validation-research-issue-4374-exec-wiring`  
+PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/4380  
+Head: `d60c8316f1ee36a8257b332b1e96d93adfc02c5e`  
+LR: NO-GO · Campaign execute: none · Owner-GO: none · Merge: none
+
+## Delivered
+
+1. Removed public `--fixture-json` / `--design-go-fixture-json` from
+   `hh_hl_campaign_execute` argparse.
+2. Production Owner-GO fetcher always `default_gh_comment_fetcher` unless
+   private `_test_set_owner_go_fetcher` injection.
+3. Fresh free-disk threshold gate → `HOLD_EXECUTION_FREE_DISK_BELOW_MINIMUM`.
+4. Removed tautological surface-fingerprint self-check; fingerprint retained
+   as historical Owner binding only.
+
+## Validation
+
+- 122 hh_hl execute/prep/hardening/final-bindings/prep tests PASS
+- 55 strategy_replay / hh_hl runner filtered tests PASS
+- ruff + black --check + git diff --check PASS on touched files
+
+## Verdicts
+
+- Wiring: `WIRED_AND_REACHABLE`
+- Authorization bypass: `NO_PRODUCTION_TEST_BYPASS`
+- MUST_FIX gaps: 0

--- a/knowledge/logs/sessions/2026-08-07-4380-auth-runtime-gate-hardening.md
+++ b/knowledge/logs/sessions/2026-08-07-4380-auth-runtime-gate-hardening.md
@@ -1,9 +1,9 @@
 # Session — PR #4380 Auth/Runtime-Gate Hardening (#4374)
 
-Date: 2026-08-07  
-Branch: `batch/validation-research-issue-4374-exec-wiring`  
-PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/4380  
-Head: `d60c8316f1ee36a8257b332b1e96d93adfc02c5e`  
+Date: 2026-08-07
+Branch: `batch/validation-research-issue-4374-exec-wiring`
+PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/4380
+Head: `d60c8316f1ee36a8257b332b1e96d93adfc02c5e`
 LR: NO-GO · Campaign execute: none · Owner-GO: none · Merge: none
 
 ## Delivered

--- a/knowledge/logs/sessions/2026-08-07-4380-runtime-state-terminalization.md
+++ b/knowledge/logs/sessions/2026-08-07-4380-runtime-state-terminalization.md
@@ -1,8 +1,8 @@
 # Session — PR #4380 Per-Run Runtime Gate + State Terminalization (#4374)
 
-Date: 2026-08-07  
-Branch: `batch/validation-research-issue-4374-exec-wiring`  
-PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/4380  
+Date: 2026-08-07
+Branch: `batch/validation-research-issue-4374-exec-wiring`
+PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/4380
 LR: NO-GO · Campaign execute: none · Owner-GO: none · Merge: none
 
 ## Delivered

--- a/knowledge/logs/sessions/2026-08-07-4380-runtime-state-terminalization.md
+++ b/knowledge/logs/sessions/2026-08-07-4380-runtime-state-terminalization.md
@@ -1,0 +1,26 @@
+# Session — PR #4380 Per-Run Runtime Gate + State Terminalization (#4374)
+
+Date: 2026-08-07  
+Branch: `batch/validation-research-issue-4374-exec-wiring`  
+PR: https://github.com/jannekbuengener/Claire_de_Binare/pull/4380  
+LR: NO-GO · Campaign execute: none · Owner-GO: none · Merge: none
+
+## Delivered
+
+1. Per-run free-disk threshold via `assert_per_run_pre_dispatch` before RUNNING.
+2. `dispatch_run_with_terminalization`: controlled exceptions → BLOCKED/FAILED;
+   `STATE_RUNNING_WITHOUT_COMPLETION` preserved for hard crashes.
+
+## Validation
+
+- 246 related unit tests PASS
+- ruff / black --check / git diff --check PASS
+- Public CLI still without fixture bypass args
+
+## Verdicts
+
+- Wiring: `WIRED_AND_REACHABLE`
+- Authorization bypass: `NO_PRODUCTION_TEST_BYPASS`
+- Runtime gate: `PER_RUN_RUNTIME_GATE_PASS`
+- State terminalization: `NO_CONTROLLED_ORPHAN_RUNNING_STATE`
+- MUST_FIX gaps: 0

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -76,7 +76,10 @@ from core.replay.batch_b_strategy_registry import (
     batch_b_strategy_ids,
     get_batch_b_strategy,
 )
-from core.replay.hh_hl_continuation_common import BATCH_B_SHADOW_ADAPTER_ID
+from core.replay.hh_hl_continuation_common import (
+    BATCH_B_SHADOW_ADAPTER_ID,
+    HH_HL_CONTINUATION_STRATEGY_ID,
+)
 from core.replay.binance_window_bank_adapter import (
     BinanceWindowBankAdapterError,
     load_binance_window_dataset,
@@ -233,6 +236,7 @@ _BINANCE_WINDOW_DATASET_STRATEGIES: frozenset[str] = frozenset(
     {
         RANGE_MEAN_REVERSION_STRATEGY_ID,
         MOMENTUM_CAPTURE_STRATEGY_ID,
+        HH_HL_CONTINUATION_STRATEGY_ID,
     }
 )
 
@@ -1539,6 +1543,40 @@ def _write_supplementary_artifacts(
 # ---------------------------------------------------------------------------
 # Orchestration
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Typed single-run outcome (CLI keeps int exit codes)
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True, slots=True)
+class ArvpReplayOutcome:
+    """Structured result for a single ARVP replay orchestration."""
+
+    exit_code: int
+    run_id: str | None = None
+    artifact_root: str | None = None
+    gate_result: dict[str, Any] | None = None
+    metrics: dict[str, Any] | None = None
+    content_fingerprint: str | None = None
+    detail: str = ""
+
+
+def _metrics_subset_from_backtest(backtest_report: Mapping[str, Any]) -> dict[str, Any]:
+    raw_metrics = (
+        backtest_report.get("metrics") if isinstance(backtest_report, Mapping) else None
+    )
+    metrics = dict(raw_metrics) if isinstance(raw_metrics, Mapping) else {}
+    out: dict[str, Any] = {}
+    for key in (
+        "closed_trades_total",
+        "fees_total_quote",
+        "net_pnl_quote",
+        "expectancy_r",
+        "max_drawdown_r",
+    ):
+        if key in metrics:
+            out[key] = metrics[key]
+    return out
+
+
 def run_arvp_replay(config: ARVPReplayConfig) -> int:
     """Orchestrate a full ARVP replay run (baseline or scenario group).
 
@@ -1547,6 +1585,18 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
 
     Returns:
         Exit code integer: 0 success, 1 config error, 2 runtime/input error.
+    """
+    return int(run_arvp_replay_detailed(config).exit_code)
+
+
+def run_arvp_replay_detailed(config: ARVPReplayConfig) -> ArvpReplayOutcome:
+    """Orchestrate a full ARVP replay run (baseline or scenario group).
+
+    Args:
+        config: Validated ARVPReplayConfig instance.
+
+    Returns:
+        ArvpReplayOutcome with exit_code 0/1/2 and optional metrics bindings.
     """
     # Strategy-aware warmup count
     warmup_count = _strategy_warmup_count(config)
@@ -1560,15 +1610,18 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 f"(strategy_id={config.strategy_id!r}; HARDEN_PR_4373_BEFORE_MERGE).",
                 file=sys.stderr,
             )
-            return 1
-        return _run_scenario_group_path_with_candles(config, warmup_count=warmup_count)
+            return ArvpReplayOutcome(exit_code=1)
+        sg_code = int(
+            _run_scenario_group_path_with_candles(config, warmup_count=warmup_count)
+        )
+        return ArvpReplayOutcome(exit_code=sg_code, detail="scenario_group_path")
 
     # Single-run path: strategy-aware dispatch
     try:
         dataset_result = _load_dataset_result(config, warmup_count=warmup_count)
     except ReplayRunnerError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     candles: list[dict[str, Any]] = [dict(candle) for candle in dataset_result.candles]
 
@@ -1577,7 +1630,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
             "DRY-RUN: config valid, dataset loaded. "
             f"source={config.dataset_source!r}, candles_total={len(candles)}."
         )
-        return 0
+        return ArvpReplayOutcome(exit_code=0)
 
     output_dir = Path(config.output_directory)
     code_commit = _get_code_commit()
@@ -1622,7 +1675,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
         )
     except (ReplayRunnerError, RunRegistryError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     started_at_utc = _utc_now_iso()
     artifact_root = str(output_dir / run_id)
@@ -1644,7 +1697,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
         )
     except RunRegistryError as exc:
         print(f"ERROR: Failed to write running run record: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     # Delegate to the strategy-specific backtest surface
     try:
@@ -1676,7 +1729,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 file=sys.stderr,
             )
         print(f"ERROR: Replay execution failed: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
     except Exception as exc:
         try:
             _append_failed_record(
@@ -1698,7 +1751,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 file=sys.stderr,
             )
         print(f"ERROR: Unexpected runtime failure: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     # Bridge backtest report → replay contract shape
     try:
@@ -1734,7 +1787,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 file=sys.stderr,
             )
         print(f"ERROR: Failed to build replay report input: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     # Write artifact bundle via reporter (#1805 surface)
     reporter = ReplayReporter()
@@ -1761,7 +1814,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 file=sys.stderr,
             )
         print(f"ERROR: Replay reporter failed: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     # Write supplementary artifacts (CLI layer, not part of canonical hash)
     artifact_root = str(bundle_dir)
@@ -1788,7 +1841,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 file=sys.stderr,
             )
         print(f"ERROR: Failed to write supplementary artifacts: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     # Determinism check
     gate_status = (backtest_report.get("gate_result") or {}).get("status")
@@ -1847,7 +1900,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 "ERROR: --deterministic-verify is set; aborting with exit code 2.",
                 file=sys.stderr,
             )
-            return 2
+            return ArvpReplayOutcome(exit_code=2)
 
     completed_record = ReplayRunRecord(
         run_id=run_id,
@@ -1868,7 +1921,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
         registry.append(completed_record)
     except RunRegistryError as exc:
         print(f"ERROR: Failed to write completed run record: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     try:
         _write_operator_summary_artifact(bundle_dir, completed_record)
@@ -1894,7 +1947,7 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
                 file=sys.stderr,
             )
         print(f"ERROR: Failed to write operator summary: {exc}", file=sys.stderr)
-        return 2
+        return ArvpReplayOutcome(exit_code=2)
 
     print(f"Shadow replay complete: run_id={run_id}")
     print("  status=completed")
@@ -1907,7 +1960,22 @@ def run_arvp_replay(config: ARVPReplayConfig) -> int:
     print(f"  gate_result={gate_status or 'UNKNOWN'}")
     print(f"  deterministic_replay_ok={deterministic_replay_ok}")
     print(f"  bundle_dir={bundle_dir}")
-    return 0
+    return ArvpReplayOutcome(
+        exit_code=0,
+        run_id=run_id,
+        artifact_root=str(bundle_dir),
+        gate_result=(
+            dict(backtest_report.get("gate_result") or {})
+            if isinstance(backtest_report.get("gate_result"), Mapping)
+            else {"status": gate_status}
+        ),
+        metrics=_metrics_subset_from_backtest(backtest_report),
+        content_fingerprint=(
+            str(dataset_result.content_fingerprint)
+            if dataset_result.content_fingerprint is not None
+            else None
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py
+++ b/tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py
@@ -28,13 +28,22 @@ from tools.arvp_vacation.campaign_executor_providers import (
 )
 from tools.arvp_vacation.campaign_profile import CampaignProfileError, load_profile
 from tools.arvp_vacation.hh_hl_campaign_execute import (
+    HOLD_FREE_DISK_BELOW_MINIMUM,
+    HhHlCampaignExecuteError,
+    _owner_go_fetcher,
+    _test_set_free_disk_bytes,
     _test_set_git_sha_resolver,
     _test_set_now_utc,
     _test_set_owner_go_fetcher,
     _test_set_single_run_callable,
+    assert_free_disk_meets_budget,
+    build_parser,
     main as execute_main,
 )
-from tools.arvp_vacation.hh_hl_campaign_execution_authorization import OwnerGoComment
+from tools.arvp_vacation.hh_hl_campaign_execution_authorization import (
+    OwnerGoComment,
+    default_gh_comment_fetcher,
+)
 from tools.arvp_vacation.hh_hl_campaign_sha_gate import GitShaResolver
 from tools.arvp_vacation.hh_hl_single_run_callable import (
     HOLD_DATASET_CONTENT_MISMATCH,
@@ -55,6 +64,8 @@ DATASET_DIGEST = "10f94c34e32db28a9393c38f944db4968b42e87d9ed223397e3637ff44323a
 SURFACE_FP = "43f67ae4ae420bb7c474c5bcc47333f7933bcc302e2128086ad2b7db023046cf"
 DESIGN_BODY_FP = "415400720d28c998dad6b311c71f9107395e3dd17528d4137d097918d682887d"
 WINDOW_FP = "3e7fc8e8024972405eb0e53c2f483e8d5999dda1d9d56fda44b3c40b9f966d5c"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIN_FREE_DISK = 21474836480
 
 
 def _budget() -> dict[str, int]:
@@ -68,7 +79,7 @@ def _budget() -> dict[str, int]:
         "max_parallelism": 1,
         "max_run_wall_time_seconds": 3600,
         "max_total_failures": 5,
-        "minimum_free_disk_bytes": 21474836480,
+        "minimum_free_disk_bytes": MIN_FREE_DISK,
     }
 
 
@@ -99,7 +110,7 @@ def _go_payload(**overrides: Any) -> dict[str, Any]:
         "execution_sha": EXEC_SHA,
         "execution_surface_id": "services.validation.strategy_replay_runner.single_run",
         "expected_run_count": 39,
-        "expires_at_utc": (datetime.now(timezone.utc) + timedelta(days=2))
+        "expires_at_utc": (datetime.now(timezone.utc) + timedelta(days=7))
         .replace(microsecond=0)
         .isoformat()
         .replace("+00:00", "Z"),
@@ -162,11 +173,43 @@ def _clear_test_hooks():
     _test_set_git_sha_resolver(None)
     _test_set_now_utc(None)
     _test_set_single_run_callable(None)
+    _test_set_free_disk_bytes(None)
     yield
     _test_set_owner_go_fetcher(None)
     _test_set_git_sha_resolver(None)
     _test_set_now_utc(None)
     _test_set_single_run_callable(None)
+    _test_set_free_disk_bytes(None)
+
+
+def _install_valid_go_and_sha(
+    *, free_disk_bytes: int | None = MIN_FREE_DISK
+) -> list[Any]:
+    """Private-injection seams only (never CLI fixtures). Returns hit_count list."""
+    hits: list[Any] = []
+    comment = _owner_comment()
+
+    def _fetch(repository: str, issue: int, comment_id: int) -> OwnerGoComment:
+        hits.append(("fetch", repository, issue, comment_id))
+        return comment
+
+    def _fake_callable(req: dict[str, Any]) -> RunResult:
+        hits.append(("callable", req))
+        return RunResult(exit_code=0, metrics={})
+
+    _test_set_owner_go_fetcher(_fetch)
+    _test_set_git_sha_resolver(
+        GitShaResolver(
+            fetch=lambda: None,
+            resolve_main_tip=lambda: EXEC_SHA,
+            object_type=lambda sha: "commit",
+            head=lambda: EXEC_SHA,
+        )
+    )
+    if free_disk_bytes is not None:
+        _test_set_free_disk_bytes(free_disk_bytes)
+    _test_set_single_run_callable(_fake_callable)
+    return hits
 
 
 def test_resolve_campaign_executor_wires_production_callable():
@@ -375,6 +418,156 @@ def test_invalid_fence_go_hold(tmp_path: Path, capsys):
     assert code == 1
     out = capsys.readouterr().out
     assert "HOLD_EXECUTION_GO_BLOCK_MISSING" in out or "HOLD_EXECUTION_GO" in out
+
+
+def test_public_cli_rejects_fixture_json():
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(
+            ["--execution-go-comment-id", "1", "--fixture-json", "x.json", "preflight"]
+        )
+    assert exc.value.code == 2
+
+
+def test_public_cli_rejects_design_go_fixture_json():
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(
+            [
+                "--execution-go-comment-id",
+                "1",
+                "--design-go-fixture-json",
+                "x.json",
+                "preflight",
+            ]
+        )
+    assert exc.value.code == 2
+
+
+def test_production_owner_go_fetcher_is_live_when_no_injection():
+    assert _owner_go_fetcher(None) is default_gh_comment_fetcher
+
+
+def test_private_owner_go_injection_still_usable():
+    seen: list[int] = []
+
+    def _fetch(repository: str, issue: int, comment_id: int) -> OwnerGoComment:
+        seen.append(comment_id)
+        return _owner_comment()
+
+    _test_set_owner_go_fetcher(_fetch)
+    assert _owner_go_fetcher(None) is _fetch
+    _owner_go_fetcher(None)("jannekbuengener/Claire_de_Binare", 4374, 42)
+    assert seen == [42]
+
+
+def test_fabricated_owner_go_cannot_mint_context_via_cli(tmp_path: Path, capsys):
+    """Local JSON + --fixture-json must not be a production path."""
+    fabricated = tmp_path / "fake_owner_go.json"
+    fabricated.write_text(
+        json.dumps(
+            {
+                "id": 1,
+                "issue_number": 4374,
+                "user": {"login": "jannekbuengener"},
+                "body": _fence_body(_go_payload()),
+                "created_at": "2026-08-07T07:36:48Z",
+                "updated_at": "2026-08-07T07:36:48Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(
+            [
+                "--repo-root",
+                str(REPO_ROOT),
+                "--execution-go-comment-id",
+                "1",
+                "--fixture-json",
+                str(fabricated),
+                "preflight",
+            ]
+        )
+
+
+def test_assert_free_disk_below_minimum_hold():
+    with pytest.raises(HhHlCampaignExecuteError) as exc:
+        assert_free_disk_meets_budget(
+            budget=_budget(),
+            free_disk_bytes=1,
+        )
+    assert exc.value.reason_code == HOLD_FREE_DISK_BELOW_MINIMUM
+
+
+def test_assert_free_disk_equal_or_above_minimum_pass():
+    assert (
+        assert_free_disk_meets_budget(
+            budget=_budget(),
+            free_disk_bytes=MIN_FREE_DISK,
+        )
+        == MIN_FREE_DISK
+    )
+    assert (
+        assert_free_disk_meets_budget(
+            budget=_budget(),
+            free_disk_bytes=MIN_FREE_DISK + 1,
+        )
+        == MIN_FREE_DISK + 1
+    )
+
+
+def test_preflight_free_disk_below_minimum_before_callable(capsys):
+    hits = _install_valid_go_and_sha(free_disk_bytes=1)
+    code = execute_main(
+        [
+            "--repo-root",
+            str(REPO_ROOT),
+            "--execution-go-comment-id",
+            "999001",
+            "preflight",
+        ]
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert HOLD_FREE_DISK_BELOW_MINIMUM in out
+    assert not any(h[0] == "callable" for h in hits)
+
+
+def test_execute_free_disk_below_minimum_replay_hit_count_zero(capsys):
+    hits = _install_valid_go_and_sha(free_disk_bytes=1)
+    code = execute_main(
+        [
+            "--repo-root",
+            str(REPO_ROOT),
+            "--execution-go-comment-id",
+            "999001",
+            "execute",
+        ]
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert HOLD_FREE_DISK_BELOW_MINIMUM in out
+    assert not any(h[0] == "callable" for h in hits)
+
+
+def test_preflight_free_disk_at_minimum_passes_disk_gate(capsys):
+    """Disk gate PASS when free >= minimum; later gates may still HOLD (no real GO/plan)."""
+    hits = _install_valid_go_and_sha(free_disk_bytes=MIN_FREE_DISK)
+    code = execute_main(
+        [
+            "--repo-root",
+            str(REPO_ROOT),
+            "--execution-go-comment-id",
+            "999001",
+            "preflight",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert HOLD_FREE_DISK_BELOW_MINIMUM not in out
+    assert not any(h[0] == "callable" for h in hits)
+    # Preflight never dispatches callables; success or non-disk HOLD both OK here.
+    assert code in (0, 1)
 
 
 def test_execute_serial_loop_with_fake_callable(tmp_path: Path, monkeypatch, capsys):

--- a/tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py
+++ b/tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py
@@ -1,0 +1,396 @@
+"""Unit tests for hh_hl production execution wiring (#4374).
+
+Never starts a real campaign or physical binance-window replay. All replay
+surfaces are injected fakes with call counters.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from core.replay.hh_hl_continuation_common import (
+    BATCH_B_SHADOW_ADAPTER_ID,
+    HH_HL_CONTINUATION_STRATEGY_ID,
+    frozen_hh_hl_parameters,
+)
+from services.validation.strategy_replay_runner import (
+    ARVPReplayConfig,
+    ArvpReplayOutcome,
+)
+from tools.arvp_vacation.campaign_executor_providers import (
+    HhHlSingleRunReplayProvider,
+    resolve_campaign_executor,
+)
+from tools.arvp_vacation.campaign_profile import CampaignProfileError, load_profile
+from tools.arvp_vacation.hh_hl_campaign_execute import (
+    _test_set_git_sha_resolver,
+    _test_set_now_utc,
+    _test_set_owner_go_fetcher,
+    _test_set_single_run_callable,
+    main as execute_main,
+)
+from tools.arvp_vacation.hh_hl_campaign_execution_authorization import OwnerGoComment
+from tools.arvp_vacation.hh_hl_campaign_sha_gate import GitShaResolver
+from tools.arvp_vacation.hh_hl_single_run_callable import (
+    HOLD_DATASET_CONTENT_MISMATCH,
+    HOLD_FROZEN_PARAM_MISMATCH,
+    HOLD_PB1_FORBIDDEN,
+    HOLD_SCENARIO_GROUP_FORBIDDEN,
+    assert_frozen_hh_hl_parameters,
+    build_hh_hl_arvp_replay_config,
+    build_production_single_run_callable,
+)
+from tools.arvp_vacation.sensitivity_campaign_executor import RunEnvelope, RunResult
+
+EXEC_SHA = "ba6b1d94c6da480b77fa3ffcb7d46bba6f0d42a2"
+MANIFEST_FP = "1b1165b8b049099324cfc97c0858919f7f04fab985584cff54ad7161ecfcfc07"
+RUN_PLAN_FP = "4b72e08eb3f1f5473be771a98033ae2b19a96ee2da8e8e83177db700f10e482b"
+DATASET_SEL = "3e9ed68736b51fecb299d228c856be80a597cb1dc72fcba595453b856b58bd52"
+DATASET_DIGEST = "10f94c34e32db28a9393c38f944db4968b42e87d9ed223397e3637ff44323af9"
+SURFACE_FP = "43f67ae4ae420bb7c474c5bcc47333f7933bcc302e2128086ad2b7db023046cf"
+DESIGN_BODY_FP = "415400720d28c998dad6b311c71f9107395e3dd17528d4137d097918d682887d"
+WINDOW_FP = "3e7fc8e8024972405eb0e53c2f483e8d5999dda1d9d56fda44b3c40b9f966d5c"
+
+
+def _budget() -> dict[str, int]:
+    return {
+        "log_retention_days": 30,
+        "max_artifact_bytes": 21474836480,
+        "max_attempts_per_run": 1,
+        "max_campaign_wall_time_seconds": 172800,
+        "max_consecutive_failures": 3,
+        "max_in_flight_runs": 1,
+        "max_parallelism": 1,
+        "max_run_wall_time_seconds": 3600,
+        "max_total_failures": 5,
+        "minimum_free_disk_bytes": 21474836480,
+    }
+
+
+def _go_payload(**overrides: Any) -> dict[str, Any]:
+    payload = {
+        "absolute_bans_unchanged": True,
+        "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
+        "analyzer_profile_id": "hh_hl_analyzer_prep_v1",
+        "authorizes": ["exactly_bound_replay_only_campaign_execution"],
+        "authorizing_github_login": "jannekbuengener",
+        "bound_main_sha": EXEC_SHA,
+        "campaign_id": "arvp-hh-hl-continuation-4374-prep-v1",
+        "dataset_content_fingerprint_digest": DATASET_DIGEST,
+        "dataset_selection_sha256": DATASET_SEL,
+        "design_go_body_fingerprint": DESIGN_BODY_FP,
+        "design_go_comment_id": 5206657394,
+        "does_not_authorize": [
+            "stage_b",
+            "oos",
+            "stress",
+            "paper",
+            "live",
+            "echtgeld",
+            "promotion",
+            "merge",
+        ],
+        "evidence_namespace": "artifacts/arvp_campaign/hh_hl_continuation/4374",
+        "execution_sha": EXEC_SHA,
+        "execution_surface_id": "services.validation.strategy_replay_runner.single_run",
+        "expected_run_count": 39,
+        "expires_at_utc": (datetime.now(timezone.utc) + timedelta(days=2))
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "granted_capabilities": ["campaign_execution_replay_only"],
+        "issue": 4374,
+        "lr_status": "NO-GO",
+        "manifest_fingerprint": MANIFEST_FP,
+        "manifest_id": "arvp-hh-hl-continuation-4374-prep-v1",
+        "manifest_path": "config/arvp/hh_hl_campaign_4374_v1.json",
+        "max_run_count": 39,
+        "repository": "jannekbuengener/Claire_de_Binare",
+        "reproduction_policy": "hh_hl_reproduction_prep_v1",
+        "resource_budget": _budget(),
+        "resume_policy": {
+            "allow_resume": True,
+            "refuse_binding_mismatch": True,
+            "refuse_running_without_completion": True,
+            "retry_failed": True,
+            "skip_succeeded_identical_bindings": True,
+        },
+        "run_plan_fingerprint": RUN_PLAN_FP,
+        "schema_version": "cdb.hh_hl_campaign_execution_authorization.v1",
+        "status": "GO_HH_HL_CAMPAIGN_EXECUTION",
+        "strategy_set": [HH_HL_CONTINUATION_STRATEGY_ID],
+        "strategy_version": "cdb.batch_b.hh_hl_continuation_v1.spec.1",
+        "surface_capability_fingerprint": SURFACE_FP,
+        "variant_count": 1,
+        "window_count": 39,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fence_body(payload: dict[str, Any]) -> str:
+    return (
+        "```cdb.hh_hl_campaign_execution_authorization.v1\n"
+        + json.dumps(payload, indent=2, sort_keys=True)
+        + "\n```\n"
+    )
+
+
+def _owner_comment(
+    payload: dict[str, Any] | None = None, *, body: str | None = None
+) -> OwnerGoComment:
+    pl = payload or _go_payload()
+    return OwnerGoComment(
+        comment_id=999001,
+        issue_number=4374,
+        author_login="jannekbuengener",
+        body=body if body is not None else _fence_body(pl),
+        created_at="2026-08-07T07:36:48Z",
+        updated_at="2026-08-07T07:36:48Z",
+        repository="jannekbuengener/Claire_de_Binare",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_test_hooks():
+    _test_set_owner_go_fetcher(None)
+    _test_set_git_sha_resolver(None)
+    _test_set_now_utc(None)
+    _test_set_single_run_callable(None)
+    yield
+    _test_set_owner_go_fetcher(None)
+    _test_set_git_sha_resolver(None)
+    _test_set_now_utc(None)
+    _test_set_single_run_callable(None)
+
+
+def test_resolve_campaign_executor_wires_production_callable():
+    provider = resolve_campaign_executor(load_profile("hh_hl_continuation_replay_v1"))
+    assert isinstance(provider, HhHlSingleRunReplayProvider)
+    callable_ = provider._resolve_single_run_callable()
+    assert callable_ is not None
+
+
+def test_build_arvp_config_exact_bindings(tmp_path: Path):
+    req = {
+        "strategy_id": HH_HL_CONTINUATION_STRATEGY_ID,
+        "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
+        "window_id": "binance_1m_month_2017_10",
+        "parameters": frozen_hh_hl_parameters(),
+        "output_dir": str(tmp_path / "run1"),
+        "dataset_content_fingerprint": WINDOW_FP,
+        "scenario_group_id": None,
+        "scenario_ids": None,
+    }
+    cfg = build_hh_hl_arvp_replay_config(req)
+    assert isinstance(cfg, ARVPReplayConfig)
+    assert cfg.dataset_source == "binance_window"
+    assert cfg.binance_window_id == "binance_1m_month_2017_10"
+    assert cfg.strategy_id == HH_HL_CONTINUATION_STRATEGY_ID
+    assert cfg.adapter_id == BATCH_B_SHADOW_ADAPTER_ID
+    assert cfg.scenario_ids is None
+    assert cfg.scenario_group_id is None
+    assert cfg.dry_run is False
+    assert cfg.output_directory.endswith("replay")
+
+
+def test_frozen_param_mismatch_hold():
+    with pytest.raises(CampaignProfileError) as exc:
+        assert_frozen_hh_hl_parameters({"swing_left_bars": 99})
+    assert HOLD_FROZEN_PARAM_MISMATCH in str(exc.value)
+
+
+def test_pb1_and_scenario_group_hold(tmp_path: Path):
+    base = {
+        "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
+        "window_id": "binance_1m_month_2017_10",
+        "parameters": frozen_hh_hl_parameters(),
+        "output_dir": str(tmp_path),
+        "dataset_content_fingerprint": WINDOW_FP,
+    }
+    with pytest.raises(CampaignProfileError) as exc:
+        build_hh_hl_arvp_replay_config({**base, "strategy_id": "primary_breakout_v1"})
+    assert HOLD_PB1_FORBIDDEN in str(exc.value)
+    with pytest.raises(CampaignProfileError) as exc2:
+        build_hh_hl_arvp_replay_config(
+            {
+                **base,
+                "strategy_id": HH_HL_CONTINUATION_STRATEGY_ID,
+                "scenario_group_id": "x",
+            }
+        )
+    assert HOLD_SCENARIO_GROUP_FORBIDDEN in str(exc2.value)
+
+
+def test_dataset_mismatch_before_replay(monkeypatch, tmp_path: Path):
+    calls: list[Any] = []
+
+    def _fake_load(window_id, warmup_candles=0, window_bank_root=None):
+        class _Inner:
+            content_fingerprint = "a" * 64
+
+        class _Loaded:
+            dataset_result = _Inner()
+
+        return _Loaded()
+
+    def _detailed(cfg: ARVPReplayConfig) -> ArvpReplayOutcome:
+        calls.append(cfg)
+        return ArvpReplayOutcome(exit_code=0)
+
+    monkeypatch.setattr(
+        "tools.arvp_vacation.hh_hl_single_run_callable.load_binance_window_dataset",
+        _fake_load,
+    )
+    runnable = build_production_single_run_callable(replay_detailed=_detailed)
+    req = {
+        "strategy_id": HH_HL_CONTINUATION_STRATEGY_ID,
+        "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
+        "window_id": "binance_1m_month_2017_10",
+        "parameters": frozen_hh_hl_parameters(),
+        "output_dir": str(tmp_path / "r"),
+        "dataset_content_fingerprint": WINDOW_FP,
+    }
+    with pytest.raises(CampaignProfileError) as exc:
+        runnable(req)
+    assert HOLD_DATASET_CONTENT_MISMATCH in str(exc.value)
+    assert calls == []
+
+
+def test_production_callable_maps_outcome_metrics(monkeypatch, tmp_path: Path):
+    def _fake_load(window_id, warmup_candles=0, window_bank_root=None):
+        class _Inner:
+            content_fingerprint = WINDOW_FP
+
+        class _Loaded:
+            dataset_result = _Inner()
+
+        return _Loaded()
+
+    def _detailed(cfg: ARVPReplayConfig) -> ArvpReplayOutcome:
+        assert cfg.strategy_id == HH_HL_CONTINUATION_STRATEGY_ID
+        assert cfg.adapter_id == BATCH_B_SHADOW_ADAPTER_ID
+        assert cfg.dataset_source == "binance_window"
+        assert cfg.scenario_ids is None
+        return ArvpReplayOutcome(
+            exit_code=0,
+            run_id="run-1",
+            artifact_root=str(tmp_path / "replay" / "run-1"),
+            gate_result={"status": "NOT_RANKING_READY", "ranking_ready": False},
+            metrics={
+                "closed_trades_total": 1,
+                "fees_total_quote": "0.1",
+                "net_pnl_quote": "1.0",
+                "expectancy_r": "0.2",
+                "max_drawdown_r": "0.3",
+            },
+            content_fingerprint=WINDOW_FP,
+        )
+
+    monkeypatch.setattr(
+        "tools.arvp_vacation.hh_hl_single_run_callable.load_binance_window_dataset",
+        _fake_load,
+    )
+    runnable = build_production_single_run_callable(replay_detailed=_detailed)
+    result = runnable(
+        {
+            "strategy_id": HH_HL_CONTINUATION_STRATEGY_ID,
+            "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
+            "window_id": "binance_1m_month_2017_10",
+            "parameters": frozen_hh_hl_parameters(),
+            "output_dir": str(tmp_path / "r"),
+            "dataset_content_fingerprint": WINDOW_FP,
+        }
+    )
+    assert result.exit_code == 0
+    assert result.metrics["closed_trades_total"] == 1
+    assert result.metrics["gate_result"]["status"] == "NOT_RANKING_READY"
+    assert result.metrics["run_id"] == "run-1"
+
+
+def test_provider_requires_authorization_before_callable(tmp_path: Path):
+    calls: list[Any] = []
+
+    def _fake(req: dict[str, Any]) -> RunResult:
+        calls.append(req)
+        return RunResult(exit_code=0, metrics={})
+
+    provider = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_fake
+    )
+    envelope = RunEnvelope(
+        run_key="rk",
+        campaign_id="arvp-hh-hl-continuation-4374-prep-v1",
+        manifest_fingerprint=MANIFEST_FP,
+        execution_sha=EXEC_SHA,
+        window_id="binance_1m_month_2017_10",
+        strategy_id=HH_HL_CONTINUATION_STRATEGY_ID,
+        parameters=frozen_hh_hl_parameters(),
+        slot_id="hh_hl_baseline_001",
+        phase="BASELINE",
+        label="spec_frozen_baseline",
+        physical_parameter_set_fingerprint="p" * 64,
+        effective_config_fingerprint="e" * 64,
+        dataset_content_fingerprint=WINDOW_FP,
+        seed="s",
+        output_dir=str(tmp_path),
+        run_plan_fingerprint=RUN_PLAN_FP,
+        authorization_fingerprint="a" * 64,
+    )
+    with pytest.raises(CampaignProfileError) as exc:
+        provider.execute(envelope, authorization_context=None)
+    assert "HOLD_EXECUTION_OWNER_GO_REQUIRED" in str(exc.value)
+    assert calls == []
+
+
+def test_invalid_fence_go_hold(tmp_path: Path, capsys):
+    bad = _owner_comment(body="`cdb.hh_hl_campaign_execution_authorization.v1\n{}\n`\n")
+
+    def _fetch(repository: str, issue: int, comment_id: int) -> OwnerGoComment:
+        return bad
+
+    _test_set_owner_go_fetcher(_fetch)
+    _test_set_git_sha_resolver(
+        GitShaResolver(
+            fetch=lambda: None,
+            resolve_main_tip=lambda: EXEC_SHA,
+            object_type=lambda sha: "commit",
+            head=lambda: EXEC_SHA,
+        )
+    )
+    code = execute_main(
+        [
+            "--repo-root",
+            str(Path(__file__).resolve().parents[3]),
+            "--execution-go-comment-id",
+            "999001",
+            "preflight",
+        ]
+    )
+    assert code == 1
+    out = capsys.readouterr().out
+    assert "HOLD_EXECUTION_GO_BLOCK_MISSING" in out or "HOLD_EXECUTION_GO" in out
+
+
+def test_execute_serial_loop_with_fake_callable(tmp_path: Path, monkeypatch, capsys):
+    """Fresh execute plans START for all runs but uses injected callable (0 real replays)."""
+    # This test focuses on provider wiring + auth gate rather than full 39-run rebuild
+    # (FINAL plan rebuild needs live design/dataset gates). Keep it narrow.
+    provider = resolve_campaign_executor(load_profile("hh_hl_continuation_replay_v1"))
+    assert provider._single_run_callable is not None
+    # Ensure injected override still works for tests
+    calls: list[Any] = []
+
+    def _fake(req: dict[str, Any]) -> RunResult:
+        calls.append(req)
+        return RunResult(exit_code=0, metrics={"closed_trades_total": 0})
+
+    override = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_fake
+    )
+    assert override._resolve_single_run_callable() is _fake

--- a/tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py
+++ b/tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py
@@ -37,13 +37,18 @@ from tools.arvp_vacation.hh_hl_campaign_execute import (
     _test_set_owner_go_fetcher,
     _test_set_single_run_callable,
     assert_free_disk_meets_budget,
+    assert_per_run_pre_dispatch,
     build_parser,
+    dispatch_run_with_terminalization,
     main as execute_main,
 )
 from tools.arvp_vacation.hh_hl_campaign_execution_authorization import (
     OwnerGoComment,
+    authorization_context_from_verified_go,
     default_gh_comment_fetcher,
+    verify_owner_execution_go_comment,
 )
+from tools.arvp_vacation.hh_hl_campaign_lifecycle import bindings_from_authorization
 from tools.arvp_vacation.hh_hl_campaign_sha_gate import GitShaResolver
 from tools.arvp_vacation.hh_hl_single_run_callable import (
     HOLD_DATASET_CONTENT_MISMATCH,
@@ -54,7 +59,15 @@ from tools.arvp_vacation.hh_hl_single_run_callable import (
     build_hh_hl_arvp_replay_config,
     build_production_single_run_callable,
 )
+from tools.arvp_vacation.campaign_profile import CampaignProfileError
 from tools.arvp_vacation.sensitivity_campaign_executor import RunEnvelope, RunResult
+from tools.arvp_vacation.sensitivity_campaign_state import (
+    SensitivityStateError,
+    commit_successful_result,
+    inspect_run_for_resume,
+    run_envelope_path,
+    write_run_envelope,
+)
 
 EXEC_SHA = "ba6b1d94c6da480b77fa3ffcb7d46bba6f0d42a2"
 MANIFEST_FP = "1b1165b8b049099324cfc97c0858919f7f04fab985584cff54ad7161ecfcfc07"
@@ -587,3 +600,325 @@ def test_execute_serial_loop_with_fake_callable(tmp_path: Path, monkeypatch, cap
         load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_fake
     )
     assert override._resolve_single_run_callable() is _fake
+
+
+def _mint_auth_ctx():
+    comment = _owner_comment()
+
+    def _fetch(repository: str, issue: int, comment_id: int) -> OwnerGoComment:
+        return comment
+
+    verified = verify_owner_execution_go_comment(
+        comment_id=999001,
+        expected={},
+        repository="jannekbuengener/Claire_de_Binare",
+        issue=4374,
+        fetcher=_fetch,
+        now_utc=datetime.now(timezone.utc),
+    )
+    return authorization_context_from_verified_go(verified)
+
+
+def _make_envelope(tmp_path: Path, *, ctx=None, run_key: str = "rk1") -> RunEnvelope:
+    auth_fp = ctx.authorization_fingerprint if ctx is not None else ("a" * 64)
+    return RunEnvelope(
+        run_key=run_key,
+        campaign_id="arvp-hh-hl-continuation-4374-prep-v1",
+        manifest_fingerprint=MANIFEST_FP,
+        execution_sha=EXEC_SHA,
+        window_id="binance_1m_month_2017_10",
+        strategy_id=HH_HL_CONTINUATION_STRATEGY_ID,
+        parameters=frozen_hh_hl_parameters(),
+        slot_id="hh_hl_baseline_001",
+        phase="BASELINE",
+        label="spec_frozen_baseline",
+        physical_parameter_set_fingerprint="p" * 64,
+        effective_config_fingerprint=MANIFEST_FP,
+        dataset_content_fingerprint=WINDOW_FP,
+        seed="s",
+        output_dir=str(tmp_path / "runs" / run_key),
+        run_plan_fingerprint=RUN_PLAN_FP,
+        authorization_fingerprint=auth_fp,
+        attempt=1,
+    )
+
+
+def test_per_run_disk_drop_before_second_dispatch_no_running(tmp_path: Path):
+    """Campaign-start disk OK; second per-run check fails before RUNNING/callable."""
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    evidence_root = tmp_path / "evidence"
+    hits: list[str] = []
+    disk_reads = {"n": 0}
+
+    def _disk() -> int:
+        disk_reads["n"] += 1
+        # First per-run gate OK; second drops below minimum.
+        return MIN_FREE_DISK if disk_reads["n"] == 1 else 1
+
+    _test_set_free_disk_bytes(_disk)
+
+    def _ok(req: dict[str, Any]) -> RunResult:
+        hits.append("ok")
+        return RunResult(exit_code=0, metrics={})
+
+    provider = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_ok
+    )
+    budget = _budget()
+
+    r1 = dispatch_run_with_terminalization(
+        provider=provider,
+        ctx=ctx,
+        envelope=_make_envelope(tmp_path, ctx=ctx, run_key="rk1"),
+        evidence_root=evidence_root,
+        bindings=bindings,
+        run_key="rk1",
+        attempt=1,
+        repo_root=REPO_ROOT,
+        budget=budget,
+    )
+    commit_successful_result(
+        evidence_root,
+        run_key="rk1",
+        bindings=bindings,
+        attempt=1,
+        envelope=_make_envelope(tmp_path, ctx=ctx, run_key="rk1").as_dict(),
+        result=r1.metrics,
+        exit_code=0,
+    )
+    assert hits == ["ok"]
+    assert json.loads(run_envelope_path(evidence_root, "rk1").read_text())[
+        "status"
+    ] == ("SUCCEEDED")
+
+    with pytest.raises(HhHlCampaignExecuteError) as exc:
+        dispatch_run_with_terminalization(
+            provider=provider,
+            ctx=ctx,
+            envelope=_make_envelope(tmp_path, ctx=ctx, run_key="rk2"),
+            evidence_root=evidence_root,
+            bindings=bindings,
+            run_key="rk2",
+            attempt=1,
+            repo_root=REPO_ROOT,
+            budget=budget,
+        )
+    assert exc.value.reason_code == HOLD_FREE_DISK_BELOW_MINIMUM
+    assert hits == ["ok"]
+    assert not run_envelope_path(evidence_root, "rk2").exists()
+
+
+def test_per_run_disk_equal_minimum_passes(tmp_path: Path):
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    _test_set_free_disk_bytes(MIN_FREE_DISK)
+    envelope = _make_envelope(tmp_path, ctx=ctx)
+    assert_per_run_pre_dispatch(
+        ctx=ctx,
+        repo_root=REPO_ROOT,
+        budget=_budget(),
+        envelope=envelope,
+    )
+
+
+def test_provider_campaign_profile_error_terminals_blocked(tmp_path: Path):
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    evidence_root = tmp_path / "evidence"
+    _test_set_free_disk_bytes(MIN_FREE_DISK)
+
+    def _raise(req: dict[str, Any]) -> RunResult:
+        raise CampaignProfileError("HOLD_EXECUTION_DATASET_CONTENT_MISMATCH")
+
+    provider = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_raise
+    )
+    with pytest.raises(CampaignProfileError):
+        dispatch_run_with_terminalization(
+            provider=provider,
+            ctx=ctx,
+            envelope=_make_envelope(tmp_path, ctx=ctx),
+            evidence_root=evidence_root,
+            bindings=bindings,
+            run_key="rk1",
+            attempt=1,
+            repo_root=REPO_ROOT,
+            budget=_budget(),
+        )
+    env = json.loads(
+        run_envelope_path(evidence_root, "rk1").read_text(encoding="utf-8")
+    )
+    assert env["status"] == "BLOCKED"
+    assert (
+        "HOLD_EXECUTION_DATASET_CONTENT_MISMATCH" in env["envelope"]["terminal_reason"]
+    )
+
+
+def test_provider_auth_expiry_terminals_blocked_zero_hits(tmp_path: Path):
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    evidence_root = tmp_path / "evidence"
+    _test_set_free_disk_bytes(MIN_FREE_DISK)
+    hits: list[Any] = []
+
+    def _never(req: dict[str, Any]) -> RunResult:
+        hits.append(req)
+        return RunResult(exit_code=0, metrics={})
+
+    provider = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_never
+    )
+    # Force expiry at provider boundary via past now_utc injection on context check:
+    # mutate by wrapping execute to raise auth HOLD.
+    original = provider.execute
+
+    def _expired(envelope, authorization_context=None, *, now_utc=None):
+        raise CampaignProfileError("HOLD_EXECUTION_GO_EXPIRED")
+
+    provider.execute = _expired  # type: ignore[method-assign]
+    with pytest.raises(CampaignProfileError):
+        dispatch_run_with_terminalization(
+            provider=provider,
+            ctx=ctx,
+            envelope=_make_envelope(tmp_path, ctx=ctx),
+            evidence_root=evidence_root,
+            bindings=bindings,
+            run_key="rk1",
+            attempt=1,
+            repo_root=REPO_ROOT,
+            budget=_budget(),
+        )
+    assert hits == []
+    env = json.loads(
+        run_envelope_path(evidence_root, "rk1").read_text(encoding="utf-8")
+    )
+    assert env["status"] == "BLOCKED"
+    del original
+
+
+def test_provider_nonzero_exit_terminals_failed(tmp_path: Path):
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    evidence_root = tmp_path / "evidence"
+    _test_set_free_disk_bytes(MIN_FREE_DISK)
+
+    def _fail(req: dict[str, Any]) -> RunResult:
+        return RunResult(exit_code=7, metrics={"err": True})
+
+    provider = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_fail
+    )
+    result = dispatch_run_with_terminalization(
+        provider=provider,
+        ctx=ctx,
+        envelope=_make_envelope(tmp_path, ctx=ctx),
+        evidence_root=evidence_root,
+        bindings=bindings,
+        run_key="rk1",
+        attempt=1,
+        repo_root=REPO_ROOT,
+        budget=_budget(),
+    )
+    assert result.exit_code == 7
+    env = json.loads(
+        run_envelope_path(evidence_root, "rk1").read_text(encoding="utf-8")
+    )
+    assert env["status"] == "FAILED"
+    assert env["exit_code"] == 7
+
+
+def test_unexpected_provider_exception_terminals_failed_and_stops(tmp_path: Path):
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    evidence_root = tmp_path / "evidence"
+    _test_set_free_disk_bytes(MIN_FREE_DISK)
+
+    def _boom(req: dict[str, Any]) -> RunResult:
+        raise RuntimeError("boom-side-effect")
+
+    provider = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_boom
+    )
+    with pytest.raises(HhHlCampaignExecuteError) as exc:
+        dispatch_run_with_terminalization(
+            provider=provider,
+            ctx=ctx,
+            envelope=_make_envelope(tmp_path, ctx=ctx),
+            evidence_root=evidence_root,
+            bindings=bindings,
+            run_key="rk1",
+            attempt=1,
+            repo_root=REPO_ROOT,
+            budget=_budget(),
+        )
+    assert exc.value.reason_code == "HOLD_EXECUTION_PROVIDER_UNEXPECTED"
+    env = json.loads(
+        run_envelope_path(evidence_root, "rk1").read_text(encoding="utf-8")
+    )
+    assert env["status"] == "FAILED"
+    assert "UNEXPECTED:RuntimeError" in env["envelope"]["terminal_reason"]
+
+
+def test_successful_dispatch_then_commit_succeeded(tmp_path: Path):
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    evidence_root = tmp_path / "evidence"
+    _test_set_free_disk_bytes(MIN_FREE_DISK)
+
+    def _ok(req: dict[str, Any]) -> RunResult:
+        return RunResult(exit_code=0, metrics={"closed_trades_total": 0})
+
+    provider = HhHlSingleRunReplayProvider(
+        load_profile("hh_hl_continuation_replay_v1"), single_run_callable=_ok
+    )
+    envelope = _make_envelope(tmp_path, ctx=ctx)
+    result = dispatch_run_with_terminalization(
+        provider=provider,
+        ctx=ctx,
+        envelope=envelope,
+        evidence_root=evidence_root,
+        bindings=bindings,
+        run_key="rk1",
+        attempt=1,
+        repo_root=REPO_ROOT,
+        budget=_budget(),
+    )
+    fp = commit_successful_result(
+        evidence_root,
+        run_key="rk1",
+        bindings=bindings,
+        attempt=1,
+        envelope=envelope.as_dict(),
+        result=result.metrics,
+        exit_code=0,
+    )
+    assert fp
+    env = json.loads(
+        run_envelope_path(evidence_root, "rk1").read_text(encoding="utf-8")
+    )
+    assert env["status"] == "SUCCEEDED"
+
+
+def test_hard_crash_running_without_completion_still_blocks_resume(tmp_path: Path):
+    """Do not weaken STATE_RUNNING_WITHOUT_COMPLETION for real crashes."""
+    ctx = _mint_auth_ctx()
+    bindings = bindings_from_authorization(ctx)
+    evidence_root = tmp_path / "evidence"
+    write_run_envelope(
+        evidence_root,
+        run_key="rk_crash",
+        bindings=bindings,
+        status="RUNNING",
+        attempt=1,
+        envelope={"run_key": "rk_crash"},
+    )
+    with pytest.raises(SensitivityStateError) as exc:
+        inspect_run_for_resume(
+            evidence_root,
+            run_key="rk_crash",
+            bindings=bindings,
+            max_attempts=1,
+            retry_failed=True,
+        )
+    assert "STATE_RUNNING_WITHOUT_COMPLETION" in str(exc.value)

--- a/tools/arvp_vacation/campaign_executor_providers.py
+++ b/tools/arvp_vacation/campaign_executor_providers.py
@@ -26,6 +26,9 @@ from tools.arvp_vacation.hh_hl_campaign_execution_authorization import (
     AuthorizationContext,
     HhHlExecutionAuthorizationError,
 )
+from tools.arvp_vacation.hh_hl_single_run_callable import (
+    build_production_single_run_callable,
+)
 from tools.arvp_vacation.sensitivity_campaign_executor import (
     CampaignRunExecutor,
     RunEnvelope,
@@ -97,13 +100,21 @@ class HhHlSingleRunReplayProvider:
         params = dict(envelope.parameters or {})
         if "scenario_group_id" in params or "scenario_ids" in params:
             raise CampaignProfileError("HH_HL_SCENARIO_GROUP_FORBIDDEN")
+        if not envelope.output_dir:
+            raise CampaignProfileError("HOLD_EXECUTION_OUTPUT_DIR_REQUIRED")
+        if not envelope.dataset_content_fingerprint:
+            raise CampaignProfileError(
+                "HOLD_EXECUTION_DATASET_CONTENT_FINGERPRINT_REQUIRED"
+            )
         return {
-            "dataset_source": "file_or_bound_window",
+            "dataset_source": "binance_window",
             "strategy_id": HH_HL_CONTINUATION_STRATEGY_ID,
             "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
             "window_id": envelope.window_id,
             "run_key": envelope.run_key,
             "parameters": params,
+            "output_dir": envelope.output_dir,
+            "dataset_content_fingerprint": envelope.dataset_content_fingerprint,
             "scenario_group_id": None,
             "scenario_ids": None,
             "surface": self.SURFACE_ID,
@@ -233,7 +244,13 @@ def resolve_campaign_executor(profile: CampaignProfile) -> CampaignRunExecutor:
         return StrategyReplayCampaignExecutor(adapter_id=profile.adapter_id)
 
     if profile.executor_provider_id == HH_HL_EXECUTOR_PROVIDER_ID:
-        return HhHlSingleRunReplayProvider(profile)
+        # Production path: wire the real strategy_replay_runner single-run
+        # callable. Tests may still construct HhHlSingleRunReplayProvider with an
+        # injected fake callable; resolve_campaign_executor never leaves it unset.
+        return HhHlSingleRunReplayProvider(
+            profile,
+            single_run_callable=build_production_single_run_callable(),
+        )
 
     raise CampaignProfileError(
         f"HOLD_REGISTRY_PROVIDER_MISSING:{profile.executor_provider_id}"

--- a/tools/arvp_vacation/hh_hl_campaign_execute.py
+++ b/tools/arvp_vacation/hh_hl_campaign_execute.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
@@ -83,6 +84,7 @@ from tools.arvp_vacation.sensitivity_campaign_budget import (
 from tools.arvp_vacation.sensitivity_campaign_executor import (
     ATTEMPT_KIND_PRIMARY,
     RunEnvelope,
+    RunResult,
 )
 from tools.arvp_vacation.sensitivity_campaign_state import (
     SensitivityStateError,
@@ -104,9 +106,23 @@ _TEST_GIT_SHA_RESOLVER: GitShaResolver | None = None
 _TEST_NOW_UTC: datetime | None = None
 _TEST_WINDOW_BANK_ROOT: Path | None = None
 _TEST_SINGLE_RUN_CALLABLE = None
-_TEST_FREE_DISK_BYTES: int | None = None
+_TEST_FREE_DISK_BYTES: int | Callable[[], int] | None = None
 
 HOLD_FREE_DISK_BELOW_MINIMUM = "HOLD_EXECUTION_FREE_DISK_BELOW_MINIMUM"
+_TERMINAL_REASON_MAX_LEN = 480
+
+# Provider / surface safety HOLDs → terminal BLOCKED (not FAILED).
+_SAFETY_HOLD_MARKERS = (
+    "HOLD_EXECUTION_",
+    "HOLD_AUTHORIZATION",
+    "HH_HL_",
+    "HOLD_FROZEN",
+    "HOLD_DATASET",
+    "HOLD_PB1",
+    "HOLD_SCENARIO",
+    "HOLD_STRATEGY",
+    "HOLD_ADAPTER",
+)
 
 
 class HhHlCampaignExecuteError(ValueError):
@@ -140,7 +156,9 @@ def _test_set_single_run_callable(callable_) -> None:
     _TEST_SINGLE_RUN_CALLABLE = callable_
 
 
-def _test_set_free_disk_bytes(free_disk_bytes: int | None) -> None:
+def _test_set_free_disk_bytes(
+    free_disk_bytes: int | Callable[[], int] | None,
+) -> None:
     global _TEST_FREE_DISK_BYTES
     _TEST_FREE_DISK_BYTES = free_disk_bytes
 
@@ -199,7 +217,12 @@ def _load_design_receipt(
 
 def _current_free_disk_bytes(repo_root: Path) -> int:
     if _TEST_FREE_DISK_BYTES is not None:
-        return int(_TEST_FREE_DISK_BYTES)
+        value = (
+            _TEST_FREE_DISK_BYTES()
+            if callable(_TEST_FREE_DISK_BYTES)
+            else _TEST_FREE_DISK_BYTES
+        )
+        return int(value)
     return int(measure_free_disk_bytes(repo_root))
 
 
@@ -217,6 +240,209 @@ def assert_free_disk_meets_budget(
             f"free_disk_bytes={free} < minimum_free_disk_bytes={minimum}",
         )
     return free
+
+
+def _sanitize_terminal_reason(raw: str) -> str:
+    text = " ".join(str(raw or "").split())
+    if len(text) > _TERMINAL_REASON_MAX_LEN:
+        return text[: _TERMINAL_REASON_MAX_LEN - 3] + "..."
+    return text
+
+
+def _exception_reason_code(exc: BaseException) -> str:
+    code = getattr(exc, "reason_code", None)
+    if code:
+        return str(code)
+    return str(exc)
+
+
+def _is_safety_hold_exception(exc: BaseException) -> bool:
+    """Controlled provider/surface safety HOLDs terminalize as BLOCKED."""
+    if isinstance(
+        exc,
+        (
+            CampaignProfileError,
+            HhHlExecutionAuthorizationError,
+            HhHlCampaignExecuteError,
+            HhHlDatasetBindingError,
+        ),
+    ):
+        marker = _exception_reason_code(exc)
+        return any(token in marker for token in _SAFETY_HOLD_MARKERS)
+    return False
+
+
+def assert_per_run_pre_dispatch(
+    *,
+    ctx: AuthorizationContext,
+    repo_root: Path,
+    budget: Mapping[str, Any],
+    envelope: RunEnvelope,
+) -> None:
+    """Non-mutating gates immediately before RUNNING / replay artifacts.
+
+    Campaign-start free-disk remains in ``_rebuild_bound_plans``; this is the
+    fresh per-run threshold check. ``surface_capability_fingerprint`` is not
+    re-checked here (historical Owner binding only).
+    """
+    ctx.assert_not_expired(now_utc=_now_utc())
+    assert_free_disk_meets_budget(
+        budget=budget,
+        free_disk_bytes=_current_free_disk_bytes(repo_root),
+    )
+    if not envelope.window_id or ".." in str(envelope.window_id):
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_WINDOW_ID_REQUIRED", str(envelope.window_id)
+        )
+    if not str(envelope.dataset_content_fingerprint or "").strip():
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_DATASET_CONTENT_FINGERPRINT_REQUIRED"
+        )
+    if envelope.strategy_id != HH_HL_CONTINUATION_STRATEGY_ID:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_STRATEGY_MISMATCH", str(envelope.strategy_id)
+        )
+    # Shape / frozen-param / PB1 / scenario-group bans (no dataset load yet).
+    from tools.arvp_vacation.hh_hl_single_run_callable import (
+        build_hh_hl_arvp_replay_config,
+    )
+
+    build_hh_hl_arvp_replay_config(
+        {
+            "strategy_id": envelope.strategy_id,
+            "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
+            "window_id": envelope.window_id,
+            "parameters": envelope.parameters,
+            "output_dir": envelope.output_dir,
+            "dataset_content_fingerprint": envelope.dataset_content_fingerprint,
+            "scenario_group_id": None,
+            "scenario_ids": None,
+        },
+        window_bank_root=_TEST_WINDOW_BANK_ROOT,
+    )
+
+
+def _write_terminal_run_envelope(
+    *,
+    evidence_root: Path,
+    run_key: str,
+    bindings: Any,
+    attempt: int,
+    envelope: RunEnvelope,
+    status: str,
+    reason: str,
+    exit_code: int | None = None,
+) -> None:
+    payload = dict(envelope.as_dict())
+    payload["terminal_reason"] = _sanitize_terminal_reason(reason)
+    write_run_envelope(
+        evidence_root,
+        run_key=run_key,
+        bindings=bindings,
+        status=status,
+        attempt=attempt,
+        envelope=payload,
+        exit_code=exit_code,
+    )
+
+
+def dispatch_run_with_terminalization(
+    *,
+    provider: Any,
+    ctx: AuthorizationContext,
+    envelope: RunEnvelope,
+    evidence_root: Path,
+    bindings: Any,
+    run_key: str,
+    attempt: int,
+    repo_root: Path,
+    budget: Mapping[str, Any],
+) -> RunResult:
+    """Pre-dispatch gates → RUNNING → provider → always terminal on controlled paths.
+
+    ``STATE_RUNNING_WITHOUT_COMPLETION`` remains for real process crashes; this
+    helper only closes controlled Python exception paths.
+    """
+    assert_per_run_pre_dispatch(
+        ctx=ctx,
+        repo_root=repo_root,
+        budget=budget,
+        envelope=envelope,
+    )
+
+    out_dir = Path(envelope.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "bound_run_envelope.json").write_text(
+        json.dumps(envelope.as_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    write_run_envelope(
+        evidence_root,
+        run_key=run_key,
+        bindings=bindings,
+        status="RUNNING",
+        attempt=attempt,
+        envelope=envelope.as_dict(),
+    )
+
+    try:
+        result = provider.execute(
+            envelope, authorization_context=ctx, now_utc=_now_utc()
+        )
+    except BaseException as exc:
+        # KeyboardInterrupt / SystemExit: do not swallow; RUNNING may remain
+        # (crash semantics). Controlled exceptions must terminalize.
+        if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+            raise
+        if _is_safety_hold_exception(exc):
+            _write_terminal_run_envelope(
+                evidence_root=evidence_root,
+                run_key=run_key,
+                bindings=bindings,
+                attempt=attempt,
+                envelope=envelope,
+                status="BLOCKED",
+                reason=_exception_reason_code(exc),
+            )
+            raise
+        _write_terminal_run_envelope(
+            evidence_root=evidence_root,
+            run_key=run_key,
+            bindings=bindings,
+            attempt=attempt,
+            envelope=envelope,
+            status="FAILED",
+            reason=f"UNEXPECTED:{type(exc).__name__}:{_sanitize_terminal_reason(str(exc))}",
+            exit_code=1,
+        )
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_PROVIDER_UNEXPECTED",
+            type(exc).__name__,
+        ) from exc
+
+    if not isinstance(result, RunResult):
+        _write_terminal_run_envelope(
+            evidence_root=evidence_root,
+            run_key=run_key,
+            bindings=bindings,
+            attempt=attempt,
+            envelope=envelope,
+            status="BLOCKED",
+            reason="HH_HL_SINGLE_RUN_RESULT_INVALID",
+        )
+        raise CampaignProfileError("HH_HL_SINGLE_RUN_RESULT_INVALID")
+
+    if int(result.exit_code) != 0:
+        write_run_envelope(
+            evidence_root,
+            run_key=run_key,
+            bindings=bindings,
+            status="FAILED",
+            attempt=attempt,
+            envelope=envelope.as_dict(),
+            exit_code=int(result.exit_code),
+        )
+    return result
 
 
 def _verify_execution_go(
@@ -576,7 +802,6 @@ def cmd_execute(args: argparse.Namespace) -> int:
                 skipped += 1
                 continue
 
-            ctx.assert_not_expired(now_utc=_now_utc())
             planned = planned_by_key[run_key]
             window_fp = str(per_window.get(planned.window_id) or "")
             if not window_fp:
@@ -610,38 +835,23 @@ def cmd_execute(args: argparse.Namespace) -> int:
                 reproduction_attempt=0,
                 attempt_kind=ATTEMPT_KIND_PRIMARY,
             )
-            # Persist bound envelope beside the run for audit.
-            out_dir = Path(envelope.output_dir)
-            out_dir.mkdir(parents=True, exist_ok=True)
-            (out_dir / "bound_run_envelope.json").write_text(
-                json.dumps(envelope.as_dict(), indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-            write_run_envelope(
-                evidence_root,
-                run_key=run_key,
+            result = dispatch_run_with_terminalization(
+                provider=provider,
+                ctx=ctx,
+                envelope=envelope,
+                evidence_root=evidence_root,
                 bindings=bindings,
-                status="RUNNING",
+                run_key=run_key,
                 attempt=attempt,
-                envelope=envelope.as_dict(),
+                repo_root=repo_root,
+                budget=budget,
             )
             dispatched += 1
-            result = provider.execute(
-                envelope, authorization_context=ctx, now_utc=_now_utc()
-            )
             if result.exit_code != 0:
                 failed += 1
                 consecutive_failures += 1
                 total_failures += 1
-                write_run_envelope(
-                    evidence_root,
-                    run_key=run_key,
-                    bindings=bindings,
-                    status="FAILED",
-                    attempt=attempt,
-                    envelope=envelope.as_dict(),
-                    exit_code=result.exit_code,
-                )
+                # FAILED envelope already persisted by dispatch_run_with_terminalization.
                 assert_failure_thresholds(
                     budget=budget,
                     consecutive_failures=consecutive_failures,

--- a/tools/arvp_vacation/hh_hl_campaign_execute.py
+++ b/tools/arvp_vacation/hh_hl_campaign_execute.py
@@ -15,7 +15,7 @@ import argparse
 import json
 import sys
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -25,6 +25,7 @@ from core.replay.hh_hl_continuation_common import (
     HH_HL_CONTINUATION_STRATEGY_ID,
     frozen_hh_hl_parameters,
 )
+from core.utils.clock import utcnow as cdb_utcnow
 from tools.arvp_vacation.campaign_executor_providers import (
     HhHlSingleRunReplayProvider,
     resolve_campaign_executor,
@@ -183,7 +184,7 @@ def _load_json(path: Path) -> dict[str, Any]:
 def _now_utc() -> datetime:
     if _TEST_NOW_UTC is not None:
         return _TEST_NOW_UTC
-    return datetime.now(timezone.utc)
+    return cdb_utcnow()
 
 
 def _owner_go_fetcher(_args: argparse.Namespace | None = None) -> OwnerGoFetcher:

--- a/tools/arvp_vacation/hh_hl_campaign_execute.py
+++ b/tools/arvp_vacation/hh_hl_campaign_execute.py
@@ -1,0 +1,765 @@
+"""hh_hl campaign execute entry-point (#4374).
+
+Supervised offline-replay orchestration:
+
+* ``preflight`` — verify Owner-GO + wiring + plan/state; 0 replays
+* ``execute``   — re-verify GO, then run at most 39 bound baseline replays
+* ``status``    — read-only progress; 0 replays
+
+Never posts or edits an Owner-GO. Never bypasses AuthorizationContext.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from core.replay.canonical_json import canonical_hash
+from core.replay.hh_hl_continuation_common import (
+    BATCH_B_SHADOW_ADAPTER_ID,
+    HH_HL_CONTINUATION_STRATEGY_ID,
+    frozen_hh_hl_parameters,
+)
+from tools.arvp_vacation.campaign_executor_providers import (
+    HhHlSingleRunReplayProvider,
+    resolve_campaign_executor,
+)
+from tools.arvp_vacation.campaign_profile import (
+    HH_HL_REPLAY_PROFILE_ID,
+    CampaignProfileError,
+    load_profile,
+)
+from tools.arvp_vacation.hh_hl_campaign_dataset import (
+    HhHlDatasetBindingError,
+    load_pass_receipt,
+)
+from tools.arvp_vacation.hh_hl_campaign_design_authorization import (
+    HhHlDesignAuthorizationError,
+    build_reference_design_receipt,
+    verify_design_go_comment,
+)
+from tools.arvp_vacation.hh_hl_campaign_execution_authorization import (
+    CAMPAIGN_ID,
+    DEFAULT_REPO,
+    ISSUE_NUMBER,
+    AuthorizationContext,
+    HhHlExecutionAuthorizationError,
+    OwnerGoComment,
+    OwnerGoFetcher,
+    authorization_context_from_verified_go,
+    default_gh_comment_fetcher,
+    verify_owner_execution_go_comment,
+)
+from tools.arvp_vacation.hh_hl_campaign_final_manifest import PROJECT_ROOT
+from tools.arvp_vacation.hh_hl_campaign_lifecycle import (
+    HH_HL_EXPECTED_RUN_COUNT,
+    HhHlLifecycleError,
+    assert_startable,
+    bindings_from_authorization,
+    hh_hl_evidence_root_for,
+    plan_resume_actions,
+    reverify_owner_go_for_resume_or_start,
+    validate_primary_run_keys,
+)
+from tools.arvp_vacation.hh_hl_campaign_run_plan import (
+    build_hh_hl_final_run_plan,
+    build_hh_hl_run_plan,
+)
+from tools.arvp_vacation.hh_hl_campaign_sha_gate import (
+    GitShaResolver,
+    HhHlShaGateError,
+    assert_checked_out_matches_execution_sha,
+    assert_execution_sha_exists,
+    resolve_live_git_sha_resolver,
+)
+from tools.arvp_vacation.sensitivity_campaign_budget import (
+    SensitivityBudgetError,
+    assert_failure_thresholds,
+    validate_resource_budget,
+)
+from tools.arvp_vacation.sensitivity_campaign_executor import (
+    ATTEMPT_KIND_PRIMARY,
+    RunEnvelope,
+)
+from tools.arvp_vacation.sensitivity_campaign_state import (
+    SensitivityStateError,
+    commit_successful_result,
+    write_campaign_envelope,
+    write_run_envelope,
+)
+
+DEFAULT_MANIFEST_REL = "config/arvp/hh_hl_campaign_4374_v1.json"
+DEFAULT_DATASET_RECEIPT_REL = (
+    "docs/evidence/arvp_hh_hl_dataset_local_proof_receipt_4374.json"
+)
+DEFAULT_DESIGN_GO_COMMENT_ID = 5206657394
+
+# Injectable test surfaces (never argparse). Production leaves these None.
+_TEST_OWNER_GO_FETCHER: OwnerGoFetcher | None = None
+_TEST_GIT_SHA_RESOLVER: GitShaResolver | None = None
+_TEST_NOW_UTC: datetime | None = None
+_TEST_WINDOW_BANK_ROOT: Path | None = None
+_TEST_SINGLE_RUN_CALLABLE = None
+
+
+class HhHlCampaignExecuteError(ValueError):
+    def __init__(self, reason_code: str, detail: str = "") -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code if not detail else f"{reason_code}: {detail}")
+
+
+def _test_set_owner_go_fetcher(fetcher: OwnerGoFetcher | None) -> None:
+    global _TEST_OWNER_GO_FETCHER
+    _TEST_OWNER_GO_FETCHER = fetcher
+
+
+def _test_set_git_sha_resolver(resolver: GitShaResolver | None) -> None:
+    global _TEST_GIT_SHA_RESOLVER
+    _TEST_GIT_SHA_RESOLVER = resolver
+
+
+def _test_set_now_utc(now_utc: datetime | None) -> None:
+    global _TEST_NOW_UTC
+    _TEST_NOW_UTC = now_utc
+
+
+def _test_set_window_bank_root(root: Path | None) -> None:
+    global _TEST_WINDOW_BANK_ROOT
+    _TEST_WINDOW_BANK_ROOT = root
+
+
+def _test_set_single_run_callable(callable_) -> None:
+    global _TEST_SINGLE_RUN_CALLABLE
+    _TEST_SINGLE_RUN_CALLABLE = callable_
+
+
+def _emit(payload: Mapping[str, Any]) -> None:
+    sys.stdout.write(json.dumps(dict(payload), indent=2, sort_keys=True) + "\n")
+    sys.stdout.flush()
+
+
+def _repo_root(args: argparse.Namespace) -> Path:
+    root = getattr(args, "repo_root", None)
+    return Path(root) if root else PROJECT_ROOT
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise HhHlCampaignExecuteError("HOLD_JSON_ROOT_INVALID", str(path))
+    return payload
+
+
+def _now_utc() -> datetime:
+    if _TEST_NOW_UTC is not None:
+        return _TEST_NOW_UTC
+    return datetime.now(timezone.utc)
+
+
+def _owner_go_fetcher(args: argparse.Namespace) -> OwnerGoFetcher:
+    if _TEST_OWNER_GO_FETCHER is not None:
+        return _TEST_OWNER_GO_FETCHER
+    fixture = getattr(args, "fixture_json", None)
+    if fixture:
+        data = _load_json(Path(fixture))
+
+        def _fetch(repository: str, issue: int, comment_id: int) -> OwnerGoComment:
+            return OwnerGoComment(
+                comment_id=int(data.get("id") or comment_id),
+                issue_number=int(data.get("issue_number") or issue),
+                author_login=str(
+                    (data.get("user") or {}).get("login")
+                    or data.get("author_login")
+                    or ""
+                ),
+                body=str(data.get("body") or ""),
+                created_at=str(data.get("created_at") or ""),
+                updated_at=str(data.get("updated_at") or ""),
+                repository=str(data.get("repository") or repository or DEFAULT_REPO),
+            )
+
+        return _fetch
+    return default_gh_comment_fetcher
+
+
+def _git_resolver(repo_root: Path) -> GitShaResolver:
+    if _TEST_GIT_SHA_RESOLVER is not None:
+        return _TEST_GIT_SHA_RESOLVER
+    return resolve_live_git_sha_resolver(repo_root)
+
+
+def _load_design_receipt(
+    repo_root: Path, args: argparse.Namespace
+) -> Mapping[str, Any]:
+    """Resolve Design-GO ratification receipt (reference by default; fixture optional)."""
+    comment_id = int(
+        getattr(args, "design_go_comment_id", None) or DEFAULT_DESIGN_GO_COMMENT_ID
+    )
+    design_fixture = getattr(args, "design_go_fixture_json", None)
+    if design_fixture:
+        from tools.arvp_vacation.hh_hl_campaign_design_authorization import (
+            DesignGoComment,
+        )
+
+        data = _load_json(Path(design_fixture))
+
+        def _fetch(repository: str, issue: int, cid: int) -> DesignGoComment:
+            return DesignGoComment(
+                comment_id=int(data.get("id") or cid),
+                issue_number=int(data.get("issue_number") or issue),
+                author_login=str(
+                    (data.get("user") or {}).get("login")
+                    or data.get("author_login")
+                    or ""
+                ),
+                body=str(data.get("body") or ""),
+                created_at=str(data.get("created_at") or ""),
+                updated_at=str(data.get("updated_at") or ""),
+                repository=str(data.get("repository") or repository or DEFAULT_REPO),
+            )
+
+        result = verify_design_go_comment(
+            comment_id=comment_id,
+            repository=DEFAULT_REPO,
+            issue=ISSUE_NUMBER,
+            fetcher=_fetch,
+            repo_root=repo_root,
+        )
+        receipt = result["receipt"]
+        return receipt.as_dict() if hasattr(receipt, "as_dict") else dict(receipt)
+    receipt = build_reference_design_receipt(comment_id=comment_id, repo_root=repo_root)
+    return receipt.as_dict()
+
+
+def _verify_execution_go(
+    args: argparse.Namespace,
+) -> tuple[AuthorizationContext, dict[str, Any]]:
+    comment_id = int(getattr(args, "execution_go_comment_id") or 0)
+    if comment_id <= 0:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_OWNER_GO_REQUIRED", "missing --execution-go-comment-id"
+        )
+    expected_path = getattr(args, "expected_bindings_json", None)
+    expected: Mapping[str, Any] | None = None
+    if expected_path:
+        expected = _load_json(Path(expected_path))
+    verified = verify_owner_execution_go_comment(
+        comment_id=comment_id,
+        expected=expected or {},
+        repository=DEFAULT_REPO,
+        issue=ISSUE_NUMBER,
+        fetcher=_owner_go_fetcher(args),
+        now_utc=_now_utc(),
+    )
+    ctx = authorization_context_from_verified_go(verified)
+    ctx.assert_not_expired(now_utc=_now_utc())
+    return ctx, dict(verified)
+
+
+def _assert_production_provider_wired(profile_id: str = HH_HL_REPLAY_PROFILE_ID) -> str:
+    provider = resolve_campaign_executor(load_profile(profile_id))
+    if not isinstance(provider, HhHlSingleRunReplayProvider):
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_SURFACE_NOT_WIRED_AT_AUTHORIZED_SHA",
+            f"got {type(provider).__name__}",
+        )
+    # Resolve without invoking — unset still raises.
+    provider._resolve_single_run_callable()
+    return provider.SURFACE_ID
+
+
+def _rebuild_bound_plans(
+    *,
+    repo_root: Path,
+    args: argparse.Namespace,
+    ctx: AuthorizationContext,
+) -> tuple[Any, Any, Mapping[str, str]]:
+    manifest = _load_json(
+        repo_root / (getattr(args, "manifest", None) or DEFAULT_MANIFEST_REL)
+    )
+    dataset_receipt = load_pass_receipt(
+        repo_root
+        / (getattr(args, "dataset_receipt", None) or DEFAULT_DATASET_RECEIPT_REL)
+    )
+    design_receipt = _load_design_receipt(repo_root, args)
+    resolver = _git_resolver(repo_root)
+    assert_execution_sha_exists(ctx.execution_sha, resolver=resolver)
+    assert_checked_out_matches_execution_sha(ctx.execution_sha, resolver=resolver)
+
+    final_plan = build_hh_hl_final_run_plan(
+        final_manifest=manifest,
+        design_receipt=design_receipt,
+        dataset_receipt=dataset_receipt,
+        planning_sha=ctx.bound_main_sha,
+        pre_final=False,
+        live_main_resolver=None,  # already checked out + existence gated above
+        profile=load_profile(HH_HL_REPLAY_PROFILE_ID),
+    )
+    if final_plan.run_plan_fingerprint != ctx.run_plan_fingerprint:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_RUN_PLAN_MISMATCH",
+            f"plan={final_plan.run_plan_fingerprint} go={ctx.run_plan_fingerprint}",
+        )
+    if final_plan.manifest_fingerprint != ctx.manifest_fingerprint:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_MANIFEST_MISMATCH",
+            f"plan={final_plan.manifest_fingerprint} go={ctx.manifest_fingerprint}",
+        )
+    if str(dataset_receipt.selection_sha256) != str(
+        ctx.payload.get("dataset_selection_sha256") or ""
+    ):
+        raise HhHlCampaignExecuteError("HOLD_EXECUTION_DATASET_DRIFT", "selection")
+    if str(dataset_receipt.content_fingerprint_digest) != str(
+        ctx.payload.get("dataset_content_fingerprint_digest") or ""
+    ):
+        raise HhHlCampaignExecuteError("HOLD_EXECUTION_DATASET_DRIFT", "content_digest")
+    if (
+        str(ctx.payload.get("execution_surface_id") or "")
+        != HhHlSingleRunReplayProvider.SURFACE_ID
+    ):
+        raise HhHlCampaignExecuteError("HOLD_EXECUTION_SURFACE_BINDING_MISMATCH")
+    if str(ctx.payload.get("surface_capability_fingerprint") or "") != str(
+        ctx.surface_capability_fingerprint
+    ):
+        raise HhHlCampaignExecuteError("HOLD_EXECUTION_SURFACE_BINDING_MISMATCH", "fp")
+
+    budget = validate_resource_budget(ctx.resource_budget)
+    if int(budget["max_parallelism"]) != 1 or int(budget["max_in_flight_runs"]) != 1:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_RESOURCE_BUDGET_INVALID", "parallelism"
+        )
+    if int(budget["max_attempts_per_run"]) != 1:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_RESOURCE_BUDGET_INVALID", "attempts"
+        )
+    if int(ctx.expected_run_count) != HH_HL_EXPECTED_RUN_COUNT:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_RUN_COUNT_MISMATCH", str(ctx.expected_run_count)
+        )
+    if int(ctx.payload.get("max_run_count") or 0) != HH_HL_EXPECTED_RUN_COUNT:
+        raise HhHlCampaignExecuteError("HOLD_EXECUTION_MAX_RUN_COUNT_MISMATCH")
+
+    run_plan = build_hh_hl_run_plan(
+        profile=load_profile(HH_HL_REPLAY_PROFILE_ID),
+        manifest=manifest,
+        planning_sha=ctx.bound_main_sha,
+        dataset_receipt=dataset_receipt,
+    )
+    keys = validate_primary_run_keys(final_plan.run_keys)
+    if tuple(run_plan.run_keys) != keys:
+        raise HhHlCampaignExecuteError(
+            "HOLD_EXECUTION_RUN_KEYS_MISMATCH", "final vs operational plan"
+        )
+    per_window = dict(dataset_receipt.per_window_content_fingerprints or {})
+    return final_plan, run_plan, per_window
+
+
+def _evidence_root_for(ctx: AuthorizationContext, repo_root: Path) -> Path:
+    return hh_hl_evidence_root_for(
+        base=repo_root,
+        campaign_id=ctx.campaign_id,
+        manifest_fingerprint=ctx.manifest_fingerprint,
+        authorization_id=ctx.authorization_fingerprint,
+    )
+
+
+def _seed_for(campaign_id: str, window_id: str, slot_id: str) -> str:
+    return canonical_hash(
+        {
+            "campaign_id": campaign_id,
+            "window_id": window_id,
+            "slot_id": slot_id,
+            "strategy_id": HH_HL_CONTINUATION_STRATEGY_ID,
+        }
+    )
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    repo_root = _repo_root(args)
+    try:
+        surface_id = _assert_production_provider_wired()
+        ctx, verified = _verify_execution_go(args)
+        final_plan, run_plan, _per_window = _rebuild_bound_plans(
+            repo_root=repo_root, args=args, ctx=ctx
+        )
+        bindings = bindings_from_authorization(ctx)
+        evidence_root = _evidence_root_for(ctx, repo_root)
+        startable = assert_startable(
+            evidence_root,
+            bindings=bindings,
+            allow_resume=bool(ctx.resume_policy.get("allow_resume", True)),
+        )
+        actions = plan_resume_actions(
+            evidence_root,
+            bindings=bindings,
+            run_keys=final_plan.run_keys,
+            max_attempts=1,
+            retry_failed=bool(ctx.resume_policy.get("retry_failed", True)),
+        )
+    except (
+        HhHlCampaignExecuteError,
+        HhHlExecutionAuthorizationError,
+        HhHlLifecycleError,
+        HhHlDatasetBindingError,
+        HhHlDesignAuthorizationError,
+        HhHlShaGateError,
+        CampaignProfileError,
+        SensitivityBudgetError,
+        SensitivityStateError,
+        ValueError,
+    ) as exc:
+        reason = getattr(exc, "reason_code", None) or str(exc)
+        _emit(
+            {
+                "ok": False,
+                "command": "preflight",
+                "reason_code": reason,
+                "replays": False,
+            }
+        )
+        return 1
+
+    _emit(
+        {
+            "ok": True,
+            "command": "preflight",
+            "replays": False,
+            "surface_id": surface_id,
+            "authorization_fingerprint": ctx.authorization_fingerprint,
+            "github_comment_id": ctx.github_comment_id,
+            "comment_updated_at": ctx.comment_updated_at,
+            "expires_at_utc": ctx.expires_at_utc,
+            "execution_sha": ctx.execution_sha,
+            "run_plan_fingerprint": final_plan.run_plan_fingerprint,
+            "expected_run_count": HH_HL_EXPECTED_RUN_COUNT,
+            "run_key_count": len(run_plan.run_keys),
+            "evidence_root": evidence_root.as_posix(),
+            "startable": startable,
+            "resume_actions": actions,
+            "verified_reason_code": verified.get("reason_code"),
+        }
+    )
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    repo_root = _repo_root(args)
+    try:
+        ctx, _verified = _verify_execution_go(args)
+        final_plan, _run_plan, _per_window = _rebuild_bound_plans(
+            repo_root=repo_root, args=args, ctx=ctx
+        )
+        bindings = bindings_from_authorization(ctx)
+        evidence_root = _evidence_root_for(ctx, repo_root)
+        startable = assert_startable(
+            evidence_root,
+            bindings=bindings,
+            allow_resume=bool(ctx.resume_policy.get("allow_resume", True)),
+        )
+        actions = plan_resume_actions(
+            evidence_root,
+            bindings=bindings,
+            run_keys=final_plan.run_keys,
+            max_attempts=1,
+            retry_failed=bool(ctx.resume_policy.get("retry_failed", True)),
+        )
+    except (
+        HhHlCampaignExecuteError,
+        HhHlExecutionAuthorizationError,
+        HhHlLifecycleError,
+        HhHlDatasetBindingError,
+        HhHlDesignAuthorizationError,
+        HhHlShaGateError,
+        CampaignProfileError,
+        SensitivityBudgetError,
+        SensitivityStateError,
+        ValueError,
+    ) as exc:
+        reason = getattr(exc, "reason_code", None) or str(exc)
+        _emit(
+            {"ok": False, "command": "status", "reason_code": reason, "replays": False}
+        )
+        return 1
+
+    counts = {"start": 0, "skip": 0, "retry": 0}
+    for action in actions.values():
+        counts[action] = counts.get(action, 0) + 1
+    _emit(
+        {
+            "ok": True,
+            "command": "status",
+            "replays": False,
+            "authorization_fingerprint": ctx.authorization_fingerprint,
+            "evidence_root": evidence_root.as_posix(),
+            "startable": startable,
+            "action_counts": counts,
+            "resume_actions": actions,
+        }
+    )
+    return 0
+
+
+def cmd_execute(args: argparse.Namespace) -> int:
+    repo_root = _repo_root(args)
+    try:
+        _assert_production_provider_wired()
+        # Fresh verify first to capture bound updated_at, then resume-safe reverify.
+        ctx, verified = _verify_execution_go(args)
+        ctx = reverify_owner_go_for_resume_or_start(
+            comment_id=int(args.execution_go_comment_id),
+            expected=(
+                _load_json(Path(args.expected_bindings_json))
+                if getattr(args, "expected_bindings_json", None)
+                else dict(verified.get("payload") or {})
+            ),
+            fetcher=_owner_go_fetcher(args),
+            bound_comment_updated_at=str(verified.get("comment_updated_at") or ""),
+            now_utc=_now_utc(),
+            repository=DEFAULT_REPO,
+            issue=ISSUE_NUMBER,
+        )
+        final_plan, run_plan, per_window = _rebuild_bound_plans(
+            repo_root=repo_root, args=args, ctx=ctx
+        )
+        bindings = bindings_from_authorization(ctx)
+        evidence_root = _evidence_root_for(ctx, repo_root)
+        startable = assert_startable(
+            evidence_root,
+            bindings=bindings,
+            allow_resume=bool(ctx.resume_policy.get("allow_resume", True)),
+        )
+        actions = plan_resume_actions(
+            evidence_root,
+            bindings=bindings,
+            run_keys=final_plan.run_keys,
+            max_attempts=1,
+            retry_failed=bool(ctx.resume_policy.get("retry_failed", True)),
+        )
+        budget = validate_resource_budget(ctx.resource_budget)
+
+        profile = load_profile(HH_HL_REPLAY_PROFILE_ID)
+        if _TEST_SINGLE_RUN_CALLABLE is not None:
+            provider = HhHlSingleRunReplayProvider(
+                profile, single_run_callable=_TEST_SINGLE_RUN_CALLABLE
+            )
+        else:
+            from tools.arvp_vacation.hh_hl_single_run_callable import (
+                build_production_single_run_callable,
+            )
+
+            provider = HhHlSingleRunReplayProvider(
+                profile,
+                single_run_callable=build_production_single_run_callable(
+                    window_bank_root=_TEST_WINDOW_BANK_ROOT
+                ),
+            )
+
+        write_campaign_envelope(
+            evidence_root,
+            bindings=bindings,
+            run_count=HH_HL_EXPECTED_RUN_COUNT,
+            extra={
+                "campaign_id": CAMPAIGN_ID,
+                "startable": startable,
+                "phase": "PRIMARY",
+            },
+        )
+
+        planned_by_key = {r.run_key: r for r in run_plan.runs}
+        succeeded = 0
+        skipped = 0
+        failed = 0
+        consecutive_failures = 0
+        total_failures = 0
+        dispatched = 0
+
+        for run_key in final_plan.run_keys:
+            if dispatched >= HH_HL_EXPECTED_RUN_COUNT:
+                raise HhHlCampaignExecuteError("HOLD_SCOPE_GROWTH", "run_40_forbidden")
+            action = actions[run_key]
+            if action == "skip":
+                skipped += 1
+                continue
+
+            ctx.assert_not_expired(now_utc=_now_utc())
+            planned = planned_by_key[run_key]
+            window_fp = str(per_window.get(planned.window_id) or "")
+            if not window_fp:
+                raise HhHlCampaignExecuteError(
+                    "HOLD_EXECUTION_DATASET_DRIFT",
+                    f"missing window fp:{planned.window_id}",
+                )
+
+            attempt = 1
+            envelope = RunEnvelope(
+                run_key=planned.run_key,
+                campaign_id=ctx.campaign_id,
+                manifest_fingerprint=ctx.manifest_fingerprint,
+                execution_sha=ctx.execution_sha,
+                window_id=planned.window_id,
+                strategy_id=HH_HL_CONTINUATION_STRATEGY_ID,
+                parameters=dict(frozen_hh_hl_parameters()),
+                slot_id=planned.slot_id,
+                phase=planned.phase,
+                label=planned.label,
+                physical_parameter_set_fingerprint=(
+                    planned.physical_parameter_set_fingerprint
+                ),
+                effective_config_fingerprint=ctx.manifest_fingerprint,
+                dataset_content_fingerprint=window_fp,
+                seed=_seed_for(ctx.campaign_id, planned.window_id, planned.slot_id),
+                output_dir=str(evidence_root / "runs" / planned.run_key),
+                run_plan_fingerprint=ctx.run_plan_fingerprint,
+                authorization_fingerprint=ctx.authorization_fingerprint,
+                attempt=attempt,
+                reproduction_attempt=0,
+                attempt_kind=ATTEMPT_KIND_PRIMARY,
+            )
+            # Persist bound envelope beside the run for audit.
+            out_dir = Path(envelope.output_dir)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "bound_run_envelope.json").write_text(
+                json.dumps(envelope.as_dict(), indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            write_run_envelope(
+                evidence_root,
+                run_key=run_key,
+                bindings=bindings,
+                status="RUNNING",
+                attempt=attempt,
+                envelope=envelope.as_dict(),
+            )
+            dispatched += 1
+            result = provider.execute(
+                envelope, authorization_context=ctx, now_utc=_now_utc()
+            )
+            if result.exit_code != 0:
+                failed += 1
+                consecutive_failures += 1
+                total_failures += 1
+                write_run_envelope(
+                    evidence_root,
+                    run_key=run_key,
+                    bindings=bindings,
+                    status="FAILED",
+                    attempt=attempt,
+                    envelope=envelope.as_dict(),
+                    exit_code=result.exit_code,
+                )
+                assert_failure_thresholds(
+                    budget=budget,
+                    consecutive_failures=consecutive_failures,
+                    total_failures=total_failures,
+                )
+                continue
+
+            consecutive_failures = 0
+            commit_successful_result(
+                evidence_root,
+                run_key=run_key,
+                bindings=bindings,
+                attempt=attempt,
+                envelope=envelope.as_dict(),
+                result=result.metrics,
+                exit_code=0,
+            )
+            succeeded += 1
+
+        if succeeded + skipped + failed > HH_HL_EXPECTED_RUN_COUNT:
+            raise HhHlCampaignExecuteError("HOLD_SCOPE_GROWTH", "extra_runs")
+
+        complete = succeeded + skipped == HH_HL_EXPECTED_RUN_COUNT and failed == 0
+        _emit(
+            {
+                "ok": complete,
+                "command": "execute",
+                "phase_outcome": (
+                    "PRIMARY_COMPLETE" if complete else "PRIMARY_INCOMPLETE"
+                ),
+                "authorization_fingerprint": ctx.authorization_fingerprint,
+                "evidence_root": evidence_root.as_posix(),
+                "succeeded": succeeded,
+                "skipped": skipped,
+                "failed": failed,
+                "dispatched": dispatched,
+                "expected_run_count": HH_HL_EXPECTED_RUN_COUNT,
+                "adapter_id": BATCH_B_SHADOW_ADAPTER_ID,
+                "strategy_id": HH_HL_CONTINUATION_STRATEGY_ID,
+            }
+        )
+        return 0 if complete else 1
+    except (
+        HhHlCampaignExecuteError,
+        HhHlExecutionAuthorizationError,
+        HhHlLifecycleError,
+        HhHlDatasetBindingError,
+        HhHlDesignAuthorizationError,
+        HhHlShaGateError,
+        CampaignProfileError,
+        SensitivityBudgetError,
+        SensitivityStateError,
+        ValueError,
+    ) as exc:
+        reason = getattr(exc, "reason_code", None) or str(exc)
+        _emit({"ok": False, "command": "execute", "reason_code": reason})
+        return 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="hh_hl_campaign_execute",
+        description="hh_hl authorized offline-replay campaign entry-point",
+    )
+    parser.add_argument("--repo-root", default=None)
+    parser.add_argument("--manifest", default=DEFAULT_MANIFEST_REL)
+    parser.add_argument("--dataset-receipt", default=DEFAULT_DATASET_RECEIPT_REL)
+    parser.add_argument(
+        "--execution-go-comment-id",
+        type=int,
+        required=False,
+        default=None,
+        help="Required for preflight/execute/status (Owner Execution-GO comment id).",
+    )
+    parser.add_argument(
+        "--fixture-json", default=None, help="Test-only Owner-GO fixture"
+    )
+    parser.add_argument("--expected-bindings-json", default=None)
+    parser.add_argument(
+        "--design-go-comment-id", type=int, default=DEFAULT_DESIGN_GO_COMMENT_ID
+    )
+    parser.add_argument("--design-go-fixture-json", default=None)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_pre = sub.add_parser("preflight", help="Verify GO/wiring/plan/state; 0 replays")
+    p_pre.set_defaults(func=cmd_preflight)
+
+    p_ex = sub.add_parser("execute", help="Start/resume bound 39-run offline campaign")
+    p_ex.set_defaults(func=cmd_execute)
+
+    p_st = sub.add_parser("status", help="Read-only campaign status; 0 replays")
+    p_st.set_defaults(func=cmd_status)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "execution_go_comment_id", None):
+        _emit(
+            {
+                "ok": False,
+                "reason_code": "HOLD_EXECUTION_OWNER_GO_REQUIRED",
+                "detail": "missing --execution-go-comment-id",
+            }
+        )
+        return 1
+    return int(args.func(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/arvp_vacation/hh_hl_campaign_execute.py
+++ b/tools/arvp_vacation/hh_hl_campaign_execute.py
@@ -40,7 +40,6 @@ from tools.arvp_vacation.hh_hl_campaign_dataset import (
 from tools.arvp_vacation.hh_hl_campaign_design_authorization import (
     HhHlDesignAuthorizationError,
     build_reference_design_receipt,
-    verify_design_go_comment,
 )
 from tools.arvp_vacation.hh_hl_campaign_execution_authorization import (
     CAMPAIGN_ID,
@@ -48,7 +47,6 @@ from tools.arvp_vacation.hh_hl_campaign_execution_authorization import (
     ISSUE_NUMBER,
     AuthorizationContext,
     HhHlExecutionAuthorizationError,
-    OwnerGoComment,
     OwnerGoFetcher,
     authorization_context_from_verified_go,
     default_gh_comment_fetcher,
@@ -76,6 +74,7 @@ from tools.arvp_vacation.hh_hl_campaign_sha_gate import (
     assert_execution_sha_exists,
     resolve_live_git_sha_resolver,
 )
+from tools.arvp_vacation.hh_hl_campaign_surface import measure_free_disk_bytes
 from tools.arvp_vacation.sensitivity_campaign_budget import (
     SensitivityBudgetError,
     assert_failure_thresholds,
@@ -98,12 +97,16 @@ DEFAULT_DATASET_RECEIPT_REL = (
 )
 DEFAULT_DESIGN_GO_COMMENT_ID = 5206657394
 
-# Injectable test surfaces (never argparse). Production leaves these None.
+# Injectable test surfaces (never argparse / never env). Production leaves these
+# None. Private Python test seams only — not a production CLI surface.
 _TEST_OWNER_GO_FETCHER: OwnerGoFetcher | None = None
 _TEST_GIT_SHA_RESOLVER: GitShaResolver | None = None
 _TEST_NOW_UTC: datetime | None = None
 _TEST_WINDOW_BANK_ROOT: Path | None = None
 _TEST_SINGLE_RUN_CALLABLE = None
+_TEST_FREE_DISK_BYTES: int | None = None
+
+HOLD_FREE_DISK_BELOW_MINIMUM = "HOLD_EXECUTION_FREE_DISK_BELOW_MINIMUM"
 
 
 class HhHlCampaignExecuteError(ValueError):
@@ -137,6 +140,11 @@ def _test_set_single_run_callable(callable_) -> None:
     _TEST_SINGLE_RUN_CALLABLE = callable_
 
 
+def _test_set_free_disk_bytes(free_disk_bytes: int | None) -> None:
+    global _TEST_FREE_DISK_BYTES
+    _TEST_FREE_DISK_BYTES = free_disk_bytes
+
+
 def _emit(payload: Mapping[str, Any]) -> None:
     sys.stdout.write(json.dumps(dict(payload), indent=2, sort_keys=True) + "\n")
     sys.stdout.flush()
@@ -160,29 +168,15 @@ def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _owner_go_fetcher(args: argparse.Namespace) -> OwnerGoFetcher:
+def _owner_go_fetcher(_args: argparse.Namespace | None = None) -> OwnerGoFetcher:
+    """Resolve the Owner-GO fetcher.
+
+    Production always uses ``default_gh_comment_fetcher``. The only non-live
+    substitution is the private ``_test_set_owner_go_fetcher`` seam used by unit
+    tests — never argparse, never environment variables.
+    """
     if _TEST_OWNER_GO_FETCHER is not None:
         return _TEST_OWNER_GO_FETCHER
-    fixture = getattr(args, "fixture_json", None)
-    if fixture:
-        data = _load_json(Path(fixture))
-
-        def _fetch(repository: str, issue: int, comment_id: int) -> OwnerGoComment:
-            return OwnerGoComment(
-                comment_id=int(data.get("id") or comment_id),
-                issue_number=int(data.get("issue_number") or issue),
-                author_login=str(
-                    (data.get("user") or {}).get("login")
-                    or data.get("author_login")
-                    or ""
-                ),
-                body=str(data.get("body") or ""),
-                created_at=str(data.get("created_at") or ""),
-                updated_at=str(data.get("updated_at") or ""),
-                repository=str(data.get("repository") or repository or DEFAULT_REPO),
-            )
-
-        return _fetch
     return default_gh_comment_fetcher
 
 
@@ -195,44 +189,34 @@ def _git_resolver(repo_root: Path) -> GitShaResolver:
 def _load_design_receipt(
     repo_root: Path, args: argparse.Namespace
 ) -> Mapping[str, Any]:
-    """Resolve Design-GO ratification receipt (reference by default; fixture optional)."""
+    """Resolve the frozen Design-GO ratification receipt (no CLI fixture path)."""
     comment_id = int(
         getattr(args, "design_go_comment_id", None) or DEFAULT_DESIGN_GO_COMMENT_ID
     )
-    design_fixture = getattr(args, "design_go_fixture_json", None)
-    if design_fixture:
-        from tools.arvp_vacation.hh_hl_campaign_design_authorization import (
-            DesignGoComment,
-        )
-
-        data = _load_json(Path(design_fixture))
-
-        def _fetch(repository: str, issue: int, cid: int) -> DesignGoComment:
-            return DesignGoComment(
-                comment_id=int(data.get("id") or cid),
-                issue_number=int(data.get("issue_number") or issue),
-                author_login=str(
-                    (data.get("user") or {}).get("login")
-                    or data.get("author_login")
-                    or ""
-                ),
-                body=str(data.get("body") or ""),
-                created_at=str(data.get("created_at") or ""),
-                updated_at=str(data.get("updated_at") or ""),
-                repository=str(data.get("repository") or repository or DEFAULT_REPO),
-            )
-
-        result = verify_design_go_comment(
-            comment_id=comment_id,
-            repository=DEFAULT_REPO,
-            issue=ISSUE_NUMBER,
-            fetcher=_fetch,
-            repo_root=repo_root,
-        )
-        receipt = result["receipt"]
-        return receipt.as_dict() if hasattr(receipt, "as_dict") else dict(receipt)
     receipt = build_reference_design_receipt(comment_id=comment_id, repo_root=repo_root)
     return receipt.as_dict()
+
+
+def _current_free_disk_bytes(repo_root: Path) -> int:
+    if _TEST_FREE_DISK_BYTES is not None:
+        return int(_TEST_FREE_DISK_BYTES)
+    return int(measure_free_disk_bytes(repo_root))
+
+
+def assert_free_disk_meets_budget(
+    *,
+    budget: Mapping[str, Any],
+    free_disk_bytes: int,
+) -> int:
+    """Fresh runtime free-disk gate (threshold check, not receipt byte-equality)."""
+    minimum = int(budget.get("minimum_free_disk_bytes") or 0)
+    free = int(free_disk_bytes)
+    if free < minimum:
+        raise HhHlCampaignExecuteError(
+            HOLD_FREE_DISK_BELOW_MINIMUM,
+            f"free_disk_bytes={free} < minimum_free_disk_bytes={minimum}",
+        )
+    return free
 
 
 def _verify_execution_go(
@@ -317,17 +301,24 @@ def _rebuild_bound_plans(
         ctx.payload.get("dataset_content_fingerprint_digest") or ""
     ):
         raise HhHlCampaignExecuteError("HOLD_EXECUTION_DATASET_DRIFT", "content_digest")
+    # Live surface identity: authorized execution_surface_id must match the
+    # production provider surface. surface_capability_fingerprint on the
+    # AuthorizationContext remains the Owner-authorized *historical*
+    # post-merge surface-receipt binding — it is retained on ctx and must not
+    # be treated as proof of the current physical execution surface (a
+    # payload↔ctx self-compare would be tautological).
     if (
         str(ctx.payload.get("execution_surface_id") or "")
         != HhHlSingleRunReplayProvider.SURFACE_ID
     ):
         raise HhHlCampaignExecuteError("HOLD_EXECUTION_SURFACE_BINDING_MISMATCH")
-    if str(ctx.payload.get("surface_capability_fingerprint") or "") != str(
-        ctx.surface_capability_fingerprint
-    ):
-        raise HhHlCampaignExecuteError("HOLD_EXECUTION_SURFACE_BINDING_MISMATCH", "fp")
 
     budget = validate_resource_budget(ctx.resource_budget)
+    # Fresh free-disk threshold check (not byte-equality to a past receipt).
+    assert_free_disk_meets_budget(
+        budget=budget,
+        free_disk_bytes=_current_free_disk_bytes(repo_root),
+    )
     if int(budget["max_parallelism"]) != 1 or int(budget["max_in_flight_runs"]) != 1:
         raise HhHlCampaignExecuteError(
             "HOLD_EXECUTION_RESOURCE_BUDGET_INVALID", "parallelism"
@@ -725,14 +716,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Required for preflight/execute/status (Owner Execution-GO comment id).",
     )
-    parser.add_argument(
-        "--fixture-json", default=None, help="Test-only Owner-GO fixture"
-    )
     parser.add_argument("--expected-bindings-json", default=None)
     parser.add_argument(
         "--design-go-comment-id", type=int, default=DEFAULT_DESIGN_GO_COMMENT_ID
     )
-    parser.add_argument("--design-go-fixture-json", default=None)
+    # Intentionally absent from the public production CLI:
+    # --fixture-json, --design-go-fixture-json, --skip-*, --offline, --fake-*,
+    # and any env-based Owner-GO bypass. Unit tests inject via
+    # _test_set_owner_go_fetcher / _test_set_free_disk_bytes only.
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_pre = sub.add_parser("preflight", help="Verify GO/wiring/plan/state; 0 replays")

--- a/tools/arvp_vacation/hh_hl_single_run_callable.py
+++ b/tools/arvp_vacation/hh_hl_single_run_callable.py
@@ -1,0 +1,219 @@
+"""Production single-run callable for hh_hl campaign execution (#4374).
+
+Binds ``HhHlSingleRunReplayProvider`` to the existing
+``services.validation.strategy_replay_runner`` single-run path. Never calls
+``run_hh_hl_continuation_backtest`` directly and never opens PB1 / scenario-group
+surfaces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from core.replay.binance_window_bank_adapter import (
+    BinanceWindowBankAdapterError,
+    load_binance_window_dataset,
+)
+from core.replay.hh_hl_continuation_common import (
+    BATCH_B_SHADOW_ADAPTER_ID,
+    HH_HL_CONTINUATION_STRATEGY_ID,
+    frozen_hh_hl_parameters,
+    hh_hl_warmup_candles,
+)
+from services.validation.strategy_replay_runner import (
+    ARVPReplayConfig,
+    ArvpReplayOutcome,
+    run_arvp_replay_detailed,
+)
+from tools.arvp_vacation.campaign_profile import CampaignProfileError
+from tools.arvp_vacation.sensitivity_campaign_executor import RunResult
+
+DetailedReplayInvoker = Callable[[ARVPReplayConfig], ArvpReplayOutcome]
+
+HOLD_FROZEN_PARAM_MISMATCH = "HOLD_EXECUTION_FROZEN_PARAM_MISMATCH"
+HOLD_DATASET_CONTENT_MISMATCH = "HOLD_EXECUTION_DATASET_CONTENT_MISMATCH"
+HOLD_WINDOW_ID_REQUIRED = "HOLD_EXECUTION_WINDOW_ID_REQUIRED"
+HOLD_OUTPUT_DIR_REQUIRED = "HOLD_EXECUTION_OUTPUT_DIR_REQUIRED"
+HOLD_DATASET_FP_REQUIRED = "HOLD_EXECUTION_DATASET_CONTENT_FINGERPRINT_REQUIRED"
+HOLD_STRATEGY_MISMATCH = "HOLD_EXECUTION_STRATEGY_MISMATCH"
+HOLD_ADAPTER_MISMATCH = "HOLD_EXECUTION_ADAPTER_MISMATCH"
+HOLD_PB1_FORBIDDEN = "HOLD_EXECUTION_PB1_FORBIDDEN"
+HOLD_SCENARIO_GROUP_FORBIDDEN = "HOLD_EXECUTION_SCENARIO_GROUP_FORBIDDEN"
+HOLD_REPLAY_CONFIG_INVALID = "HOLD_EXECUTION_REPLAY_CONFIG_INVALID"
+HOLD_DATASET_LOAD_FAILED = "HOLD_EXECUTION_DATASET_LOAD_FAILED"
+
+
+def assert_frozen_hh_hl_parameters(
+    parameters: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Fail closed unless request parameters exactly match the frozen spec."""
+    frozen = frozen_hh_hl_parameters()
+    actual = dict(parameters or {})
+    if actual != frozen:
+        raise CampaignProfileError(
+            f"{HOLD_FROZEN_PARAM_MISMATCH}: expected={frozen!r} actual={actual!r}"
+        )
+    return frozen
+
+
+def build_hh_hl_arvp_replay_config(
+    request: Mapping[str, Any],
+    *,
+    window_bank_root: Path | None = None,
+) -> ARVPReplayConfig:
+    """Map a bound single-run request to ``ARVPReplayConfig`` (no loose overrides)."""
+    strategy_id = str(request.get("strategy_id") or "")
+    adapter_id = str(request.get("adapter_id") or "")
+    if strategy_id == "primary_breakout_v1":
+        raise CampaignProfileError(HOLD_PB1_FORBIDDEN)
+    if strategy_id != HH_HL_CONTINUATION_STRATEGY_ID:
+        raise CampaignProfileError(f"{HOLD_STRATEGY_MISMATCH}:{strategy_id}")
+    if adapter_id != BATCH_B_SHADOW_ADAPTER_ID:
+        raise CampaignProfileError(f"{HOLD_ADAPTER_MISMATCH}:{adapter_id}")
+    if (
+        request.get("scenario_group_id") is not None
+        or request.get("scenario_ids") is not None
+    ):
+        raise CampaignProfileError(HOLD_SCENARIO_GROUP_FORBIDDEN)
+
+    window_id = str(request.get("window_id") or "").strip()
+    if not window_id or ".." in window_id:
+        raise CampaignProfileError(HOLD_WINDOW_ID_REQUIRED)
+
+    output_dir = str(request.get("output_dir") or "").strip()
+    if not output_dir:
+        raise CampaignProfileError(HOLD_OUTPUT_DIR_REQUIRED)
+
+    assert_frozen_hh_hl_parameters(request.get("parameters"))
+
+    bank_root = window_bank_root
+    if bank_root is None and request.get("window_bank_root"):
+        bank_root = Path(str(request["window_bank_root"]))
+
+    config = ARVPReplayConfig(
+        dataset_source="binance_window",
+        binance_window_id=window_id,
+        window_bank_root=str(bank_root.resolve()) if bank_root is not None else None,
+        strategy_id=HH_HL_CONTINUATION_STRATEGY_ID,
+        adapter_id=BATCH_B_SHADOW_ADAPTER_ID,
+        symbol="BTCUSDT",
+        speedup_profile="instant",
+        output_directory=str(Path(output_dir) / "replay"),
+        dry_run=False,
+        scenario_ids=None,
+        scenario_group_id=None,
+        # PB1 lookbacks unused by hh_hl runner; keep valid defaults for validate().
+        entry_lookback_minutes=240,
+        exit_lookback_minutes=120,
+        breakout_buffer=0.0005,
+        min_minutes_between_entries=int(
+            frozen_hh_hl_parameters()["min_minutes_between_entries"]
+        ),
+    )
+    try:
+        config.validate()
+    except ValueError as exc:
+        raise CampaignProfileError(f"{HOLD_REPLAY_CONFIG_INVALID}:{exc}") from exc
+    return config
+
+
+def assert_request_dataset_content_fingerprint(
+    request: Mapping[str, Any],
+    *,
+    window_bank_root: Path | None = None,
+) -> str:
+    """Physically load the bound window and compare content fingerprint before replay."""
+    expected = str(request.get("dataset_content_fingerprint") or "").strip()
+    if not expected or len(expected) != 64:
+        raise CampaignProfileError(HOLD_DATASET_FP_REQUIRED)
+
+    window_id = str(request.get("window_id") or "").strip()
+    if not window_id:
+        raise CampaignProfileError(HOLD_WINDOW_ID_REQUIRED)
+
+    bank_root = window_bank_root
+    if bank_root is None and request.get("window_bank_root"):
+        bank_root = Path(str(request["window_bank_root"]))
+
+    try:
+        loaded = load_binance_window_dataset(
+            window_id,
+            warmup_candles=hh_hl_warmup_candles(),
+            window_bank_root=bank_root,
+        )
+    except BinanceWindowBankAdapterError as exc:
+        raise CampaignProfileError(f"{HOLD_DATASET_LOAD_FAILED}:{exc}") from exc
+
+    actual = str(loaded.dataset_result.content_fingerprint or "")
+    if actual != expected:
+        raise CampaignProfileError(
+            f"{HOLD_DATASET_CONTENT_MISMATCH}: expected={expected} actual={actual}"
+        )
+    return actual
+
+
+def outcome_to_run_result(outcome: ArvpReplayOutcome) -> RunResult:
+    """Map typed replay outcome into campaign ``RunResult`` metrics."""
+    metrics: dict[str, Any] = {}
+    if outcome.metrics:
+        metrics.update(dict(outcome.metrics))
+    if outcome.gate_result is not None:
+        metrics["gate_result"] = dict(outcome.gate_result)
+    if outcome.run_id:
+        metrics["run_id"] = outcome.run_id
+    if outcome.artifact_root:
+        metrics["artifact_root"] = outcome.artifact_root
+    if outcome.content_fingerprint:
+        metrics["content_fingerprint"] = outcome.content_fingerprint
+    return RunResult(
+        exit_code=int(outcome.exit_code),
+        metrics=metrics,
+        detail=str(outcome.detail or ""),
+    )
+
+
+def build_production_single_run_callable(
+    *,
+    window_bank_root: Path | None = None,
+    replay_detailed: DetailedReplayInvoker | None = None,
+) -> Callable[[Mapping[str, Any]], RunResult]:
+    """Return the production SingleRunCallable used by the hh_hl provider."""
+
+    invoker = replay_detailed or run_arvp_replay_detailed
+
+    def _run(request: Mapping[str, Any]) -> RunResult:
+        config = build_hh_hl_arvp_replay_config(
+            request, window_bank_root=window_bank_root
+        )
+        # Dataset binding must pass before any backtest / replay orchestration.
+        assert_request_dataset_content_fingerprint(
+            request, window_bank_root=window_bank_root
+        )
+        Path(config.output_directory).mkdir(parents=True, exist_ok=True)
+        outcome = invoker(config)
+        if not isinstance(outcome, ArvpReplayOutcome):
+            raise CampaignProfileError("HOLD_EXECUTION_REPLAY_OUTCOME_INVALID")
+        return outcome_to_run_result(outcome)
+
+    return _run
+
+
+__all__ = [
+    "HOLD_ADAPTER_MISMATCH",
+    "HOLD_DATASET_CONTENT_MISMATCH",
+    "HOLD_DATASET_FP_REQUIRED",
+    "HOLD_DATASET_LOAD_FAILED",
+    "HOLD_FROZEN_PARAM_MISMATCH",
+    "HOLD_OUTPUT_DIR_REQUIRED",
+    "HOLD_PB1_FORBIDDEN",
+    "HOLD_REPLAY_CONFIG_INVALID",
+    "HOLD_SCENARIO_GROUP_FORBIDDEN",
+    "HOLD_STRATEGY_MISMATCH",
+    "HOLD_WINDOW_ID_REQUIRED",
+    "assert_frozen_hh_hl_parameters",
+    "assert_request_dataset_content_fingerprint",
+    "build_hh_hl_arvp_replay_config",
+    "build_production_single_run_callable",
+    "outcome_to_run_result",
+]


### PR DESCRIPTION
## Summary
- Wire `HhHlSingleRunReplayProvider` to the real `strategy_replay_runner` single-run path via `build_production_single_run_callable` (no direct backtest bypass).
- Add fail-closed campaign entry-point `hh_hl_campaign_execute` (`preflight` / `execute` / `status`) with AuthorizationContext gates, lifecycle/resume, and exact 39-run budget.
- Extend `run_arvp_replay_detailed` / `ArvpReplayOutcome` and allow `hh_hl_continuation_v1` on `binance_window` datasets.

## Test plan
- [x] `pytest tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py` (+ prep/hardening/final-bindings/hh_hl runner regressions) — 111 passed
- [x] `ruff check` / `black --check` on touched Python
- [ ] No live campaign execute / no Owner-GO post in this PR

## Non-goals
- Campaign execution, Owner-GO post/edit, analyzer, reproduction, Stage-B/paper/live/promotion, merge

Refs #4374