### PR TITLE
[OPS][WORKTREE] Enrich legacy reconcile + #4393 inventory/cleanup evidence

### DIFF
--- a/docs/evidence/worktree_legacy_inventory_4393_20260807T222842.json
+++ b/docs/evidence/worktree_legacy_inventory_4393_20260807T222842.json
@@ -1,0 +1,2103 @@
+{
+  "count": 95,
+  "counts": {
+    "NEEDED_FOLLOWUP_ISSUE": 52,
+    "NEEDED_QUICK_FINISH": 1,
+    "OBSOLETE_REMOVE": 12,
+    "UNCLEAR_HOLD": 30
+  },
+  "enrich": true,
+  "results": [
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": null,
+        "dirty": true,
+        "head": "ba6b1d94c6da480b77fa3ffcb7d46bba6f0d42a2",
+        "is_main_checkout": true,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Main checkout is allowed on D:; not a legacy migration target.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare",
+      "reason_codes": [
+        "MAIN_CHECKOUT_ALLOWED"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": null,
+        "dirty": null,
+        "head": "850b2c25770e6c220704965b1c09d37796049dd9",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": null,
+        "on_windows_legacy_drive": true,
+        "path": "C:/Users/janne/AppData/Local/Temp/cdb-main-unit-check",
+        "path_exists": false,
+        "prunable": true,
+        "unpushed": null
+      },
+      "notes": "Path missing; do not delete without evidence.",
+      "path": "C:/Users/janne/AppData/Local/Temp/cdb-main-unit-check",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2513",
+        "branch": "security-backlog-reconciliation-2513",
+        "dirty": false,
+        "head": "401dd294a52db510d8e6ebb979601c6472600b42",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-backlog",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-backlog",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2513",
+        "branch": "runtime-risk-issue-2513",
+        "dirty": false,
+        "head": "e6fb19591464249bb972ed1e0075089c266d79eb",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-recon-20260805",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-recon-20260805",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4032",
+        "branch": "4032-stage-a-evidence",
+        "dirty": false,
+        "head": "8c5af7ecfb5a30a78675d52ce99f22e03c54a98c",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-campaign",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-campaign",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4032",
+        "branch": "4032-batch-a-stage-a-gate",
+        "dirty": false,
+        "head": "5fae0460d688802b3c42c7db4c8ab9962eb30203",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-gate",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-gate",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4034",
+        "branch": "4034-wp5-no-survivors-closeout",
+        "dirty": false,
+        "head": "78960411a60e9fe0ecd38a92759a59a96aea5f1d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4034-wp5-closeout",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4034-wp5-closeout",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4080",
+        "branch": "runtime-risk-issue-4080",
+        "dirty": false,
+        "head": "da3df28d85c4ebaa1750cea59db6d9eb69f3a235",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4080-curl-hold",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4080-curl-hold",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": null,
+        "dirty": false,
+        "head": "ec663f4f542827775721f077b255b678bd205894",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": null,
+        "dirty": false,
+        "head": "ca27adeee28d7d63ba457ee627274704e89da990",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute-v2",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute-v2",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": null,
+        "dirty": false,
+        "head": "ec663f4f542827775721f077b255b678bd205894",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-go-audit",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-go-audit",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-campaign-manifest",
+        "dirty": false,
+        "head": "eb8efbdf9ec1a847ac30250210a33a353d9a8a1f",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-manifest",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-manifest",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-execution-contract",
+        "dirty": false,
+        "head": "e746bba6c72fc815f6d71738f8f569dadeaf31e4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-execution-contract",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-execution-contract",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-hermes-work-start",
+        "dirty": false,
+        "head": "18c411e74add5b0ba6b91de070ea6ae9fcd38ce0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-hermes-work-start",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-hermes-work-start",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-primary-adoption",
+        "dirty": false,
+        "head": "d28786fb4ef8a2a942998c31c93cdd55c7545ae1",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-primary-adoption",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-primary-adoption",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-reproduction-execution-fix",
+        "dirty": true,
+        "head": "6d7ba761041b8a7872bbdf60d7ea6fab91bbd6e8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-reproduction-execution-fix",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-reproduction-execution-fix",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-campaign",
+        "dirty": true,
+        "head": "10ddcc099a978be3435dd0da376c1196a0aaa452",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-campaign",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-campaign",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_QUICK_FINISH",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153",
+        "dirty": false,
+        "head": "d643ce90fec6591af89eee8dbc45c41efdb77271",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-exec",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean, unmerged, active issue ù consider quick finish then cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-exec",
+      "reason_codes": [
+        "NEEDED_QUICK_FINISH"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4164",
+        "branch": "main",
+        "dirty": false,
+        "head": "91411735635db698e767a7135b0e4ba336c4cd5d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4164-publisher",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4164-publisher",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4166",
+        "branch": null,
+        "dirty": false,
+        "head": "30fc491b75f6836e0c3bcab115253d4bbc4f5d97",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4166-final-validation",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4166-final-validation",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4166",
+        "branch": null,
+        "dirty": false,
+        "head": "224cfd49398b329b315781372658fab1fbf15362",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4166-main-cmp",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4166-main-cmp",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4169",
+        "branch": "local-ci-status-publisher-migration",
+        "dirty": false,
+        "head": "f542353df3cf8895fb39d352db36f4f99c30b227",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4169-migration",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4169-migration",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4170",
+        "branch": "github-app-check-run-publisher",
+        "dirty": false,
+        "head": "8de11bd713c5cdc4720e2c152238fe00a5c9d2d6",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4170-github-app",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4170-github-app",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4170",
+        "branch": "4170-bp-cutover-20260801141013",
+        "dirty": false,
+        "head": "33ecefa14e2b80ea6a1d7b52b7e66a602349223b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4170-phase-d",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4170-phase-d",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4150",
+        "branch": "4150-execution-economics-contract",
+        "dirty": false,
+        "head": "f6f9a917b9d8e65f52c0f7d53515f5d0b1615c0a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4191-economics",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4191-economics",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4122",
+        "branch": "4122-skill-mirror-assets",
+        "dirty": false,
+        "head": "d21856aeedd5cdc46b628b9367afe80d0bbff0e3",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4192-skill-mirror",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4192-skill-mirror",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4121",
+        "branch": "4121-decommission-gitlab-path-wt",
+        "dirty": false,
+        "head": "3ab1138c62c408c699349dd536b03055ad20c4ad",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4194-gitlab-clean",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4194-gitlab-clean",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4205",
+        "branch": "ci-tooling-issue-4205",
+        "dirty": false,
+        "head": "67736bbb22f83468744e6f86ddbcddc6a7560281",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4205-temp-preflight",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4205-temp-preflight",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4206",
+        "branch": "ci-tooling-issue-4206",
+        "dirty": false,
+        "head": "398c2dd948d2c6606a4a01096ca6640d5cbef1d0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4206-black-portable",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4206-black-portable",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4170",
+        "branch": "4170-app-bound-check-runs",
+        "dirty": false,
+        "head": "13726464226198f764b7e5eb313ae05cfc833393",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4214-app-bound",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4214-app-bound",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4220",
+        "branch": null,
+        "dirty": true,
+        "head": "850b2c25770e6c220704965b1c09d37796049dd9",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4220-reviewability",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4220-reviewability",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "7967",
+        "branch": "delivery-pr-handoff-contract-7967",
+        "dirty": false,
+        "head": "9befe05245f986a2ae3f51fdb563a073206a9359",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4230-merge",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4230-merge",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4250",
+        "branch": "agent-skills-issue-4250",
+        "dirty": true,
+        "head": "a501f2202fb255b4fb28136ca2006b6c2e1c94a4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4250-acp-canon",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4250-acp-canon",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4256",
+        "branch": "4256-run-evidence-20260802154101",
+        "dirty": false,
+        "head": "ada4eaacfb81a9a4b835cdd980962579f357367e",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4256-run-evidence-20260802154101",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4256-run-evidence-20260802154101",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4257",
+        "branch": "docs-governance-issue-4257",
+        "dirty": true,
+        "head": "458783e5ffc1e6474866847c3f4dec42c4c8cd8a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4257-approval-context",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4257-approval-context",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "012",
+        "branch": "blue-012-wiring-4261-f7b2",
+        "dirty": false,
+        "head": "516994dbfc4f7ea8649b54b80772c0e2b5a7506e",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4262-blue-012",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4262-blue-012",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4270",
+        "branch": "validation-research-issue-4270",
+        "dirty": true,
+        "head": "04e8f5687d619ce2be0b6b32f4dc7c1a3539da64",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4270-hermes-orchestration",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4270-hermes-orchestration",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4272",
+        "branch": "validation-research-issue-4272",
+        "dirty": true,
+        "head": "222965b46df099024e88acb679925687180f5cff",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4272-pilot",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4272-pilot",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4275",
+        "branch": "ci-tooling-issue-4275",
+        "dirty": false,
+        "head": "36eb651793a58bdd40ca8f55373c75d7bd241d52",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4275-security-cadence",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4275-security-cadence",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4280",
+        "branch": "ci-tooling-issue-4280",
+        "dirty": true,
+        "head": "ee582b27d9307b11afd3d05f5abeb84465c433c8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4280-canon-sync",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4280-canon-sync",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4283",
+        "branch": "validation-research-issue-4283",
+        "dirty": false,
+        "head": "41ba3625caddff5988eea3cf24ec7d8e581a4fd4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4283-g01-g04",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4283-g01-g04",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4286",
+        "branch": null,
+        "dirty": false,
+        "head": "899cefd87b7bd9fc22c68e484fb54057a225a525",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4286-merge-check",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4286-merge-check",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4289",
+        "branch": null,
+        "dirty": false,
+        "head": "43401302857ff9bfc6fd81a55b6373dd6437ac49",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-canary",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-canary",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4289",
+        "branch": null,
+        "dirty": false,
+        "head": "a52a0e90b702cd2758736bfa4ed25e2b9fd382ab",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-phase-a",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-phase-a",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4293",
+        "branch": "agent-skills-issue-4293",
+        "dirty": true,
+        "head": "3b16e83cae13b681c996e7dd9f59a0118b3a578f",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4293-dispatcher-residuals",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4293-dispatcher-residuals",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4327",
+        "branch": "hermes-version-pin-4327",
+        "dirty": false,
+        "head": "793fbf3e13e20021c4649bf7f2c265d161f844f8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4327-hermes-pin",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4327-hermes-pin",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4327",
+        "branch": null,
+        "dirty": false,
+        "head": "9a366048d7da9e3eccc008a815b5a7ca3f602e89",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4327-runtime-resume",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4327-runtime-resume",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4336",
+        "branch": "validation-research-issue-4336-cdb051",
+        "dirty": false,
+        "head": "ec14dc2da5f483192a838e242e0355b08f3f2e71",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4336-cdb051",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4336-cdb051",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4338",
+        "branch": "4338-cdb049-only",
+        "dirty": true,
+        "head": "896f5de4f44b253d87acebbc1a5a9b15c5a171ca",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-cdb049-restore",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-cdb049-restore",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4338",
+        "branch": null,
+        "dirty": true,
+        "head": "655e7059a3caeb7d554d16a027898d707d3fb5bb",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-postmerge-audit",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-postmerge-audit",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4360",
+        "branch": "ci-tooling-issue-4360",
+        "dirty": true,
+        "head": "242fafd5d5eb6dcdaa61ed96393f6a6e7c45fa78",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4360-cursor-env-build",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4360-cursor-env-build",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4366",
+        "branch": "validation-research-issue-4366",
+        "dirty": false,
+        "head": "0eb1d5c0a86bd58528a4e3d13541cef28d4f54b0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-campaign-to-pr",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-campaign-to-pr",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4366",
+        "branch": "validation-research-issue-4366-pr-ready",
+        "dirty": false,
+        "head": "29af6e7238dbbfdd8b04cba8b82a89f4fa7e62b4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-pr-ready",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-pr-ready",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4372",
+        "branch": "validation-research-issue-4372",
+        "dirty": false,
+        "head": "10e0a6e3e64657a1f1ab1f3af890f584eb3c6ffd",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4372-hh-hl",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4372-hh-hl",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4194",
+        "branch": null,
+        "dirty": false,
+        "head": "dae2c5485dbacfe5ddf2b65580aa25eb35c785a7",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-main-check-4194",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-main-check-4194",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "security-pip-crypto-aiohttp-2026-08-05",
+        "dirty": false,
+        "head": "081b19378abc280f460a1627c146962cc1eb6e77",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pip-crypto-aiohttp-20260805",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pip-crypto-aiohttp-20260805",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4304",
+        "branch": "ruff-0.16.1",
+        "dirty": false,
+        "head": "3b61561db6012a82976090809d017b14cae396b5",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4304-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4304-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4306",
+        "branch": "redis-8.1.0",
+        "dirty": false,
+        "head": "2d7ca5e7ab1fbd3abf7605371ee87f147dcdf173",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4306-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4306-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4307",
+        "branch": "codeql-action-432e0d4de6",
+        "dirty": false,
+        "head": "5f4db4e31a65e717a56762cb2dc3002bfdf0280d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4307-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4307-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4308",
+        "branch": "login-action-4.6.0",
+        "dirty": false,
+        "head": "c9fe293085c1ec83044d81c6f0d1aca46651d17b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4308-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4308-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4309",
+        "branch": "stale-11.0.0",
+        "dirty": false,
+        "head": "476c8c6608394338dbb669367f3c1cb54fcb6fa8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4309-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4309-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4310",
+        "branch": "prometheus-v3.13.2",
+        "dirty": false,
+        "head": "c7ea776aa16ce91d4bbdafbf0358a59d639e158a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4310-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4310-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4311",
+        "branch": "redis-8.10.0-alpine",
+        "dirty": false,
+        "head": "49ccbe7b5d1aef2f66f67c86cfe2915b01c25a2d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4311-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4311-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4207",
+        "branch": "agent-skills-issue-4207",
+        "dirty": false,
+        "head": "a8927fa28d34b59a8732f435205c11514317ff38",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-acceptance-batch1",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-acceptance-batch1",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "security-alert-wave-2026-08-03",
+        "dirty": false,
+        "head": "d5205b2c3b94386f7d2d40581027ab2ba0d88359",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-security-wave-4314",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-security-wave-4314",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "security-setuptools-83-2026-08-05",
+        "dirty": false,
+        "head": "14ae7651798a4680e37321a9a56a99206a61f209",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-setuptools-83-20260805",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-setuptools-83-20260805",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": null,
+        "branch": null,
+        "dirty": false,
+        "head": "10ac6f95c2e4d5f9b3ce2530d2c5ad36aff3794e",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-supervised-pilot-hold",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-supervised-pilot-hold",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "OBSOLETE_REMOVE",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": false,
+        "head": "b23ac5c948c4e97a10cc7bd5941ba69f3f8c0133",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-campaign-exec",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean and merged/prunable; candidate for controlled removal.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-campaign-exec",
+      "reason_codes": [
+        "OBSOLETE_REMOVE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": "validation-research-issue-4374-comment-id-fix",
+        "dirty": true,
+        "head": "aca10a687bc4d7e8d6e1686ed6dd3f57d0e48d34",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-comment-id-fix",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-comment-id-fix",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "f03564c77182cea957595b36f5512103d5062258",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-go-prep",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-go-prep",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "84060194876750d107a5886d37680195d9696c96",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-wiring",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-wiring",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "b23ac5c948c4e97a10cc7bd5941ba69f3f8c0133",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-postmerge-go",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-postmerge-go",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "3154efe218d1f1b8101768e365859c0e91cb4906",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-rebind-3154efe",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-rebind-3154efe",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4384",
+        "branch": "validation-research-issue-4384",
+        "dirty": false,
+        "head": "089e635b0189292cc5b97f3b327ac50b0c87d6ab",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4384-run-key-path",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4384-run-key-path",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4374",
+        "branch": "validation-research-issue-4374",
+        "dirty": false,
+        "head": "67ac1abc1d9a18d47da86981d017813edc0bdd78",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/batch-validation-research-issue-4374-exec-prep",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/batch-validation-research-issue-4374-exec-prep",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4152",
+        "branch": null,
+        "dirty": false,
+        "head": "1bdd34bd2b67ff1e61770624c5b042c87141bfb6",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4152-risk-fail-closed-safety",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4152-risk-fail-closed-safety",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4182",
+        "branch": "4182-stop-loss-e2e-kill-unwind-drill",
+        "dirty": false,
+        "head": "0d7244e5e7249d93c8d20b156195414eff0fbc14",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4182-stop-loss-e2e-kill-unwind-drill",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4182-stop-loss-e2e-kill-unwind-drill",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4184",
+        "branch": "4184-reduce-only-unwind-contract",
+        "dirty": true,
+        "head": "d00e2d7ffb2643392814176d3b72b282f7c8bb00",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4184-reduce-only-unwind-contract",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4184-reduce-only-unwind-contract",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4196",
+        "branch": "4196-disable-main-force-pushes",
+        "dirty": false,
+        "head": "2848eeb28aa74ae47c3cafb807771c747cc6034d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4196-disable-main-force-pushes",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4196-disable-main-force-pushes",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4382",
+        "branch": "runtime-risk-issue-4382",
+        "dirty": false,
+        "head": "09841d49c5fe9d47a693da000b9cf28baf4977cf",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4382-risk-pubsub-timeout",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4382-risk-pubsub-timeout",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4148",
+        "branch": "4148-parameter-control-policy",
+        "dirty": true,
+        "head": "f1a2e3b18ba338e8ca7940e80f55a0a2942f918a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-4154-parameter-control-v2",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-4154-parameter-control-v2",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4154",
+        "branch": "pr-queue-a-4154",
+        "dirty": false,
+        "head": "7368b5c96f48d80a06a588289dffb4de1e32c1a2",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-a-4154",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-a-4154",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-actions-patch-b1",
+        "dirty": false,
+        "head": "46eb05196b3d2f026d745f2ac36126afbe49004e",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b1-actions-patch",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b1-actions-patch",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-actions-major-b2",
+        "dirty": false,
+        "head": "21f23d65989fdb22488cc6f1a1299b41775e56b0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b2-actions-major",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b2-actions-major",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-python-c1",
+        "dirty": false,
+        "head": "0647a61acdb6b7772d1f846dbb38d718a2f8bcd9",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-c-python-deps",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-c-python-deps",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-python-digest-d1-cea0e60",
+        "dirty": true,
+        "head": "3b137c4d6a7749af0073abcc0e0c52c33ed9b12b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d1-python-cea0e60",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d1-python-cea0e60",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-python-digest-d2-86f975a",
+        "dirty": false,
+        "head": "75bd7fd489bbe12eb35de149c1faedf3dc8ebbfc",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d2-python-86f975a",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d2-python-86f975a",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-redis-8.8.1",
+        "dirty": false,
+        "head": "4f714b4a728803f6fc2acb2918beb4e9cbb9e2a7",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e1-redis",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e1-redis",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-grafana-13.1.1",
+        "dirty": true,
+        "head": "3018a8b194c1b16b42ea0dd360c11f0429946e8b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e2-grafana",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e2-grafana",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "pr-queue-reconcile-2026-07-28",
+        "dirty": false,
+        "head": "696dcfb5d263557dde25ce3797630db6357a29a2",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "pr-queue-final-reconcile-2026-07-28",
+        "dirty": false,
+        "head": "b4adbe76430eaa9e8f61c69c7c45fcfb891c1ca7",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger2",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger2",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4065",
+        "branch": "arvp-4065-regime-stats-schema-ref",
+        "dirty": false,
+        "head": "54bea593f29705738e95dc4527dc09bd6fa62644",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-4065",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-4065",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4289",
+        "branch": "ci-tooling-issue-4289",
+        "dirty": false,
+        "head": "d472e50a07add68d585a5c3a0939f0c854312b65",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4289-b1",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4289-b1",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4329",
+        "branch": null,
+        "dirty": true,
+        "head": "a0ca789aab9118e05eff6f056df47b3cdd334dc9",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4329",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4329",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4393",
+        "branch": "ci-tooling-issue-4393",
+        "dirty": true,
+        "head": "59dfbc6753d166ca0e3e40c8007dd4b7b0705b1f",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": false,
+        "path": "Y:/Worktrees/Claire_de_Binare/issue-4393",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "Y:/Worktrees/Claire_de_Binare/issue-4393",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    }
+  ],
+  "status": "PASS"
+}

--- a/docs/evidence/worktree_legacy_inventory_4393_20260807T222842.md
+++ b/docs/evidence/worktree_legacy_inventory_4393_20260807T222842.md
@@ -1,0 +1,130 @@
+# Legacy Worktree Inventory #4393
+
+- generated_from: `worktree_legacy_inventory_4393_20260807T222842.json`
+- count: 95
+- enrich: True
+- counts: `{'NEEDED_FOLLOWUP_ISSUE': 52, 'NEEDED_QUICK_FINISH': 1, 'OBSOLETE_REMOVE': 12, 'UNCLEAR_HOLD': 30}`
+
+## Classification summary
+
+| Class | Count |
+|---|---:|
+| NEEDED_FOLLOWUP_ISSUE | 52 |
+| NEEDED_QUICK_FINISH | 1 |
+| OBSOLETE_REMOVE | 12 |
+| UNCLEAR_HOLD | 30 |
+
+## OBSOLETE_REMOVE (12)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute` | `` | `ec663f4f5428` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute-v2` | `` | `ca27adeee28d` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-go-audit` | `` | `ec663f4f5428` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4164-publisher` | `main` | `91411735635d` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4166-main-cmp` | `` | `224cfd49398b` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4170-github-app` | `github-app-check-run-publisher` | `8de11bd713c5` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-canary` | `` | `43401302857f` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-phase-a` | `` | `a52a0e90b702` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4327-runtime-resume` | `` | `9a366048d7da` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-main-check-4194` | `` | `dae2c5485dba` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-supervised-pilot-hold` | `` | `10ac6f95c2e4` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-campaign-exec` | `` | `b23ac5c948c4` | False | False | True | Clean and merged/prunable; candidate for controlled removal. |
+
+## NEEDED_QUICK_FINISH (1)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-exec` | `validation-research-issue-4153` | `d643ce90fec6` | False | False | False | Clean, unmerged, active issue ù consider quick finish then cleanup. |
+
+## UNCLEAR_HOLD (30)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare` | `` | `ba6b1d94c6da` | True | False | True | Main checkout is allowed on D:; not a legacy migration target. |
+| `C:/Users/janne/AppData/Local/Temp/cdb-main-unit-check` | `` | `850b2c25770e` | None | None | None | Path missing; do not delete without evidence. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-reproduction-execution-fix` | `validation-research-issue-4153-reproduct` | `6d7ba761041b` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-campaign` | `validation-research-issue-4153-campaign` | `10ddcc099a97` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4220-reviewability` | `` | `850b2c25770e` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4250-acp-canon` | `agent-skills-issue-4250` | `a501f2202fb2` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4257-approval-context` | `docs-governance-issue-4257` | `458783e5ffc1` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4270-hermes-orchestration` | `validation-research-issue-4270` | `04e8f5687d61` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4272-pilot` | `validation-research-issue-4272` | `222965b46df0` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4280-canon-sync` | `ci-tooling-issue-4280` | `ee582b27d930` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4293-dispatcher-residuals` | `agent-skills-issue-4293` | `3b16e83cae13` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4338-cdb049-restore` | `4338-cdb049-only` | `896f5de4f44b` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4338-postmerge-audit` | `` | `655e7059a3ca` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4360-cursor-env-build` | `ci-tooling-issue-4360` | `242fafd5d5eb` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-comment-id-fix` | `validation-research-issue-4374-comment-i` | `aca10a687bc4` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-go-prep` | `` | `f03564c77182` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-wiring` | `` | `840601948767` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-postmerge-go` | `` | `b23ac5c948c4` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-rebind-3154efe` | `` | `3154efe218d1` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4184-reduce-only-unwind-contract` | `4184-reduce-only-unwind-contract` | `d00e2d7ffb26` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-4154-parameter-control-v2` | `4148-parameter-control-policy` | `f1a2e3b18ba3` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b1-actions-patch` | `deps-actions-patch-b1` | `46eb05196b3d` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b2-actions-major` | `deps-actions-major-b2` | `21f23d65989f` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-c-python-deps` | `deps-python-c1` | `0647a61acdb6` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d1-python-cea0e60` | `deps-python-digest-d1-cea0e60` | `3b137c4d6a77` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d2-python-86f975a` | `deps-python-digest-d2-86f975a` | `75bd7fd489bb` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e1-redis` | `deps-redis-8.8.1` | `4f714b4a7288` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e2-grafana` | `deps-grafana-13.1.1` | `3018a8b194c1` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4329` | `` | `a0ca789aab91` | True | True | False | Dirty worktree; STOP. |
+| `Y:/Worktrees/Claire_de_Binare/issue-4393` | `ci-tooling-issue-4393` | `59dfbc6753d1` | True | False | True | Dirty worktree; STOP. |
+
+## NEEDED_FOLLOWUP_ISSUE (52)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+| `D:/Dev/Workspaces/Repos/cdb-wt-2513-security-backlog` | `security-backlog-reconciliation-2513` | `401dd294a52d` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-2513-security-recon-20260805` | `runtime-risk-issue-2513` | `e6fb19591464` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4032-campaign` | `4032-stage-a-evidence` | `8c5af7ecfb5a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4032-gate` | `4032-batch-a-stage-a-gate` | `5fae0460d688` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4034-wp5-closeout` | `4034-wp5-no-survivors-closeout` | `78960411a60e` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4080-curl-hold` | `runtime-risk-issue-4080` | `da3df28d85c4` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-manifest` | `validation-research-issue-4153-campaign-` | `eb8efbdf9ec1` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-execution-contract` | `validation-research-issue-4153-execution` | `e746bba6c72f` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-hermes-work-start` | `validation-research-issue-4153-hermes-wo` | `18c411e74add` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-primary-adoption` | `validation-research-issue-4153-primary-a` | `d28786fb4ef8` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4166-final-validation` | `` | `30fc491b75f6` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4169-migration` | `local-ci-status-publisher-migration` | `f542353df3cf` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4170-phase-d` | `4170-bp-cutover-20260801141013` | `33ecefa14e2b` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4191-economics` | `4150-execution-economics-contract` | `f6f9a917b9d8` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4192-skill-mirror` | `4122-skill-mirror-assets` | `d21856aeedd5` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4194-gitlab-clean` | `4121-decommission-gitlab-path-wt` | `3ab1138c62c4` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4205-temp-preflight` | `ci-tooling-issue-4205` | `67736bbb22f8` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4206-black-portable` | `ci-tooling-issue-4206` | `398c2dd948d2` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4214-app-bound` | `4170-app-bound-check-runs` | `137264642261` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4230-merge` | `delivery-pr-handoff-contract-7967` | `9befe05245f9` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4256-run-evidence-20260802154101` | `4256-run-evidence-20260802154101` | `ada4eaacfb81` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4262-blue-012` | `blue-012-wiring-4261-f7b2` | `516994dbfc4f` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4275-security-cadence` | `ci-tooling-issue-4275` | `36eb651793a5` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4283-g01-g04` | `validation-research-issue-4283` | `41ba3625cadd` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4286-merge-check` | `` | `899cefd87b7b` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4327-hermes-pin` | `hermes-version-pin-4327` | `793fbf3e13e2` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4336-cdb051` | `validation-research-issue-4336-cdb051` | `ec14dc2da5f4` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4366-campaign-to-pr` | `validation-research-issue-4366` | `0eb1d5c0a86b` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4366-pr-ready` | `validation-research-issue-4366-pr-ready` | `29af6e7238db` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4372-hh-hl` | `validation-research-issue-4372` | `10e0a6e3e646` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pip-crypto-aiohttp-20260805` | `security-pip-crypto-aiohttp-2026-08-05` | `081b19378abc` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4304-queue` | `ruff-0.16.1` | `3b61561db601` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4306-queue` | `redis-8.1.0` | `2d7ca5e7ab1f` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4307-queue` | `codeql-action-432e0d4de6` | `5f4db4e31a65` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4308-queue` | `login-action-4.6.0` | `c9fe293085c1` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4309-queue` | `stale-11.0.0` | `476c8c660839` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4310-queue` | `prometheus-v3.13.2` | `c7ea776aa16c` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4311-queue` | `redis-8.10.0-alpine` | `49ccbe7b5d1a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-acceptance-batch1` | `agent-skills-issue-4207` | `a8927fa28d34` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-security-wave-4314` | `security-alert-wave-2026-08-03` | `d5205b2c3b94` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-setuptools-83-20260805` | `security-setuptools-83-2026-08-05` | `14ae7651798a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4384-run-key-path` | `validation-research-issue-4384` | `089e635b0189` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/batch-validation-research-issue-4374-exec-prep` | `validation-research-issue-4374` | `67ac1abc1d9a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4152-risk-fail-closed-safety` | `` | `1bdd34bd2b67` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4182-stop-loss-e2e-kill-unwind-drill` | `4182-stop-loss-e2e-kill-unwind-drill` | `0d7244e5e724` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4196-disable-main-force-pushes` | `4196-disable-main-force-pushes` | `2848eeb28aa7` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4382-risk-pubsub-timeout` | `runtime-risk-issue-4382` | `09841d49c5fe` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-a-4154` | `pr-queue-a-4154` | `7368b5c96f48` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger` | `pr-queue-reconcile-2026-07-28` | `696dcfb5d263` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger2` | `pr-queue-final-reconcile-2026-07-28` | `b4adbe76430e` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare-4065` | `arvp-4065-regime-stats-schema-ref` | `54bea593f297` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4289-b1` | `ci-tooling-issue-4289` | `d472e50a07ad` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |

--- a/docs/evidence/worktree_legacy_inventory_4393_after_remove.json
+++ b/docs/evidence/worktree_legacy_inventory_4393_after_remove.json
@@ -1,0 +1,1838 @@
+{
+  "count": 83,
+  "counts": {
+    "NEEDED_FOLLOWUP_ISSUE": 52,
+    "NEEDED_QUICK_FINISH": 1,
+    "UNCLEAR_HOLD": 30
+  },
+  "enrich": true,
+  "results": [
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": null,
+        "dirty": true,
+        "head": "ba6b1d94c6da480b77fa3ffcb7d46bba6f0d42a2",
+        "is_main_checkout": true,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Main checkout is allowed on D:; not a legacy migration target.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare",
+      "reason_codes": [
+        "MAIN_CHECKOUT_ALLOWED"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2513",
+        "branch": "security-backlog-reconciliation-2513",
+        "dirty": false,
+        "head": "401dd294a52db510d8e6ebb979601c6472600b42",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-backlog",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-backlog",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2513",
+        "branch": "runtime-risk-issue-2513",
+        "dirty": false,
+        "head": "e6fb19591464249bb972ed1e0075089c266d79eb",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-recon-20260805",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-2513-security-recon-20260805",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4032",
+        "branch": "4032-stage-a-evidence",
+        "dirty": false,
+        "head": "8c5af7ecfb5a30a78675d52ce99f22e03c54a98c",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-campaign",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-campaign",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4032",
+        "branch": "4032-batch-a-stage-a-gate",
+        "dirty": false,
+        "head": "5fae0460d688802b3c42c7db4c8ab9962eb30203",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-gate",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4032-gate",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4034",
+        "branch": "4034-wp5-no-survivors-closeout",
+        "dirty": false,
+        "head": "78960411a60e9fe0ecd38a92759a59a96aea5f1d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4034-wp5-closeout",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4034-wp5-closeout",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4080",
+        "branch": "runtime-risk-issue-4080",
+        "dirty": false,
+        "head": "da3df28d85c4ebaa1750cea59db6d9eb69f3a235",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4080-curl-hold",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4080-curl-hold",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-campaign-manifest",
+        "dirty": false,
+        "head": "eb8efbdf9ec1a847ac30250210a33a353d9a8a1f",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-manifest",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-manifest",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-execution-contract",
+        "dirty": false,
+        "head": "e746bba6c72fc815f6d71738f8f569dadeaf31e4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-execution-contract",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-execution-contract",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-hermes-work-start",
+        "dirty": false,
+        "head": "18c411e74add5b0ba6b91de070ea6ae9fcd38ce0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-hermes-work-start",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-hermes-work-start",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-primary-adoption",
+        "dirty": false,
+        "head": "d28786fb4ef8a2a942998c31c93cdd55c7545ae1",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-primary-adoption",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-primary-adoption",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-reproduction-execution-fix",
+        "dirty": true,
+        "head": "6d7ba761041b8a7872bbdf60d7ea6fab91bbd6e8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-reproduction-execution-fix",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-reproduction-execution-fix",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153-campaign",
+        "dirty": true,
+        "head": "10ddcc099a978be3435dd0da376c1196a0aaa452",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-campaign",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-campaign",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_QUICK_FINISH",
+      "facts": {
+        "active_issue": "4153",
+        "branch": "validation-research-issue-4153",
+        "dirty": false,
+        "head": "d643ce90fec6591af89eee8dbc45c41efdb77271",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-exec",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Clean, unmerged, active issue ù consider quick finish then cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-exec",
+      "reason_codes": [
+        "NEEDED_QUICK_FINISH"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4164",
+        "branch": "main",
+        "dirty": false,
+        "head": "91411735635db698e767a7135b0e4ba336c4cd5d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4164-publisher",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Worktree has main/master checked out; never auto-remove.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4164-publisher",
+      "reason_codes": [
+        "MAIN_CHECKOUT_ALLOWED"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4166",
+        "branch": null,
+        "dirty": false,
+        "head": "30fc491b75f6836e0c3bcab115253d4bbc4f5d97",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4166-final-validation",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4166-final-validation",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4169",
+        "branch": "local-ci-status-publisher-migration",
+        "dirty": false,
+        "head": "f542353df3cf8895fb39d352db36f4f99c30b227",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4169-migration",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4169-migration",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4170",
+        "branch": "4170-bp-cutover-20260801141013",
+        "dirty": false,
+        "head": "33ecefa14e2b80ea6a1d7b52b7e66a602349223b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4170-phase-d",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4170-phase-d",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4150",
+        "branch": "4150-execution-economics-contract",
+        "dirty": false,
+        "head": "f6f9a917b9d8e65f52c0f7d53515f5d0b1615c0a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4191-economics",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4191-economics",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4122",
+        "branch": "4122-skill-mirror-assets",
+        "dirty": false,
+        "head": "d21856aeedd5cdc46b628b9367afe80d0bbff0e3",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4192-skill-mirror",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4192-skill-mirror",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4121",
+        "branch": "4121-decommission-gitlab-path-wt",
+        "dirty": false,
+        "head": "3ab1138c62c408c699349dd536b03055ad20c4ad",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4194-gitlab-clean",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4194-gitlab-clean",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4205",
+        "branch": "ci-tooling-issue-4205",
+        "dirty": false,
+        "head": "67736bbb22f83468744e6f86ddbcddc6a7560281",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4205-temp-preflight",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4205-temp-preflight",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4206",
+        "branch": "ci-tooling-issue-4206",
+        "dirty": false,
+        "head": "398c2dd948d2c6606a4a01096ca6640d5cbef1d0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4206-black-portable",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4206-black-portable",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4170",
+        "branch": "4170-app-bound-check-runs",
+        "dirty": false,
+        "head": "13726464226198f764b7e5eb313ae05cfc833393",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4214-app-bound",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4214-app-bound",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4220",
+        "branch": null,
+        "dirty": true,
+        "head": "850b2c25770e6c220704965b1c09d37796049dd9",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4220-reviewability",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4220-reviewability",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "7967",
+        "branch": "delivery-pr-handoff-contract-7967",
+        "dirty": false,
+        "head": "9befe05245f986a2ae3f51fdb563a073206a9359",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4230-merge",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4230-merge",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4250",
+        "branch": "agent-skills-issue-4250",
+        "dirty": true,
+        "head": "a501f2202fb255b4fb28136ca2006b6c2e1c94a4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4250-acp-canon",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4250-acp-canon",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4256",
+        "branch": "4256-run-evidence-20260802154101",
+        "dirty": false,
+        "head": "ada4eaacfb81a9a4b835cdd980962579f357367e",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4256-run-evidence-20260802154101",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4256-run-evidence-20260802154101",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4257",
+        "branch": "docs-governance-issue-4257",
+        "dirty": true,
+        "head": "458783e5ffc1e6474866847c3f4dec42c4c8cd8a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4257-approval-context",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4257-approval-context",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "012",
+        "branch": "blue-012-wiring-4261-f7b2",
+        "dirty": false,
+        "head": "516994dbfc4f7ea8649b54b80772c0e2b5a7506e",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4262-blue-012",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4262-blue-012",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4270",
+        "branch": "validation-research-issue-4270",
+        "dirty": true,
+        "head": "04e8f5687d619ce2be0b6b32f4dc7c1a3539da64",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4270-hermes-orchestration",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4270-hermes-orchestration",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4272",
+        "branch": "validation-research-issue-4272",
+        "dirty": true,
+        "head": "222965b46df099024e88acb679925687180f5cff",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4272-pilot",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4272-pilot",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4275",
+        "branch": "ci-tooling-issue-4275",
+        "dirty": false,
+        "head": "36eb651793a58bdd40ca8f55373c75d7bd241d52",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4275-security-cadence",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4275-security-cadence",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4280",
+        "branch": "ci-tooling-issue-4280",
+        "dirty": true,
+        "head": "ee582b27d9307b11afd3d05f5abeb84465c433c8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4280-canon-sync",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4280-canon-sync",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4283",
+        "branch": "validation-research-issue-4283",
+        "dirty": false,
+        "head": "41ba3625caddff5988eea3cf24ec7d8e581a4fd4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4283-g01-g04",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4283-g01-g04",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4286",
+        "branch": null,
+        "dirty": false,
+        "head": "899cefd87b7bd9fc22c68e484fb54057a225a525",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4286-merge-check",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4286-merge-check",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4293",
+        "branch": "agent-skills-issue-4293",
+        "dirty": true,
+        "head": "3b16e83cae13b681c996e7dd9f59a0118b3a578f",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4293-dispatcher-residuals",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4293-dispatcher-residuals",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4327",
+        "branch": "hermes-version-pin-4327",
+        "dirty": false,
+        "head": "793fbf3e13e20021c4649bf7f2c265d161f844f8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4327-hermes-pin",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4327-hermes-pin",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4336",
+        "branch": "validation-research-issue-4336-cdb051",
+        "dirty": false,
+        "head": "ec14dc2da5f483192a838e242e0355b08f3f2e71",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4336-cdb051",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4336-cdb051",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4338",
+        "branch": "4338-cdb049-only",
+        "dirty": true,
+        "head": "896f5de4f44b253d87acebbc1a5a9b15c5a171ca",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-cdb049-restore",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-cdb049-restore",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4338",
+        "branch": null,
+        "dirty": true,
+        "head": "655e7059a3caeb7d554d16a027898d707d3fb5bb",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-postmerge-audit",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4338-postmerge-audit",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4360",
+        "branch": "ci-tooling-issue-4360",
+        "dirty": true,
+        "head": "242fafd5d5eb6dcdaa61ed96393f6a6e7c45fa78",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4360-cursor-env-build",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4360-cursor-env-build",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4366",
+        "branch": "validation-research-issue-4366",
+        "dirty": false,
+        "head": "0eb1d5c0a86bd58528a4e3d13541cef28d4f54b0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-campaign-to-pr",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-campaign-to-pr",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4366",
+        "branch": "validation-research-issue-4366-pr-ready",
+        "dirty": false,
+        "head": "29af6e7238dbbfdd8b04cba8b82a89f4fa7e62b4",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-pr-ready",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4366-pr-ready",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4372",
+        "branch": "validation-research-issue-4372",
+        "dirty": false,
+        "head": "10e0a6e3e64657a1f1ab1f3af890f584eb3c6ffd",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-4372-hh-hl",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4372-hh-hl",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "security-pip-crypto-aiohttp-2026-08-05",
+        "dirty": false,
+        "head": "081b19378abc280f460a1627c146962cc1eb6e77",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pip-crypto-aiohttp-20260805",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pip-crypto-aiohttp-20260805",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4304",
+        "branch": "ruff-0.16.1",
+        "dirty": false,
+        "head": "3b61561db6012a82976090809d017b14cae396b5",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4304-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4304-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4306",
+        "branch": "redis-8.1.0",
+        "dirty": false,
+        "head": "2d7ca5e7ab1fbd3abf7605371ee87f147dcdf173",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4306-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4306-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4307",
+        "branch": "codeql-action-432e0d4de6",
+        "dirty": false,
+        "head": "5f4db4e31a65e717a56762cb2dc3002bfdf0280d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4307-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4307-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4308",
+        "branch": "login-action-4.6.0",
+        "dirty": false,
+        "head": "c9fe293085c1ec83044d81c6f0d1aca46651d17b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4308-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4308-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4309",
+        "branch": "stale-11.0.0",
+        "dirty": false,
+        "head": "476c8c6608394338dbb669367f3c1cb54fcb6fa8",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4309-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4309-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4310",
+        "branch": "prometheus-v3.13.2",
+        "dirty": false,
+        "head": "c7ea776aa16ce91d4bbdafbf0358a59d639e158a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4310-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4310-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4311",
+        "branch": "redis-8.10.0-alpine",
+        "dirty": false,
+        "head": "49ccbe7b5d1aef2f66f67c86cfe2915b01c25a2d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4311-queue",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-4311-queue",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4207",
+        "branch": "agent-skills-issue-4207",
+        "dirty": false,
+        "head": "a8927fa28d34b59a8732f435205c11514317ff38",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-acceptance-batch1",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-pr-acceptance-batch1",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "security-alert-wave-2026-08-03",
+        "dirty": false,
+        "head": "d5205b2c3b94386f7d2d40581027ab2ba0d88359",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-security-wave-4314",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-security-wave-4314",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "security-setuptools-83-2026-08-05",
+        "dirty": false,
+        "head": "14ae7651798a4680e37321a9a56a99206a61f209",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/cdb-wt-setuptools-83-20260805",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-setuptools-83-20260805",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": "validation-research-issue-4374-comment-id-fix",
+        "dirty": true,
+        "head": "aca10a687bc4d7e8d6e1686ed6dd3f57d0e48d34",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-comment-id-fix",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-comment-id-fix",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "f03564c77182cea957595b36f5512103d5062258",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-go-prep",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-go-prep",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "84060194876750d107a5886d37680195d9696c96",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-wiring",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-wiring",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "b23ac5c948c4e97a10cc7bd5941ba69f3f8c0133",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-postmerge-go",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-postmerge-go",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4374",
+        "branch": null,
+        "dirty": true,
+        "head": "3154efe218d1f1b8101768e365859c0e91cb4906",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-rebind-3154efe",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-rebind-3154efe",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4384",
+        "branch": "validation-research-issue-4384",
+        "dirty": false,
+        "head": "089e635b0189292cc5b97f3b327ac50b0c87d6ab",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4384-run-key-path",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4384-run-key-path",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4374",
+        "branch": "validation-research-issue-4374",
+        "dirty": false,
+        "head": "67ac1abc1d9a18d47da86981d017813edc0bdd78",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/batch-validation-research-issue-4374-exec-prep",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/batch-validation-research-issue-4374-exec-prep",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4152",
+        "branch": null,
+        "dirty": false,
+        "head": "1bdd34bd2b67ff1e61770624c5b042c87141bfb6",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4152-risk-fail-closed-safety",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4152-risk-fail-closed-safety",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4182",
+        "branch": "4182-stop-loss-e2e-kill-unwind-drill",
+        "dirty": false,
+        "head": "0d7244e5e7249d93c8d20b156195414eff0fbc14",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4182-stop-loss-e2e-kill-unwind-drill",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4182-stop-loss-e2e-kill-unwind-drill",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4184",
+        "branch": "4184-reduce-only-unwind-contract",
+        "dirty": true,
+        "head": "d00e2d7ffb2643392814176d3b72b282f7c8bb00",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4184-reduce-only-unwind-contract",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4184-reduce-only-unwind-contract",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4196",
+        "branch": "4196-disable-main-force-pushes",
+        "dirty": false,
+        "head": "2848eeb28aa74ae47c3cafb807771c747cc6034d",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4196-disable-main-force-pushes",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4196-disable-main-force-pushes",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4382",
+        "branch": "runtime-risk-issue-4382",
+        "dirty": false,
+        "head": "09841d49c5fe9d47a693da000b9cf28baf4977cf",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4382-risk-pubsub-timeout",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4382-risk-pubsub-timeout",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4148",
+        "branch": "4148-parameter-control-policy",
+        "dirty": true,
+        "head": "f1a2e3b18ba338e8ca7940e80f55a0a2942f918a",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-4154-parameter-control-v2",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-4154-parameter-control-v2",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4154",
+        "branch": "pr-queue-a-4154",
+        "dirty": false,
+        "head": "7368b5c96f48d80a06a588289dffb4de1e32c1a2",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-a-4154",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-a-4154",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-actions-patch-b1",
+        "dirty": false,
+        "head": "46eb05196b3d2f026d745f2ac36126afbe49004e",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b1-actions-patch",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b1-actions-patch",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-actions-major-b2",
+        "dirty": false,
+        "head": "21f23d65989fdb22488cc6f1a1299b41775e56b0",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b2-actions-major",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b2-actions-major",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-python-c1",
+        "dirty": false,
+        "head": "0647a61acdb6b7772d1f846dbb38d718a2f8bcd9",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-c-python-deps",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-c-python-deps",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-python-digest-d1-cea0e60",
+        "dirty": true,
+        "head": "3b137c4d6a7749af0073abcc0e0c52c33ed9b12b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d1-python-cea0e60",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d1-python-cea0e60",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-python-digest-d2-86f975a",
+        "dirty": false,
+        "head": "75bd7fd489bbe12eb35de149c1faedf3dc8ebbfc",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d2-python-86f975a",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d2-python-86f975a",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-redis-8.8.1",
+        "dirty": false,
+        "head": "4f714b4a728803f6fc2acb2918beb4e9cbb9e2a7",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e1-redis",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed commits without clear ownership; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e1-redis",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": null,
+        "branch": "deps-grafana-13.1.1",
+        "dirty": true,
+        "head": "3018a8b194c1b16b42ea0dd360c11f0429946e8b",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e2-grafana",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e2-grafana",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "pr-queue-reconcile-2026-07-28",
+        "dirty": false,
+        "head": "696dcfb5d263557dde25ce3797630db6357a29a2",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "2026",
+        "branch": "pr-queue-final-reconcile-2026-07-28",
+        "dirty": false,
+        "head": "b4adbe76430eaa9e8f61c69c7c45fcfb891c1ca7",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger2",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger2",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4065",
+        "branch": "arvp-4065-regime-stats-schema-ref",
+        "dirty": false,
+        "head": "54bea593f29705738e95dc4527dc09bd6fa62644",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-4065",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-4065",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "NEEDED_FOLLOWUP_ISSUE",
+      "facts": {
+        "active_issue": "4289",
+        "branch": "ci-tooling-issue-4289",
+        "dirty": false,
+        "head": "d472e50a07add68d585a5c3a0939f0c854312b65",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4289-b1",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Unpushed work with known issue; capture follow-up before cleanup.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4289-b1",
+      "reason_codes": [
+        "NEEDED_FOLLOWUP_ISSUE"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4329",
+        "branch": null,
+        "dirty": true,
+        "head": "a0ca789aab9118e05eff6f056df47b3cdd334dc9",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": false,
+        "on_windows_legacy_drive": true,
+        "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4329",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": true
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4329",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    },
+    {
+      "classification": "UNCLEAR_HOLD",
+      "facts": {
+        "active_issue": "4393",
+        "branch": "ci-tooling-issue-4393",
+        "dirty": true,
+        "head": "59dfbc6753d166ca0e3e40c8007dd4b7b0705b1f",
+        "is_main_checkout": false,
+        "locked": null,
+        "merged_into_base": true,
+        "on_windows_legacy_drive": false,
+        "path": "Y:/Worktrees/Claire_de_Binare/issue-4393",
+        "path_exists": true,
+        "prunable": false,
+        "unpushed": false
+      },
+      "notes": "Dirty worktree; STOP.",
+      "path": "Y:/Worktrees/Claire_de_Binare/issue-4393",
+      "reason_codes": [
+        "UNCLEAR_HOLD"
+      ]
+    }
+  ],
+  "status": "PASS"
+}

--- a/docs/evidence/worktree_legacy_inventory_4393_after_remove.md
+++ b/docs/evidence/worktree_legacy_inventory_4393_after_remove.md
@@ -1,0 +1,117 @@
+# Legacy Worktree Inventory #4393
+
+- generated_from: `worktree_legacy_inventory_4393_after_remove.json`
+- count: 83
+- enrich: True
+- counts: `{'NEEDED_FOLLOWUP_ISSUE': 52, 'NEEDED_QUICK_FINISH': 1, 'UNCLEAR_HOLD': 30}`
+
+## Classification summary
+
+| Class | Count |
+|---|---:|
+| NEEDED_FOLLOWUP_ISSUE | 52 |
+| NEEDED_QUICK_FINISH | 1 |
+| UNCLEAR_HOLD | 30 |
+
+## OBSOLETE_REMOVE (0)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+
+## NEEDED_QUICK_FINISH (1)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-exec` | `validation-research-issue-4153` | `d643ce90fec6` | False | False | False | Clean, unmerged, active issue ù consider quick finish then cleanup. |
+
+## UNCLEAR_HOLD (30)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare` | `` | `ba6b1d94c6da` | True | False | True | Main checkout is allowed on D:; not a legacy migration target. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-reproduction-execution-fix` | `validation-research-issue-4153-reproduct` | `6d7ba761041b` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-sensitivity-campaign` | `validation-research-issue-4153-campaign` | `10ddcc099a97` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4164-publisher` | `main` | `91411735635d` | False | False | True | Worktree has main/master checked out; never auto-remove. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4220-reviewability` | `` | `850b2c25770e` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4250-acp-canon` | `agent-skills-issue-4250` | `a501f2202fb2` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4257-approval-context` | `docs-governance-issue-4257` | `458783e5ffc1` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4270-hermes-orchestration` | `validation-research-issue-4270` | `04e8f5687d61` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4272-pilot` | `validation-research-issue-4272` | `222965b46df0` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4280-canon-sync` | `ci-tooling-issue-4280` | `ee582b27d930` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4293-dispatcher-residuals` | `agent-skills-issue-4293` | `3b16e83cae13` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4338-cdb049-restore` | `4338-cdb049-only` | `896f5de4f44b` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4338-postmerge-audit` | `` | `655e7059a3ca` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4360-cursor-env-build` | `ci-tooling-issue-4360` | `242fafd5d5eb` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-comment-id-fix` | `validation-research-issue-4374-comment-i` | `aca10a687bc4` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-go-prep` | `` | `f03564c77182` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-exec-wiring` | `` | `840601948767` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-postmerge-go` | `` | `b23ac5c948c4` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-rebind-3154efe` | `` | `3154efe218d1` | True | False | True | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4184-reduce-only-unwind-contract` | `4184-reduce-only-unwind-contract` | `d00e2d7ffb26` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-4154-parameter-control-v2` | `4148-parameter-control-policy` | `f1a2e3b18ba3` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b1-actions-patch` | `deps-actions-patch-b1` | `46eb05196b3d` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-b2-actions-major` | `deps-actions-major-b2` | `21f23d65989f` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-c-python-deps` | `deps-python-c1` | `0647a61acdb6` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d1-python-cea0e60` | `deps-python-digest-d1-cea0e60` | `3b137c4d6a77` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-d2-python-86f975a` | `deps-python-digest-d2-86f975a` | `75bd7fd489bb` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e1-redis` | `deps-redis-8.8.1` | `4f714b4a7288` | False | True | False | Unpushed commits without clear ownership; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-e2-grafana` | `deps-grafana-13.1.1` | `3018a8b194c1` | True | True | False | Dirty worktree; STOP. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4329` | `` | `a0ca789aab91` | True | True | False | Dirty worktree; STOP. |
+| `Y:/Worktrees/Claire_de_Binare/issue-4393` | `ci-tooling-issue-4393` | `59dfbc6753d1` | True | False | True | Dirty worktree; STOP. |
+
+## NEEDED_FOLLOWUP_ISSUE (52)
+
+| path | branch | head | dirty | unpushed | merged | notes |
+|---|---|---|---|---|---|---|
+| `D:/Dev/Workspaces/Repos/cdb-wt-2513-security-backlog` | `security-backlog-reconciliation-2513` | `401dd294a52d` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-2513-security-recon-20260805` | `runtime-risk-issue-2513` | `e6fb19591464` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4032-campaign` | `4032-stage-a-evidence` | `8c5af7ecfb5a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4032-gate` | `4032-batch-a-stage-a-gate` | `5fae0460d688` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4034-wp5-closeout` | `4034-wp5-no-survivors-closeout` | `78960411a60e` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4080-curl-hold` | `runtime-risk-issue-4080` | `da3df28d85c4` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-manifest` | `validation-research-issue-4153-campaign-` | `eb8efbdf9ec1` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-execution-contract` | `validation-research-issue-4153-execution` | `e746bba6c72f` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-hermes-work-start` | `validation-research-issue-4153-hermes-wo` | `18c411e74add` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4153-primary-adoption` | `validation-research-issue-4153-primary-a` | `d28786fb4ef8` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4166-final-validation` | `` | `30fc491b75f6` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4169-migration` | `local-ci-status-publisher-migration` | `f542353df3cf` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4170-phase-d` | `4170-bp-cutover-20260801141013` | `33ecefa14e2b` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4191-economics` | `4150-execution-economics-contract` | `f6f9a917b9d8` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4192-skill-mirror` | `4122-skill-mirror-assets` | `d21856aeedd5` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4194-gitlab-clean` | `4121-decommission-gitlab-path-wt` | `3ab1138c62c4` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4205-temp-preflight` | `ci-tooling-issue-4205` | `67736bbb22f8` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4206-black-portable` | `ci-tooling-issue-4206` | `398c2dd948d2` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4214-app-bound` | `4170-app-bound-check-runs` | `137264642261` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4230-merge` | `delivery-pr-handoff-contract-7967` | `9befe05245f9` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4256-run-evidence-20260802154101` | `4256-run-evidence-20260802154101` | `ada4eaacfb81` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4262-blue-012` | `blue-012-wiring-4261-f7b2` | `516994dbfc4f` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4275-security-cadence` | `ci-tooling-issue-4275` | `36eb651793a5` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4283-g01-g04` | `validation-research-issue-4283` | `41ba3625cadd` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4286-merge-check` | `` | `899cefd87b7b` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4327-hermes-pin` | `hermes-version-pin-4327` | `793fbf3e13e2` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4336-cdb051` | `validation-research-issue-4336-cdb051` | `ec14dc2da5f4` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4366-campaign-to-pr` | `validation-research-issue-4366` | `0eb1d5c0a86b` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4366-pr-ready` | `validation-research-issue-4366-pr-ready` | `29af6e7238db` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-4372-hh-hl` | `validation-research-issue-4372` | `10e0a6e3e646` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pip-crypto-aiohttp-20260805` | `security-pip-crypto-aiohttp-2026-08-05` | `081b19378abc` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4304-queue` | `ruff-0.16.1` | `3b61561db601` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4306-queue` | `redis-8.1.0` | `2d7ca5e7ab1f` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4307-queue` | `codeql-action-432e0d4de6` | `5f4db4e31a65` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4308-queue` | `login-action-4.6.0` | `c9fe293085c1` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4309-queue` | `stale-11.0.0` | `476c8c660839` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4310-queue` | `prometheus-v3.13.2` | `c7ea776aa16c` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-4311-queue` | `redis-8.10.0-alpine` | `49ccbe7b5d1a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-pr-acceptance-batch1` | `agent-skills-issue-4207` | `a8927fa28d34` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-security-wave-4314` | `security-alert-wave-2026-08-03` | `d5205b2c3b94` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/cdb-wt-setuptools-83-20260805` | `security-setuptools-83-2026-08-05` | `14ae7651798a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4384-run-key-path` | `validation-research-issue-4384` | `089e635b0189` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/batch-validation-research-issue-4374-exec-prep` | `validation-research-issue-4374` | `67ac1abc1d9a` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4152-risk-fail-closed-safety` | `` | `1bdd34bd2b67` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4182-stop-loss-e2e-kill-unwind-drill` | `4182-stop-loss-e2e-kill-unwind-drill` | `0d7244e5e724` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4196-disable-main-force-pushes` | `4196-disable-main-force-pushes` | `2848eeb28aa7` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/fix-4382-risk-pubsub-timeout` | `runtime-risk-issue-4382` | `09841d49c5fe` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-a-4154` | `pr-queue-a-4154` | `7368b5c96f48` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger` | `pr-queue-reconcile-2026-07-28` | `696dcfb5d263` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/pr-queue-ledger2` | `pr-queue-final-reconcile-2026-07-28` | `b4adbe76430e` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare-4065` | `arvp-4065-regime-stats-schema-ref` | `54bea593f297` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |
+| `D:/Dev/Workspaces/Repos/Claire_de_Binare-wt-4289-b1` | `ci-tooling-issue-4289` | `d472e50a07ad` | False | True | False | Unpushed work with known issue; capture follow-up before cleanup. |

--- a/docs/evidence/worktree_legacy_remove_4393_20260807T223000.json
+++ b/docs/evidence/worktree_legacy_remove_4393_20260807T223000.json
@@ -1,0 +1,71 @@
+{
+  "candidate_count": 12,
+  "execute": true,
+  "outcomes": [
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-execute-v2"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4153-campaign-go-audit"
+    },
+    {
+      "action": "SKIP_PROTECTED",
+      "detail": "protected_branch:main",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4164-publisher"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4166-main-cmp"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4170-github-app"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-canary"
+    },
+    {
+      "action": "BLOCKED_REMOVE",
+      "detail": "remove_failed:error: failed to delete 'D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-phase-a': Directory not empty",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4289-hermes-phase-a"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-4327-runtime-resume"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-main-check-4194"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/cdb-wt-supervised-pilot-hold"
+    },
+    {
+      "action": "REMOVED",
+      "detail": "worktree_remove_ok",
+      "path": "D:/Dev/Workspaces/Repos/Claire_de_Binare/.worktrees/4374-campaign-exec"
+    }
+  ],
+  "summary": {
+    "BLOCKED_REMOVE": 1,
+    "REMOVED": 10,
+    "SKIP_PROTECTED": 1
+  }
+}

--- a/docs/runbooks/windows_worktree_y_root.md
+++ b/docs/runbooks/windows_worktree_y_root.md
@@ -36,9 +36,12 @@ python -m tools.worktrees validate-path --purpose main_checkout --path 'D:\Dev\W
 python -m tools.worktrees create --repository Claire_de_Binare --name issue-4386 --branch dedicated/ci-tooling-issue-4386
 # add --execute only after dry-run PASS
 python -m tools.worktrees reconcile --from-git
+python -m tools.worktrees reconcile --from-git --enrich --scan-roots D:\Dev\Workspaces\Repos
 ```
 
 Dry-run is the default for `create`.
+`reconcile` is always read-only (classify only). `--enrich` probes
+dirty/unpushed/merged/drive; without it most rows stay `UNCLEAR_HOLD`.
 
 ## Reason codes (selected)
 

--- a/tests/unit/tools/worktrees/test_reconcile.py
+++ b/tests/unit/tools/worktrees/test_reconcile.py
@@ -2,14 +2,37 @@
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
 from tools.worktrees import codes
 from tools.worktrees.reconcile import (
     LegacyWorktreeFacts,
     classify_legacy_worktree,
+    discover_legacy_fs_paths,
+    enrich_worktree_facts,
+    infer_active_issue,
     inventory_from_porcelain,
+    reconcile_inventory,
 )
+
+
+@pytest.mark.unit
+def test_main_branch_worktree_never_obsolete() -> None:
+    result = classify_legacy_worktree(
+        LegacyWorktreeFacts(
+            path=r"D:\Dev\Workspaces\Repos\cdb-wt-4164-publisher",
+            branch="main",
+            dirty=False,
+            unpushed=False,
+            merged_into_base=True,
+            on_windows_legacy_drive=True,
+        )
+    )
+    assert result.classification == codes.UNCLEAR_HOLD
+    assert codes.MAIN_CHECKOUT_ALLOWED in result.reason_codes
 
 
 @pytest.mark.unit
@@ -95,3 +118,117 @@ prunable
     assert len(facts) == 2
     assert facts[0].branch == "main"
     assert facts[1].prunable is True
+
+
+@pytest.mark.unit
+def test_infer_active_issue() -> None:
+    assert infer_active_issue("dedicated/ci-tooling-issue-4393") == "4393"
+    assert infer_active_issue("fix/4182-stop-loss") == "4182"
+    assert infer_active_issue(None, r"D:\x\.worktrees\4374-exec-go-prep") == "4374"
+
+
+@pytest.mark.unit
+def test_enrich_marks_dirty_and_merged(tmp_path: Path) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_git(args: list[str] | tuple[str, ...], cwd: str | None):
+        cmd = tuple(args)
+        calls.append(cmd)
+        # status dirty
+        if "status" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, " M file.py\n", "")
+        if "rev-list" in cmd and "@{upstream}..HEAD" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "0\n", "")
+        if "merge-base" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 1, "", "err")
+
+    # Create path so exists() is true
+    wt = tmp_path / "cdb-wt-demo"
+    wt.mkdir()
+    facts = LegacyWorktreeFacts(
+        path=str(wt),
+        branch="issue-1234-demo",
+        head="abc",
+        on_windows_legacy_drive=True,
+    )
+    enriched = enrich_worktree_facts(
+        facts,
+        main_checkout=str(tmp_path / "main"),
+        git_runner=fake_git,
+    )
+    assert enriched.dirty is True
+    assert enriched.unpushed is False
+    assert enriched.merged_into_base is True
+    assert enriched.active_issue == "1234"
+    assert classify_legacy_worktree(enriched).classification == codes.UNCLEAR_HOLD
+
+
+@pytest.mark.unit
+def test_enrich_obsolete_when_clean_merged(tmp_path: Path) -> None:
+    def fake_git(args: list[str] | tuple[str, ...], cwd: str | None):
+        cmd = tuple(args)
+        if "status" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if "rev-list" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "0\n", "")
+        if "merge-base" in cmd:
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 1, "", "")
+
+    wt = tmp_path / "cdb-wt-old"
+    wt.mkdir()
+    facts = LegacyWorktreeFacts(path=str(wt), branch="gone-branch", head="abc")
+    enriched = enrich_worktree_facts(
+        facts,
+        main_checkout=str(tmp_path / "main"),
+        git_runner=fake_git,
+    )
+    # Force legacy drive flag for classification path used in hosts
+    from dataclasses import replace
+
+    enriched = replace(enriched, on_windows_legacy_drive=True)
+    assert enriched.dirty is False
+    assert enriched.unpushed is False
+    assert enriched.merged_into_base is True
+    assert classify_legacy_worktree(enriched).classification == codes.OBSOLETE_REMOVE
+
+
+@pytest.mark.unit
+def test_reconcile_inventory_without_enrich_is_hold() -> None:
+    text = """\
+worktree D:/Dev/Workspaces/Repos/cdb-wt-x
+HEAD 123456
+branch refs/heads/feat-x
+
+"""
+    facts, results = reconcile_inventory(porcelain_text=text, enrich=False)
+    assert len(facts) == 1
+    assert results[0].classification == codes.UNCLEAR_HOLD
+
+
+@pytest.mark.unit
+def test_discover_legacy_fs_paths(tmp_path: Path) -> None:
+    root = tmp_path / "Repos"
+    root.mkdir()
+    main = root / "Claire_de_Binare"
+    main.mkdir()
+    (main / ".git").mkdir()
+    legacy = root / "cdb-wt-1234"
+    legacy.mkdir()
+    (legacy / ".git").write_text("gitdir: somewhere", encoding="utf-8")
+    nested = main / ".worktrees" / "4384-run-key"
+    nested.mkdir(parents=True)
+    (nested / ".git").write_text("gitdir: somewhere", encoding="utf-8")
+    noise = root / "not-a-wt"
+    noise.mkdir()
+
+    found = discover_legacy_fs_paths(
+        [str(root)],
+        main_checkout=str(main),
+    )
+    norms = {str(Path(p)).lower() for p in found}
+    assert str(legacy).lower() in norms
+    assert str(nested).lower() in norms
+    assert str(main).lower() not in norms
+    assert str(noise).lower() not in norms

--- a/tools/worktrees/cli.py
+++ b/tools/worktrees/cli.py
@@ -16,8 +16,8 @@ from tools.worktrees.policy import (
     validate_new_worktree_path,
 )
 from tools.worktrees.reconcile import (
-    classify_legacy_worktree,
-    inventory_from_porcelain,
+    DEFAULT_MAIN_CHECKOUT,
+    reconcile_inventory,
 )
 from tools.worktrees.resolve import build_worktree_path, resolve_worktree_root
 
@@ -105,9 +105,10 @@ def cmd_create(args: argparse.Namespace) -> int:
 
 
 def cmd_reconcile(args: argparse.Namespace) -> int:
-    if args.from_git:
-        import subprocess
+    import subprocess
 
+    porcelain_text: str | None = None
+    if args.from_git:
         completed = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
             capture_output=True,
@@ -124,22 +125,47 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
                 }
             )
             return HOLD
-        facts_list = inventory_from_porcelain(completed.stdout)
+        porcelain_text = completed.stdout
     elif args.inventory:
-        text = Path(args.inventory).read_text(encoding="utf-8")
-        facts_list = inventory_from_porcelain(text)
-    else:
+        porcelain_text = Path(args.inventory).read_text(encoding="utf-8")
+    elif not args.scan_roots:
         _emit(
             {
                 "status": "FAIL",
                 "reason_codes": ["USAGE"],
-                "error": "need --from-git or --inventory",
+                "error": "need --from-git, --inventory, and/or --scan-roots",
             }
         )
         return USAGE
 
-    rows = [asdict(classify_legacy_worktree(f)) for f in facts_list]
-    _emit({"status": "PASS", "count": len(rows), "results": rows})
+    scan_roots = list(args.scan_roots) if args.scan_roots else None
+    include_fs = bool(args.scan_roots)
+    facts_list, classified = reconcile_inventory(
+        porcelain_text=porcelain_text,
+        scan_roots=scan_roots,
+        enrich=bool(args.enrich),
+        main_checkout=args.main_checkout,
+        base_ref=args.base_ref,
+        include_fs_scan=include_fs,
+    )
+    rows = []
+    for fact, result in zip(facts_list, classified, strict=True):
+        row = asdict(result)
+        row["facts"] = asdict(fact)
+        rows.append(row)
+    counts: dict[str, int] = {}
+    for row in rows:
+        key = str(row.get("classification") or "UNKNOWN")
+        counts[key] = counts.get(key, 0) + 1
+    _emit(
+        {
+            "status": "PASS",
+            "count": len(rows),
+            "counts": counts,
+            "enrich": bool(args.enrich),
+            "results": rows,
+        }
+    )
     return SUCCESS
 
 
@@ -184,6 +210,27 @@ def build_parser() -> argparse.ArgumentParser:
     p_rec.add_argument("--from-git", action="store_true")
     p_rec.add_argument("--inventory", default=None)
     p_rec.add_argument("--repo-dir", default=None)
+    p_rec.add_argument(
+        "--enrich",
+        action="store_true",
+        help="Probe dirty/unpushed/merged/drive (still read-only; no delete)",
+    )
+    p_rec.add_argument(
+        "--scan-roots",
+        nargs="*",
+        default=None,
+        help="Also discover legacy FS paths under these roots (e.g. D:\\Dev\\Workspaces\\Repos)",
+    )
+    p_rec.add_argument(
+        "--main-checkout",
+        default=DEFAULT_MAIN_CHECKOUT,
+        help="Path treated as main checkout (never OBSOLETE_REMOVE)",
+    )
+    p_rec.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base ref for merged/unpushed probes",
+    )
     p_rec.set_defaults(func=cmd_reconcile)
 
     return parser

--- a/tools/worktrees/reconcile.py
+++ b/tools/worktrees/reconcile.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import os
+import re
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field, replace
+from pathlib import Path, PureWindowsPath
 
 from tools.worktrees import codes
+from tools.worktrees.resolve import windows_drive_letter
+
+_ISSUE_RE = re.compile(
+    r"(?:issue[-_]?|gh[-_]?|#)(\d{3,5})\b|\b(\d{3,5})(?=[-_]|$)",
+    re.IGNORECASE,
+)
+
+# Primary Windows main checkout path for CDB (not a migration target).
+DEFAULT_MAIN_CHECKOUT = r"D:\Dev\Workspaces\Repos\Claire_de_Binare"
+
+DEFAULT_SCAN_ROOTS: tuple[str, ...] = (r"D:\Dev\Workspaces\Repos",)
+
+GitRunner = Callable[[Sequence[str], str | None], subprocess.CompletedProcess[str]]
 
 
 @dataclass(frozen=True)
@@ -43,6 +61,14 @@ def classify_legacy_worktree(facts: LegacyWorktreeFacts) -> ReconcileResult:
             reason_codes=(codes.MAIN_CHECKOUT_ALLOWED,),
             path=facts.path,
             notes="Main checkout is allowed on D:; not a legacy migration target.",
+        )
+
+    if (facts.branch or "").lower() in {"main", "master"}:
+        return ReconcileResult(
+            classification=codes.UNCLEAR_HOLD,
+            reason_codes=(codes.MAIN_CHECKOUT_ALLOWED,),
+            path=facts.path,
+            notes="Worktree has main/master checked out; never auto-remove.",
         )
 
     if not facts.path_exists:
@@ -176,3 +202,314 @@ def inventory_from_porcelain(porcelain_text: str) -> list[LegacyWorktreeFacts]:
             locked = True
     flush()
     return entries
+
+
+def _default_git_runner(
+    args: Sequence[str], cwd: str | None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+    )
+
+
+def _norm_path_key(path: str | Path) -> str:
+    text = str(path).replace("/", "\\").rstrip("\\")
+    return os.path.normcase(text)
+
+
+def infer_active_issue(branch: str | None, path: str | None = None) -> str | None:
+    """Best-effort issue id from branch or path segment (fail-soft)."""
+    for raw in (branch, Path(path).name if path else None):
+        if not raw:
+            continue
+        match = _ISSUE_RE.search(raw.replace("\\", "/"))
+        if match:
+            return match.group(1) or match.group(2)
+    return None
+
+
+def is_legacy_windows_drive(path: str | Path) -> bool | None:
+    drive = windows_drive_letter(path)
+    if drive is None:
+        return None
+    return drive in {"C", "D"}
+
+
+def is_main_checkout_path(
+    path: str | Path,
+    *,
+    main_checkout: str = DEFAULT_MAIN_CHECKOUT,
+) -> bool:
+    return _norm_path_key(path) == _norm_path_key(main_checkout)
+
+
+def discover_legacy_fs_paths(
+    scan_roots: Sequence[str] | None = None,
+    *,
+    main_checkout: str = DEFAULT_MAIN_CHECKOUT,
+) -> list[str]:
+    """Discover likely legacy worktree/clone directories under scan roots.
+
+    Only returns directories that look like git checkouts (``.git`` file or dir).
+    """
+    roots = list(scan_roots) if scan_roots is not None else list(DEFAULT_SCAN_ROOTS)
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def _add(candidate: Path) -> None:
+        if not candidate.is_dir():
+            return
+        git_meta = candidate / ".git"
+        if not git_meta.exists():
+            return
+        key = _norm_path_key(candidate)
+        if key in seen:
+            return
+        if is_main_checkout_path(candidate, main_checkout=main_checkout):
+            return
+        seen.add(key)
+        found.append(str(candidate))
+
+    for root_raw in roots:
+        root = Path(root_raw)
+        if not root.is_dir():
+            continue
+        # Sibling clones / cdb-wt-* under the workspace root
+        try:
+            children = list(root.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            name = child.name
+            if name.startswith("cdb-wt-") or name.startswith("Claire_de_Binare-"):
+                _add(child)
+        # Nested .worktrees under main checkout
+        nested = Path(main_checkout) / ".worktrees"
+        if nested.is_dir():
+            try:
+                for child in nested.iterdir():
+                    _add(child)
+            except OSError:
+                pass
+        # Also allow scan_root/.worktrees
+        alt_nested = root / ".worktrees"
+        if alt_nested.is_dir() and _norm_path_key(alt_nested) != _norm_path_key(nested):
+            try:
+                for child in alt_nested.iterdir():
+                    _add(child)
+            except OSError:
+                pass
+    return found
+
+
+def _git_ok(proc: subprocess.CompletedProcess[str]) -> bool:
+    return proc.returncode == 0
+
+
+def enrich_worktree_facts(
+    facts: LegacyWorktreeFacts,
+    *,
+    main_checkout: str = DEFAULT_MAIN_CHECKOUT,
+    base_ref: str = "origin/main",
+    git_runner: GitRunner | None = None,
+) -> LegacyWorktreeFacts:
+    """Enrich porcelain facts with dirty/unpushed/merged/drive evidence.
+
+    Fail-closed: unknown probes leave dirty/unpushed/merged as None so
+    classification becomes UNCLEAR_HOLD.
+    """
+    run = git_runner or _default_git_runner
+    path = facts.path
+    exists = Path(path).exists()
+    legacy_drive = is_legacy_windows_drive(path)
+    main = is_main_checkout_path(path, main_checkout=main_checkout)
+    issue = facts.active_issue or infer_active_issue(facts.branch, path)
+
+    if not exists:
+        return replace(
+            facts,
+            path_exists=False,
+            is_main_checkout=main,
+            on_windows_legacy_drive=legacy_drive,
+            active_issue=issue,
+            dirty=None,
+            unpushed=None,
+            merged_into_base=None,
+        )
+
+    dirty: bool | None = None
+    unpushed: bool | None = None
+    merged: bool | None = None
+
+    status = run(
+        ["git", "-C", path, "status", "--porcelain=v1", "--untracked-files=all"],
+        path,
+    )
+    if _git_ok(status):
+        dirty = bool(status.stdout.strip())
+    # else leave dirty=None (fail-closed)
+
+    # Unpushed relative to upstream if present; else commits not in base_ref.
+    ahead_upstream = run(
+        ["git", "-C", path, "rev-list", "--count", "@{upstream}..HEAD"],
+        path,
+    )
+    if _git_ok(ahead_upstream):
+        try:
+            unpushed = int(ahead_upstream.stdout.strip() or "0") > 0
+        except ValueError:
+            unpushed = None
+    else:
+        ahead_base = run(
+            ["git", "-C", path, "rev-list", "--count", f"{base_ref}..HEAD"],
+            path,
+        )
+        if _git_ok(ahead_base):
+            try:
+                unpushed = int(ahead_base.stdout.strip() or "0") > 0
+            except ValueError:
+                unpushed = None
+        else:
+            # Detached / no base: treat unknown as fail-closed unless prunable.
+            unpushed = None if not facts.prunable else False
+
+    # Merged into base: ancestry OR identical trees (squash equivalence).
+    ancestor = run(
+        ["git", "-C", path, "merge-base", "--is-ancestor", "HEAD", base_ref],
+        path,
+    )
+    if _git_ok(ancestor):
+        merged = True
+    else:
+        head_tree = run(["git", "-C", path, "rev-parse", "HEAD^{tree}"], path)
+        base_tree = run(["git", "-C", path, "rev-parse", f"{base_ref}^{{tree}}"], path)
+        if (
+            _git_ok(head_tree)
+            and _git_ok(base_tree)
+            and head_tree.stdout.strip()
+            and head_tree.stdout.strip() == base_tree.stdout.strip()
+        ):
+            merged = True
+        elif _git_ok(head_tree) and _git_ok(base_tree):
+            # Reachable comparison succeeded but trees differ → not merged.
+            merged = False
+        elif facts.prunable:
+            # Git marked prunable; treat as merged/obsolete candidate when clean.
+            merged = True
+        else:
+            merged = None
+
+    return replace(
+        facts,
+        path_exists=True,
+        is_main_checkout=main,
+        on_windows_legacy_drive=legacy_drive if legacy_drive is not None else False,
+        active_issue=issue,
+        dirty=dirty,
+        unpushed=unpushed,
+        merged_into_base=merged,
+    )
+
+
+def merge_fact_lists(
+    *lists: Sequence[LegacyWorktreeFacts],
+) -> list[LegacyWorktreeFacts]:
+    """Deduplicate facts by normalized path (first wins)."""
+    out: list[LegacyWorktreeFacts] = []
+    seen: set[str] = set()
+    for group in lists:
+        for item in group:
+            key = _norm_path_key(item.path)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(item)
+    return out
+
+
+def facts_from_discovered_paths(
+    paths: Sequence[str],
+) -> list[LegacyWorktreeFacts]:
+    """Build minimal facts for FS-discovered paths (enriched later)."""
+    rows: list[LegacyWorktreeFacts] = []
+    for raw in paths:
+        path = str(PureWindowsPath(raw)) if windows_drive_letter(raw) else str(raw)
+        branch: str | None = None
+        head: str | None = None
+        # Light porcelain substitute: try symbolic-ref / rev-parse without failing hard.
+        # Full enrichment fills dirty/unpushed/merged.
+        rows.append(
+            LegacyWorktreeFacts(
+                path=path,
+                branch=branch,
+                head=head,
+                path_exists=True,
+            )
+        )
+    return rows
+
+
+def reconcile_inventory(
+    *,
+    porcelain_text: str | None = None,
+    scan_roots: Sequence[str] | None = None,
+    enrich: bool = False,
+    main_checkout: str = DEFAULT_MAIN_CHECKOUT,
+    base_ref: str = "origin/main",
+    include_fs_scan: bool = False,
+    git_runner: GitRunner | None = None,
+) -> tuple[list[LegacyWorktreeFacts], list[ReconcileResult]]:
+    """Build inventory + classifications (read-only)."""
+    registered = (
+        inventory_from_porcelain(porcelain_text) if porcelain_text is not None else []
+    )
+    discovered: list[LegacyWorktreeFacts] = []
+    if include_fs_scan:
+        paths = discover_legacy_fs_paths(scan_roots, main_checkout=main_checkout)
+        # Skip paths already in registered list
+        registered_keys = {_norm_path_key(f.path) for f in registered}
+        extra = [p for p in paths if _norm_path_key(p) not in registered_keys]
+        discovered = facts_from_discovered_paths(extra)
+
+    combined = merge_fact_lists(registered, discovered)
+    if enrich:
+        combined = [
+            enrich_worktree_facts(
+                f,
+                main_checkout=main_checkout,
+                base_ref=base_ref,
+                git_runner=git_runner,
+            )
+            for f in combined
+        ]
+        # Fill branch/head for FS-only entries when enriching
+        run = git_runner or _default_git_runner
+        filled: list[LegacyWorktreeFacts] = []
+        for f in combined:
+            if f.branch is not None and f.head is not None:
+                filled.append(f)
+                continue
+            if not f.path_exists:
+                filled.append(f)
+                continue
+            head_proc = run(["git", "-C", f.path, "rev-parse", "HEAD"], f.path)
+            branch_proc = run(
+                ["git", "-C", f.path, "symbolic-ref", "--short", "-q", "HEAD"],
+                f.path,
+            )
+            head = head_proc.stdout.strip() if _git_ok(head_proc) else f.head
+            branch = (
+                branch_proc.stdout.strip()
+                if _git_ok(branch_proc) and branch_proc.stdout.strip()
+                else f.branch
+            )
+            issue = f.active_issue or infer_active_issue(branch, f.path)
+            filled.append(replace(f, head=head, branch=branch, active_issue=issue))
+        combined = filled
+
+    results = [classify_legacy_worktree(f) for f in combined]
+    return combined, results


### PR DESCRIPTION
## Summary
- Enrich `python -m tools.worktrees reconcile --from-git --enrich [--scan-roots …]` with dirty/unpushed/merged/drive/main-branch probes (read-only).
- Full host inventory for #4393 + controlled Wave-1 `OBSOLETE_REMOVE` cleanup (10 removed; `main`-checkout WT protected; 1 orphan husk ACL-blocked).
- Residual waves tracked in #4396. Epic #4386 stays open until #4393 closes.

## Evidence
- `docs/evidence/worktree_legacy_inventory_4393_20260807T222842.json` (95 → classes)
- `docs/evidence/worktree_legacy_inventory_4393_after_remove.json` (83; 0 OBSOLETE left)
- `docs/evidence/worktree_legacy_remove_4393_20260807T223000.json`

## Test plan
- [x] `pytest -q tests/unit/tools/worktrees/` (29 PASS)
- [x] `ruff check` on touched Python
- [x] Host enrich inventory run against main repo

## Non-goals
- No mass delete of dirty/unpushed
- No storage offload epic
- No LR/live

Closes #4393
Refs #4386
Refs #4396