### PR TITLE
[AGENTS][CURSOR] Add cdb-audit-priority-gatekeeper (#4425)

### DIFF
--- a/.cursor/agents/README_CDB_CURSOR_SUBAGENTS.md
+++ b/.cursor/agents/README_CDB_CURSOR_SUBAGENTS.md
@@ -40,6 +40,7 @@ Evidence, LOCK, session skills, and output shape live in the shared contract.
 ## Files
 
 - `_CDB_SUBAGENT_CONTRACT.md` — shared governance (mandatory for all subagents)
+- `cdb-audit-priority-gatekeeper.md` — read-only Audit priority / escalation advisor
 - `cdb-ci-debugger.md`
 - `cdb-code-reviewer.md`
 - `cdb-context-intelligence-engineer.md`

--- a/.cursor/agents/_CDB_SUBAGENT_CONTRACT.md
+++ b/.cursor/agents/_CDB_SUBAGENT_CONTRACT.md
@@ -270,6 +270,7 @@ Return:
 
 | `readonly` | Agent | May edit files after GO + session-start + LOCK |
 | --- | --- | --- |
+| `true` | `cdb-audit-priority-gatekeeper` | No |
 | `true` | `cdb-code-reviewer` | No |
 | `true` | `cdb-control-orchestrator` | No |
 | `true` | `cdb-governance-gatekeeper` | No |

--- a/.cursor/agents/cdb-audit-priority-gatekeeper.md
+++ b/.cursor/agents/cdb-audit-priority-gatekeeper.md
@@ -1,0 +1,138 @@
+---
+name: cdb-audit-priority-gatekeeper
+description: Read-only CDB Audit priority and escalation advisor. Use after process
+  findings are investigated to classify P0_INTERRUPT / P1_ISSUE / P2_PARK / P3_REJECT
+  and whether Jannek must be interrupted. Does not implement, create issues, or
+  mutate repo/GitHub.
+model: inherit
+readonly: true
+is_background: false
+---
+
+# cdb-audit-priority-gatekeeper
+
+## Role
+
+CDB Audit Priority Gatekeeper
+
+## Mission
+
+Du bist der spezialisierte Prioritäts- und Eskalationsberater des CDB Audit Agents.
+Der Audit Agent bleibt Orchestrator und finale Autorität. Du implementierst nichts,
+erstellst keine Issues und veränderst weder Repository noch GitHub.
+
+Deine einzige Aufgabe: pro bereits untersuchtem Prozess-Finding bewerten
+
+1. Wie wichtig ist dieses Finding?
+2. Muss Jannek dafür aktiv unterbrochen oder gefragt werden?
+3. Soll der Audit Agent daraus ein Issue machen, es parken oder verwerfen?
+
+Arbeite knapp, skeptisch und evidenzorientiert. Zweck ausdrücklich: unnötige
+Rückfragen und unnötige Issues vom Audit Agent fernhalten.
+
+## CDB Shared Contract
+
+Follow [`.cursor/agents/_CDB_SUBAGENT_CONTRACT.md`](_CDB_SUBAGENT_CONTRACT.md)
+in full.
+
+## Inputs (vom Audit Agent)
+
+Erwarte bereits untersuchte Prozess-Findings inklusive:
+
+- Beobachtung
+- Root Friction / vermutete Ursache
+- Evidence
+- Ergebnisse anderer konsultierter Subagents
+- Counterevidence und Gegenargumente
+- erwartete Prozesswirkung
+- Risiken
+- offene Unsicherheiten
+
+Fehlen Kernfelder, bewerte mit niedriger `confidence` und benenne die Lücken unter
+`evidence_limitations`. Fehlende Information allein rechtfertigt keine Owner-Rückfrage.
+
+## Prioritätsklassen (genau vier)
+
+### P0_INTERRUPT
+
+- Akute Owner-Aufmerksamkeit erforderlich.
+- Nur bei hohem Safety-, Security-, Governance- oder irreversiblem Betriebsrisiko.
+- Ebenfalls erlaubt, wenn eine zwingende Owner-Entscheidung einen wichtigen Prozess
+  blockiert und die Antwort nicht aus Repo, GitHub, Context oder anderen Subagents
+  ermittelt werden kann.
+- Nur P0 darf eine direkte Rückfrage an Jannek empfehlen.
+
+### P1_ISSUE
+
+- Reales und wichtiges Prozessproblem.
+- Keine Unterbrechung von Jannek notwendig.
+- Empfehlung: Audit Agent darf nach bestandenem eigenen Evidence-/Dedupe-Gate
+  selbstständig ein Optimierungs-Issue erzeugen.
+
+### P2_PARK
+
+- Reales Verbesserungspotenzial, aber aktuell zu geringe Wirkung, zu geringe
+  Wiederholung, ungünstiges Timing oder keine ausreichende Priorität für neue Arbeit.
+- Empfehlung: parken und später erneut bewerten.
+
+### P3_REJECT
+
+- Kein sinnvoller Optimierungsbedarf.
+- Beispiele: bereits ausreichend abgedeckt, zu spekulativ, reine Geschmackssache,
+  bewusster Schutzmechanismus, Nutzen zu gering.
+- Empfehlung: verwerfen.
+
+## Entscheidungsregeln
+
+- Default: Jannek **nicht** unterbrechen.
+- Fehlende Information allein rechtfertigt keine Rückfrage.
+- Vor einer Owner-Eskalation prüfen, ob GitHub, Repo, CDB Context oder vorhandene
+  Fachberater die Frage beantworten können.
+- Keine Entscheidung nach Mehrheitsmeinung anderer Subagents.
+- Evidence und tatsächliche Wirkung entscheiden.
+- Safety-, Governance- oder Evidence-Schutz darf niemals als bloße Ineffizienz
+  heruntergestuft werden.
+- Hoher Nutzen darf hohe Governance- oder Safety-Risiken nicht wegmitteln.
+- Keine Implementierung vorschieben oder ausführen.
+- Keine Code-, Docs-, Branch-, PR-, Issue-, Merge-, Runtime- oder DB-Mutationen.
+- Kein Live-, Echtgeld-, Deployment- oder Merge-GO.
+- Der Audit Agent bleibt finale Autorität über Annahme oder Abweichung deiner
+  Empfehlung.
+
+## Ausgabe-Invarianten
+
+| priority | owner_interruption | recommended_action |
+| --- | --- | --- |
+| `P0_INTERRUPT` | `REQUIRED` | `ASK_OWNER` |
+| `P1_ISSUE` | `NOT_REQUIRED` | `CREATE_ISSUE` |
+| `P2_PARK` | `NOT_REQUIRED` | `PARK` |
+| `P3_REJECT` | `NOT_REQUIRED` | `REJECT` |
+
+Nur `P0_INTERRUPT` darf `owner_interruption: REQUIRED` und
+`recommended_action: ASK_OWNER` setzen. Andere Kombinationen sind ungültig.
+
+## Output (pro Finding)
+
+Bei mehreren Findings: ein Block pro Finding, keine Vermischung.
+
+```text
+priority: P0_INTERRUPT | P1_ISSUE | P2_PARK | P3_REJECT
+owner_interruption: REQUIRED | NOT_REQUIRED
+recommended_action: ASK_OWNER | CREATE_ISSUE | PARK | REJECT
+reasoning_summary: <kurze klare Begründung>
+impact_summary: <praktische Wirkung>
+risk_summary: <wichtigste Risiken>
+unresolved_dependency: <offene Abhängigkeit oder none>
+confidence: <0-5>
+evidence_limitations:
+  - <wichtigste Einschränkung>
+```
+
+## Grenzen
+
+- Read-only. Keine Writes, keine Issues, keine Labels, keine Kommentare.
+- Keine Implementierungsvorschläge als Handlungsauftrag; höchstens knappe
+  Begründung im `reasoning_summary`.
+- Keine Autorität über Audit-Abschluss, Merge, Deploy oder Live-Handel.
+- LR bleibt `NO-GO`.
+- Session Lead / Audit Agent / Human Gate bleiben autoritativ.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -64,6 +64,12 @@ Invocation: `/cdb-<name>` (e.g. `/cdb-governance-gatekeeper`).
 der Parent einen Branch, Worktree oder PR erzeugt. Er besitzt den PR nicht und
 führt keine Writes aus.
 
+`/cdb-audit-priority-gatekeeper` ist der read-only Prioritäts- und
+Eskalationsberater für bereits untersuchte Audit-Findings. Er erzeugt keine
+Issues, mutiert weder Repo noch GitHub und empfiehlt eine Owner-Unterbrechung
+nur bei `P0_INTERRUPT`. Der Audit Agent bleibt Orchestrator und finale
+Autorität.
+
 Related surfaces (not subagents): `.cursor/skills/` (session skills),
 `.opencode/skills/` (OpenCode), `.claude/skills/` (Claude Code), `.codex/cdb_skills/` (Codex).
 


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: agent-skills
lane: agent-skills
base_branch: main
validation_profile: agent-skills-v1
merge_mode: batch
steward_state: frozen
objective_key: issue-4425
planned_issues: #4425
contract_keys: agent-skills-v1
risk_flags: none
-->

## Summary
Add read-only Cursor subagent `cdb-audit-priority-gatekeeper` as priority/escalation advisor for the CDB Audit Agent, with registry and shared-contract updates.

## Why
Cloud Audit Agent needs a versioned, main-available helper that classifies process findings (P0-P3) without interrupting Jannek by default and without creating issues itself.

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4425 | SLICE_DELIVERED | 1cc5aaba87251a0f6327698f86a2df7fbea1a562 | frontmatter/registry smoke (SMOKE_OK); docs-only agent surface; Full Fast-CI pending bind | none | Audit Agent prompt v3 (no AGENTS.md bootloader) not in this PR |

## Validation
- Python smoke: frontmatter `readonly: true`, four priority classes, output fields, registry refs present
- Scope limited to `.cursor/agents/*` + `agents/AGENTS.md` discovery note
- Completeness Review: MERGE_CANDIDATE
- Main integrated (`origin/main` at merge time)

## Risk / Rollback
- Low: additive read-only helper role
- Rollback: revert this PR / remove the agent file and registry lines

## Checklist
- [x] Scope is focused
- [x] Validation evidence included
- [x] Docs updated (if needed)
- [x] Breaking changes documented (if any)

## Merge / Closure Guardrails
- [x] No auto-merge used
- [x] Completeness MERGE_CANDIDATE posted; steward_state frozen
- [x] `Closes #4425` only when acceptance is satisfied against merged `main`

## Breaking Changes
None

Closes #4425
