### PR TITLE
[OPS][CI][COST] Eliminate redundant hosted PR CI (#4401)

### DIFF
--- a/.github/control-plane/generated/agent-workflow-map.json
+++ b/.github/control-plane/generated/agent-workflow-map.json
@@ -310,8 +310,8 @@
       "name": "ci",
       "purpose": "ci",
       "triggers": [
-        "pull_request",
-        "push"
+        "push",
+        "workflow_dispatch"
       ],
       "permissions": [
         "read-only"
@@ -328,7 +328,6 @@
       "name": "CodeQL Python",
       "purpose": "CodeQL Python",
       "triggers": [
-        "pull_request",
         "push",
         "schedule",
         "workflow_dispatch"
@@ -477,7 +476,6 @@
       "name": "Docs Conflict Guard",
       "purpose": "Docs Conflict Guard",
       "triggers": [
-        "pull_request",
         "push",
         "workflow_dispatch"
       ],
@@ -816,7 +814,6 @@
       "name": "Repository Canon Guard",
       "purpose": "Repository Canon Guard",
       "triggers": [
-        "pull_request",
         "push",
         "workflow_dispatch"
       ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
-# Canonical PR gate (advisory workflow content; not BP-required).
-# Validation logic is delegated to the local CI orchestrator (Issue #4163).
-# Required merge context remains App-bound Check Run `cdb-local-ci` (`app_id=4410232`) (see merge_policy_ci_gate.md).
+# Hosted Fast-CI mirror (advisory; not BP-required).
+# PR-path duplication removed in #4401: Final-Head evidence is local
+# `python ci/scripts/run.py --profile fast` published as App Check Run
+# `cdb-local-ci` (`app_id=4410232`). See merge_policy_ci_gate.md.
+# Retained: push-to-main (post-squash tip differs from PR head) + manual dispatch.
 # This workflow is not the Docker CI lab baseline; 431B baseline is base.yml + test.yml.
 name: ci
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
     branches: [ main ]
     paths:
@@ -17,6 +17,7 @@ on:
       - '.github/workflows/**'
       - 'requirements*.txt'
       - 'pyproject.toml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -34,7 +35,10 @@ jobs:
   surrealdb-validate:
     name: surrealdb-validate
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.event.head_commit.modified, 'infrastructure/surrealdb/'))
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+       contains(toJSON(github.event.commits.*.modified), 'infrastructure/surrealdb/'))
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/codeql-python.yml
+++ b/.github/workflows/codeql-python.yml
@@ -6,10 +6,10 @@ name: CodeQL Python
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-  # NOISE-FREEZE (#2613): push and pull_request auto-triggers disabled due to billing/account-locked
-  # RESTORED (#3659): billing recovery complete, triggers re-enabled
+  # #4401: PR trigger removed to cut hosted runner minutes on every synchronize.
+  # Independent security value retained on every land-to-main + weekly schedule +
+  # manual dispatch. Not equivalent to Fast-CI unit/lint (not moved to local).
+  # NOISE-FREEZE (#2613) / RESTORED (#3659) history preserved above for audit.
   schedule:
     - cron: "21 3 * * 1"
   workflow_dispatch:

--- a/.github/workflows/docs-conflict-guard.yml
+++ b/.github/workflows/docs-conflict-guard.yml
@@ -1,11 +1,10 @@
 name: Docs Conflict Guard
 
-# NOISE-FREEZE (#2613): auto-triggers disabled due to billing/account-locked
-# RESTORED (#3659): billing recovery complete, triggers re-enabled
+# #4401: PR trigger removed — equivalent coverage is in local Fast-CI docs stage
+# (`python -m tools.ci.docs_conflict_guard` via ci/stages/docs.py → cdb-local-ci).
+# Retained: push-to-main (post-squash tip) + manual dispatch.
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   workflow_dispatch:
 

--- a/.github/workflows/repository-canon-guard.yml
+++ b/.github/workflows/repository-canon-guard.yml
@@ -1,11 +1,10 @@
 name: Repository Canon Guard
 
-# NOISE-FREEZE (#2613): auto-triggers disabled due to billing/account-locked
-# RESTORED (#3659): billing recovery complete, triggers re-enabled
+# #4401: PR trigger removed — equivalent coverage is in local Fast-CI docs stage
+# (`python -m tools.ci.repository_canon_guard` via ci/stages/docs.py → cdb-local-ci).
+# Retained: push-to-main (post-squash tip) + manual dispatch.
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   workflow_dispatch:
 

--- a/docs/ci/index.md
+++ b/docs/ci/index.md
@@ -34,13 +34,14 @@ verifizierbar via `gh api` Check Runs — nicht via Commit Status.
 
 | Workflow | Rolle | Trigger |
 |---|---|---|
-| [`ci.yml`](../../.github/workflows/ci.yml) | Hosted Actions, advisory | `pull_request`, gefilterter `push` |
-| [`policy-gate.yml`](../../.github/workflows/policy-gate.yml) | Hosted Actions, advisory | `pull_request` |
+| [`ci.yml`](../../.github/workflows/ci.yml) | Hosted Fast-CI mirror, advisory (#4401: kein PR) | gefilterter `push`, `workflow_dispatch` |
+| [`policy-gate.yml`](../../.github/workflows/policy-gate.yml) | Hosted lightweight PR policy gate | `pull_request` |
 
 `ci.yml` und `policy-gate.yml` sind seit Migration #4169 **nicht mehr**
-branch-protection-required. Sie bleiben als Workflow-Inhalt / Safety-Gates
-nützlich (Hosted-Actions-Signal), ersetzen aber nicht `cdb-local-ci`. Ein
-rotes/blockiertes Hosted-Actions-Billing-/Runner-Lock ist eine
+branch-protection-required. Ab #4401 startet die breite hosted Fast-CI nicht
+mehr auf jedem PR — Final-Head-Evidence ist lokale Fast-CI + App Check Run
+`cdb-local-ci`. `policy-gate` bleibt als leichter hosted Safety-Gate.
+Ein rotes/blockiertes Hosted-Actions-Billing-/Runner-Lock ist eine
 Infrastruktur-Bedingung, kein Code-Fehler, und darf nicht mit einem
 fehlenden/roten `cdb-local-ci` verwechselt werden.
 

--- a/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
+++ b/docs/runbooks/GITHUB_WORKFLOW_REGISTER.md
@@ -1,7 +1,7 @@
 # GitHub Workflow Register
 
 **Repo:** Claire de Binare  
-**Stand:** 2026-07-16  
+**Stand:** 2026-08-07 (#4401 hosted-PR trigger reduction)
 **Workflow-Dateien:** 57  
 **Entfernungs-Scope:** 13 Workflow-Dateien plus 5 exklusive Support-Dateien  
 **Daten-Datei im Workflow-Ordner:** `labels.json` (kein Workflow)
@@ -32,13 +32,15 @@ dieser Tabelle.
 
 | Workflow | Rolle |
 |---|---|
-| `ci.yml` | Hosted Actions, advisory (nicht branch-protection-required) |
-| `policy-gate.yml` | Hosted Actions, advisory (nicht branch-protection-required) |
+| `ci.yml` | Hosted Actions, advisory; post-merge/manual mirror (#4401, nicht PR) |
+| `policy-gate.yml` | Hosted Actions, advisory lightweight PR policy gate |
 
 `ci.yml` und `policy-gate.yml` sind seit Migration #4169 keine
-Branch-Protection-Required-Checks mehr. Andere Workflows liefern
-ergänzende Prüfungen, Reports oder Automatisierung, ersetzen aber ebenfalls
-nicht `cdb-local-ci`.
+Branch-Protection-Required-Checks mehr. Ab #4401 startet die breite
+hosted Fast-CI (`ci.yml`) nicht mehr auf jedem PR — Final-Head-Evidence
+kommt aus lokaler Fast-CI + App Check Run `cdb-local-ci`. Andere Workflows
+liefern ergänzende Prüfungen, Reports oder Automatisierung, ersetzen aber
+ebenfalls nicht `cdb-local-ci`.
 
 ## Vollständiges Inventar
 
@@ -59,8 +61,8 @@ nicht `cdb-local-ci`.
 | `cdb-dependabot-autopilot.yml` | aktiv | schedule, workflow_dispatch | read-only | low |
 | `cdb-post-merge-followup-scanner.yml` | aktiv | pull_request, workflow_dispatch | issues:write | medium |
 | `cdb-weekly-control-hygiene-classifier.yml` | aktiv | schedule, workflow_dispatch | issues:write | medium |
-| `ci.yml` | aktiv | pull_request, push | read-only | low |
-| `codeql-python.yml` | aktiv | pull_request, push, schedule, workflow_dispatch | read-only | low |
+| `ci.yml` | aktiv | push, workflow_dispatch | read-only | low |
+| `codeql-python.yml` | aktiv | push, schedule, workflow_dispatch | read-only | low |
 | `contracts.yml` | aktiv | push, schedule, workflow_dispatch | read-only | low |
 | `control_board_upsert.yml` | aktiv | schedule, workflow_dispatch | read-only | low |
 | `copilot-housekeeping.yml` | aktiv | schedule, workflow_dispatch | issues:write, pull-requests:write | medium |
@@ -68,8 +70,8 @@ nicht `cdb-local-ci`.
 | `core-guard.yml` | aktiv | push, schedule, workflow_dispatch | read-only | low |
 | `delivery-gate.yml` | aktiv | schedule, workflow_dispatch | read-only | low |
 | `docker-publish.yml` | aktiv | push, workflow_dispatch | read-only | low |
-| `docs-conflict-guard.yml` | aktiv | pull_request, push, workflow_dispatch | read-only | low |
-| `repository-canon-guard.yml` | aktiv | pull_request, push, workflow_dispatch | read-only | low |
+| `docs-conflict-guard.yml` | aktiv | push, workflow_dispatch | read-only | low |
+| `repository-canon-guard.yml` | aktiv | push, workflow_dispatch | read-only | low |
 | `e2e-happy-path.yaml` | aktiv | schedule, workflow_dispatch | read-only | low |
 | `e2e-tests.yml` | aktiv | schedule, workflow_dispatch | issues:write | medium |
 | `e2e.yml` | aktiv | push, schedule, workflow_dispatch | read-only | low |

--- a/docs/runbooks/merge_policy_ci_gate.md
+++ b/docs/runbooks/merge_policy_ci_gate.md
@@ -39,8 +39,11 @@ Für Pull Requests auf `main` gilt genau ein merge-relevanter Required Context
 
 Die früheren Required Checks `ci (Unit/Integration + Lint gesammelt)` und
 `policy-gate` sind **nicht mehr** branch-protection-required (Migration #4169).
-`ci.yml` und `policy-gate.yml` bleiben als Workflow-Inhalt / Safety-Gates
-nützlich, ersetzen aber den Required Context nicht.
+Ab #4401 startet die breite hosted Fast-CI (`ci.yml`) **nicht** mehr auf
+jedem `pull_request` — sie bleibt als post-merge/`workflow_dispatch`-Mirror
+für den Squash-Tip auf `main`. `policy-gate.yml` bleibt ein leichter
+hosted PR-Safety-Gate (Labels/Scope/Workflow-Permissions). Beide ersetzen
+den Required Context `cdb-local-ci` nicht.
 
 **Post-#4170 Phase D (live):** Branch Protection akzeptiert `cdb-local-ci`
 ausschließlich als Check Run der GitHub App `4410232`. Ein gleichnamiger

--- a/tests/unit/scripts/test_ci_workflow_delegates_to_local_ci.py
+++ b/tests/unit/scripts/test_ci_workflow_delegates_to_local_ci.py
@@ -44,9 +44,11 @@ def test_ci_workflow_identity_stable() -> None:
     payload = _load_ci()
     assert payload.get("name") == "ci"
     triggers = helpers.extract_on_triggers(payload)
-    assert triggers == {"pull_request", "push"}
+    # #4401: PR trigger removed; push-to-main + workflow_dispatch retained.
+    assert triggers == {"push", "workflow_dispatch"}
     text = CI_WORKFLOW.read_text(encoding="utf-8")
     assert "branches: [ main ]" in text or "branches: [main]" in text
+    assert "pull_request" not in helpers.extract_on_triggers(payload)
     row = helpers.build_trigger_permission_row(CI_WORKFLOW)
     assert row.write_permissions == ()
     permissions = helpers.extract_top_level_permissions(payload)
@@ -120,3 +122,35 @@ def test_policy_gate_remains_github_native() -> None:
     assert ORCHESTRATOR not in content
     assert "actions/github-script@" in content
     assert "full policy-gate parity" not in content.lower()
+
+
+def test_hosted_pr_triggers_removed_when_local_fast_ci_covers() -> None:
+    """#4401: drop PR triggers for Fast-CI-covered hosted mirrors; keep policy-gate."""
+    covered_by_fast_ci = (
+        "ci.yml",
+        "docs-conflict-guard.yml",
+        "repository-canon-guard.yml",
+    )
+    for name in covered_by_fast_ci:
+        triggers = helpers.extract_on_triggers(
+            helpers.load_workflow_yaml(helpers.WORKFLOWS_DIR / name)
+        )
+        assert "pull_request" not in triggers, name
+        assert "push" in triggers or "workflow_dispatch" in triggers
+    # CodeQL is not Fast-CI-equivalent; PR trigger removed for cost, push+schedule kept.
+    codeql = helpers.extract_on_triggers(
+        helpers.load_workflow_yaml(helpers.WORKFLOWS_DIR / "codeql-python.yml")
+    )
+    assert "pull_request" not in codeql
+    assert {"push", "schedule", "workflow_dispatch"} <= codeql
+    policy = helpers.extract_on_triggers(
+        helpers.load_workflow_yaml(helpers.WORKFLOWS_DIR / "policy-gate.yml")
+    )
+    assert "pull_request" in policy
+    docs_stage = (helpers.REPO_ROOT / "ci" / "stages" / "docs.py").read_text(
+        encoding="utf-8"
+    )
+    assert "tools.ci.docs_conflict_guard" in docs_stage
+    assert "tools.ci.repository_canon_guard" in docs_stage
+    run_text = _joined_run_scripts(_ci_job_steps(_load_ci()))
+    assert ORCHESTRATOR in run_text and "--profile fast" in run_text

--- a/tests/unit/scripts/test_workflow_inventory_register_contract.py
+++ b/tests/unit/scripts/test_workflow_inventory_register_contract.py
@@ -45,10 +45,14 @@ def test_control_plane_unit_register_paths_exist() -> None:
 
 
 def test_control_plane_unit_register_remains_partial_by_design() -> None:
-    payload = json.loads(helpers.CONTROL_PLANE_REGISTER_JSON.read_text(encoding="utf-8"))
+    payload = json.loads(
+        helpers.CONTROL_PLANE_REGISTER_JSON.read_text(encoding="utf-8")
+    )
     assert payload.get("coverage") == "partial"
     assert payload.get("catalog_scope") == "control-plane-sprint1"
-    assert payload.get("unit_count", 0) < len(helpers.list_workflow_yaml_files(helpers.WORKFLOWS_DIR))
+    assert payload.get("unit_count", 0) < len(
+        helpers.list_workflow_yaml_files(helpers.WORKFLOWS_DIR)
+    )
 
 
 @pytest.mark.parametrize(
@@ -60,8 +64,13 @@ def test_control_plane_unit_register_remains_partial_by_design() -> None:
         ("surrealdb-memory-proof.yml", "manual-only"),
     ],
 )
-def test_register_classifies_current_workflows(filename: str, expected_status: str) -> None:
-    assert helpers.parse_register_status_map(helpers.WORKFLOW_REGISTER_MD)[filename] == expected_status
+def test_register_classifies_current_workflows(
+    filename: str, expected_status: str
+) -> None:
+    assert (
+        helpers.parse_register_status_map(helpers.WORKFLOW_REGISTER_MD)[filename]
+        == expected_status
+    )
 
 
 def test_canonical_ci_is_active() -> None:
@@ -75,8 +84,10 @@ def test_canonical_ci_is_active() -> None:
 def test_fixture_detects_unregistered_workflow_drift() -> None:
     scan = helpers.scan_workflow_inventory(
         workflows_dir=_fixture_dir("inventory_drift"),
-        register_md_path=_fixture_dir("inventory_drift") / "GITHUB_WORKFLOW_REGISTER.md",
-        control_plane_json_path=_fixture_dir("inventory_drift") / "workflow-register.json",
+        register_md_path=_fixture_dir("inventory_drift")
+        / "GITHUB_WORKFLOW_REGISTER.md",
+        control_plane_json_path=_fixture_dir("inventory_drift")
+        / "workflow-register.json",
     )
     assert scan.unregistered_on_disk == ("orphan.yml",)
 
@@ -84,7 +95,9 @@ def test_fixture_detects_unregistered_workflow_drift() -> None:
 def test_fixture_detects_register_missing_file_drift() -> None:
     scan = helpers.scan_workflow_inventory(
         workflows_dir=_fixture_dir("register_missing_file"),
-        register_md_path=_fixture_dir("register_missing_file") / "GITHUB_WORKFLOW_REGISTER.md",
-        control_plane_json_path=_fixture_dir("register_missing_file") / "workflow-register.json",
+        register_md_path=_fixture_dir("register_missing_file")
+        / "GITHUB_WORKFLOW_REGISTER.md",
+        control_plane_json_path=_fixture_dir("register_missing_file")
+        / "workflow-register.json",
     )
     assert scan.missing_on_disk == ("ghost.yml",)

--- a/tests/unit/scripts/test_workflow_inventory_register_contract.py
+++ b/tests/unit/scripts/test_workflow_inventory_register_contract.py
@@ -67,7 +67,9 @@ def test_register_classifies_current_workflows(filename: str, expected_status: s
 def test_canonical_ci_is_active() -> None:
     workflow_path = helpers.WORKFLOWS_DIR / helpers.ACTIVE_CANONICAL_CI_WORKFLOW
     triggers = helpers.extract_on_triggers(helpers.load_workflow_yaml(workflow_path))
-    assert {"pull_request", "push"} <= triggers
+    # #4401: hosted Fast-CI mirror is post-merge + manual; PR path is cdb-local-ci.
+    assert {"push", "workflow_dispatch"} <= triggers
+    assert "pull_request" not in triggers
 
 
 def test_fixture_detects_unregistered_workflow_drift() -> None:

--- a/tests/unit/scripts/test_workflow_trigger_permission_matrix.py
+++ b/tests/unit/scripts/test_workflow_trigger_permission_matrix.py
@@ -37,8 +37,11 @@ def test_trigger_matrix_is_complete() -> None:
 @pytest.mark.parametrize(
     "filename,expected_triggers",
     [
-        ("ci.yml", ("pull_request", "push")),
+        ("ci.yml", ("push", "workflow_dispatch")),
         ("policy-gate.yml", ("pull_request",)),
+        ("docs-conflict-guard.yml", ("push", "workflow_dispatch")),
+        ("repository-canon-guard.yml", ("push", "workflow_dispatch")),
+        ("codeql-python.yml", ("push", "schedule", "workflow_dispatch")),
         ("required-checks-audit.yml", ("workflow_dispatch",)),
         ("project_reconcile_daily.yml", ("schedule", "workflow_dispatch")),
     ],

--- a/tests/unit/scripts/test_workflow_trigger_permission_matrix.py
+++ b/tests/unit/scripts/test_workflow_trigger_permission_matrix.py
@@ -60,7 +60,9 @@ def test_known_triggers(filename: str, expected_triggers: tuple[str, ...]) -> No
         ("cdb-daily-delta-triage.yml", ("issues:write",)),
     ],
 )
-def test_known_write_permissions(filename: str, expected_permissions: tuple[str, ...]) -> None:
+def test_known_write_permissions(
+    filename: str, expected_permissions: tuple[str, ...]
+) -> None:
     row = helpers.build_trigger_permission_row(helpers.WORKFLOWS_DIR / filename)
     assert row.write_permissions == expected_permissions
 
@@ -71,12 +73,16 @@ def test_write_permissions_use_canonical_tokens() -> None:
 
 
 def test_fixture_flags_pull_request_target() -> None:
-    row = helpers.build_trigger_permission_row(FIXTURES_ROOT / "forbidden_trigger" / "bad.yml")
+    row = helpers.build_trigger_permission_row(
+        FIXTURES_ROOT / "forbidden_trigger" / "bad.yml"
+    )
     assert row.forbidden_triggers == ("pull_request_target",)
 
 
 def test_fixture_surfaces_missing_permissions() -> None:
-    row = helpers.build_trigger_permission_row(FIXTURES_ROOT / "missing_permissions" / "implicit.yml")
+    row = helpers.build_trigger_permission_row(
+        FIXTURES_ROOT / "missing_permissions" / "implicit.yml"
+    )
     assert row.has_explicit_permissions is False
 
 


### PR DESCRIPTION
## Summary
Closes #4401

Reduce GitHub-hosted runner minutes on normal PRs by removing PR triggers that duplicate local Fast-CI / `cdb-local-ci`, while keeping independent lightweight policy and post-merge/security surfaces.

## Problem
`cdb-local-ci` (App Check Run `app_id=4410232`) is already the only branch-protection-required Final-Head gate. Hosted `ci.yml` still ran `python ci/scripts/run.py --profile fast` on every PR, duplicating the same Fast-CI scope and burning runner minutes. Docs/Canon guards and CodeQL also fired on every synchronize.

## Before CI Matrix
Typical PR head (sample PR #4400 / #4398):
| Check | Hosted? | ~Duration | Required BP? |
|---|---|---|---|
| `ci (Unit/Integration + Lint gesammelt)` | yes | ~4–5 min | no |
| `surrealdb-validate` | yes | ~10s | no |
| `Analyze Python` / CodeQL | yes | ~3–4 min | no |
| `Check Docs For Merge Conflict Markers` (windows-latest) | yes | ~20–30s | no |
| `guard` (repository-canon) | yes | ~10s | no |
| `policy-gate` | yes | ~5–10s | no |
| `capture-intent` | yes | ~5s | no |
| `cdb-local-ci` | local publish | n/a hosted | **yes** |

Approx hosted wall per synchronize: **~8–10 min** concurrent (dominant: `ci` + CodeQL). Exact \$ billing unavailable via API (404).

## After CI Matrix
On PR synchronize:
| Check | Hosted? | Rationale |
|---|---|---|
| `policy-gate` | yes | Independent label/scope/workflow-permission gate |
| `capture-intent` / milestone metadata | yes | Lightweight automation |
| `cdb-local-ci` | local | Authoritative Final-Head gate |
| `ci` / docs-conflict / repository-canon / CodeQL | **no PR trigger** | Covered locally or retained on push/schedule |

Post-merge / schedule retained:
- `ci.yml`: path-filtered `push` to `main` + `workflow_dispatch`
- docs-conflict / repository-canon: `push` + `workflow_dispatch`
- CodeQL: `push` + weekly `schedule` + `workflow_dispatch`

## Hosted Jobs Removed/Reduced
- Removed `pull_request` from `ci.yml` (MOVE_TO_LOCAL_CDB_CI / REMOVE_REDUNDANT_TRIGGER)
- Removed `pull_request` from `docs-conflict-guard.yml` (covered by `ci/stages/docs.py`)
- Removed `pull_request` from `repository-canon-guard.yml` (covered by `ci/stages/docs.py`)
- Removed `pull_request` from `codeql-python.yml` (cost; security retained on main+schedule)

## Hosted Jobs Retained + Rationale
- `policy-gate.yml` — independent fail-closed PR policy (KEEP_HOSTED_LIGHTWEIGHT)
- `auto-milestone-pr-intent.yml` — metadata (KEEP_HOSTED_LIGHTWEIGHT)
- CodeQL push/schedule — independent security value (MANUAL_OR_SCHEDULED / post-merge)
- Post-merge `ci.yml` — squash tip SHA differs from PR head

## cdb-local-ci Coverage Proof
- Fast profile stages: lint, unit, docs, governance (`ci/config/stages.yaml`)
- Docs stage runs `tools.ci.docs_conflict_guard` + `tools.ci.repository_canon_guard`
- Governance stage runs SurrealQL validate (same files as hosted `surrealdb-validate`)
- Hosted `ci.yml` job still delegates to `python ci/scripts/run.py --profile fast` (post-merge only)
- CodeQL is **not** claimed as Fast-CI-equivalent; only PR trigger reduced

## Branch Protection
Live (pre-change, unchanged by this PR): required check = `cdb-local-ci` only (`app_id=4410232`), `strict: true`. No BP transition required — removed checks were never BP-required.

## Cost / Runner Minute Evidence
- Before (per PR sync): ~ci 5m + CodeQL 3.5m + windows docs ~0.5m + light jobs ≈ **~9 hosted minutes** (parallel wall ~5m)
- After (per PR sync): policy-gate + milestone intent ≈ **~0.2–0.5 hosted minutes**
- Savings order of magnitude: **>90% hosted minutes per synchronize** (exact \$ not available)

## Validation
- Targeted: workflow contract tests (64 passed) + new #4401 regression test
- `git diff --check` clean
- Real-PR proof: this PR should not start `ci` / docs-conflict / canon / CodeQL on synchronize

## Safety Boundaries
- No LR / live / echtgeld / trading changes
- No `--admin` bypass, no fake-green, `cdb-local-ci` remains required
- No Wave-3 #4396 / storage offloading
- Security: CodeQL retained on land-to-main + weekly schedule