### PR TITLE
[RISK][RUNTIME] Fix cdb_risk pubsub socket_timeout crash-loop (#4382)

### DIFF
--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -1387,7 +1387,26 @@ class RiskManager:
     def _listen_regime_stream(self):
         if not self.redis_client or not self.config.regime_stream:
             return
-        last_id = "0-0"
+        global current_regime, risk_off_active
+        # Bootstrap latest regime, then continue from that ID — avoid replaying
+        # the full stream on every restart (amplifier for #4382 crash-loop).
+        last_id = "$"
+        try:
+            recent = self.redis_client.xrevrange(
+                self.config.regime_stream, "+", "-", count=1
+            )
+            if recent:
+                entry_id, payload = recent[0]
+                last_id = entry_id
+                regime = payload.get("regime", "UNKNOWN")
+                current_regime = regime
+                risk_off_active = regime == "HIGH_VOL_CHAOTIC"
+                logger.info(
+                    "Bootstrap Regime: %s (risk_off=%s)", regime, risk_off_active
+                )
+        except Exception as err:  # noqa: BLE001
+            logger.warning("Regime bootstrap failed, starting from $: %s", err)
+            last_id = "$"
         while self.running:
             try:
                 response = self.redis_client.xread(
@@ -1399,7 +1418,6 @@ class RiskManager:
                     for entry_id, payload in entries:
                         last_id = entry_id
                         regime = payload.get("regime", "UNKNOWN")
-                        global current_regime, risk_off_active
                         current_regime = regime
                         risk_off_active = regime == "HIGH_VOL_CHAOTIC"
                         logger.info(
@@ -2725,17 +2743,29 @@ class RiskManager:
             )
 
     def listen_order_results(self):
-        """Hintergrund-Listener für order_result Topic"""
+        """Hintergrund-Listener für order_result Topic.
+
+        Uses get_message(timeout=...) like execution so idle socket_timeout
+        from create_redis_client does not kill the thread / process (#4382).
+        """
         if not self.pubsub_results:
             return
 
         logger.info("Order-Result Listener aktiv")
 
         try:
-            for message in self.pubsub_results.listen():
-                if not self.running:
-                    break
-                if message.get("type") != "message":
+            while self.running:
+                try:
+                    message = self.pubsub_results.get_message(timeout=1.0)
+                except redis.TimeoutError as err:
+                    logger.debug("Order-Result PubSub idle timeout: %s", err)
+                    continue
+                except redis.ConnectionError as err:
+                    logger.error("Order-Result PubSub connection error: %s", err)
+                    time.sleep(1)
+                    continue
+
+                if not message or message.get("type") != "message":
                     continue
                 try:
                     payload = json.loads(message["data"])
@@ -2761,7 +2791,11 @@ class RiskManager:
             logger.info("Order-Result Listener beendet")
 
     def run(self):
-        """Hauptschleife"""
+        """Hauptschleife.
+
+        Uses get_message(timeout=...) like execution so blocking pubsub.listen()
+        cannot turn create_redis_client socket_timeout=5.0 into a crash-loop (#4382).
+        """
         self.running = True
         stats["status"] = "running"
         stats["started_at"] = utcnow().isoformat()
@@ -2801,11 +2835,24 @@ class RiskManager:
             logger.info("Shutdown-Stream Listener Thread gestartet")
 
         try:
-            for message in self.pubsub.listen():
-                if not self.running:
+            while self.running:
+                try:
+                    message = self.pubsub.get_message(timeout=1.0)
+                except redis.TimeoutError as err:
+                    logger.debug("Signal PubSub idle timeout: %s", err)
+                    continue
+                except redis.ConnectionError as err:
+                    logger.error("Signal PubSub connection error: %s", err)
+                    time.sleep(1)
+                    continue
+                except KeyboardInterrupt:
+                    logger.info("Shutdown via Keyboard")
                     break
 
-                if message["type"] == "message":
+                if not message:
+                    continue
+
+                if message.get("type") == "message":
                     try:
                         data = json.loads(message["data"])
                         signal = Signal.from_dict(data)
@@ -2831,8 +2878,6 @@ class RiskManager:
                             "orders_skipped"
                         ] += 1  # Silent drop: Signal parsing error
 
-        except KeyboardInterrupt:
-            logger.info("Shutdown via Keyboard")
         finally:
             self.shutdown()
 

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -1397,9 +1397,7 @@ class RiskManager:
         global current_regime, risk_off_active
         current_regime = "UNKNOWN"
         risk_off_active = True
-        logger.error(
-            "Regime state unknown — fail-closed risk_off=True (%s)", reason
-        )
+        logger.error("Regime state unknown — fail-closed risk_off=True (%s)", reason)
 
     def _resubscribe_signal_pubsub(self) -> bool:
         """Recreate and resubscribe the signal pubsub after a disconnect."""

--- a/services/risk/service.py
+++ b/services/risk/service.py
@@ -1384,12 +1384,80 @@ class RiskManager:
         allocation = self._get_allocation_state(strategy_id)
         return 0 < allocation.allocation_pct <= self.config.early_live_max_alloc
 
-    def _listen_regime_stream(self):
-        if not self.redis_client or not self.config.regime_stream:
-            return
+    def _apply_regime_state(self, regime: str) -> None:
+        """Update module regime state with fail-closed UNKNOWN handling."""
         global current_regime, risk_off_active
-        # Bootstrap latest regime, then continue from that ID — avoid replaying
-        # the full stream on every restart (amplifier for #4382 crash-loop).
+        normalized = (regime or "UNKNOWN").strip() or "UNKNOWN"
+        current_regime = normalized
+        # Fail-closed: unknown or chaotic keeps risk_off asserted.
+        risk_off_active = normalized in {"HIGH_VOL_CHAOTIC", "UNKNOWN"}
+
+    def _fail_closed_unknown_regime(self, reason: str) -> None:
+        """Assert risk_off when current regime cannot be proven."""
+        global current_regime, risk_off_active
+        current_regime = "UNKNOWN"
+        risk_off_active = True
+        logger.error(
+            "Regime state unknown — fail-closed risk_off=True (%s)", reason
+        )
+
+    def _resubscribe_signal_pubsub(self) -> bool:
+        """Recreate and resubscribe the signal pubsub after a disconnect."""
+        if not self.redis_client:
+            logger.error("Signal PubSub resubscribe failed: no redis client")
+            return False
+        try:
+            if self.pubsub is not None:
+                try:
+                    self.pubsub.close()
+                except Exception:  # noqa: BLE001
+                    logger.debug("Prior signal pubsub close failed", exc_info=True)
+            self.pubsub = self.redis_client.pubsub()
+            self.pubsub.subscribe(self.config.input_topic)
+            logger.info(
+                "Signal PubSub resubscribed to topic: %s", self.config.input_topic
+            )
+            return True
+        except Exception as err:  # noqa: BLE001
+            logger.error("Signal PubSub resubscribe failed: %s", err)
+            return False
+
+    def _resubscribe_order_results_pubsub(self) -> bool:
+        """Recreate and resubscribe the order-results pubsub after a disconnect."""
+        if not self.redis_client:
+            logger.error("Order-Result PubSub resubscribe failed: no redis client")
+            return False
+        try:
+            if self.pubsub_results is not None:
+                try:
+                    self.pubsub_results.close()
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "Prior order-results pubsub close failed", exc_info=True
+                    )
+            self.pubsub_results = self.redis_client.pubsub()
+            self.pubsub_results.subscribe(self.config.input_topic_order_results)
+            logger.info(
+                "Order-Result PubSub resubscribed to topic: %s",
+                self.config.input_topic_order_results,
+            )
+            return True
+        except Exception as err:  # noqa: BLE001
+            logger.error("Order-Result PubSub resubscribe failed: %s", err)
+            return False
+
+    def _listen_regime_stream(self):
+        if not self.config.regime_stream:
+            return
+        if not self.redis_client:
+            self._fail_closed_unknown_regime("regime stream configured without redis")
+            return
+
+        # Fail-closed until bootstrap proves a concrete non-unknown regime.
+        # Prevents missing an already-active HIGH_VOL_CHAOTIC after restart.
+        global current_regime, risk_off_active
+        current_regime = "UNKNOWN"
+        risk_off_active = True
         last_id = "$"
         try:
             recent = self.redis_client.xrevrange(
@@ -1399,14 +1467,23 @@ class RiskManager:
                 entry_id, payload = recent[0]
                 last_id = entry_id
                 regime = payload.get("regime", "UNKNOWN")
-                current_regime = regime
-                risk_off_active = regime == "HIGH_VOL_CHAOTIC"
+                self._apply_regime_state(regime)
                 logger.info(
-                    "Bootstrap Regime: %s (risk_off=%s)", regime, risk_off_active
+                    "Bootstrap Regime: %s (risk_off=%s)",
+                    current_regime,
+                    risk_off_active,
                 )
+            else:
+                self._fail_closed_unknown_regime(
+                    "regime stream empty at bootstrap; waiting for next event"
+                )
+                last_id = "$"
         except Exception as err:  # noqa: BLE001
-            logger.warning("Regime bootstrap failed, starting from $: %s", err)
+            self._fail_closed_unknown_regime(
+                f"regime bootstrap xrevrange failed: {err}"
+            )
             last_id = "$"
+
         while self.running:
             try:
                 response = self.redis_client.xread(
@@ -1418,12 +1495,14 @@ class RiskManager:
                     for entry_id, payload in entries:
                         last_id = entry_id
                         regime = payload.get("regime", "UNKNOWN")
-                        current_regime = regime
-                        risk_off_active = regime == "HIGH_VOL_CHAOTIC"
+                        self._apply_regime_state(regime)
                         logger.info(
-                            "Regime-Update: %s (risk_off=%s)", regime, risk_off_active
+                            "Regime-Update: %s (risk_off=%s)",
+                            current_regime,
+                            risk_off_active,
                         )
             except Exception as err:  # noqa: BLE001
+                # Keep last known fail-closed posture; do not clear risk_off on errors.
                 logger.error("Regime-Stream Fehler: %s", err)
                 time.sleep(1)
 
@@ -2762,7 +2841,8 @@ class RiskManager:
                     continue
                 except redis.ConnectionError as err:
                     logger.error("Order-Result PubSub connection error: %s", err)
-                    time.sleep(1)
+                    if not self._resubscribe_order_results_pubsub():
+                        time.sleep(1)
                     continue
 
                 if not message or message.get("type") != "message":
@@ -2843,7 +2923,8 @@ class RiskManager:
                     continue
                 except redis.ConnectionError as err:
                     logger.error("Signal PubSub connection error: %s", err)
-                    time.sleep(1)
+                    if not self._resubscribe_signal_pubsub():
+                        time.sleep(1)
                     continue
                 except KeyboardInterrupt:
                     logger.info("Shutdown via Keyboard")

--- a/tests/unit/services/test_risk_pubsub_timeout_stability.py
+++ b/tests/unit/services/test_risk_pubsub_timeout_stability.py
@@ -4,6 +4,8 @@ Live evidence (#4382): create_redis_client defaults socket_timeout=5.0; blocking
 pubsub.listen() raises redis.TimeoutError after idle, only KeyboardInterrupt is
 caught in RiskManager.run(), process exits 1, Docker restarts forever.
 Execution survives via pubsub.get_message(timeout=1.0) in a try/except loop.
+
+Also covers fail-closed regime bootstrap and ConnectionError resubscribe.
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 import redis
 
+import services.risk.service as risk_service
 from services.risk.service import RiskManager
 
 
@@ -31,6 +34,16 @@ def _idle_timeout_then_stop(manager: RiskManager, raise_count: int = 2):
         return None
 
     return _raise_or_stop
+
+
+@pytest.fixture(autouse=True)
+def _reset_regime_globals():
+    """Keep module regime posture isolated across tests."""
+    previous = (risk_service.current_regime, risk_service.risk_off_active)
+    risk_service.current_regime = "UNKNOWN"
+    risk_service.risk_off_active = False
+    yield
+    risk_service.current_regime, risk_service.risk_off_active = previous
 
 
 @pytest.mark.unit
@@ -122,3 +135,174 @@ def test_regime_stream_bootstraps_latest_instead_of_full_replay():
     manager.redis_client.xrevrange.assert_called_once()
     stream_arg = manager.redis_client.xread.call_args[0][0]
     assert stream_arg == {"stream.regime_signals": "99-0"}
+    assert risk_service.current_regime == "TREND_UP"
+    assert risk_service.risk_off_active is False
+
+
+@pytest.mark.unit
+def test_regime_bootstrap_xrevrange_failure_is_fail_closed():
+    """Bootstrap failure must assert risk_off, not continue as risk-on."""
+    manager = RiskManager()
+    manager.running = True
+    manager.redis_client = MagicMock()
+    manager.config.regime_stream = "stream.regime_signals"
+    manager.redis_client.xrevrange.side_effect = redis.ConnectionError(
+        "xrevrange unavailable"
+    )
+
+    def _xread(*_args, **_kwargs):
+        manager.running = False
+        return []
+
+    manager.redis_client.xread.side_effect = _xread
+    risk_service.risk_off_active = False
+    risk_service.current_regime = "TREND_UP"
+
+    manager._listen_regime_stream()
+
+    assert risk_service.risk_off_active is True
+    assert risk_service.current_regime == "UNKNOWN"
+    stream_arg = manager.redis_client.xread.call_args[0][0]
+    assert stream_arg == {"stream.regime_signals": "$"}
+
+
+@pytest.mark.unit
+def test_regime_bootstrap_empty_stream_is_fail_closed():
+    """Empty regime stream at start is unknown state → risk_off."""
+    manager = RiskManager()
+    manager.running = True
+    manager.redis_client = MagicMock()
+    manager.config.regime_stream = "stream.regime_signals"
+    manager.redis_client.xrevrange.return_value = []
+
+    def _xread(*_args, **_kwargs):
+        manager.running = False
+        return []
+
+    manager.redis_client.xread.side_effect = _xread
+    risk_service.risk_off_active = False
+
+    manager._listen_regime_stream()
+
+    assert risk_service.risk_off_active is True
+    assert risk_service.current_regime == "UNKNOWN"
+
+
+@pytest.mark.unit
+def test_regime_bootstrap_high_vol_chaotic_keeps_risk_off():
+    """Proven HIGH_VOL_CHAOTIC at bootstrap must keep risk_off asserted."""
+    manager = RiskManager()
+    manager.running = True
+    manager.redis_client = MagicMock()
+    manager.config.regime_stream = "stream.regime_signals"
+    manager.redis_client.xrevrange.return_value = [
+        ("42-0", {"regime": "HIGH_VOL_CHAOTIC"}),
+    ]
+
+    def _xread(*_args, **_kwargs):
+        manager.running = False
+        return []
+
+    manager.redis_client.xread.side_effect = _xread
+    manager._listen_regime_stream()
+
+    assert risk_service.current_regime == "HIGH_VOL_CHAOTIC"
+    assert risk_service.risk_off_active is True
+
+
+@pytest.mark.unit
+def test_run_connection_error_resubscribes_without_process_exit():
+    """ConnectionError on signal pubsub must resubscribe and not Exit 1."""
+    manager = RiskManager()
+    manager.redis_client = MagicMock()
+    manager.pubsub_results = None
+    manager.pubsub = MagicMock()
+    manager.config.input_topic = "signals"
+
+    replacement = MagicMock()
+    manager.redis_client.pubsub.return_value = replacement
+
+    calls = {"n": 0}
+
+    def _get_message(*_args, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise redis.ConnectionError("connection dropped")
+        manager.running = False
+        return None
+
+    manager.pubsub.get_message.side_effect = _get_message
+    replacement.get_message.side_effect = _get_message
+
+    # Avoid background stream threads racing the test.
+    manager._regime_thread = MagicMock(is_alive=MagicMock(return_value=True))
+    manager._allocation_thread = MagicMock(is_alive=MagicMock(return_value=True))
+    manager._shutdown_thread = MagicMock(is_alive=MagicMock(return_value=True))
+
+    manager.run()
+
+    assert manager.running is False
+    manager.redis_client.pubsub.assert_called()
+    replacement.subscribe.assert_called_with("signals")
+    assert manager.pubsub is replacement
+
+
+@pytest.mark.unit
+def test_order_results_connection_error_resubscribes_without_exit():
+    """ConnectionError on order-results pubsub must resubscribe and continue."""
+    manager = RiskManager()
+    manager.running = True
+    manager.redis_client = MagicMock()
+    manager.pubsub_results = MagicMock()
+    manager.config.input_topic_order_results = "order_results"
+
+    replacement = MagicMock()
+    manager.redis_client.pubsub.return_value = replacement
+
+    calls = {"n": 0}
+
+    def _get_message(*_args, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise redis.ConnectionError("order-results connection dropped")
+        manager.running = False
+        return None
+
+    manager.pubsub_results.get_message.side_effect = _get_message
+    replacement.get_message.side_effect = _get_message
+
+    manager.listen_order_results()
+
+    manager.redis_client.pubsub.assert_called()
+    replacement.subscribe.assert_called_with("order_results")
+    assert manager.pubsub_results is replacement
+
+
+@pytest.mark.unit
+def test_signal_resubscribe_failure_stays_alive_without_raising(monkeypatch):
+    """Failed resubscribe must not crash run(); loop retries while running."""
+    monkeypatch.setattr(risk_service.time, "sleep", lambda *_args, **_kwargs: None)
+
+    manager = RiskManager()
+    manager.redis_client = MagicMock()
+    manager.pubsub_results = None
+    manager.pubsub = MagicMock()
+    manager.redis_client.pubsub.side_effect = redis.ConnectionError("still down")
+
+    calls = {"n": 0}
+
+    def _get_message(*_args, **_kwargs):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise redis.ConnectionError("connection dropped")
+        manager.running = False
+        return None
+
+    manager.pubsub.get_message.side_effect = _get_message
+    manager._regime_thread = MagicMock(is_alive=MagicMock(return_value=True))
+    manager._allocation_thread = MagicMock(is_alive=MagicMock(return_value=True))
+    manager._shutdown_thread = MagicMock(is_alive=MagicMock(return_value=True))
+
+    manager.run()
+    assert manager.running is False
+    assert calls["n"] >= 2

--- a/tests/unit/services/test_risk_pubsub_timeout_stability.py
+++ b/tests/unit/services/test_risk_pubsub_timeout_stability.py
@@ -1,0 +1,124 @@
+"""Regression: cdb_risk must not crash-loop on Redis pubsub idle socket timeouts.
+
+Live evidence (#4382): create_redis_client defaults socket_timeout=5.0; blocking
+pubsub.listen() raises redis.TimeoutError after idle, only KeyboardInterrupt is
+caught in RiskManager.run(), process exits 1, Docker restarts forever.
+Execution survives via pubsub.get_message(timeout=1.0) in a try/except loop.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import redis
+
+from services.risk.service import RiskManager
+
+
+def _idle_timeout_then_stop(manager: RiskManager, raise_count: int = 2):
+    """Shared timeout injector for get_message() code paths."""
+    raised = {"n": 0}
+
+    def _raise_or_stop(*_args, **_kwargs):
+        if not manager.running:
+            return None
+        if raised["n"] < raise_count:
+            raised["n"] += 1
+            raise redis.TimeoutError("Timeout reading from socket")
+        manager.running = False
+        return None
+
+    return _raise_or_stop
+
+
+@pytest.mark.unit
+def test_run_must_survive_pubsub_socket_timeout_without_process_exit():
+    """Desired contract: idle socket TimeoutError must not escape run().
+
+    Pre-fix (main): TimeoutError propagates after finally/shutdown → Exit 1.
+    Post-fix: run() returns cleanly after controlled stop.
+    """
+    manager = RiskManager()
+    manager.redis_client = None  # skip regime/allocation/shutdown stream threads
+    manager.pubsub_results = None  # skip order-result thread
+    manager.pubsub = MagicMock()
+    manager.pubsub.get_message.side_effect = _idle_timeout_then_stop(manager)
+
+    # Contract under test: TimeoutError must not kill the process/run().
+    manager.run()
+    assert manager.running is False
+
+
+@pytest.mark.unit
+def test_listen_order_results_must_survive_pubsub_socket_timeout():
+    """Order-result listener must not die on idle socket TimeoutError."""
+    manager = RiskManager()
+    manager.running = True
+    manager.pubsub_results = MagicMock()
+    manager.pubsub_results.get_message.side_effect = _idle_timeout_then_stop(
+        manager, raise_count=2
+    )
+
+    # Desired: returns without raising.
+    manager.listen_order_results()
+    assert manager.running is False
+
+
+@pytest.mark.unit
+def test_run_still_processes_valid_signal_message(monkeypatch):
+    """Positive path: a real pubsub message still reaches process_signal."""
+    manager = RiskManager()
+    manager.redis_client = None
+    manager.pubsub_results = None
+    manager.pubsub = MagicMock()
+
+    processed = {"n": 0}
+
+    def fake_process(signal, raw_payload=None):
+        processed["n"] += 1
+        manager.running = False
+        return None
+
+    monkeypatch.setattr(manager, "process_signal", fake_process)
+
+    payload = {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "strategy_id": "test",
+        "strength": 0.5,
+    }
+
+    manager.pubsub.get_message = MagicMock(
+        side_effect=[
+            {"type": "message", "data": json.dumps(payload)},
+            None,
+        ]
+    )
+
+    manager.run()
+    assert processed["n"] >= 1
+
+
+@pytest.mark.unit
+def test_regime_stream_bootstraps_latest_instead_of_full_replay():
+    """Restart must not xread from 0-0 across the full regime history."""
+    manager = RiskManager()
+    manager.running = True
+    manager.redis_client = MagicMock()
+    manager.config.regime_stream = "stream.regime_signals"
+    manager.redis_client.xrevrange.return_value = [
+        ("99-0", {"regime": "TREND_UP"}),
+    ]
+
+    def _xread(*_args, **_kwargs):
+        manager.running = False
+        return []
+
+    manager.redis_client.xread.side_effect = _xread
+    manager._listen_regime_stream()
+
+    manager.redis_client.xrevrange.assert_called_once()
+    stream_arg = manager.redis_client.xread.call_args[0][0]
+    assert stream_arg == {"stream.regime_signals": "99-0"}


### PR DESCRIPTION
## Problem / reproduziertes Symptom

`cdb_risk` lief seit ~16h in einem Docker-Restart-Loop:
- RestartCount ≈ 890+, ExitCode=1, OOMKilled=false
- Lebensdauer pro Cycle ~5–7s
- Crash: `redis.exceptions.TimeoutError: Timeout reading from socket` auf `pubsub.listen()` (Main + order_results Thread)
- Peers (Redis/Postgres/Execution/…) healthy, RestartCount=0

## Root Cause

`create_redis_client` default `socket_timeout=5.0` + blocking `pubsub.listen()` in `RiskManager.run()` / `listen_order_results`. Idle >5s ohne Signal wirft uncaught `TimeoutError` (nur `KeyboardInterrupt` gefangen) → Process Exit 1 → Docker `unless-stopped` Loop.

Execution bleibt stabil, weil es `pubsub.get_message(timeout=1.0)` in try/except nutzt.

**Amplifier:** Regime-Stream startete bei `last_id=0-0` und replayte die volle History bei jedem Restart.

## Warum bisherige Guards das nicht erkannt haben

- `/health` spiegelt nur `stats.status`; Process-Crash macht Health zur Folge, nicht zur Ursache.
- Kein Unit-Test für idle PubSub `TimeoutError` auf dem Risk-Mainloop.
- Execution-Muster war nicht auf Risk übertragen.
- Regime `0-0` Replay war kein Contract-Test.

## Fix

- Signal- und Order-Result-Listener: `get_message(timeout=1.0)` + catch `TimeoutError` / `ConnectionError` (wie Execution).
- Regime-Stream: Bootstrap latest via `xrevrange`, dann weiter ab Cursor (kein Full-Replay von `0-0`).
- Keine Relaxation von Risk-/Exposure-/Drawdown-/Kill-Switch-/Stop-Loss-Grenzen.

## Regression Evidence

- Pre-fix: `test_run_must_survive_pubsub_socket_timeout_without_process_exit` und order-results Variante **FAILED** mit uncaught `TimeoutError`.
- Post-fix: dieselben Tests **PASSED**; Positive-Path und Regime-Bootstrap **PASSED**.
- Debug session evidence: `main_pubsub_timeout_handled` / `order_results_pubsub_timeout_handled` / `run_returned_without_exception`.

## Targeted Validation

```
python -m pytest tests/unit/services/test_risk_pubsub_timeout_stability.py tests/unit/services/test_risk_service_emission.py -v
# 7 passed
git diff --check
```

## Brain Evidence

- brain_source: repo-only / brain_status: not-used
- context_trust_level: none (LOW briefing, no enrichment records)
- Runtime + Repo live führten (docker inspect/logs + Codepfad)

## Safety Boundaries

- LR bleibt NO-GO
- Kein Live/Echtgeld
- Keine produktive Runtime-/DB-Mutation in dieser Delivery
- Keine Safety-Grenze gelockert
- Fail-closed bleibt; Idle-Timeout ist kein Safety-Signal

## Non-goals

- Kein Merge in dieser Session
- Kein `cdb-local-ci` Publish / Full Fast-CI
- Kein Stop-Loss Dedup Real-Stack Drill (#4234)
- Kein Fail-closed Safety Slice (#4152)
- Kein Image-Rebuild des laufenden Live-Containers (separater Ops-Schritt)

## Restunsicherheiten

- Laufendes Live-Image (Created ~2026-07-31) enthält diesen Fix noch nicht; Stabilität im Stack erfordert Rebuild/Recreate von `cdb_risk` nach Merge (Human/Ops).
- Kill-Switch Volume Drift live=dev.yml vs BLUE compose bleibt dokumentierter Ops-Restpunkt, war nicht die Crash-Ursache.
- ConnectionError-Reconnect resubscribiert Topics nicht explizit neu (wie Execution heute auch); separates Follow-up falls nötig.

Closes #4382