### PR TITLE
[ARVP][CAMPAIGN] #4374 window_stability + durable classifier

### DIFF
--- a/CURRENT_STATUS.md
+++ b/CURRENT_STATUS.md
@@ -12,11 +12,11 @@
 
 ## Repo / Engineering Status (2026-08-08)
 
-<!-- cdb:live-claim type=main_sha value=6fcc8afc -->
-- **Confirmed main state**: `origin/main` @ `6fcc8afcead23f42ce13259bc3fab916ea43f0a2` — tip after [#4407](https://github.com/jannekbuengener/Claire_de_Binare/pull/4407) campaign_summary persistence (supersedes prior ledger tip `43401302`).
+<!-- cdb:live-claim type=main_sha value=d0e9b871 -->
+- **Confirmed main state**: `origin/main` @ `d0e9b8718fbfdfa90f4b169b0b5fc80b3c1c71f6` — tip after [#4413](https://github.com/jannekbuengener/Claire_de_Binare/pull/4413) Final-Head skill reconciliation (supersedes prior ledger tip `6fcc8afc`).
 
-<!-- cdb:live-claim type=issue_state issue=4411 state=open -->
-- **#4411 Final-Head PR Reviewer → Merge Agent skill reconciliation**: Delivery slice on `batch/agent-skills-issue-4411` — governance/skills/policies aligned to Completeness → Conductor Final-Head prep → Cloud PR Reviewer APPROVE → Merge Agent → session-close. PR left open for Approval/Merge pipeline (no self-merge). LR **NO-GO** unchanged.
+<!-- cdb:live-claim type=issue_state issue=4411 state=closed -->
+- **#4411 Final-Head PR Reviewer → Merge Agent skill reconciliation**: **DONE_MERGED_CLOSED** via PR [#4413](https://github.com/jannekbuengener/Claire_de_Binare/pull/4413) @ `d0e9b871`. LR **NO-GO** unchanged.
 
 <!-- cdb:historical-as-of date=2026-08-06 -->
 > Historical as of 2026-08-06 — append-only ledger. Entries below record the
@@ -25,7 +25,7 @@
 
 ## Repo / Engineering Status (2026-08-06)
 
-- **Confirmed main state (historical)**: previously claimed `origin/main` @ `43401302` after Hermes [#4344](https://github.com/jannekbuengener/Claire_de_Binare/pull/4344); superseded by live tip `6fcc8afc` on 2026-08-08.
+- **Confirmed main state (historical)**: previously claimed `origin/main` @ `43401302` after Hermes [#4344](https://github.com/jannekbuengener/Claire_de_Binare/pull/4344); later tip `6fcc8afc` superseded by `d0e9b871` on 2026-08-08.
 - **#2513 / #4257 / #4258 / #4289**: historical closed/open claims from 2026-08-06 remain append-only evidence; see prior session logs. LR **NO-GO** unchanged.
 
 > Note: older 2026-08-03 lines that claimed tip `312d12e0` / `abf997d5` / `a4cfb8a8` or `#4289` still open are superseded by later tips.

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ Stage und LR sind orthogonale Systeme: `trade-capable` autorisiert kein Live-Tra
 
 <!-- cdb:status-freshness header-date=2026-08-08 -->
 **Stand 2026-08-08.**
-<!-- cdb:live-claim type=main_sha value=6fcc8afc -->
-<!-- cdb:live-claim type=issue_state issue=4411 state=open -->
+<!-- cdb:live-claim type=main_sha value=d0e9b871 -->
+<!-- cdb:live-claim type=issue_state issue=4411 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4289 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4257 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=4258 state=closed -->
 <!-- cdb:live-claim type=issue_state issue=2513 state=open -->
 <!-- cdb:live-claim type=issue_state issue=4293 state=closed -->
-Auf `origin/main` (`6fcc8afc`) sind die juengsten relevanten Merge-Cluster u. a.:
+Auf `origin/main` (`d0e9b871`) sind die juengsten relevanten Merge-Cluster u. a.:
 
-- **#4411 Final-Head approval pipeline reconciliation:** open delivery on `batch/agent-skills-issue-4411` (skills/governance → Completeness → Conductor Final-Head prep → PR Reviewer → Merge Agent). Not self-merged.
+- **#4411 Final-Head approval pipeline reconciliation:** **MERGED/CLOSED** via PR [#4413](https://github.com/jannekbuengener/Claire_de_Binare/pull/4413) @ `d0e9b871`.
 - **Hermes app mint/write-path ([#4289](https://github.com/jannekbuengener/Claire_de_Binare/issues/4289) / PR [#4344](https://github.com/jannekbuengener/Claire_de_Binare/pull/4344)):** **MERGED** @ `43401302` (ancestor of tip). Issue `#4289` **CLOSED**.  <!-- pragma: allowlist secret -->
 - **Security Backlog Reconciliation ([#2513](https://github.com/jannekbuengener/Claire_de_Binare/issues/2513) / PR [#4303](https://github.com/jannekbuengener/Claire_de_Binare/pull/4303)):** **MERGED** @ `312d12e0` (ancestor of tip). Offene Security-Issues bleiben Upstream-HOLDs (geparkt bis FixedVersion). Meta `#2513` bleibt Tracker.
 - **ACP E2E Pilot Foundation ([#4258](https://github.com/jannekbuengener/Claire_de_Binare/issues/4258) / PR [#4301](https://github.com/jannekbuengener/Claire_de_Binare/pull/4301)):** **MERGED** @ `abf997d5` (mock-first). Issue `#4258` **CLOSED** (live GitHub). Dedicated PR [#4302](https://github.com/jannekbuengener/Claire_de_Binare/pull/4302) remains historical delivery evidence (`Refs` only; kein zweiter Cursor-Create ohne neues Human-GO).

--- a/agents/prompts/2026-08-08-4374-window-stability-classifier-execute-prompt.md
+++ b/agents/prompts/2026-08-08-4374-window-stability-classifier-execute-prompt.md
@@ -1,0 +1,70 @@
+# #4374 Execute — window_stability build + durable re-classify
+
+Status: PLANNING_ONLY until Owner posts `GO_HH_HL_WINDOW_STABILITY_CLASSIFIER_EXECUTE`.
+LR: NO-GO. No Stage B / Paper / Live / Echtgeld / Promotion / Primary mutation.
+
+## Preconditions
+
+1. Slice contracts merged on `main` (or this batch branch after merge):
+   - `cdb.hh_hl_window_stability.v1`
+   - `cdb.hh_hl_analyzer_classification.v1`
+   - `cdb.hh_hl_classifier_threshold_policy.v1`
+2. Live Owner-GO comment on #4374 with fence
+   `cdb.hh_hl_window_stability_classifier_authorization.v1`
+   and status `GO_HH_HL_WINDOW_STABILITY_CLASSIFIER_EXECUTE`.
+3. Bound Primary unchanged:
+   - `campaign_phase=PRIMARY_COMPLETE` 39/39
+   - param FP `9067cd6aa48ad2cc2a7932af50e990888048b8f912b8f3e3ad0dd5b318d1c0a4`
+   - summary FP `e5faae11041706e8668252387808f3bd193bdb24c8505d6ba1a7e162413adf28`
+   - Owner Primary GO `5222204496` (do not reuse as this execute GO)
+4. Reproduction evidence from GO `5223567140` remains PASS (read-only bind).
+5. Optional: Owner-ratified threshold policy
+   (`uniform_negative_sign_reject_v1`, `policy_status=OWNER_RATIFIED`).
+   Without it, max verdict is `INCONCLUSIVE` /
+   `ANALYZER_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT`.
+
+## Sequence (STOP after step 8)
+
+1. **Owner-/Contract-Gate** — verify GO fence live via `gh api`; verify schemas present.
+2. **Primary read-only bind** — recompute sha256 of `campaign_summary.json` + envelope; abort if drift.
+3. **Stability Artifact erzeugen**
+
+```bash
+python -m tools.arvp_vacation.hh_hl_window_stability build \
+  --evidence-root "<PRIMARY_ROOT>" \
+  --bindings-json "<bindings.json>" \
+  --run-keys-json "<expected_run_keys.json>" \
+  --write
+```
+
+4. **Stability Artifact validieren**
+
+```bash
+python -m tools.arvp_vacation.hh_hl_window_stability validate \
+  --artifact "<PRIMARY_ROOT>/window_stability.json"
+```
+
+5. **Analyzer mit Stability erneut ausführen** — call
+   `classify_hh_hl_campaign(...)` with bound stability (+ ratified policy if present).
+6. **durable Classification Artifact schreiben** — new file only; do **not**
+   overwrite `docs/evidence/arvp_hh_hl_analyzer_classification_4374_5223567140.json`.
+7. **Ergebnis berichten** on #4374 (classification, reason_code, fingerprints).
+8. **STOP** — no Stage B, no Paper, no Live, no automatic follow-up execute.
+
+## Hard non-goals
+
+- No new replay runs
+- No reproduction re-run
+- No primary run-tree mutation
+- No inventing PROMISING thresholds
+- No #4153 21/19 matrix assumptions
+- Do not close #4374 unless Owner explicitly asks
+
+## Expected statuses
+
+| Condition | Verdict |
+|---|---|
+| Stability missing/invalid | `INCONCLUSIVE` / `ANALYZER_INCONCLUSIVE_WINDOW_STABILITY_ABSENT` |
+| Stability OK, policy absent/draft | `INCONCLUSIVE` / `…_THRESHOLD_POLICY_ABSENT` or `…_NOT_RATIFIED` |
+| Stability OK + ratified uniform-negative rule fires | `REJECTED` / `ANALYZER_REJECTED_UNIFORM_NEGATIVE_SIGN` |
+| PROMISING | only if Owner-ratified promising rule exists and fires (v1 draft has none) |

--- a/docs/contracts/cdb_hh_hl_analyzer_classification.v1.schema.json
+++ b/docs/contracts/cdb_hh_hl_analyzer_classification.v1.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/cdb_hh_hl_analyzer_classification.v1.schema.json",
+  "title": "CDB hh_hl Durable Analyzer Classification v1",
+  "description": "Durable, fingerprinted analyzer classification for hh_hl campaigns (#4374). Binds stability evidence and optional Owner-ratified threshold policy. PROMISING is research follow-up only; never promotion/Paper/Live.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "classifier_code_version",
+    "analyzer_profile_id",
+    "analyzer_profile_fingerprint",
+    "classification",
+    "reason_code",
+    "fired_rules",
+    "reproduction_pass",
+    "auto_promotion",
+    "pnl_only_ranking_forbidden",
+    "promising_means",
+    "forbidden_statements",
+    "input_fingerprints",
+    "classification_fingerprint"
+  ],
+  "properties": {
+    "schema_version": { "const": "cdb.hh_hl_analyzer_classification.v1" },
+    "classifier_code_version": {
+      "const": "hh_hl_durable_classifier.v1"
+    },
+    "analyzer_profile_id": { "const": "hh_hl_analyzer_prep_v1" },
+    "analyzer_profile_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "policy_id": { "type": ["string", "null"] },
+    "policy_version": { "type": ["string", "null"] },
+    "policy_fingerprint": { "type": ["string", "null"] },
+    "policy_status": {
+      "type": ["string", "null"],
+      "enum": ["DRAFT", "OWNER_RATIFIED", null]
+    },
+    "classification": {
+      "type": "string",
+      "enum": ["PROMISING", "INCONCLUSIVE", "REJECTED", "BLOCKED"]
+    },
+    "reason_code": { "type": "string", "minLength": 1 },
+    "fired_rules": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "reproduction_pass": { "type": "boolean" },
+    "window_stability_present": { "type": "boolean" },
+    "auto_promotion": { "const": false },
+    "pnl_only_ranking_forbidden": { "const": true },
+    "promising_means": {
+      "const": "only research follow-up, no promotion"
+    },
+    "forbidden_statements": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "input_fingerprints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "campaign_summary_fingerprint",
+        "reproduction_summary_fingerprint",
+        "window_stability_fingerprint",
+        "threshold_policy_fingerprint",
+        "analyzer_profile_fingerprint"
+      ],
+      "properties": {
+        "campaign_summary_fingerprint": {
+          "type": ["string", "null"]
+        },
+        "reproduction_summary_fingerprint": {
+          "type": ["string", "null"]
+        },
+        "window_stability_fingerprint": {
+          "type": ["string", "null"]
+        },
+        "threshold_policy_fingerprint": {
+          "type": ["string", "null"]
+        },
+        "analyzer_profile_fingerprint": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      }
+    },
+    "note": { "type": "string" },
+    "classification_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/docs/contracts/cdb_hh_hl_classifier_threshold_policy.v1.schema.json
+++ b/docs/contracts/cdb_hh_hl_classifier_threshold_policy.v1.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/cdb_hh_hl_classifier_threshold_policy.v1.schema.json",
+  "title": "CDB hh_hl Classifier Threshold Policy v1",
+  "description": "Owner-ratifiable threshold policy for the durable hh_hl analyzer classifier (#4374). Separated from descriptive window_stability evidence. Does not authorize Paper/Live/Echtgeld/promotion. PROMISING means research follow-up only. No free percentage cutoffs; v1 REJECTED rule is sign-consistency only.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "policy_id",
+    "policy_status",
+    "issue",
+    "auto_promotion",
+    "pnl_only_ranking_forbidden",
+    "promising_means",
+    "rejected_rules",
+    "promising_rules",
+    "policy_fingerprint"
+  ],
+  "properties": {
+    "schema_version": { "const": "cdb.hh_hl_classifier_threshold_policy.v1" },
+    "policy_id": { "type": "string", "minLength": 1 },
+    "policy_status": {
+      "type": "string",
+      "enum": ["DRAFT", "OWNER_RATIFIED"]
+    },
+    "issue": { "type": "integer", "minimum": 1 },
+    "auto_promotion": { "const": false },
+    "pnl_only_ranking_forbidden": { "const": true },
+    "promising_means": {
+      "const": "only research follow-up, no promotion"
+    },
+    "rejected_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rule_id", "reason_code"],
+        "properties": {
+          "rule_id": { "type": "string" },
+          "reason_code": { "type": "string" },
+          "requires": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "promising_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rule_id", "reason_code"],
+        "properties": {
+          "rule_id": { "type": "string" },
+          "reason_code": { "type": "string" },
+          "requires": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "owner_ratified_at_utc": { "type": ["string", "null"] },
+    "owner_github_login": { "type": ["string", "null"] },
+    "policy_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "notes": { "type": "string" }
+  }
+}

--- a/docs/contracts/cdb_hh_hl_window_stability.v1.schema.json
+++ b/docs/contracts/cdb_hh_hl_window_stability.v1.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://claire-de-binare/docs/contracts/cdb_hh_hl_window_stability.v1.schema.json",
+  "title": "CDB hh_hl Window Stability Evidence v1",
+  "description": "Derived, descriptive cross-window stability evidence for hh_hl campaigns (#4374). Computed read-only from immutable primary Pack-A per-window metrics. Does not authorize PROMISING/REJECTED thresholds, Stage B, Paper, Live, or promotion. overlap_policy is always descriptive_non_iid.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "calculation_version",
+    "campaign_id",
+    "issue",
+    "authorization_fingerprint",
+    "execution_sha",
+    "manifest_fingerprint",
+    "run_plan_fingerprint",
+    "dataset_selection_sha256",
+    "dataset_content_fingerprint_digest",
+    "physical_parameter_set_fingerprint",
+    "campaign_summary_fingerprint",
+    "source_run_count",
+    "window_ids",
+    "raw_metrics_used",
+    "overlap_policy",
+    "derived_from",
+    "metrics",
+    "evidence_fingerprint"
+  ],
+  "properties": {
+    "schema_version": { "const": "cdb.hh_hl_window_stability.v1" },
+    "calculation_version": { "const": "hh_hl_window_stability_calc.v1" },
+    "campaign_id": { "type": "string", "minLength": 1 },
+    "issue": { "type": "integer", "minimum": 1 },
+    "authorization_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "execution_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "manifest_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "run_plan_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "dataset_selection_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "dataset_content_fingerprint_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "physical_parameter_set_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "campaign_summary_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "source_run_count": { "type": "integer", "minimum": 1 },
+    "window_ids": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "raw_metrics_used": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "net_pnl_quote",
+          "expectancy_r",
+          "max_drawdown_r",
+          "closed_trades_total",
+          "fees_total_quote",
+          "gate_result.status"
+        ]
+      }
+    },
+    "overlap_policy": { "const": "descriptive_non_iid" },
+    "derived_from": { "const": "primary" },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "n_total",
+        "n_traded",
+        "n_zero_trade",
+        "series",
+        "sign_shares",
+        "concentration",
+        "gate_status_histogram"
+      ],
+      "properties": {
+        "n_total": { "type": "integer", "minimum": 0 },
+        "n_traded": { "type": "integer", "minimum": 0 },
+        "n_zero_trade": { "type": "integer", "minimum": 0 },
+        "series": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "net_pnl_quote",
+            "expectancy_r",
+            "max_drawdown_r",
+            "fees_total_quote",
+            "closed_trades_total"
+          ],
+          "properties": {
+            "net_pnl_quote": { "$ref": "#/$defs/series_stats" },
+            "expectancy_r": { "$ref": "#/$defs/series_stats" },
+            "max_drawdown_r": { "$ref": "#/$defs/series_stats" },
+            "fees_total_quote": { "$ref": "#/$defs/series_stats" },
+            "closed_trades_total": { "$ref": "#/$defs/series_stats" }
+          }
+        },
+        "sign_shares": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["net_pnl_quote", "expectancy_r"],
+          "properties": {
+            "net_pnl_quote": { "$ref": "#/$defs/sign_shares" },
+            "expectancy_r": { "$ref": "#/$defs/sign_shares" }
+          }
+        },
+        "concentration": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "top1_abs_pnl_share",
+            "top3_abs_pnl_share",
+            "denominator_zero"
+          ],
+          "properties": {
+            "top1_abs_pnl_share": { "type": ["number", "null"] },
+            "top3_abs_pnl_share": { "type": ["number", "null"] },
+            "denominator_zero": { "type": "boolean" }
+          }
+        },
+        "gate_status_histogram": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "evidence_fingerprint": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  },
+  "$defs": {
+    "series_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["median", "minimum", "maximum", "q25", "q75", "n"],
+      "properties": {
+        "median": { "type": ["number", "null"] },
+        "minimum": { "type": ["number", "null"] },
+        "maximum": { "type": ["number", "null"] },
+        "q25": { "type": ["number", "null"] },
+        "q75": { "type": ["number", "null"] },
+        "n": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "sign_shares": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "positive_share",
+        "negative_share",
+        "zero_share",
+        "n_traded"
+      ],
+      "properties": {
+        "positive_share": { "type": ["number", "null"] },
+        "negative_share": { "type": ["number", "null"] },
+        "zero_share": { "type": ["number", "null"] },
+        "n_traded": { "type": "integer", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/docs/contracts/examples/hh_hl_classifier_threshold_policy_uniform_negative_sign_reject_v1.draft.json
+++ b/docs/contracts/examples/hh_hl_classifier_threshold_policy_uniform_negative_sign_reject_v1.draft.json
@@ -1,0 +1,27 @@
+{
+  "auto_promotion": false,
+  "issue": 4374,
+  "notes": "DRAFT only. Not active until policy_status=OWNER_RATIFIED. PROMISING rules intentionally empty.",
+  "owner_github_login": null,
+  "owner_ratified_at_utc": null,
+  "pnl_only_ranking_forbidden": true,
+  "policy_fingerprint": "1cdae92d424dd31678917b5b13b0e0a548e07a488edd5ed36d947fb4e3165810",
+  "policy_id": "uniform_negative_sign_reject_v1",
+  "policy_status": "DRAFT",
+  "promising_means": "only research follow-up, no promotion",
+  "promising_rules": [],
+  "rejected_rules": [
+    {
+      "reason_code": "ANALYZER_REJECTED_UNIFORM_NEGATIVE_SIGN",
+      "requires": {
+        "all_gates_not_ranking_ready": true,
+        "n_total_gt_zero": true,
+        "n_traded_equals_n_total": true,
+        "negative_share_expectancy_r": 1.0,
+        "negative_share_net_pnl_quote": 1.0
+      },
+      "rule_id": "uniform_negative_sign_reject_v1"
+    }
+  ],
+  "schema_version": "cdb.hh_hl_classifier_threshold_policy.v1"
+}

--- a/docs/contracts/examples/hh_hl_window_stability.v1.example.json
+++ b/docs/contracts/examples/hh_hl_window_stability.v1.example.json
@@ -1,0 +1,100 @@
+{
+  "authorization_fingerprint": "6870e4cd7a0cf4589f3aabb3e91a7c3f2b0f54032b43680e7f1d0bddd6238295",
+  "calculation_version": "hh_hl_window_stability_calc.v1",
+  "campaign_id": "arvp-hh-hl-continuation-4374-prep-v1",
+  "campaign_summary_fingerprint": "ec0b7fc3f5e8c2806007d2cf8568983a354ff3f8a953d1761c55f9103dd51b97",
+  "dataset_content_fingerprint_digest": "422959eef889b23d671a96d3bc94e2e8192bdfc3eb2a20cb87c850b40cb43d26",
+  "dataset_selection_sha256": "15c2b9da3d48ff1f0541981ca7c4ee00cd117d530f5bb52536a14962949ae9f6",
+  "derived_from": "primary",
+  "evidence_fingerprint": "09b93f9a127500e666f73e9de462513d0624e027f11118107d197fa37eaed9fb",
+  "execution_sha": "79b150d452a6bebddc5a8f1b0db39c77ebbfe1c3",
+  "issue": 4374,
+  "manifest_fingerprint": "1e18c986fbea93aac8a896c5d9804c8563d32e649020601b9af215c292d24973",
+  "metrics": {
+    "concentration": {
+      "denominator_zero": false,
+      "top1_abs_pnl_share": 0.5714285714285714,
+      "top3_abs_pnl_share": 1.0
+    },
+    "gate_status_histogram": {
+      "NOT_RANKING_READY": 3
+    },
+    "n_total": 3,
+    "n_traded": 3,
+    "n_zero_trade": 0,
+    "series": {
+      "closed_trades_total": {
+        "maximum": 10.0,
+        "median": 10.0,
+        "minimum": 10.0,
+        "n": 3,
+        "q25": 10.0,
+        "q75": 10.0
+      },
+      "expectancy_r": {
+        "maximum": -0.005,
+        "median": -0.01,
+        "minimum": -0.02,
+        "n": 3,
+        "q25": -0.015,
+        "q75": -0.0075
+      },
+      "fees_total_quote": {
+        "maximum": 10.0,
+        "median": 10.0,
+        "minimum": 10.0,
+        "n": 3,
+        "q25": 10.0,
+        "q75": 10.0
+      },
+      "max_drawdown_r": {
+        "maximum": 0.5,
+        "median": 0.5,
+        "minimum": 0.5,
+        "n": 3,
+        "q25": 0.5,
+        "q75": 0.5
+      },
+      "net_pnl_quote": {
+        "maximum": -50.0,
+        "median": -100.0,
+        "minimum": -200.0,
+        "n": 3,
+        "q25": -150.0,
+        "q75": -75.0
+      }
+    },
+    "sign_shares": {
+      "expectancy_r": {
+        "n_traded": 3,
+        "negative_share": 1.0,
+        "positive_share": 0.0,
+        "zero_share": 0.0
+      },
+      "net_pnl_quote": {
+        "n_traded": 3,
+        "negative_share": 1.0,
+        "positive_share": 0.0,
+        "zero_share": 0.0
+      }
+    }
+  },
+  "overlap_policy": "descriptive_non_iid",
+  "physical_parameter_set_fingerprint": "536293274fcc36b8287b0143a4724d64d8085344945ce674482f14d5fe29c2bb",
+  "raw_metrics_used": [
+    "net_pnl_quote",
+    "expectancy_r",
+    "max_drawdown_r",
+    "closed_trades_total",
+    "fees_total_quote",
+    "gate_result.status"
+  ],
+  "run_plan_fingerprint": "1f8c80868939423c6815dcf1fa95e771e08c05468500072e98f5312118d46fa0",
+  "schema_version": "cdb.hh_hl_window_stability.v1",
+  "source_run_count": 3,
+  "window_ids": [
+    "w_a",
+    "w_b",
+    "w_c"
+  ]
+}

--- a/docs/evidence/arvp_hh_hl_owner_threshold_policy_go_comment_4374.md
+++ b/docs/evidence/arvp_hh_hl_owner_threshold_policy_go_comment_4374.md
@@ -1,0 +1,37 @@
+## GO_HH_HL_CLASSIFIER_THRESHOLD_POLICY_RATIFY (Owner draft — do not auto-post)
+
+Authorizes only: Owner ratification of `uniform_negative_sign_reject_v1` for #4374 durable classifier.
+Does **not** authorize Stage B / Paper / Live / Echtgeld / Promotion / Primary mutation / new replays.
+
+```cdb.hh_hl_classifier_threshold_policy.v1
+{
+  "schema_version": "cdb.hh_hl_classifier_threshold_policy.v1",
+  "policy_id": "uniform_negative_sign_reject_v1",
+  "policy_status": "OWNER_RATIFIED",
+  "issue": 4374,
+  "auto_promotion": false,
+  "pnl_only_ranking_forbidden": true,
+  "promising_means": "only research follow-up, no promotion",
+  "rejected_rules": [
+    {
+      "rule_id": "uniform_negative_sign_reject_v1",
+      "reason_code": "ANALYZER_REJECTED_UNIFORM_NEGATIVE_SIGN",
+      "requires": {
+        "n_traded_equals_n_total": true,
+        "n_total_gt_zero": true,
+        "negative_share_net_pnl_quote": 1.0,
+        "negative_share_expectancy_r": 1.0,
+        "all_gates_not_ranking_ready": true
+      }
+    }
+  ],
+  "promising_rules": [],
+  "owner_ratified_at_utc": "<OWNER_SETS_ISO_UTC>",
+  "owner_github_login": "jannekbuengener",
+  "notes": "Sign-consistency REJECTED only. PROMISING rules empty until separate Owner criteria."
+}
+```
+
+After posting, recompute `policy_fingerprint` via:
+
+`python -c "from tools.arvp_vacation.hh_hl_campaign_analyzer import build_threshold_policy; import json; print(json.dumps(build_threshold_policy(...), indent=2))"`

--- a/docs/evidence/arvp_hh_hl_owner_threshold_policy_go_package_4374.json
+++ b/docs/evidence/arvp_hh_hl_owner_threshold_policy_go_package_4374.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "cdb.hh_hl_classifier_threshold_policy_authorization.v1.draft",
+  "status": "AWAITING_OWNER_GO",
+  "repository": "jannekbuengener/Claire_de_Binare",
+  "issue": 4374,
+  "lr_status": "NO-GO",
+  "policy_draft_path": "docs/contracts/examples/hh_hl_classifier_threshold_policy_uniform_negative_sign_reject_v1.draft.json",
+  "policy_id": "uniform_negative_sign_reject_v1",
+  "policy_status_required": "OWNER_RATIFIED",
+  "authorizes": [
+    "ratify_hh_hl_classifier_threshold_policy_uniform_negative_sign_reject_v1"
+  ],
+  "does_not_authorize": [
+    "stage_b",
+    "oos",
+    "stress",
+    "paper",
+    "live",
+    "echtgeld",
+    "promotion",
+    "primary_mutation",
+    "new_replay_runs",
+    "capital_allocation",
+    "ml_rl"
+  ],
+  "policy_semantics": {
+    "rejected_rule": "uniform_negative_sign_reject_v1",
+    "rejected_means": "sign-consistency across all traded windows; not a free profitability percentage cutoff",
+    "promising_rules": [],
+    "promising_means": "only research follow-up, no promotion",
+    "auto_promotion": false,
+    "pnl_only_ranking_forbidden": true
+  },
+  "notes": "Owner must post a fenced ratification comment on #4374 setting policy_status=OWNER_RATIFIED with login + timestamp. Agents must not forge Owner ratification. DRAFT policy alone cannot produce REJECTED/PROMISING."
+}

--- a/docs/evidence/arvp_hh_hl_owner_window_stability_classifier_go_comment_4374.md
+++ b/docs/evidence/arvp_hh_hl_owner_window_stability_classifier_go_comment_4374.md
@@ -1,0 +1,42 @@
+## GO_HH_HL_WINDOW_STABILITY_CLASSIFIER_EXECUTE (Owner draft — do not auto-post)
+
+Authorizes only: Primary read-only `window_stability` build → validate → durable classifier → new classification artifact → STOP.
+Does **not** reuse Primary GO `5222204496` or Reproduction GO `5223567140`.
+Does **not** authorize Paper / Live / Echtgeld / Promotion / Stage B / OOS / Stress / Primary mutation / new replays.
+
+```cdb.hh_hl_window_stability_classifier_authorization.v1
+{
+  "schema_version": "cdb.hh_hl_window_stability_classifier_authorization.v1.draft",
+  "status": "GO_HH_HL_WINDOW_STABILITY_CLASSIFIER_EXECUTE",
+  "repository": "jannekbuengener/Claire_de_Binare",
+  "issue": 4374,
+  "authorizing_github_login": "jannekbuengener",
+  "lr_status": "NO-GO",
+  "campaign_id": "arvp-hh-hl-continuation-4374-prep-v1",
+  "execute_prompt_path": "agents/prompts/2026-08-08-4374-window-stability-classifier-execute-prompt.md",
+  "physical_parameter_set_fingerprint": "9067cd6aa48ad2cc2a7932af50e990888048b8f912b8f3e3ad0dd5b318d1c0a4",
+  "campaign_summary_fingerprint": "e5faae11041706e8668252387808f3bd193bdb24c8505d6ba1a7e162413adf28",
+  "reproduction_owner_go_comment_id": 5223567140,
+  "authorizes": [
+    "build_window_stability_from_primary_readonly",
+    "validate_window_stability_artifact",
+    "run_durable_hh_hl_classifier",
+    "write_new_classification_artifact"
+  ],
+  "does_not_authorize": [
+    "stage_b",
+    "oos",
+    "stress",
+    "paper",
+    "live",
+    "echtgeld",
+    "promotion",
+    "primary_mutation",
+    "new_replay_runs",
+    "reproduction_rerun",
+    "merge",
+    "issue_close"
+  ],
+  "expires_at_utc": "<OWNER_SETS_FUTURE_UTC>"
+}
+```

--- a/docs/evidence/arvp_hh_hl_owner_window_stability_classifier_go_package_4374.json
+++ b/docs/evidence/arvp_hh_hl_owner_window_stability_classifier_go_package_4374.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "cdb.hh_hl_window_stability_classifier_authorization.v1.draft",
+  "status": "AWAITING_OWNER_GO",
+  "repository": "jannekbuengener/Claire_de_Binare",
+  "issue": 4374,
+  "lr_status": "NO-GO",
+  "campaign_id": "arvp-hh-hl-continuation-4374-prep-v1",
+  "execute_prompt_path": "agents/prompts/2026-08-08-4374-window-stability-classifier-execute-prompt.md",
+  "owner_comment_draft_path": "docs/evidence/arvp_hh_hl_owner_window_stability_classifier_go_comment_4374.md",
+  "bound_primary": {
+    "physical_parameter_set_fingerprint": "9067cd6aa48ad2cc2a7932af50e990888048b8f912b8f3e3ad0dd5b318d1c0a4",
+    "campaign_summary_fingerprint": "e5faae11041706e8668252387808f3bd193bdb24c8505d6ba1a7e162413adf28",
+    "campaign_phase": "PRIMARY_COMPLETE",
+    "primary_owner_go_comment_id": 5222204496,
+    "reproduction_owner_go_comment_id": 5223567140
+  },
+  "authorizes": [
+    "build_window_stability_from_primary_readonly",
+    "validate_window_stability_artifact",
+    "run_durable_hh_hl_classifier",
+    "write_new_classification_artifact"
+  ],
+  "does_not_authorize": [
+    "stage_b",
+    "oos",
+    "stress",
+    "paper",
+    "live",
+    "echtgeld",
+    "promotion",
+    "primary_mutation",
+    "new_replay_runs",
+    "reproduction_rerun",
+    "merge",
+    "issue_close",
+    "ml_rl"
+  ],
+  "stop_after": [
+    "stability_build",
+    "stability_validate",
+    "classifier_run",
+    "report",
+    "STOP"
+  ],
+  "notes": "Owner must post the fenced GO on #4374. Agents must not forge or auto-post. Do not reuse Primary GO 5222204496 or Reproduction GO 5223567140 as this authorization."
+}

--- a/knowledge/logs/sessions/2026-08-08-4374-window-stability-classifier-impl.md
+++ b/knowledge/logs/sessions/2026-08-08-4374-window-stability-classifier-impl.md
@@ -1,0 +1,60 @@
+# Session — #4374 window_stability + durable classifier implementation
+
+Date: 2026-08-08
+Surface: Cursor worktree `batch-validation-research-issue-4374-exec-prep`
+Branch: `batch/validation-research-issue-4374`
+Result: delivery slice for contracts + library + tests + Owner-GO prep
+Issue: #4374 (OPEN; Refs only — not closed)
+
+## Brain Evidence
+
+- brain_source: repo-only
+- brain_status: not-used
+- context_brain_attempted: true
+- context_available: false
+- repo_fallback_reason: insufficient_evidence
+
+## Delivered
+
+### Slice 1
+- `docs/contracts/cdb_hh_hl_window_stability.v1.schema.json`
+- `tools/arvp_vacation/hh_hl_window_stability.py`
+- `tests/unit/arvp/test_hh_hl_window_stability.py`
+- example artifact under `docs/contracts/examples/`
+
+### Slice 2
+- `docs/contracts/cdb_hh_hl_analyzer_classification.v1.schema.json`
+- `docs/contracts/cdb_hh_hl_classifier_threshold_policy.v1.schema.json`
+- durable `classify_hh_hl_campaign` in `hh_hl_campaign_analyzer.py`
+- `tests/unit/arvp/test_hh_hl_campaign_analyzer_classification.py`
+
+### Owner threshold policy prep
+- DRAFT `uniform_negative_sign_reject_v1` example (PROMISING rules empty)
+- Owner GO package + comment draft for ratification
+
+### Future execute window prep
+- Execute prompt + Owner GO package/comment draft
+- No live stability build / no analyzer re-execute against primary
+
+## Validation
+
+```bash
+python -m pytest tests/unit/arvp/test_hh_hl_window_stability.py \
+  tests/unit/arvp/test_hh_hl_campaign_analyzer_classification.py -q
+```
+
+All targeted tests PASS (Windows pytest tmp cleanup PermissionError is infra noise).
+
+## Safety
+
+- LR NO-GO
+- Primary immutable
+- No Stage B / Paper / Live
+- PROMISING remains research follow-up only
+- No #4153 matrix assumptions
+
+## Next step
+
+1. Merge batch PR (separate merge session).
+2. Owner ratify threshold policy (optional for REJECTED path).
+3. Owner post Execute-GO; then run execute prompt sequence and STOP.

--- a/tests/unit/arvp/test_hh_hl_campaign_analyzer_classification.py
+++ b/tests/unit/arvp/test_hh_hl_campaign_analyzer_classification.py
@@ -1,0 +1,237 @@
+"""Unit tests for durable hh_hl analyzer classification (#4374).
+
+test_id: tc_hh_hl_durable_classifier_001
+test_type: Bauteil-Test / Schutz-Test
+cdb_area: arvp_campaign
+issue_ref: #4374
+live_relevant: false
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from tools.arvp_vacation.hh_hl_campaign_analyzer import (
+    REASON_INCONCLUSIVE_STABILITY_ABSENT,
+    REASON_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT,
+    REASON_REJECTED_UNIFORM_NEGATIVE_SIGN,
+    build_hh_hl_analyzer_profile,
+    build_threshold_policy,
+    build_uniform_negative_sign_reject_policy_draft,
+    classify_hh_hl_campaign,
+)
+from tools.arvp_vacation.hh_hl_window_stability import build_window_stability
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+CLASSIFICATION_SCHEMA = (
+    PROJECT_ROOT
+    / "docs"
+    / "contracts"
+    / "cdb_hh_hl_analyzer_classification.v1.schema.json"
+)
+POLICY_SCHEMA = (
+    PROJECT_ROOT
+    / "docs"
+    / "contracts"
+    / "cdb_hh_hl_classifier_threshold_policy.v1.schema.json"
+)
+
+
+def _fp(seed: str) -> str:
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _bindings(**overrides):
+    base = {
+        "campaign_id": "arvp-hh-hl-continuation-4374-prep-v1",
+        "issue": 4374,
+        "authorization_fingerprint": _fp("auth"),
+        "execution_sha": "79b150d452a6bebddc5a8f1b0db39c77ebbfe1c3",
+        "manifest_fingerprint": _fp("manifest"),
+        "run_plan_fingerprint": _fp("run_plan"),
+        "dataset_selection_sha256": _fp("dataset_sel"),
+        "dataset_content_fingerprint_digest": _fp("dataset_content"),
+        "physical_parameter_set_fingerprint": _fp("params"),
+        "campaign_summary_fingerprint": _fp("summary"),
+        "source_run_count": 3,
+    }
+    base.update(overrides)
+    return base
+
+
+def _window(window_id: str, *, net_pnl: float, expectancy: float, trades: int = 10):
+    return {
+        "window_id": window_id,
+        "result": {
+            "net_pnl_quote": net_pnl,
+            "expectancy_r": expectancy,
+            "max_drawdown_r": 0.5,
+            "fees_total_quote": 10.0,
+            "closed_trades_total": trades,
+            "gate_result": {"status": "NOT_RANKING_READY"},
+        },
+    }
+
+
+def _stability_all_negative():
+    return build_window_stability(
+        bindings=_bindings(),
+        window_records=[
+            _window("w_a", net_pnl=-100.0, expectancy=-0.01),
+            _window("w_b", net_pnl=-200.0, expectancy=-0.02),
+            _window("w_c", net_pnl=-50.0, expectancy=-0.005),
+        ],
+    )
+
+
+def _profile():
+    return build_hh_hl_analyzer_profile(
+        expected_run_keys=["k1", "k2", "k3"],
+    )
+
+
+@pytest.fixture(scope="module")
+def classification_validator() -> Draft202012Validator:
+    return Draft202012Validator(
+        json.loads(CLASSIFICATION_SCHEMA.read_text(encoding="utf-8"))
+    )
+
+
+@pytest.fixture(scope="module")
+def policy_validator() -> Draft202012Validator:
+    return Draft202012Validator(json.loads(POLICY_SCHEMA.read_text(encoding="utf-8")))
+
+
+@pytest.mark.unit
+def test_missing_stability_never_promising(classification_validator):
+    result = classify_hh_hl_campaign(
+        analyzer_profile=_profile(),
+        reproduction_pass=True,
+        window_stability=None,
+    )
+    assert result["classification"] == "INCONCLUSIVE"
+    assert result["reason_code"] == REASON_INCONCLUSIVE_STABILITY_ABSENT
+    assert result["classification"] != "PROMISING"
+    classification_validator.validate(result)
+
+
+@pytest.mark.unit
+def test_classifier_requires_bound_stability_artifact(classification_validator):
+    result = classify_hh_hl_campaign(
+        analyzer_profile=_profile(),
+        reproduction_pass=True,
+        window_stability=None,
+        threshold_policy=build_uniform_negative_sign_reject_policy_draft(),
+    )
+    assert result["reason_code"] == REASON_INCONCLUSIVE_STABILITY_ABSENT
+    assert result["input_fingerprints"]["window_stability_fingerprint"] is None
+    classification_validator.validate(result)
+
+
+@pytest.mark.unit
+def test_stability_without_policy_inconclusive(classification_validator):
+    result = classify_hh_hl_campaign(
+        analyzer_profile=_profile(),
+        reproduction_pass=True,
+        window_stability=_stability_all_negative(),
+        threshold_policy=None,
+    )
+    assert result["classification"] == "INCONCLUSIVE"
+    assert result["reason_code"] == REASON_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT
+    assert result["window_stability_present"] is True
+    classification_validator.validate(result)
+
+
+@pytest.mark.unit
+def test_policy_fingerprint_bound_into_classification(
+    classification_validator, policy_validator
+):
+    policy = build_threshold_policy(
+        policy_id="uniform_negative_sign_reject_v1",
+        policy_status="OWNER_RATIFIED",
+        issue=4374,
+        rejected_rules=build_uniform_negative_sign_reject_policy_draft()[
+            "rejected_rules"
+        ],
+        promising_rules=[],
+        owner_ratified_at_utc="2026-08-08T00:00:00Z",
+        owner_github_login="jannekbuengener",
+    )
+    policy_validator.validate(policy)
+    result = classify_hh_hl_campaign(
+        analyzer_profile=_profile(),
+        reproduction_pass=True,
+        window_stability=_stability_all_negative(),
+        threshold_policy=policy,
+        campaign_summary_fingerprint=_fp("summary"),
+        reproduction_summary_fingerprint=_fp("repro"),
+    )
+    assert result["policy_fingerprint"] == policy["policy_fingerprint"]
+    assert (
+        result["input_fingerprints"]["threshold_policy_fingerprint"]
+        == policy["policy_fingerprint"]
+    )
+    assert result["classification"] == "REJECTED"
+    assert result["reason_code"] == REASON_REJECTED_UNIFORM_NEGATIVE_SIGN
+    classification_validator.validate(result)
+
+
+@pytest.mark.unit
+def test_same_inputs_and_policy_same_verdict_fingerprint():
+    policy = build_threshold_policy(
+        policy_id="uniform_negative_sign_reject_v1",
+        policy_status="OWNER_RATIFIED",
+        issue=4374,
+        rejected_rules=build_uniform_negative_sign_reject_policy_draft()[
+            "rejected_rules"
+        ],
+        promising_rules=[],
+        owner_ratified_at_utc="2026-08-08T00:00:00Z",
+        owner_github_login="jannekbuengener",
+    )
+    stability = _stability_all_negative()
+    profile = _profile()
+    a = classify_hh_hl_campaign(
+        analyzer_profile=profile,
+        reproduction_pass=True,
+        window_stability=stability,
+        threshold_policy=policy,
+    )
+    b = classify_hh_hl_campaign(
+        analyzer_profile=copy.deepcopy(profile),
+        reproduction_pass=True,
+        window_stability=copy.deepcopy(stability),
+        threshold_policy=copy.deepcopy(policy),
+    )
+    assert a == b
+    assert a["classification_fingerprint"] == b["classification_fingerprint"]
+
+
+@pytest.mark.unit
+def test_draft_policy_does_not_reject():
+    policy = build_uniform_negative_sign_reject_policy_draft()
+    assert policy["policy_status"] == "DRAFT"
+    result = classify_hh_hl_campaign(
+        analyzer_profile=_profile(),
+        reproduction_pass=True,
+        window_stability=_stability_all_negative(),
+        threshold_policy=policy,
+    )
+    assert result["classification"] == "INCONCLUSIVE"
+    assert "NOT_RATIFIED" in result["reason_code"]
+
+
+@pytest.mark.unit
+def test_reproduction_not_pass_blocked():
+    result = classify_hh_hl_campaign(
+        analyzer_profile=_profile(),
+        reproduction_pass=False,
+        window_stability=_stability_all_negative(),
+    )
+    assert result["classification"] == "BLOCKED"

--- a/tests/unit/arvp/test_hh_hl_window_stability.py
+++ b/tests/unit/arvp/test_hh_hl_window_stability.py
@@ -27,7 +27,9 @@ from tools.arvp_vacation.hh_hl_window_stability import (
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
-SCHEMA_PATH = PROJECT_ROOT / "docs" / "contracts" / "cdb_hh_hl_window_stability.v1.schema.json"
+SCHEMA_PATH = (
+    PROJECT_ROOT / "docs" / "contracts" / "cdb_hh_hl_window_stability.v1.schema.json"
+)
 
 
 def _fp(seed: str) -> str:

--- a/tests/unit/arvp/test_hh_hl_window_stability.py
+++ b/tests/unit/arvp/test_hh_hl_window_stability.py
@@ -1,0 +1,262 @@
+"""Unit tests for hh_hl window_stability derived evidence (#4374).
+
+test_id: tc_hh_hl_window_stability_001
+test_type: Bauteil-Test / Schutz-Test
+cdb_area: arvp_campaign
+issue_ref: #4374
+live_relevant: false
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from tools.arvp_vacation.hh_hl_window_stability import (
+    SCHEMA_VERSION,
+    HhHlWindowStabilityError,
+    assert_bindings_match,
+    build_window_stability,
+    validate_window_stability_artifact,
+    write_window_stability_artifact,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = PROJECT_ROOT / "docs" / "contracts" / "cdb_hh_hl_window_stability.v1.schema.json"
+
+
+def _fp(seed: str) -> str:
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _bindings(**overrides):
+    base = {
+        "campaign_id": "arvp-hh-hl-continuation-4374-prep-v1",
+        "issue": 4374,
+        "authorization_fingerprint": _fp("auth"),
+        "execution_sha": "79b150d452a6bebddc5a8f1b0db39c77ebbfe1c3",
+        "manifest_fingerprint": _fp("manifest"),
+        "run_plan_fingerprint": _fp("run_plan"),
+        "dataset_selection_sha256": _fp("dataset_sel"),
+        "dataset_content_fingerprint_digest": _fp("dataset_content"),
+        "physical_parameter_set_fingerprint": _fp("params"),
+        "campaign_summary_fingerprint": _fp("summary"),
+        "source_run_count": 3,
+    }
+    base.update(overrides)
+    return base
+
+
+def _window(
+    window_id: str,
+    *,
+    net_pnl: float,
+    expectancy: float,
+    drawdown: float = 0.5,
+    fees: float = 10.0,
+    trades: int = 10,
+    gate: str = "NOT_RANKING_READY",
+):
+    return {
+        "window_id": window_id,
+        "result": {
+            "net_pnl_quote": net_pnl,
+            "expectancy_r": expectancy,
+            "max_drawdown_r": drawdown,
+            "fees_total_quote": fees,
+            "closed_trades_total": trades,
+            "gate_result": {"status": gate},
+        },
+    }
+
+
+def _three_windows(**overrides_by_id):
+    defaults = {
+        "w_a": dict(net_pnl=-100.0, expectancy=-0.01, trades=10),
+        "w_b": dict(net_pnl=-200.0, expectancy=-0.02, trades=20),
+        "w_c": dict(net_pnl=-50.0, expectancy=-0.005, trades=5),
+    }
+    defaults.update(overrides_by_id)
+    return [_window(wid, **kwargs) for wid, kwargs in defaults.items()]
+
+
+@pytest.fixture(scope="module")
+def schema_validator() -> Draft202012Validator:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    return Draft202012Validator(schema)
+
+
+@pytest.mark.unit
+def test_identical_inputs_identical_fingerprint(schema_validator):
+    bindings = _bindings()
+    records = _three_windows()
+    a = build_window_stability(bindings=bindings, window_records=records)
+    b = build_window_stability(bindings=bindings, window_records=copy.deepcopy(records))
+    assert a["evidence_fingerprint"] == b["evidence_fingerprint"]
+    assert a["schema_version"] == SCHEMA_VERSION
+    schema_validator.validate(a)
+    validate_window_stability_artifact(a)
+
+
+@pytest.mark.unit
+def test_shuffled_window_order_same_fingerprint():
+    bindings = _bindings()
+    records = _three_windows()
+    shuffled = [records[2], records[0], records[1]]
+    a = build_window_stability(bindings=bindings, window_records=records)
+    b = build_window_stability(bindings=bindings, window_records=shuffled)
+    assert a["evidence_fingerprint"] == b["evidence_fingerprint"]
+    assert a["window_ids"] == ["w_a", "w_b", "w_c"]
+
+
+@pytest.mark.unit
+def test_missing_window_count_fail_closed():
+    bindings = _bindings(source_run_count=3)
+    records = _three_windows()[:2]
+    with pytest.raises(HhHlWindowStabilityError) as exc:
+        build_window_stability(bindings=bindings, window_records=records)
+    assert exc.value.reason_code == "WINDOW_STABILITY_WINDOW_COUNT_MISMATCH"
+
+
+@pytest.mark.unit
+def test_duplicate_window_fail_closed():
+    bindings = _bindings(source_run_count=2)
+    records = [
+        _window("w_a", net_pnl=-1.0, expectancy=-0.1),
+        _window("w_a", net_pnl=-2.0, expectancy=-0.2),
+    ]
+    with pytest.raises(HhHlWindowStabilityError) as exc:
+        build_window_stability(bindings=bindings, window_records=records)
+    assert exc.value.reason_code == "WINDOW_STABILITY_DUPLICATE_WINDOW"
+
+
+@pytest.mark.unit
+def test_binding_mismatch_fail_closed():
+    artifact = build_window_stability(
+        bindings=_bindings(),
+        window_records=_three_windows(),
+    )
+    with pytest.raises(HhHlWindowStabilityError) as exc:
+        assert_bindings_match(
+            artifact,
+            expected_bindings=_bindings(authorization_fingerprint=_fp("other")),
+        )
+    assert exc.value.reason_code == "WINDOW_STABILITY_BINDING_MISMATCH"
+
+
+@pytest.mark.unit
+def test_parameter_fp_mismatch_fail_closed():
+    artifact = build_window_stability(
+        bindings=_bindings(),
+        window_records=_three_windows(),
+    )
+    with pytest.raises(HhHlWindowStabilityError) as exc:
+        assert_bindings_match(
+            artifact,
+            expected_bindings=_bindings(
+                physical_parameter_set_fingerprint=_fp("other-params")
+            ),
+        )
+    assert exc.value.reason_code == "WINDOW_STABILITY_BINDING_MISMATCH"
+
+
+@pytest.mark.unit
+def test_dataset_fp_mismatch_fail_closed():
+    artifact = build_window_stability(
+        bindings=_bindings(),
+        window_records=_three_windows(),
+    )
+    with pytest.raises(HhHlWindowStabilityError) as exc:
+        assert_bindings_match(
+            artifact,
+            expected_bindings=_bindings(
+                dataset_content_fingerprint_digest=_fp("other-dataset")
+            ),
+        )
+    assert exc.value.reason_code == "WINDOW_STABILITY_BINDING_MISMATCH"
+
+
+@pytest.mark.unit
+def test_missing_required_metric_fail_closed():
+    bindings = _bindings(source_run_count=1)
+    bad = {
+        "window_id": "w_a",
+        "result": {
+            "net_pnl_quote": -1.0,
+            # expectancy_r missing
+            "max_drawdown_r": 0.1,
+            "fees_total_quote": 1.0,
+            "closed_trades_total": 1,
+            "gate_result": {"status": "NOT_RANKING_READY"},
+        },
+    }
+    with pytest.raises(HhHlWindowStabilityError) as exc:
+        build_window_stability(bindings=bindings, window_records=[bad])
+    assert exc.value.reason_code == "WINDOW_STABILITY_MISSING_REQUIRED_METRIC"
+
+
+@pytest.mark.unit
+def test_no_trade_window_excluded_from_sign_shares():
+    bindings = _bindings(source_run_count=3)
+    records = _three_windows(
+        w_b=dict(net_pnl=0.0, expectancy=0.0, trades=0),
+    )
+    artifact = build_window_stability(bindings=bindings, window_records=records)
+    assert artifact["metrics"]["n_zero_trade"] == 1
+    assert artifact["metrics"]["n_traded"] == 2
+    shares = artifact["metrics"]["sign_shares"]["net_pnl_quote"]
+    assert shares["n_traded"] == 2
+    assert shares["negative_share"] == 1.0
+
+
+@pytest.mark.unit
+def test_all_zero_trade_null_shares_and_concentration():
+    bindings = _bindings(source_run_count=2)
+    records = [
+        _window("w_a", net_pnl=0.0, expectancy=0.0, trades=0),
+        _window("w_b", net_pnl=0.0, expectancy=0.0, trades=0),
+    ]
+    artifact = build_window_stability(bindings=bindings, window_records=records)
+    assert artifact["metrics"]["n_traded"] == 0
+    assert artifact["metrics"]["sign_shares"]["net_pnl_quote"]["positive_share"] is None
+    assert artifact["metrics"]["concentration"]["denominator_zero"] is True
+    assert artifact["metrics"]["concentration"]["top1_abs_pnl_share"] is None
+
+
+@pytest.mark.unit
+def test_extreme_concentration_visible():
+    bindings = _bindings(source_run_count=3)
+    records = _three_windows(
+        w_a=dict(net_pnl=-1000.0, expectancy=-0.1, trades=10),
+        w_b=dict(net_pnl=-1.0, expectancy=-0.01, trades=10),
+        w_c=dict(net_pnl=-1.0, expectancy=-0.01, trades=10),
+    )
+    artifact = build_window_stability(bindings=bindings, window_records=records)
+    top1 = artifact["metrics"]["concentration"]["top1_abs_pnl_share"]
+    assert top1 is not None
+    assert top1 > 0.99
+
+
+@pytest.mark.unit
+def test_write_does_not_mutate_primary_result_hashes(tmp_path: Path):
+    runs = tmp_path / "runs" / "rk_demo"
+    runs.mkdir(parents=True)
+    result_path = runs / "result.json"
+    payload = {"hello": "world", "net_pnl_quote": -1}
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+    before = hashlib.sha256(result_path.read_bytes()).hexdigest()
+
+    artifact = build_window_stability(
+        bindings=_bindings(),
+        window_records=_three_windows(),
+    )
+    write_window_stability_artifact(tmp_path, artifact)
+
+    after = hashlib.sha256(result_path.read_bytes()).hexdigest()
+    assert before == after
+    assert (tmp_path / "window_stability.json").is_file()

--- a/tools/arvp_vacation/hh_hl_campaign_analyzer.py
+++ b/tools/arvp_vacation/hh_hl_campaign_analyzer.py
@@ -1,6 +1,8 @@
-"""hh_hl analyzer profile — planning-only (#4374).
+"""hh_hl analyzer profile + durable classifier (#4374).
 
 No 21/19 matrix assumption. Classifications are research-only (no promotion).
+window_stability is descriptive evidence; economic REJECTED/PROMISING requires
+an Owner-ratified threshold policy.
 """
 
 from __future__ import annotations
@@ -9,8 +11,16 @@ from typing import Any, Mapping, Sequence
 
 from core.replay.canonical_json import canonical_hash
 from tools.arvp_vacation.hh_hl_campaign_grid import expand_hh_hl_variants
+from tools.arvp_vacation.hh_hl_window_stability import (
+    SCHEMA_VERSION as WINDOW_STABILITY_SCHEMA,
+    validate_window_stability_artifact,
+)
 
 ANALYZER_PROFILE_ID = "hh_hl_analyzer_prep_v1"
+CLASSIFIER_CODE_VERSION = "hh_hl_durable_classifier.v1"
+CLASSIFICATION_SCHEMA_VERSION = "cdb.hh_hl_analyzer_classification.v1"
+THRESHOLD_POLICY_SCHEMA_VERSION = "cdb.hh_hl_classifier_threshold_policy.v1"
+
 ALLOWED_CLASSIFICATIONS = (
     "PROMISING",
     "INCONCLUSIVE",
@@ -25,9 +35,44 @@ CLASSIFICATION_MEANING = {
     "BLOCKED": "contracts, data, reproduction, or completeness failed",
 }
 
+FORBIDDEN_STATEMENTS = (
+    "promoted",
+    "paper ready",
+    "live ready",
+    "pnl_only_ranking",
+    "production ready",
+    "4153_21_19_matrix",
+)
+
+REASON_BLOCKED_REPRODUCTION = "ANALYZER_BLOCKED_REPRODUCTION_NOT_PASS"
+REASON_BLOCKED_COMPLETENESS = "ANALYZER_BLOCKED_FIXTURE_INCOMPLETE"
+REASON_INCONCLUSIVE_STABILITY_ABSENT = (
+    "ANALYZER_INCONCLUSIVE_WINDOW_STABILITY_ABSENT"
+)
+REASON_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT = (
+    "ANALYZER_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT"
+)
+REASON_INCONCLUSIVE_POLICY_NOT_RATIFIED = (
+    "ANALYZER_INCONCLUSIVE_THRESHOLD_POLICY_NOT_RATIFIED"
+)
+REASON_INCONCLUSIVE_INSUFFICIENT_SIGNAL = (
+    "ANALYZER_INCONCLUSIVE_INSUFFICIENT_SIGNAL"
+)
+REASON_REJECTED_UNIFORM_NEGATIVE_SIGN = "ANALYZER_REJECTED_UNIFORM_NEGATIVE_SIGN"
+
+UNIFORM_NEGATIVE_SIGN_REJECT_RULE_ID = "uniform_negative_sign_reject_v1"
+
 
 class HhHlAnalyzerProfileError(ValueError):
     """Fail-closed analyzer profile violation."""
+
+
+class HhHlClassifierError(ValueError):
+    """Fail-closed durable classifier violation."""
+
+    def __init__(self, reason_code: str, detail: str = "") -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code if not detail else f"{reason_code}: {detail}")
 
 
 def build_hh_hl_analyzer_profile(
@@ -88,12 +133,14 @@ def classify_fixture_completeness(
     if foreign or missing or reproduction_pass is not True:
         return {
             "classification": "BLOCKED",
+            "reason_code": REASON_BLOCKED_COMPLETENESS,
             "missing_run_keys": missing,
             "foreign_run_keys": sorted(foreign),
             "reproduction_pass": reproduction_pass,
         }
     return {
         "classification": "INCONCLUSIVE",
+        "reason_code": "ANALYZER_FIXTURE_COMPLETE_NO_ECONOMICS",
         "missing_run_keys": [],
         "foreign_run_keys": [],
         "reproduction_pass": True,
@@ -107,3 +154,356 @@ def assert_not_4153_matrix(payload: Mapping[str, Any]) -> None:
         or payload.get("physical_parameter_sets") == 19
     ):
         raise HhHlAnalyzerProfileError("ANALYZER_4153_MATRIX_LEAK")
+
+
+def fingerprint_threshold_policy(policy: Mapping[str, Any]) -> str:
+    body = {k: v for k, v in policy.items() if k != "policy_fingerprint"}
+    return canonical_hash(body)
+
+
+def build_threshold_policy(
+    *,
+    policy_id: str,
+    policy_status: str,
+    issue: int,
+    rejected_rules: Sequence[Mapping[str, Any]],
+    promising_rules: Sequence[Mapping[str, Any]] = (),
+    owner_ratified_at_utc: str | None = None,
+    owner_github_login: str | None = None,
+    notes: str = "",
+) -> dict[str, Any]:
+    if policy_status not in {"DRAFT", "OWNER_RATIFIED"}:
+        raise HhHlClassifierError("CLASSIFIER_POLICY_STATUS_INVALID", policy_status)
+    if policy_status == "OWNER_RATIFIED":
+        if not owner_ratified_at_utc or not owner_github_login:
+            raise HhHlClassifierError("CLASSIFIER_POLICY_RATIFICATION_INCOMPLETE")
+    body: dict[str, Any] = {
+        "schema_version": THRESHOLD_POLICY_SCHEMA_VERSION,
+        "policy_id": policy_id,
+        "policy_status": policy_status,
+        "issue": int(issue),
+        "auto_promotion": False,
+        "pnl_only_ranking_forbidden": True,
+        "promising_means": CLASSIFICATION_MEANING["PROMISING"],
+        "rejected_rules": [dict(rule) for rule in rejected_rules],
+        "promising_rules": [dict(rule) for rule in promising_rules],
+        "owner_ratified_at_utc": owner_ratified_at_utc,
+        "owner_github_login": owner_github_login,
+    }
+    if notes:
+        body["notes"] = notes
+    return {**body, "policy_fingerprint": fingerprint_threshold_policy(body)}
+
+
+def build_uniform_negative_sign_reject_policy_draft(*, issue: int = 4374) -> dict[str, Any]:
+    """Draft Owner-ratifiable policy: sign-consistency REJECTED only; PROMISING empty."""
+    return build_threshold_policy(
+        policy_id=UNIFORM_NEGATIVE_SIGN_REJECT_RULE_ID,
+        policy_status="DRAFT",
+        issue=issue,
+        rejected_rules=[
+            {
+                "rule_id": UNIFORM_NEGATIVE_SIGN_REJECT_RULE_ID,
+                "reason_code": REASON_REJECTED_UNIFORM_NEGATIVE_SIGN,
+                "requires": {
+                    "n_traded_equals_n_total": True,
+                    "n_total_gt_zero": True,
+                    "negative_share_net_pnl_quote": 1.0,
+                    "negative_share_expectancy_r": 1.0,
+                    "all_gates_not_ranking_ready": True,
+                },
+            }
+        ],
+        promising_rules=[],
+        notes=(
+            "DRAFT only. Not active until policy_status=OWNER_RATIFIED. "
+            "PROMISING rules intentionally empty."
+        ),
+    )
+
+
+def _uniform_negative_sign_reject_fires(stability: Mapping[str, Any]) -> bool:
+    metrics = stability.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return False
+    n_total = int(metrics.get("n_total") or 0)
+    n_traded = int(metrics.get("n_traded") or 0)
+    if not (n_total > 0 and n_traded == n_total):
+        return False
+    sign = metrics.get("sign_shares")
+    if not isinstance(sign, Mapping):
+        return False
+    net = sign.get("net_pnl_quote") if isinstance(sign.get("net_pnl_quote"), Mapping) else {}
+    exp = sign.get("expectancy_r") if isinstance(sign.get("expectancy_r"), Mapping) else {}
+    if net.get("negative_share") != 1.0 or exp.get("negative_share") != 1.0:
+        return False
+    hist = metrics.get("gate_status_histogram")
+    if not isinstance(hist, Mapping) or not hist:
+        return False
+    return set(hist.keys()) == {"NOT_RANKING_READY"} and sum(int(v) for v in hist.values()) == n_total
+
+
+def _apply_rejected_rules(
+    policy: Mapping[str, Any],
+    *,
+    stability: Mapping[str, Any],
+) -> tuple[str | None, str | None]:
+    for rule in policy.get("rejected_rules") or []:
+        if not isinstance(rule, Mapping):
+            continue
+        rule_id = str(rule.get("rule_id") or "")
+        if rule_id == UNIFORM_NEGATIVE_SIGN_REJECT_RULE_ID:
+            if _uniform_negative_sign_reject_fires(stability):
+                return rule_id, str(
+                    rule.get("reason_code") or REASON_REJECTED_UNIFORM_NEGATIVE_SIGN
+                )
+    return None, None
+
+
+def _apply_promising_rules(
+    policy: Mapping[str, Any],
+    *,
+    stability: Mapping[str, Any],
+) -> tuple[str | None, str | None]:
+    del stability  # no v1 PROMISING rule may fire without explicit Owner criteria
+    for rule in policy.get("promising_rules") or []:
+        if not isinstance(rule, Mapping):
+            continue
+        # Intentionally no built-in PROMISING evaluators in v1.
+        # Owner-defined future rules must be added as explicit code paths.
+        _ = rule
+    return None, None
+
+
+def _finalize_classification(body: dict[str, Any]) -> dict[str, Any]:
+    fingerprint_body = {
+        k: v for k, v in body.items() if k != "classification_fingerprint"
+    }
+    return {
+        **body,
+        "classification_fingerprint": canonical_hash(fingerprint_body),
+    }
+
+
+def classify_hh_hl_campaign(
+    *,
+    analyzer_profile: Mapping[str, Any],
+    reproduction_pass: bool | None,
+    window_stability: Mapping[str, Any] | None,
+    threshold_policy: Mapping[str, Any] | None = None,
+    campaign_summary_fingerprint: str | None = None,
+    reproduction_summary_fingerprint: str | None = None,
+    expected_run_keys: Sequence[str] | None = None,
+    present_run_keys: Sequence[str] | None = None,
+    foreign_run_keys: Sequence[str] = (),
+) -> dict[str, Any]:
+    """Durable classifier: binds stability + optional Owner-ratified policy."""
+    assert_not_4153_matrix(analyzer_profile)
+    if analyzer_profile.get("analyzer_profile_id") != ANALYZER_PROFILE_ID:
+        raise HhHlClassifierError("CLASSIFIER_PROFILE_ID_MISMATCH")
+
+    profile_fp = str(analyzer_profile.get("analyzer_profile_fingerprint") or "")
+    if not profile_fp:
+        # Recompute if caller passed profile body without fingerprint.
+        rebuilt = build_hh_hl_analyzer_profile(
+            expected_run_keys=list(
+                analyzer_profile.get("expected_run_keys")
+                or expected_run_keys
+                or []
+            ),
+            reproduction_pass_required=bool(
+                analyzer_profile.get("reproduction_pass_required", True)
+            ),
+        )
+        profile_fp = str(rebuilt["analyzer_profile_fingerprint"])
+
+    base = {
+        "schema_version": CLASSIFICATION_SCHEMA_VERSION,
+        "classifier_code_version": CLASSIFIER_CODE_VERSION,
+        "analyzer_profile_id": ANALYZER_PROFILE_ID,
+        "analyzer_profile_fingerprint": profile_fp,
+        "policy_id": None,
+        "policy_version": None,
+        "policy_fingerprint": None,
+        "policy_status": None,
+        "auto_promotion": False,
+        "pnl_only_ranking_forbidden": True,
+        "promising_means": CLASSIFICATION_MEANING["PROMISING"],
+        "forbidden_statements": list(FORBIDDEN_STATEMENTS),
+        "window_stability_present": False,
+        "input_fingerprints": {
+            "campaign_summary_fingerprint": campaign_summary_fingerprint,
+            "reproduction_summary_fingerprint": reproduction_summary_fingerprint,
+            "window_stability_fingerprint": None,
+            "threshold_policy_fingerprint": None,
+            "analyzer_profile_fingerprint": profile_fp,
+        },
+    }
+
+    if expected_run_keys is not None and present_run_keys is not None:
+        completeness = classify_fixture_completeness(
+            expected_run_keys=expected_run_keys,
+            present_run_keys=present_run_keys,
+            reproduction_pass=reproduction_pass,
+            foreign_run_keys=foreign_run_keys,
+        )
+        if completeness["classification"] == "BLOCKED":
+            return _finalize_classification(
+                {
+                    **base,
+                    "classification": "BLOCKED",
+                    "reason_code": REASON_BLOCKED_COMPLETENESS,
+                    "fired_rules": ["fixture_completeness"],
+                    "reproduction_pass": bool(reproduction_pass),
+                    "note": "Fixture incomplete or reproduction not PASS.",
+                }
+            )
+
+    if reproduction_pass is not True:
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "BLOCKED",
+                "reason_code": REASON_BLOCKED_REPRODUCTION,
+                "fired_rules": ["reproduction_pass_required"],
+                "reproduction_pass": False,
+                "note": "Reproduction PASS required before economic classification.",
+            }
+        )
+
+    if window_stability is None:
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "INCONCLUSIVE",
+                "reason_code": REASON_INCONCLUSIVE_STABILITY_ABSENT,
+                "fired_rules": ["window_stability_absent_cap"],
+                "reproduction_pass": True,
+                "window_stability_present": False,
+                "note": (
+                    "Reproduction PASS proven; required window_stability absent "
+                    "— max INCONCLUSIVE under hh_hl_analyzer_prep_v1."
+                ),
+            }
+        )
+
+    try:
+        validated_stability = validate_window_stability_artifact(window_stability)
+    except Exception as exc:  # noqa: BLE001 — map to inconclusive absent/invalid
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "INCONCLUSIVE",
+                "reason_code": REASON_INCONCLUSIVE_STABILITY_ABSENT,
+                "fired_rules": ["window_stability_invalid"],
+                "reproduction_pass": True,
+                "window_stability_present": False,
+                "note": f"window_stability invalid: {exc}",
+            }
+        )
+
+    if validated_stability.get("schema_version") != WINDOW_STABILITY_SCHEMA:
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "INCONCLUSIVE",
+                "reason_code": REASON_INCONCLUSIVE_STABILITY_ABSENT,
+                "fired_rules": ["window_stability_schema_mismatch"],
+                "reproduction_pass": True,
+                "window_stability_present": False,
+                "note": "window_stability schema mismatch.",
+            }
+        )
+
+    stability_fp = str(validated_stability["evidence_fingerprint"])
+    base["window_stability_present"] = True
+    base["input_fingerprints"]["window_stability_fingerprint"] = stability_fp
+
+    if threshold_policy is None:
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "INCONCLUSIVE",
+                "reason_code": REASON_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT,
+                "fired_rules": ["threshold_policy_absent"],
+                "reproduction_pass": True,
+                "note": (
+                    "window_stability present; threshold policy absent — "
+                    "descriptive evidence only, no PROMISING/REJECTED."
+                ),
+            }
+        )
+
+    policy = dict(threshold_policy)
+    if policy.get("schema_version") != THRESHOLD_POLICY_SCHEMA_VERSION:
+        raise HhHlClassifierError("CLASSIFIER_POLICY_SCHEMA_MISMATCH")
+    policy_fp = fingerprint_threshold_policy(policy)
+    if str(policy.get("policy_fingerprint") or "") != policy_fp:
+        raise HhHlClassifierError("CLASSIFIER_POLICY_FINGERPRINT_MISMATCH")
+
+    base["policy_id"] = str(policy.get("policy_id"))
+    base["policy_version"] = str(policy.get("policy_id"))
+    base["policy_fingerprint"] = policy_fp
+    base["policy_status"] = str(policy.get("policy_status"))
+    base["input_fingerprints"]["threshold_policy_fingerprint"] = policy_fp
+
+    if policy.get("policy_status") != "OWNER_RATIFIED":
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "INCONCLUSIVE",
+                "reason_code": REASON_INCONCLUSIVE_POLICY_NOT_RATIFIED,
+                "fired_rules": ["threshold_policy_not_ratified"],
+                "reproduction_pass": True,
+                "note": "Threshold policy present but not OWNER_RATIFIED.",
+            }
+        )
+
+    if policy.get("auto_promotion") is not False:
+        raise HhHlClassifierError("CLASSIFIER_AUTO_PROMOTION_FORBIDDEN")
+    if policy.get("pnl_only_ranking_forbidden") is not True:
+        raise HhHlClassifierError("CLASSIFIER_PNL_ONLY_RANKING_FORBIDDEN")
+
+    fired: list[str] = []
+    rejected_rule, rejected_reason = _apply_rejected_rules(
+        policy, stability=validated_stability
+    )
+    if rejected_rule:
+        fired.append(rejected_rule)
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "REJECTED",
+                "reason_code": rejected_reason or REASON_REJECTED_UNIFORM_NEGATIVE_SIGN,
+                "fired_rules": fired,
+                "reproduction_pass": True,
+                "note": "Owner-ratified REJECTED rule fired on descriptive stability.",
+            }
+        )
+
+    promising_rule, promising_reason = _apply_promising_rules(
+        policy, stability=validated_stability
+    )
+    if promising_rule:
+        fired.append(promising_rule)
+        return _finalize_classification(
+            {
+                **base,
+                "classification": "PROMISING",
+                "reason_code": promising_reason or "ANALYZER_PROMISING_RESEARCH_FOLLOWUP",
+                "fired_rules": fired,
+                "reproduction_pass": True,
+                "note": "PROMISING means research follow-up only; no promotion.",
+            }
+        )
+
+    return _finalize_classification(
+        {
+            **base,
+            "classification": "INCONCLUSIVE",
+            "reason_code": REASON_INCONCLUSIVE_INSUFFICIENT_SIGNAL,
+            "fired_rules": ["insufficient_signal"],
+            "reproduction_pass": True,
+            "note": "Stability and ratified policy present; no REJECTED/PROMISING rule fired.",
+        }
+    )

--- a/tools/arvp_vacation/hh_hl_campaign_analyzer.py
+++ b/tools/arvp_vacation/hh_hl_campaign_analyzer.py
@@ -46,18 +46,14 @@ FORBIDDEN_STATEMENTS = (
 
 REASON_BLOCKED_REPRODUCTION = "ANALYZER_BLOCKED_REPRODUCTION_NOT_PASS"
 REASON_BLOCKED_COMPLETENESS = "ANALYZER_BLOCKED_FIXTURE_INCOMPLETE"
-REASON_INCONCLUSIVE_STABILITY_ABSENT = (
-    "ANALYZER_INCONCLUSIVE_WINDOW_STABILITY_ABSENT"
-)
+REASON_INCONCLUSIVE_STABILITY_ABSENT = "ANALYZER_INCONCLUSIVE_WINDOW_STABILITY_ABSENT"
 REASON_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT = (
     "ANALYZER_INCONCLUSIVE_THRESHOLD_POLICY_ABSENT"
 )
 REASON_INCONCLUSIVE_POLICY_NOT_RATIFIED = (
     "ANALYZER_INCONCLUSIVE_THRESHOLD_POLICY_NOT_RATIFIED"
 )
-REASON_INCONCLUSIVE_INSUFFICIENT_SIGNAL = (
-    "ANALYZER_INCONCLUSIVE_INSUFFICIENT_SIGNAL"
-)
+REASON_INCONCLUSIVE_INSUFFICIENT_SIGNAL = "ANALYZER_INCONCLUSIVE_INSUFFICIENT_SIGNAL"
 REASON_REJECTED_UNIFORM_NEGATIVE_SIGN = "ANALYZER_REJECTED_UNIFORM_NEGATIVE_SIGN"
 
 UNIFORM_NEGATIVE_SIGN_REJECT_RULE_ID = "uniform_negative_sign_reject_v1"
@@ -195,7 +191,9 @@ def build_threshold_policy(
     return {**body, "policy_fingerprint": fingerprint_threshold_policy(body)}
 
 
-def build_uniform_negative_sign_reject_policy_draft(*, issue: int = 4374) -> dict[str, Any]:
+def build_uniform_negative_sign_reject_policy_draft(
+    *, issue: int = 4374
+) -> dict[str, Any]:
     """Draft Owner-ratifiable policy: sign-consistency REJECTED only; PROMISING empty."""
     return build_threshold_policy(
         policy_id=UNIFORM_NEGATIVE_SIGN_REJECT_RULE_ID,
@@ -233,14 +231,25 @@ def _uniform_negative_sign_reject_fires(stability: Mapping[str, Any]) -> bool:
     sign = metrics.get("sign_shares")
     if not isinstance(sign, Mapping):
         return False
-    net = sign.get("net_pnl_quote") if isinstance(sign.get("net_pnl_quote"), Mapping) else {}
-    exp = sign.get("expectancy_r") if isinstance(sign.get("expectancy_r"), Mapping) else {}
+    net = (
+        sign.get("net_pnl_quote")
+        if isinstance(sign.get("net_pnl_quote"), Mapping)
+        else {}
+    )
+    exp = (
+        sign.get("expectancy_r")
+        if isinstance(sign.get("expectancy_r"), Mapping)
+        else {}
+    )
     if net.get("negative_share") != 1.0 or exp.get("negative_share") != 1.0:
         return False
     hist = metrics.get("gate_status_histogram")
     if not isinstance(hist, Mapping) or not hist:
         return False
-    return set(hist.keys()) == {"NOT_RANKING_READY"} and sum(int(v) for v in hist.values()) == n_total
+    return (
+        set(hist.keys()) == {"NOT_RANKING_READY"}
+        and sum(int(v) for v in hist.values()) == n_total
+    )
 
 
 def _apply_rejected_rules(
@@ -307,9 +316,7 @@ def classify_hh_hl_campaign(
         # Recompute if caller passed profile body without fingerprint.
         rebuilt = build_hh_hl_analyzer_profile(
             expected_run_keys=list(
-                analyzer_profile.get("expected_run_keys")
-                or expected_run_keys
-                or []
+                analyzer_profile.get("expected_run_keys") or expected_run_keys or []
             ),
             reproduction_pass_required=bool(
                 analyzer_profile.get("reproduction_pass_required", True)
@@ -490,7 +497,8 @@ def classify_hh_hl_campaign(
             {
                 **base,
                 "classification": "PROMISING",
-                "reason_code": promising_reason or "ANALYZER_PROMISING_RESEARCH_FOLLOWUP",
+                "reason_code": promising_reason
+                or "ANALYZER_PROMISING_RESEARCH_FOLLOWUP",
                 "fired_rules": fired,
                 "reproduction_pass": True,
                 "note": "PROMISING means research follow-up only; no promotion.",

--- a/tools/arvp_vacation/hh_hl_window_stability.py
+++ b/tools/arvp_vacation/hh_hl_window_stability.py
@@ -190,7 +190,9 @@ def _normalize_window_record(record: Mapping[str, Any]) -> dict[str, Any]:
     if not window_id:
         raise HhHlWindowStabilityError("WINDOW_STABILITY_MISSING_WINDOW_ID")
 
-    payload = record.get("result") if isinstance(record.get("result"), Mapping) else record
+    payload = (
+        record.get("result") if isinstance(record.get("result"), Mapping) else record
+    )
     if not isinstance(payload, Mapping):
         raise HhHlWindowStabilityError(
             "WINDOW_STABILITY_MISSING_REQUIRED_METRIC",
@@ -212,10 +214,14 @@ def _normalize_window_record(record: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "window_id": window_id,
         "net_pnl_quote": _to_float(
-            _as_decimal(payload.get("net_pnl_quote"), field="net_pnl_quote", window_id=window_id)
+            _as_decimal(
+                payload.get("net_pnl_quote"), field="net_pnl_quote", window_id=window_id
+            )
         ),
         "expectancy_r": _to_float(
-            _as_decimal(payload.get("expectancy_r"), field="expectancy_r", window_id=window_id)
+            _as_decimal(
+                payload.get("expectancy_r"), field="expectancy_r", window_id=window_id
+            )
         ),
         "max_drawdown_r": _to_float(
             _as_decimal(
@@ -514,7 +520,11 @@ def _cli(argv: Sequence[str] | None = None) -> int:
     if args.command == "validate":
         raw = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
         validated = validate_window_stability_artifact(raw)
-        print(json.dumps({"ok": True, "evidence_fingerprint": validated["evidence_fingerprint"]}))
+        print(
+            json.dumps(
+                {"ok": True, "evidence_fingerprint": validated["evidence_fingerprint"]}
+            )
+        )
         return 0
 
     bindings = json.loads(Path(args.bindings_json).read_text(encoding="utf-8"))

--- a/tools/arvp_vacation/hh_hl_window_stability.py
+++ b/tools/arvp_vacation/hh_hl_window_stability.py
@@ -1,0 +1,540 @@
+"""hh_hl window_stability derived evidence (#4374).
+
+Descriptive campaign-aggregate only. No classification thresholds.
+Primary run trees remain immutable; this module only reads them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from core.replay.canonical_json import canonical_hash
+from tools.arvp_vacation.hh_hl_campaign_summary import campaign_summary_path
+from tools.arvp_vacation.sensitivity_campaign_state import (
+    RUNS_DIRNAME,
+    read_json,
+    run_dir,
+)
+
+SCHEMA_VERSION = "cdb.hh_hl_window_stability.v1"
+CALCULATION_VERSION = "hh_hl_window_stability_calc.v1"
+OVERLAP_POLICY = "descriptive_non_iid"
+DERIVED_FROM = "primary"
+WINDOW_STABILITY_ARTIFACT_NAME = "window_stability.json"
+
+RAW_METRICS_USED: tuple[str, ...] = (
+    "net_pnl_quote",
+    "expectancy_r",
+    "max_drawdown_r",
+    "closed_trades_total",
+    "fees_total_quote",
+    "gate_result.status",
+)
+
+SERIES_METRIC_KEYS: tuple[str, ...] = (
+    "net_pnl_quote",
+    "expectancy_r",
+    "max_drawdown_r",
+    "fees_total_quote",
+    "closed_trades_total",
+)
+
+SIGN_METRIC_KEYS: tuple[str, ...] = ("net_pnl_quote", "expectancy_r")
+
+BINDING_KEYS: tuple[str, ...] = (
+    "campaign_id",
+    "issue",
+    "authorization_fingerprint",
+    "execution_sha",
+    "manifest_fingerprint",
+    "run_plan_fingerprint",
+    "dataset_selection_sha256",
+    "dataset_content_fingerprint_digest",
+    "physical_parameter_set_fingerprint",
+    "campaign_summary_fingerprint",
+    "source_run_count",
+)
+
+
+class HhHlWindowStabilityError(ValueError):
+    """Fail-closed window_stability build/validate error."""
+
+    def __init__(self, reason_code: str, detail: str = "") -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code if not detail else f"{reason_code}: {detail}")
+
+
+def _as_decimal(value: object, *, field: str, window_id: str) -> Decimal:
+    if value is None or isinstance(value, bool):
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_MISSING_REQUIRED_METRIC",
+            f"{field}@{window_id}",
+        )
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_INVALID_METRIC",
+            f"{field}@{window_id}",
+        ) from exc
+
+
+def _as_int(value: object, *, field: str, window_id: str) -> int:
+    if isinstance(value, bool) or value is None:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_MISSING_REQUIRED_METRIC",
+            f"{field}@{window_id}",
+        )
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value))
+    except (TypeError, ValueError) as exc:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_INVALID_METRIC",
+            f"{field}@{window_id}",
+        ) from exc
+
+
+def _to_float(value: Decimal) -> float:
+    return float(value)
+
+
+def _median(values: Sequence[float]) -> float | None:
+    if not values:
+        return None
+    return float(statistics.median(values))
+
+
+def _quantile(values: Sequence[float], q: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return float(ordered[0])
+    index = (len(ordered) - 1) * q
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    if lower == upper:
+        return float(ordered[lower])
+    weight = index - lower
+    return float(ordered[lower] * (1 - weight) + ordered[upper] * weight)
+
+
+def _series_stats(values: Sequence[float]) -> dict[str, Any]:
+    if not values:
+        return {
+            "median": None,
+            "minimum": None,
+            "maximum": None,
+            "q25": None,
+            "q75": None,
+            "n": 0,
+        }
+    return {
+        "median": _median(values),
+        "minimum": min(values),
+        "maximum": max(values),
+        "q25": _quantile(values, 0.25),
+        "q75": _quantile(values, 0.75),
+        "n": len(values),
+    }
+
+
+def _sign_shares(values: Sequence[float]) -> dict[str, Any]:
+    n = len(values)
+    if n == 0:
+        return {
+            "positive_share": None,
+            "negative_share": None,
+            "zero_share": None,
+            "n_traded": 0,
+        }
+    positive = sum(1 for value in values if value > 0)
+    negative = sum(1 for value in values if value < 0)
+    zero = sum(1 for value in values if value == 0)
+    return {
+        "positive_share": positive / n,
+        "negative_share": negative / n,
+        "zero_share": zero / n,
+        "n_traded": n,
+    }
+
+
+def _concentration(abs_pnls: Sequence[float]) -> dict[str, Any]:
+    total = sum(abs_pnls)
+    if total == 0:
+        return {
+            "top1_abs_pnl_share": None,
+            "top3_abs_pnl_share": None,
+            "denominator_zero": True,
+        }
+    ordered = sorted(abs_pnls, reverse=True)
+    top1 = ordered[0] / total if ordered else 0.0
+    top3 = sum(ordered[:3]) / total
+    return {
+        "top1_abs_pnl_share": top1,
+        "top3_abs_pnl_share": top3,
+        "denominator_zero": False,
+    }
+
+
+def _normalize_window_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    window_id = str(record.get("window_id") or "").strip()
+    if not window_id:
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_MISSING_WINDOW_ID")
+
+    payload = record.get("result") if isinstance(record.get("result"), Mapping) else record
+    if not isinstance(payload, Mapping):
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_MISSING_REQUIRED_METRIC",
+            f"result@{window_id}",
+        )
+
+    gate = payload.get("gate_result")
+    if not isinstance(gate, Mapping) or "status" not in gate:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_MISSING_REQUIRED_METRIC",
+            f"gate_result.status@{window_id}",
+        )
+
+    closed = _as_int(
+        payload.get("closed_trades_total"),
+        field="closed_trades_total",
+        window_id=window_id,
+    )
+    return {
+        "window_id": window_id,
+        "net_pnl_quote": _to_float(
+            _as_decimal(payload.get("net_pnl_quote"), field="net_pnl_quote", window_id=window_id)
+        ),
+        "expectancy_r": _to_float(
+            _as_decimal(payload.get("expectancy_r"), field="expectancy_r", window_id=window_id)
+        ),
+        "max_drawdown_r": _to_float(
+            _as_decimal(
+                payload.get("max_drawdown_r"),
+                field="max_drawdown_r",
+                window_id=window_id,
+            )
+        ),
+        "fees_total_quote": _to_float(
+            _as_decimal(
+                payload.get("fees_total_quote"),
+                field="fees_total_quote",
+                window_id=window_id,
+            )
+        ),
+        "closed_trades_total": closed,
+        "gate_result_status": str(gate.get("status")),
+    }
+
+
+def _validate_bindings(bindings: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key in BINDING_KEYS:
+        if key not in bindings or bindings[key] in (None, ""):
+            raise HhHlWindowStabilityError(
+                "WINDOW_STABILITY_BINDING_MISSING",
+                key,
+            )
+        out[key] = bindings[key]
+    try:
+        out["issue"] = int(out["issue"])
+        out["source_run_count"] = int(out["source_run_count"])
+    except (TypeError, ValueError) as exc:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_BINDING_INVALID",
+            "issue_or_source_run_count",
+        ) from exc
+    if out["source_run_count"] < 1:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_BINDING_INVALID",
+            "source_run_count",
+        )
+    return out
+
+
+def build_window_stability(
+    *,
+    bindings: Mapping[str, Any],
+    window_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Build descriptive window_stability artifact from Pack-A window records."""
+    bind = _validate_bindings(bindings)
+    if not window_records:
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_EMPTY_WINDOWS")
+
+    normalized = [_normalize_window_record(record) for record in window_records]
+    window_ids = [row["window_id"] for row in normalized]
+    if len(window_ids) != len(set(window_ids)):
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_DUPLICATE_WINDOW")
+
+    expected_count = int(bind["source_run_count"])
+    if len(window_ids) != expected_count:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_WINDOW_COUNT_MISMATCH",
+            f"got={len(window_ids)} expected={expected_count}",
+        )
+
+    ordered = sorted(normalized, key=lambda row: row["window_id"])
+    ordered_ids = [row["window_id"] for row in ordered]
+
+    n_total = len(ordered)
+    traded_rows = [row for row in ordered if int(row["closed_trades_total"]) > 0]
+    n_traded = len(traded_rows)
+    n_zero_trade = n_total - n_traded
+
+    series: dict[str, Any] = {}
+    for key in SERIES_METRIC_KEYS:
+        series[key] = _series_stats([float(row[key]) for row in ordered])
+
+    sign_shares = {
+        key: _sign_shares([float(row[key]) for row in traded_rows])
+        for key in SIGN_METRIC_KEYS
+    }
+    concentration = _concentration(
+        [abs(float(row["net_pnl_quote"])) for row in ordered]
+    )
+
+    gate_hist: dict[str, int] = {}
+    for row in ordered:
+        status = str(row["gate_result_status"])
+        gate_hist[status] = gate_hist.get(status, 0) + 1
+
+    body: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "calculation_version": CALCULATION_VERSION,
+        "campaign_id": str(bind["campaign_id"]),
+        "issue": int(bind["issue"]),
+        "authorization_fingerprint": str(bind["authorization_fingerprint"]),
+        "execution_sha": str(bind["execution_sha"]),
+        "manifest_fingerprint": str(bind["manifest_fingerprint"]),
+        "run_plan_fingerprint": str(bind["run_plan_fingerprint"]),
+        "dataset_selection_sha256": str(bind["dataset_selection_sha256"]),
+        "dataset_content_fingerprint_digest": str(
+            bind["dataset_content_fingerprint_digest"]
+        ),
+        "physical_parameter_set_fingerprint": str(
+            bind["physical_parameter_set_fingerprint"]
+        ),
+        "campaign_summary_fingerprint": str(bind["campaign_summary_fingerprint"]),
+        "source_run_count": expected_count,
+        "window_ids": ordered_ids,
+        "raw_metrics_used": list(RAW_METRICS_USED),
+        "overlap_policy": OVERLAP_POLICY,
+        "derived_from": DERIVED_FROM,
+        "metrics": {
+            "n_total": n_total,
+            "n_traded": n_traded,
+            "n_zero_trade": n_zero_trade,
+            "series": series,
+            "sign_shares": sign_shares,
+            "concentration": concentration,
+            "gate_status_histogram": dict(sorted(gate_hist.items())),
+        },
+    }
+    return {
+        **body,
+        "evidence_fingerprint": canonical_hash(body),
+    }
+
+
+def validate_window_stability_artifact(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    """Recompute fingerprint and enforce schema constants fail-closed."""
+    if artifact.get("schema_version") != SCHEMA_VERSION:
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_SCHEMA_MISMATCH")
+    if artifact.get("calculation_version") != CALCULATION_VERSION:
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_CALC_VERSION_MISMATCH")
+    if artifact.get("overlap_policy") != OVERLAP_POLICY:
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_OVERLAP_POLICY_INVALID")
+    if artifact.get("derived_from") != DERIVED_FROM:
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_DERIVED_FROM_INVALID")
+
+    body = {k: v for k, v in artifact.items() if k != "evidence_fingerprint"}
+    expected_fp = canonical_hash(body)
+    actual_fp = str(artifact.get("evidence_fingerprint") or "")
+    if actual_fp != expected_fp:
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_FINGERPRINT_MISMATCH",
+            f"got={actual_fp} expected={expected_fp}",
+        )
+    return dict(artifact)
+
+
+def assert_bindings_match(
+    artifact: Mapping[str, Any],
+    *,
+    expected_bindings: Mapping[str, Any],
+) -> None:
+    """Fail closed when artifact bindings diverge from expected campaign bind."""
+    bind = _validate_bindings(expected_bindings)
+    for key in BINDING_KEYS:
+        left = artifact.get(key)
+        right = bind[key]
+        if key in {"issue", "source_run_count"}:
+            if int(left) != int(right):
+                raise HhHlWindowStabilityError(
+                    "WINDOW_STABILITY_BINDING_MISMATCH",
+                    key,
+                )
+        elif str(left) != str(right):
+            raise HhHlWindowStabilityError(
+                "WINDOW_STABILITY_BINDING_MISMATCH",
+                key,
+            )
+
+
+def _extract_result_payload(raw: Mapping[str, Any]) -> Mapping[str, Any]:
+    nested = raw.get("result")
+    if isinstance(nested, Mapping):
+        return nested
+    return raw
+
+
+def load_window_records_from_primary_root(
+    evidence_root: Path,
+    *,
+    expected_run_keys: Sequence[str],
+) -> list[dict[str, Any]]:
+    """Read Pack-A metrics from primary run result.json files (read-only)."""
+    root = Path(evidence_root)
+    if not root.is_dir():
+        raise HhHlWindowStabilityError(
+            "WINDOW_STABILITY_EVIDENCE_ROOT_MISSING",
+            str(root),
+        )
+
+    keys = list(expected_run_keys)
+    if len(keys) != len(set(keys)):
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_DUPLICATE_EXPECTED_KEY")
+
+    records: list[dict[str, Any]] = []
+    for run_key in keys:
+        directory = run_dir(root, run_key)
+        result_path = directory / "result.json"
+        if not result_path.is_file():
+            raise HhHlWindowStabilityError(
+                "WINDOW_STABILITY_MISSING_WINDOW",
+                run_key,
+            )
+        raw = read_json(result_path)
+        if not isinstance(raw, Mapping):
+            raise HhHlWindowStabilityError(
+                "WINDOW_STABILITY_INVALID_RESULT",
+                run_key,
+            )
+        payload = _extract_result_payload(raw)
+        envelope_path = directory / "run_envelope.json"
+        window_id = ""
+        if envelope_path.is_file():
+            envelope = read_json(envelope_path)
+            if isinstance(envelope, Mapping):
+                window_id = str(envelope.get("window_id") or "")
+        if not window_id:
+            # Fallback: last path segment of run_key (campaign|window|...).
+            parts = str(run_key).split("|")
+            window_id = parts[1] if len(parts) >= 2 else str(run_key)
+        records.append(
+            {
+                "window_id": window_id,
+                "run_key": run_key,
+                "result": dict(payload),
+            }
+        )
+    return records
+
+
+def build_window_stability_from_primary_root(
+    *,
+    evidence_root: Path,
+    bindings: Mapping[str, Any],
+    expected_run_keys: Sequence[str],
+) -> dict[str, Any]:
+    """Build stability artifact from a bound primary evidence root (read-only)."""
+    records = load_window_records_from_primary_root(
+        evidence_root,
+        expected_run_keys=expected_run_keys,
+    )
+    return build_window_stability(bindings=bindings, window_records=records)
+
+
+def write_window_stability_artifact(
+    evidence_root: Path,
+    artifact: Mapping[str, Any],
+) -> Path:
+    """Write derived stability artifact beside campaign summary; never mutates runs/."""
+    validated = validate_window_stability_artifact(artifact)
+    root = Path(evidence_root)
+    root.mkdir(parents=True, exist_ok=True)
+    # Guard: refuse to write inside a runs/ leaf.
+    if root.name == RUNS_DIRNAME:
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_REFUSE_WRITE_IN_RUNS")
+    out = root / WINDOW_STABILITY_ARTIFACT_NAME
+    # Atomic-ish write without touching run trees.
+    tmp = out.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps(validated, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    tmp.replace(out)
+    return out
+
+
+def _cli(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build/validate cdb.hh_hl_window_stability.v1 from primary evidence "
+            "(read-only; no primary mutation)."
+        )
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    build_p = sub.add_parser("build", help="Build stability artifact from primary root")
+    build_p.add_argument("--evidence-root", required=True, type=Path)
+    build_p.add_argument("--bindings-json", required=True, type=Path)
+    build_p.add_argument("--run-keys-json", required=True, type=Path)
+    build_p.add_argument(
+        "--write",
+        action="store_true",
+        help="Write window_stability.json under evidence-root",
+    )
+
+    validate_p = sub.add_parser("validate", help="Validate an existing artifact")
+    validate_p.add_argument("--artifact", required=True, type=Path)
+
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "validate":
+        raw = json.loads(Path(args.artifact).read_text(encoding="utf-8"))
+        validated = validate_window_stability_artifact(raw)
+        print(json.dumps({"ok": True, "evidence_fingerprint": validated["evidence_fingerprint"]}))
+        return 0
+
+    bindings = json.loads(Path(args.bindings_json).read_text(encoding="utf-8"))
+    run_keys = json.loads(Path(args.run_keys_json).read_text(encoding="utf-8"))
+    if not isinstance(run_keys, list):
+        raise HhHlWindowStabilityError("WINDOW_STABILITY_RUN_KEYS_INVALID")
+    artifact = build_window_stability_from_primary_root(
+        evidence_root=Path(args.evidence_root),
+        bindings=bindings,
+        expected_run_keys=[str(k) for k in run_keys],
+    )
+    if args.write:
+        path = write_window_stability_artifact(Path(args.evidence_root), artifact)
+        # Ensure campaign summary presence is not required, but refuse if runs missing.
+        _ = campaign_summary_path(Path(args.evidence_root))
+        print(json.dumps({"ok": True, "path": str(path), **artifact}, sort_keys=True))
+    else:
+        print(json.dumps(artifact, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())


### PR DESCRIPTION
## Summary
- Add `cdb.hh_hl_window_stability.v1` descriptive derived evidence (Primary read-only; no free thresholds).
- Add durable `classify_hh_hl_campaign` with fingerprinted classification + Owner-ratifiable threshold policy separation (`uniform_negative_sign_reject_v1` DRAFT; PROMISING rules empty).
- Owner-GO prep for policy ratification and a later stability-build → re-classify execute window (no live execute in this PR).

## Test plan
- [x] `pytest tests/unit/arvp/test_hh_hl_window_stability.py tests/unit/arvp/test_hh_hl_campaign_analyzer_classification.py -q`
- [x] `ruff check` on touched Python files
- [ ] Confirm no Primary mutation / no Stage B / Paper / Live language

## Non-goals
- No stability compute against live Primary in this delivery
- No analyzer re-execute
- No Owner-GO auto-post
- Issue #4374 stays OPEN (Refs)

Refs #4374