### PR TITLE
[VALIDATION][RESEARCH] #4384 Windows-safe run_key filesystem path mapping

### DIFF
--- a/tests/unit/arvp/test_sensitivity_campaign_state.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_state.py
@@ -461,8 +461,10 @@ def test_reproduction_resume_retry_limit(tmp_path: Path) -> None:
 
 
 def test_reproduction_dir_layout(tmp_path: Path) -> None:
+    from tools.arvp_vacation.sensitivity_campaign_state import fs_dirname_for_run_key
+
     d = reproduction_dir(tmp_path, "rk1", 1)
-    assert d.parts[-3:] == ("rk1", "reproduction", "1")
+    assert d.parts[-3:] == (fs_dirname_for_run_key("rk1"), "reproduction", "1")
     env = reproduction_envelope_path(tmp_path, "rk1", 1)
     assert env.name == "run_envelope.json"
     assert env.parent == d

--- a/tests/unit/arvp/test_sensitivity_campaign_state.py
+++ b/tests/unit/arvp/test_sensitivity_campaign_state.py
@@ -527,3 +527,71 @@ def test_count_primary_succeeded_partial_blocks(tmp_path: Path) -> None:
     with pytest.raises(SensitivityStateError) as exc:
         count_primary_succeeded(root, bindings=BINDINGS, expected_run_keys=["rk1"])
     assert "STATE_PARTIAL_SUCCESS_BLOCKED" in str(exc.value)
+
+
+def test_fs_dirname_for_run_key_strips_windows_illegal_chars() -> None:
+    from tools.arvp_vacation.sensitivity_campaign_state import (
+        fs_dirname_for_run_key,
+        run_key_needs_fs_mapping,
+    )
+
+    key = (
+        "arvp-hh-hl-continuation-4374-prep-v1|binance_1m_month_2017_10|"
+        "hh_hl_baseline_001|hh_hl_continuation_v1|ec40ba4f7fd61294"
+    )
+    assert run_key_needs_fs_mapping(key) is True
+    dirname = fs_dirname_for_run_key(key)
+    assert dirname.startswith("rk_")
+    assert "|" not in dirname
+    assert all(ch not in dirname for ch in '<>:"/\\|?*')
+    # Deterministic
+    assert fs_dirname_for_run_key(key) == dirname
+
+
+def test_pipe_run_key_write_and_resume_roundtrip(tmp_path: Path) -> None:
+    from tools.arvp_vacation.sensitivity_campaign_state import (
+        LOGICAL_RUN_KEY_SIDECAR,
+        fs_dirname_for_run_key,
+        run_dir,
+    )
+
+    root = tmp_path / "ns"
+    key = "camp|window|slot|strategy|deadbeef"
+    write_campaign_envelope(root, bindings=BINDINGS, run_count=1)
+    envelope = {"run_key": key, "seed": "x"}
+    commit_successful_result(
+        root,
+        run_key=key,
+        bindings=BINDINGS,
+        attempt=1,
+        envelope=envelope,
+        result={"gate_reason": "OK", "trade_count": 0},
+    )
+    run_path = run_dir(root, key)
+    assert run_path.name == fs_dirname_for_run_key(key)
+    assert "|" not in run_path.name
+    sidecar = run_path / LOGICAL_RUN_KEY_SIDECAR
+    assert sidecar.read_text(encoding="utf-8").strip() == key
+    action = inspect_run_for_resume(
+        root,
+        run_key=key,
+        bindings=BINDINGS,
+        max_attempts=1,
+        retry_failed=True,
+    )
+    assert action == "skip"
+    # Logical key preserved in envelope payload
+    env = (run_path / "run_envelope.json").read_text(encoding="utf-8")
+    assert key in env
+
+
+def test_legacy_raw_run_dir_still_readable(tmp_path: Path) -> None:
+    """Pre-#4384 Linux trees used the raw run_key as the directory name."""
+    from tools.arvp_vacation.sensitivity_campaign_state import run_dir
+
+    root = tmp_path / "ns"
+    legacy_key = "legacy_safe_key"
+    legacy_dir = root / "runs" / legacy_key
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "run_envelope.json").write_text("{}", encoding="utf-8")
+    assert run_dir(root, legacy_key) == legacy_dir

--- a/tools/arvp_vacation/hh_hl_campaign_execute.py
+++ b/tools/arvp_vacation/hh_hl_campaign_execute.py
@@ -90,6 +90,7 @@ from tools.arvp_vacation.sensitivity_campaign_executor import (
 from tools.arvp_vacation.sensitivity_campaign_state import (
     SensitivityStateError,
     commit_successful_result,
+    run_dir,
     write_campaign_envelope,
     write_run_envelope,
 )
@@ -829,7 +830,7 @@ def cmd_execute(args: argparse.Namespace) -> int:
                 effective_config_fingerprint=ctx.manifest_fingerprint,
                 dataset_content_fingerprint=window_fp,
                 seed=_seed_for(ctx.campaign_id, planned.window_id, planned.slot_id),
-                output_dir=str(evidence_root / "runs" / planned.run_key),
+                output_dir=str(run_dir(evidence_root, planned.run_key)),
                 run_plan_fingerprint=ctx.run_plan_fingerprint,
                 authorization_fingerprint=ctx.authorization_fingerprint,
                 attempt=attempt,

--- a/tools/arvp_vacation/sensitivity_campaign_primary_adoption.py
+++ b/tools/arvp_vacation/sensitivity_campaign_primary_adoption.py
@@ -23,8 +23,10 @@ from tools.arvp_vacation.sensitivity_campaign_state import (
     CampaignBindings,
     atomic_write_json,
     count_primary_succeeded,
+    fs_dirname_for_run_key,
     read_campaign_phase,
     read_json,
+    run_dir,
     update_campaign_phase,
 )
 
@@ -76,7 +78,6 @@ def build_primary_evidence_inventory(
     """Read-only inventory. Does not mutate primary results."""
     root = Path(evidence_root)
     expected = [str(k) for k in expected_run_keys]
-    expected_set = set(expected)
     runs_dir = root / "runs"
     disk_dirs = (
         sorted(p.name for p in runs_dir.iterdir() if p.is_dir())
@@ -84,8 +85,17 @@ def build_primary_evidence_inventory(
         else []
     )
     disk_set = set(disk_dirs)
-    missing = sorted(expected_set - disk_set)
-    extra = sorted(disk_set - expected_set)
+    # Accept both fs-safe hash dirs and legacy raw-key dirs as expected.
+    expected_dir_names: set[str] = set()
+    for key in expected:
+        expected_dir_names.add(fs_dirname_for_run_key(key))
+        expected_dir_names.add(key)
+    missing = sorted(
+        key
+        for key in expected
+        if not (run_dir(root, key) / "run_envelope.json").exists()
+    )
+    extra = sorted(disk_set - expected_dir_names)
 
     status_counts: dict[str, int] = {}
     attempt_hist: dict[str, int] = {}
@@ -93,10 +103,10 @@ def build_primary_evidence_inventory(
     missing_completed = 0
     primary_results = 0
 
-    for key in disk_dirs:
-        env_path = runs_dir / key / "run_envelope.json"
+    for key in expected:
+        run_path = run_dir(root, key)
+        env_path = run_path / "run_envelope.json"
         if not env_path.exists():
-            binding_mismatches += 1
             continue
         env = read_json(env_path)
         st = str(env.get("status") or "")
@@ -112,7 +122,7 @@ def build_primary_evidence_inventory(
         ):
             if env.get(field) != expected_val:
                 binding_mismatches += 1
-        rpath = runs_dir / key / "result.json"
+        rpath = run_path / "result.json"
         if rpath.exists():
             primary_results += 1
             result = read_json(rpath)
@@ -123,8 +133,15 @@ def build_primary_evidence_inventory(
             ):
                 if result.get(field) != expected_val:
                     binding_mismatches += 1
-        if not (runs_dir / key / "COMPLETED").exists():
+        if not (run_path / "COMPLETED").exists():
             missing_completed += 1
+
+    # Foreign/orphan dirs still contribute to mismatch accounting when they
+    # contain envelopes that are not part of the expected logical key set.
+    for dirname in extra:
+        env_path = runs_dir / dirname / "run_envelope.json"
+        if env_path.exists():
+            binding_mismatches += 1
 
     primary_verdict = VERDICT_PRIMARY_COMPLETE
     if missing or extra or primary_results != len(expected):

--- a/tools/arvp_vacation/sensitivity_campaign_runner.py
+++ b/tools/arvp_vacation/sensitivity_campaign_runner.py
@@ -119,6 +119,7 @@ from tools.arvp_vacation.sensitivity_campaign_state import (
     release_campaign_lock,
     reproduction_dir,
     result_path,
+    run_dir,
     update_campaign_phase,
     write_campaign_envelope,
     write_comparison_evidence,
@@ -454,7 +455,7 @@ def _run_primary_loop(
         )
 
         attempt = 1
-        env_path = evidence_root / "runs" / planned.run_key / "run_envelope.json"
+        env_path = run_dir(evidence_root, planned.run_key) / "run_envelope.json"
         if env_path.exists() and action == "retry":
             prev = json.loads(env_path.read_text(encoding="utf-8"))
             attempt = int(prev.get("attempt") or 0) + 1
@@ -476,7 +477,7 @@ def _run_primary_loop(
             effective_config_fingerprint=eff_fp,
             dataset_content_fingerprint=_window_content_fp(manifest, planned.window_id),
             seed=_seed_for(plan.campaign_id, planned.window_id, planned.slot_id),
-            output_dir=str(evidence_root / "runs" / planned.run_key),
+            output_dir=str(run_dir(evidence_root, planned.run_key)),
             run_plan_fingerprint=plan.run_plan_fingerprint,
             authorization_fingerprint=auth_fp,
             attempt=attempt,

--- a/tools/arvp_vacation/sensitivity_campaign_state.py
+++ b/tools/arvp_vacation/sensitivity_campaign_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import tempfile
@@ -17,6 +18,53 @@ STATE_SCHEMA_VERSION = "cdb.sensitivity_campaign_state.v1"
 CAMPAIGN_ENVELOPE_NAME = "campaign_envelope.json"
 RUNS_DIRNAME = "runs"
 REPRODUCTION_DIRNAME = "reproduction"
+LOGICAL_RUN_KEY_SIDECAR = "logical_run_key.txt"
+# Windows NTFS forbidden filename characters (and path separators).
+_FS_UNSAFE_CHARS = frozenset('<>:"/\\|?*')
+_FS_DIRNAME_PREFIX = "rk_"
+
+
+def fs_dirname_for_run_key(run_key: str) -> str:
+    """Deterministic Windows-safe directory name for a logical run_key.
+
+    The logical ``run_key`` (may contain ``|``) is unchanged in envelopes and
+    fingerprints. On-disk directories use ``rk_<sha256>`` so NTFS/Win32 paths
+    never embed illegal characters (#4384).
+    """
+    digest = hashlib.sha256(str(run_key).encode("utf-8")).hexdigest()
+    return f"{_FS_DIRNAME_PREFIX}{digest}"
+
+
+def run_key_needs_fs_mapping(run_key: str) -> bool:
+    text = str(run_key)
+    return any(ch in _FS_UNSAFE_CHARS for ch in text) or text in {".", ".."} or not text
+
+
+def run_dir(root: Path, run_key: str) -> Path:
+    """Resolve the on-disk run directory for ``run_key``.
+
+    Prefers the deterministic safe dirname. Falls back to a legacy raw-key
+    directory when it already exists (Linux evidence created before #4384).
+    New writes always target the safe path.
+    """
+    safe = Path(root) / RUNS_DIRNAME / fs_dirname_for_run_key(run_key)
+    if safe.exists():
+        return safe
+    legacy = Path(root) / RUNS_DIRNAME / str(run_key)
+    # Only accept legacy dirs that Windows could never have created with
+    # unsafe chars as a *new* target; existing Linux trees remain readable.
+    if legacy.exists():
+        return legacy
+    return safe
+
+
+def write_logical_run_key_sidecar(run_directory: Path, run_key: str) -> Path:
+    """Persist the logical run_key next to run artifacts (human/ops index)."""
+    run_directory.mkdir(parents=True, exist_ok=True)
+    path = run_directory / LOGICAL_RUN_KEY_SIDECAR
+    path.write_text(str(run_key) + "\n", encoding="utf-8")
+    return path
+
 
 RUN_STATES = frozenset(
     {"PLANNED", "RUNNING", "SUCCEEDED", "FAILED", "BLOCKED", "CANCELLED"}
@@ -286,15 +334,15 @@ def _assert_same_bindings(
 
 
 def run_envelope_path(root: Path, run_key: str) -> Path:
-    return root / RUNS_DIRNAME / run_key / "run_envelope.json"
+    return run_dir(root, run_key) / "run_envelope.json"
 
 
 def result_path(root: Path, run_key: str) -> Path:
-    return root / RUNS_DIRNAME / run_key / "result.json"
+    return run_dir(root, run_key) / "result.json"
 
 
 def completion_marker_path(root: Path, run_key: str) -> Path:
-    return root / RUNS_DIRNAME / run_key / "COMPLETED"
+    return run_dir(root, run_key) / "COMPLETED"
 
 
 def write_run_envelope(
@@ -311,6 +359,7 @@ def write_run_envelope(
     if status not in RUN_STATES:
         raise SensitivityStateError(f"STATE_INVALID_RUN_STATUS:{status}")
     path = run_envelope_path(root, run_key)
+    write_logical_run_key_sidecar(path.parent, run_key)
     payload = {
         "schema_version": STATE_SCHEMA_VERSION,
         "run_key": run_key,
@@ -522,9 +571,7 @@ def reproduction_dir(root: Path, run_key: str, reproduction_attempt: int) -> Pat
     if reproduction_attempt < 1:
         raise SensitivityStateError("STATE_REPRO_ATTEMPT_INVALID")
     return (
-        root
-        / RUNS_DIRNAME
-        / run_key
+        run_dir(root, run_key)
         / REPRODUCTION_DIRNAME
         / str(int(reproduction_attempt))
     )

--- a/tools/arvp_vacation/sensitivity_campaign_state.py
+++ b/tools/arvp_vacation/sensitivity_campaign_state.py
@@ -571,9 +571,7 @@ def reproduction_dir(root: Path, run_key: str, reproduction_attempt: int) -> Pat
     if reproduction_attempt < 1:
         raise SensitivityStateError("STATE_REPRO_ATTEMPT_INVALID")
     return (
-        run_dir(root, run_key)
-        / REPRODUCTION_DIRNAME
-        / str(int(reproduction_attempt))
+        run_dir(root, run_key) / REPRODUCTION_DIRNAME / str(int(reproduction_attempt))
     )
 
 


### PR DESCRIPTION
## Summary
- Map logical campaign `run_key` values (which contain `|`) to deterministic Windows-safe directories `rk_<sha256>` for on-disk evidence.
- Keep the logical `run_key` unchanged in envelopes, bindings, and fingerprints; write `logical_run_key.txt` sidecar for ops indexing.
- Wire `hh_hl_campaign_execute` and `sensitivity_campaign_runner` through `run_dir()`; preserve legacy raw-key directories for existing Linux evidence.

## Test plan
- [x] `pytest -q tests/unit/arvp/test_sensitivity_campaign_state.py` (incl. pipe/legacy/fs_dirname cases)
- [x] `pytest -q tests/unit/arvp/test_hh_hl_campaign_execute_wiring.py`
- [x] Runtime probe: mkdir + atomic write with real `#4374` pipe run_key succeeds on Windows
- [ ] After merge: re-run `#4374` campaign execute on authorized SHA (or rebind Owner-GO if required)

Refs #4384
Refs #4374

## Non-goals
- Analyzer / promotion / paper / live
- Re-running the 39-window campaign in this PR
- Owner-GO mutation