### PR TITLE
[AGENTS] Implement cdb-control-intake skill

### DIFF
--- a/.claude/skills/cdb-control-intake/SKILL.md
+++ b/.claude/skills/cdb-control-intake/SKILL.md
@@ -2,51 +2,95 @@
 Canonical Skill Source: docs/skills/cdb-control-intake/SKILL.md
 Surface: claude
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-08-11
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-control-intake
 description: >
-  Establishes the CDB control context for a session by reading canonical control
-  surfaces and producing a fail-closed operational snapshot. Use when beginning
-  CDB repo work after session-start, or when rebuilding control context before
-  planning or implementation in Claire_de_Binare.
+  Rebuilds a fail-closed CDB control snapshot from canonical repo and GitHub
+  evidence before planning or implementation. It never derives LR or live
+  authorization from the board stage or an engineering ledger.
 disable-model-invocation: true
 ---
 
 # CDB control intake
 
-Build the minimum reliable control snapshot before planning or implementation.
+## Zweck und Grenze
 
-## Pflichtquellen
+Erzeuge vor Planung oder Implementierung einen belegten Control-Snapshot.
+Der Skill ist read-only: kein GitHub-, Repo-, DB-, Runtime- oder Live-Write.
+`CURRENT_STATUS.md` ist nur Engineering-Ledger; `CONTROL_REGISTER` ist
+Board-/Stage-Kontext; allein die LR-SSOT bestimmt das LR-Verdikt.
 
-- `docs/runbooks/CONTROL_REGISTER.md`
-- GitHub Issue `#1445` live, falls GitHub verfuegbar
-- `CURRENT_STATUS.md` nur als Ledger (nicht als Live-SSOT)
-- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-- offene PRs/Issues live, falls fuer den aktuellen Scope relevant
+## Pflichtquellen in dieser Reihenfolge
 
-## Prozess (minimal)
+1. `docs/runbooks/CONTROL_REGISTER.md`
+2. GitHub Issue `#1445` live
+3. Der neueste fuer den aktuellen Control-Stand maßgebliche Kommentar in `#1445`.
+   Wenn #1445 eine Rebaseline oder Kommentar-Entwertung anordnet, ist diese
+   Anordnung maßgeblich; alte Weekly-/Bot-/Report-Kommentare sind kein Auftrag.
+4. GitHub Issue `#1492` live, ausschließlich als Board-/`trade-capable`-Kontext
+5. `CURRENT_STATUS.md` als Ledger, niemals als Live-SSOT
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` als LR-SSOT
+7. Für den Scope relevante offene Issues/PRs live
 
-1. Read control sources in this order:
-   - `docs/runbooks/CONTROL_REGISTER.md`
-   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-   - `CURRENT_STATUS.md`
-   - GitHub `#1445` and relevant open PRs/issues live, if available
-2. Separate ledger statements from live GitHub truth.
-3. Produce a conservative control snapshot for the current session scope.
+## Ablauf
 
-## Output
-
-- Board stage
-- LR verdict
-- aktueller operativer Fokus
-- rote Checks / Unsicherheiten
-- kleinster sinnvoller naechster Slice
+1. Lies jede Pflichtquelle und erfasse Quelle, Abrufzeit, Aussage und Grenzen.
+2. Trenne die drei Statusklassen explizit:
+   - **Board stage:** nur Board-/Stage-System aus Register und #1492.
+   - **Engineering:** GitHub-live und Repo-Evidence nach Truth Order; Ledger
+     bleibt als Ledger gekennzeichnet.
+   - **LR verdict:** ausschließlich die LR-SSOT. `trade-capable` bedeutet
+     weder LR-Go noch Echtgeld-/Live-Go.
+3. Bestimme den maßgeblichen #1445-Stand. Ist nicht belastbar feststellbar,
+   behaupte keine aktuelle Priorität und setze `HOLD_CONTROL_COMMENT_AMBIGUOUS`.
+4. Prüfe relevante offene PRs/Issues live. Fehlt notwendige GitHub-Evidence,
+   setze `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`; keine Live-Wahrheit erfinden.
+5. Vergleiche Register, Live-Evidence, Ledger und LR-SSOT. Widersprüche werden
+   nach Statusklasse getrennt ausgegeben; eine nicht trennbare Aussage setzt
+   `HOLD_CONTROL_TRUTH_CONFLICT`.
+6. Gib nur bei vollständigem Snapshot den kleinsten sinnvollen nächsten Slice
+   aus. LR bleibt fail-closed `NO-GO`, wenn die LR-SSOT unklar oder nicht lesbar ist.
 
 ## Stop-Regeln
 
-- Keine LR-/Live-/Echtgeld-Ableitung aus Board stage oder Ledger.
-- Wenn Live-GitHub-Pruefung nicht verfuegbar ist: Unsicherheit explizit markieren.
-- Bei widerspruechlicher Ledger-/Live-Lage: stoppen oder klar trennen und fail-closed bewerten.
+- Pflicht-Canon fehlt oder ist nicht lesbar: `HOLD_REQUIRED_CANON_MISSING`.
+- #1445, der maßgebliche Kommentar, #1492 oder relevante GitHub-Live-Evidence
+  fehlt: `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`.
+- Board-/Ledger-Signal würde als LR-/Live-Go gelesen: `HOLD_STATUS_CLASS_MIXUP`.
+- Widerspruch lässt sich nicht sauber Board, Engineering oder LR zuordnen:
+  `HOLD_CONTROL_TRUTH_CONFLICT`.
+- Ein HOLD enthält Quellen, fehlende Evidence und den nächsten read-only Schritt;
+  er enthält keine erfundene Priorität oder Freigabe.
+
+## Ausgabevertrag
+
+```md
+Control-Snapshot
+- Board stage: <value | HOLD>
+- LR verdict: <value | HOLD>
+- Engineering-/operativer Fokus: <live evidence; ledger separat markiert>
+- Relevante offene GitHub-PRs/Issues: <Liste | keine | HOLD>
+- Rote Checks, Widersprüche, Unsicherheiten: <Liste | keine>
+- Nächster Slice: <kleinster Slice | HOLD-Code + read-only next step>
+
+Truth-Boundaries
+- Board stage ist keine LR- oder Echtgeld-Freigabe.
+- CURRENT_STATUS.md ist Ledger, nicht Live-SSOT.
+- #1492 liefert nur Stage-Kontext.
+```
+
+## Smoke
+
+Führe nach einer Änderung aus:
+
+```powershell
+pytest -q tests/unit/agents/test_control_intake_skill_contract.py
+python tools/validate_skill_surface_mirror.py --skill cdb-control-intake
+git diff --check
+```
+
+Ein PASS beweist den Dokument-/Mirror-Vertrag; die konkrete Session-Wahrheit
+bleibt erst nach ihren Live-Reads belegt.

--- a/.codex/cdb_skills/cdb-control-intake/SKILL.md
+++ b/.codex/cdb_skills/cdb-control-intake/SKILL.md
@@ -2,51 +2,95 @@
 Canonical Skill Source: docs/skills/cdb-control-intake/SKILL.md
 Surface: codex
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-08-11
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-control-intake
 description: >
-  Establishes the CDB control context for a session by reading canonical control
-  surfaces and producing a fail-closed operational snapshot. Use when beginning
-  CDB repo work after session-start, or when rebuilding control context before
-  planning or implementation in Claire_de_Binare.
+  Rebuilds a fail-closed CDB control snapshot from canonical repo and GitHub
+  evidence before planning or implementation. It never derives LR or live
+  authorization from the board stage or an engineering ledger.
 disable-model-invocation: true
 ---
 
 # CDB control intake
 
-Build the minimum reliable control snapshot before planning or implementation.
+## Zweck und Grenze
 
-## Pflichtquellen
+Erzeuge vor Planung oder Implementierung einen belegten Control-Snapshot.
+Der Skill ist read-only: kein GitHub-, Repo-, DB-, Runtime- oder Live-Write.
+`CURRENT_STATUS.md` ist nur Engineering-Ledger; `CONTROL_REGISTER` ist
+Board-/Stage-Kontext; allein die LR-SSOT bestimmt das LR-Verdikt.
 
-- `docs/runbooks/CONTROL_REGISTER.md`
-- GitHub Issue `#1445` live, falls GitHub verfuegbar
-- `CURRENT_STATUS.md` nur als Ledger (nicht als Live-SSOT)
-- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-- offene PRs/Issues live, falls fuer den aktuellen Scope relevant
+## Pflichtquellen in dieser Reihenfolge
 
-## Prozess (minimal)
+1. `docs/runbooks/CONTROL_REGISTER.md`
+2. GitHub Issue `#1445` live
+3. Der neueste fuer den aktuellen Control-Stand maßgebliche Kommentar in `#1445`.
+   Wenn #1445 eine Rebaseline oder Kommentar-Entwertung anordnet, ist diese
+   Anordnung maßgeblich; alte Weekly-/Bot-/Report-Kommentare sind kein Auftrag.
+4. GitHub Issue `#1492` live, ausschließlich als Board-/`trade-capable`-Kontext
+5. `CURRENT_STATUS.md` als Ledger, niemals als Live-SSOT
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` als LR-SSOT
+7. Für den Scope relevante offene Issues/PRs live
 
-1. Read control sources in this order:
-   - `docs/runbooks/CONTROL_REGISTER.md`
-   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-   - `CURRENT_STATUS.md`
-   - GitHub `#1445` and relevant open PRs/issues live, if available
-2. Separate ledger statements from live GitHub truth.
-3. Produce a conservative control snapshot for the current session scope.
+## Ablauf
 
-## Output
-
-- Board stage
-- LR verdict
-- aktueller operativer Fokus
-- rote Checks / Unsicherheiten
-- kleinster sinnvoller naechster Slice
+1. Lies jede Pflichtquelle und erfasse Quelle, Abrufzeit, Aussage und Grenzen.
+2. Trenne die drei Statusklassen explizit:
+   - **Board stage:** nur Board-/Stage-System aus Register und #1492.
+   - **Engineering:** GitHub-live und Repo-Evidence nach Truth Order; Ledger
+     bleibt als Ledger gekennzeichnet.
+   - **LR verdict:** ausschließlich die LR-SSOT. `trade-capable` bedeutet
+     weder LR-Go noch Echtgeld-/Live-Go.
+3. Bestimme den maßgeblichen #1445-Stand. Ist nicht belastbar feststellbar,
+   behaupte keine aktuelle Priorität und setze `HOLD_CONTROL_COMMENT_AMBIGUOUS`.
+4. Prüfe relevante offene PRs/Issues live. Fehlt notwendige GitHub-Evidence,
+   setze `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`; keine Live-Wahrheit erfinden.
+5. Vergleiche Register, Live-Evidence, Ledger und LR-SSOT. Widersprüche werden
+   nach Statusklasse getrennt ausgegeben; eine nicht trennbare Aussage setzt
+   `HOLD_CONTROL_TRUTH_CONFLICT`.
+6. Gib nur bei vollständigem Snapshot den kleinsten sinnvollen nächsten Slice
+   aus. LR bleibt fail-closed `NO-GO`, wenn die LR-SSOT unklar oder nicht lesbar ist.
 
 ## Stop-Regeln
 
-- Keine LR-/Live-/Echtgeld-Ableitung aus Board stage oder Ledger.
-- Wenn Live-GitHub-Pruefung nicht verfuegbar ist: Unsicherheit explizit markieren.
-- Bei widerspruechlicher Ledger-/Live-Lage: stoppen oder klar trennen und fail-closed bewerten.
+- Pflicht-Canon fehlt oder ist nicht lesbar: `HOLD_REQUIRED_CANON_MISSING`.
+- #1445, der maßgebliche Kommentar, #1492 oder relevante GitHub-Live-Evidence
+  fehlt: `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`.
+- Board-/Ledger-Signal würde als LR-/Live-Go gelesen: `HOLD_STATUS_CLASS_MIXUP`.
+- Widerspruch lässt sich nicht sauber Board, Engineering oder LR zuordnen:
+  `HOLD_CONTROL_TRUTH_CONFLICT`.
+- Ein HOLD enthält Quellen, fehlende Evidence und den nächsten read-only Schritt;
+  er enthält keine erfundene Priorität oder Freigabe.
+
+## Ausgabevertrag
+
+```md
+Control-Snapshot
+- Board stage: <value | HOLD>
+- LR verdict: <value | HOLD>
+- Engineering-/operativer Fokus: <live evidence; ledger separat markiert>
+- Relevante offene GitHub-PRs/Issues: <Liste | keine | HOLD>
+- Rote Checks, Widersprüche, Unsicherheiten: <Liste | keine>
+- Nächster Slice: <kleinster Slice | HOLD-Code + read-only next step>
+
+Truth-Boundaries
+- Board stage ist keine LR- oder Echtgeld-Freigabe.
+- CURRENT_STATUS.md ist Ledger, nicht Live-SSOT.
+- #1492 liefert nur Stage-Kontext.
+```
+
+## Smoke
+
+Führe nach einer Änderung aus:
+
+```powershell
+pytest -q tests/unit/agents/test_control_intake_skill_contract.py
+python tools/validate_skill_surface_mirror.py --skill cdb-control-intake
+git diff --check
+```
+
+Ein PASS beweist den Dokument-/Mirror-Vertrag; die konkrete Session-Wahrheit
+bleibt erst nach ihren Live-Reads belegt.

--- a/.cursor/skills/cdb-control-intake/SKILL.md
+++ b/.cursor/skills/cdb-control-intake/SKILL.md
@@ -2,51 +2,95 @@
 Canonical Skill Source: docs/skills/cdb-control-intake/SKILL.md
 Surface: cursor
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-08-11
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-control-intake
 description: >
-  Establishes the CDB control context for a session by reading canonical control
-  surfaces and producing a fail-closed operational snapshot. Use when beginning
-  CDB repo work after session-start, or when rebuilding control context before
-  planning or implementation in Claire_de_Binare.
+  Rebuilds a fail-closed CDB control snapshot from canonical repo and GitHub
+  evidence before planning or implementation. It never derives LR or live
+  authorization from the board stage or an engineering ledger.
 disable-model-invocation: true
 ---
 
 # CDB control intake
 
-Build the minimum reliable control snapshot before planning or implementation.
+## Zweck und Grenze
 
-## Pflichtquellen
+Erzeuge vor Planung oder Implementierung einen belegten Control-Snapshot.
+Der Skill ist read-only: kein GitHub-, Repo-, DB-, Runtime- oder Live-Write.
+`CURRENT_STATUS.md` ist nur Engineering-Ledger; `CONTROL_REGISTER` ist
+Board-/Stage-Kontext; allein die LR-SSOT bestimmt das LR-Verdikt.
 
-- `docs/runbooks/CONTROL_REGISTER.md`
-- GitHub Issue `#1445` live, falls GitHub verfuegbar
-- `CURRENT_STATUS.md` nur als Ledger (nicht als Live-SSOT)
-- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-- offene PRs/Issues live, falls fuer den aktuellen Scope relevant
+## Pflichtquellen in dieser Reihenfolge
 
-## Prozess (minimal)
+1. `docs/runbooks/CONTROL_REGISTER.md`
+2. GitHub Issue `#1445` live
+3. Der neueste fuer den aktuellen Control-Stand maßgebliche Kommentar in `#1445`.
+   Wenn #1445 eine Rebaseline oder Kommentar-Entwertung anordnet, ist diese
+   Anordnung maßgeblich; alte Weekly-/Bot-/Report-Kommentare sind kein Auftrag.
+4. GitHub Issue `#1492` live, ausschließlich als Board-/`trade-capable`-Kontext
+5. `CURRENT_STATUS.md` als Ledger, niemals als Live-SSOT
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` als LR-SSOT
+7. Für den Scope relevante offene Issues/PRs live
 
-1. Read control sources in this order:
-   - `docs/runbooks/CONTROL_REGISTER.md`
-   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-   - `CURRENT_STATUS.md`
-   - GitHub `#1445` and relevant open PRs/issues live, if available
-2. Separate ledger statements from live GitHub truth.
-3. Produce a conservative control snapshot for the current session scope.
+## Ablauf
 
-## Output
-
-- Board stage
-- LR verdict
-- aktueller operativer Fokus
-- rote Checks / Unsicherheiten
-- kleinster sinnvoller naechster Slice
+1. Lies jede Pflichtquelle und erfasse Quelle, Abrufzeit, Aussage und Grenzen.
+2. Trenne die drei Statusklassen explizit:
+   - **Board stage:** nur Board-/Stage-System aus Register und #1492.
+   - **Engineering:** GitHub-live und Repo-Evidence nach Truth Order; Ledger
+     bleibt als Ledger gekennzeichnet.
+   - **LR verdict:** ausschließlich die LR-SSOT. `trade-capable` bedeutet
+     weder LR-Go noch Echtgeld-/Live-Go.
+3. Bestimme den maßgeblichen #1445-Stand. Ist nicht belastbar feststellbar,
+   behaupte keine aktuelle Priorität und setze `HOLD_CONTROL_COMMENT_AMBIGUOUS`.
+4. Prüfe relevante offene PRs/Issues live. Fehlt notwendige GitHub-Evidence,
+   setze `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`; keine Live-Wahrheit erfinden.
+5. Vergleiche Register, Live-Evidence, Ledger und LR-SSOT. Widersprüche werden
+   nach Statusklasse getrennt ausgegeben; eine nicht trennbare Aussage setzt
+   `HOLD_CONTROL_TRUTH_CONFLICT`.
+6. Gib nur bei vollständigem Snapshot den kleinsten sinnvollen nächsten Slice
+   aus. LR bleibt fail-closed `NO-GO`, wenn die LR-SSOT unklar oder nicht lesbar ist.
 
 ## Stop-Regeln
 
-- Keine LR-/Live-/Echtgeld-Ableitung aus Board stage oder Ledger.
-- Wenn Live-GitHub-Pruefung nicht verfuegbar ist: Unsicherheit explizit markieren.
-- Bei widerspruechlicher Ledger-/Live-Lage: stoppen oder klar trennen und fail-closed bewerten.
+- Pflicht-Canon fehlt oder ist nicht lesbar: `HOLD_REQUIRED_CANON_MISSING`.
+- #1445, der maßgebliche Kommentar, #1492 oder relevante GitHub-Live-Evidence
+  fehlt: `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`.
+- Board-/Ledger-Signal würde als LR-/Live-Go gelesen: `HOLD_STATUS_CLASS_MIXUP`.
+- Widerspruch lässt sich nicht sauber Board, Engineering oder LR zuordnen:
+  `HOLD_CONTROL_TRUTH_CONFLICT`.
+- Ein HOLD enthält Quellen, fehlende Evidence und den nächsten read-only Schritt;
+  er enthält keine erfundene Priorität oder Freigabe.
+
+## Ausgabevertrag
+
+```md
+Control-Snapshot
+- Board stage: <value | HOLD>
+- LR verdict: <value | HOLD>
+- Engineering-/operativer Fokus: <live evidence; ledger separat markiert>
+- Relevante offene GitHub-PRs/Issues: <Liste | keine | HOLD>
+- Rote Checks, Widersprüche, Unsicherheiten: <Liste | keine>
+- Nächster Slice: <kleinster Slice | HOLD-Code + read-only next step>
+
+Truth-Boundaries
+- Board stage ist keine LR- oder Echtgeld-Freigabe.
+- CURRENT_STATUS.md ist Ledger, nicht Live-SSOT.
+- #1492 liefert nur Stage-Kontext.
+```
+
+## Smoke
+
+Führe nach einer Änderung aus:
+
+```powershell
+pytest -q tests/unit/agents/test_control_intake_skill_contract.py
+python tools/validate_skill_surface_mirror.py --skill cdb-control-intake
+git diff --check
+```
+
+Ein PASS beweist den Dokument-/Mirror-Vertrag; die konkrete Session-Wahrheit
+bleibt erst nach ihren Live-Reads belegt.

--- a/.opencode/skills/cdb-control-intake/SKILL.md
+++ b/.opencode/skills/cdb-control-intake/SKILL.md
@@ -2,51 +2,95 @@
 Canonical Skill Source: docs/skills/cdb-control-intake/SKILL.md
 Surface: opencode
 Sync Status: mirrored-from-canon
-Last Verified: 2026-07-01
+Last Verified: 2026-08-11
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-control-intake
 description: >
-  Establishes the CDB control context for a session by reading canonical control
-  surfaces and producing a fail-closed operational snapshot. Use when beginning
-  CDB repo work after session-start, or when rebuilding control context before
-  planning or implementation in Claire_de_Binare.
+  Rebuilds a fail-closed CDB control snapshot from canonical repo and GitHub
+  evidence before planning or implementation. It never derives LR or live
+  authorization from the board stage or an engineering ledger.
 disable-model-invocation: true
 ---
 
 # CDB control intake
 
-Build the minimum reliable control snapshot before planning or implementation.
+## Zweck und Grenze
 
-## Pflichtquellen
+Erzeuge vor Planung oder Implementierung einen belegten Control-Snapshot.
+Der Skill ist read-only: kein GitHub-, Repo-, DB-, Runtime- oder Live-Write.
+`CURRENT_STATUS.md` ist nur Engineering-Ledger; `CONTROL_REGISTER` ist
+Board-/Stage-Kontext; allein die LR-SSOT bestimmt das LR-Verdikt.
 
-- `docs/runbooks/CONTROL_REGISTER.md`
-- GitHub Issue `#1445` live, falls GitHub verfuegbar
-- `CURRENT_STATUS.md` nur als Ledger (nicht als Live-SSOT)
-- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-- offene PRs/Issues live, falls fuer den aktuellen Scope relevant
+## Pflichtquellen in dieser Reihenfolge
 
-## Prozess (minimal)
+1. `docs/runbooks/CONTROL_REGISTER.md`
+2. GitHub Issue `#1445` live
+3. Der neueste fuer den aktuellen Control-Stand maßgebliche Kommentar in `#1445`.
+   Wenn #1445 eine Rebaseline oder Kommentar-Entwertung anordnet, ist diese
+   Anordnung maßgeblich; alte Weekly-/Bot-/Report-Kommentare sind kein Auftrag.
+4. GitHub Issue `#1492` live, ausschließlich als Board-/`trade-capable`-Kontext
+5. `CURRENT_STATUS.md` als Ledger, niemals als Live-SSOT
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` als LR-SSOT
+7. Für den Scope relevante offene Issues/PRs live
 
-1. Read control sources in this order:
-   - `docs/runbooks/CONTROL_REGISTER.md`
-   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-   - `CURRENT_STATUS.md`
-   - GitHub `#1445` and relevant open PRs/issues live, if available
-2. Separate ledger statements from live GitHub truth.
-3. Produce a conservative control snapshot for the current session scope.
+## Ablauf
 
-## Output
-
-- Board stage
-- LR verdict
-- aktueller operativer Fokus
-- rote Checks / Unsicherheiten
-- kleinster sinnvoller naechster Slice
+1. Lies jede Pflichtquelle und erfasse Quelle, Abrufzeit, Aussage und Grenzen.
+2. Trenne die drei Statusklassen explizit:
+   - **Board stage:** nur Board-/Stage-System aus Register und #1492.
+   - **Engineering:** GitHub-live und Repo-Evidence nach Truth Order; Ledger
+     bleibt als Ledger gekennzeichnet.
+   - **LR verdict:** ausschließlich die LR-SSOT. `trade-capable` bedeutet
+     weder LR-Go noch Echtgeld-/Live-Go.
+3. Bestimme den maßgeblichen #1445-Stand. Ist nicht belastbar feststellbar,
+   behaupte keine aktuelle Priorität und setze `HOLD_CONTROL_COMMENT_AMBIGUOUS`.
+4. Prüfe relevante offene PRs/Issues live. Fehlt notwendige GitHub-Evidence,
+   setze `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`; keine Live-Wahrheit erfinden.
+5. Vergleiche Register, Live-Evidence, Ledger und LR-SSOT. Widersprüche werden
+   nach Statusklasse getrennt ausgegeben; eine nicht trennbare Aussage setzt
+   `HOLD_CONTROL_TRUTH_CONFLICT`.
+6. Gib nur bei vollständigem Snapshot den kleinsten sinnvollen nächsten Slice
+   aus. LR bleibt fail-closed `NO-GO`, wenn die LR-SSOT unklar oder nicht lesbar ist.
 
 ## Stop-Regeln
 
-- Keine LR-/Live-/Echtgeld-Ableitung aus Board stage oder Ledger.
-- Wenn Live-GitHub-Pruefung nicht verfuegbar ist: Unsicherheit explizit markieren.
-- Bei widerspruechlicher Ledger-/Live-Lage: stoppen oder klar trennen und fail-closed bewerten.
+- Pflicht-Canon fehlt oder ist nicht lesbar: `HOLD_REQUIRED_CANON_MISSING`.
+- #1445, der maßgebliche Kommentar, #1492 oder relevante GitHub-Live-Evidence
+  fehlt: `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`.
+- Board-/Ledger-Signal würde als LR-/Live-Go gelesen: `HOLD_STATUS_CLASS_MIXUP`.
+- Widerspruch lässt sich nicht sauber Board, Engineering oder LR zuordnen:
+  `HOLD_CONTROL_TRUTH_CONFLICT`.
+- Ein HOLD enthält Quellen, fehlende Evidence und den nächsten read-only Schritt;
+  er enthält keine erfundene Priorität oder Freigabe.
+
+## Ausgabevertrag
+
+```md
+Control-Snapshot
+- Board stage: <value | HOLD>
+- LR verdict: <value | HOLD>
+- Engineering-/operativer Fokus: <live evidence; ledger separat markiert>
+- Relevante offene GitHub-PRs/Issues: <Liste | keine | HOLD>
+- Rote Checks, Widersprüche, Unsicherheiten: <Liste | keine>
+- Nächster Slice: <kleinster Slice | HOLD-Code + read-only next step>
+
+Truth-Boundaries
+- Board stage ist keine LR- oder Echtgeld-Freigabe.
+- CURRENT_STATUS.md ist Ledger, nicht Live-SSOT.
+- #1492 liefert nur Stage-Kontext.
+```
+
+## Smoke
+
+Führe nach einer Änderung aus:
+
+```powershell
+pytest -q tests/unit/agents/test_control_intake_skill_contract.py
+python tools/validate_skill_surface_mirror.py --skill cdb-control-intake
+git diff --check
+```
+
+Ein PASS beweist den Dokument-/Mirror-Vertrag; die konkrete Session-Wahrheit
+bleibt erst nach ihren Live-Reads belegt.

--- a/docs/skills/cdb-control-intake/SKILL.md
+++ b/docs/skills/cdb-control-intake/SKILL.md
@@ -2,51 +2,95 @@
 Canonical Skill Source: docs/skills/cdb-control-intake/SKILL.md
 Surface: docs (canonical)
 Sync Status: canonical
-Last Verified: 2026-07-01
+Last Verified: 2026-08-11
 Drift Policy: Surface-Adapter duerfen nur mit dokumentierter Begruendung abweichen.
 -->
 ---
 name: cdb-control-intake
 description: >
-  Establishes the CDB control context for a session by reading canonical control
-  surfaces and producing a fail-closed operational snapshot. Use when beginning
-  CDB repo work after session-start, or when rebuilding control context before
-  planning or implementation in Claire_de_Binare.
+  Rebuilds a fail-closed CDB control snapshot from canonical repo and GitHub
+  evidence before planning or implementation. It never derives LR or live
+  authorization from the board stage or an engineering ledger.
 disable-model-invocation: true
 ---
 
 # CDB control intake
 
-Build the minimum reliable control snapshot before planning or implementation.
+## Zweck und Grenze
 
-## Pflichtquellen
+Erzeuge vor Planung oder Implementierung einen belegten Control-Snapshot.
+Der Skill ist read-only: kein GitHub-, Repo-, DB-, Runtime- oder Live-Write.
+`CURRENT_STATUS.md` ist nur Engineering-Ledger; `CONTROL_REGISTER` ist
+Board-/Stage-Kontext; allein die LR-SSOT bestimmt das LR-Verdikt.
 
-- `docs/runbooks/CONTROL_REGISTER.md`
-- GitHub Issue `#1445` live, falls GitHub verfuegbar
-- `CURRENT_STATUS.md` nur als Ledger (nicht als Live-SSOT)
-- `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-- offene PRs/Issues live, falls fuer den aktuellen Scope relevant
+## Pflichtquellen in dieser Reihenfolge
 
-## Prozess (minimal)
+1. `docs/runbooks/CONTROL_REGISTER.md`
+2. GitHub Issue `#1445` live
+3. Der neueste fuer den aktuellen Control-Stand maßgebliche Kommentar in `#1445`.
+   Wenn #1445 eine Rebaseline oder Kommentar-Entwertung anordnet, ist diese
+   Anordnung maßgeblich; alte Weekly-/Bot-/Report-Kommentare sind kein Auftrag.
+4. GitHub Issue `#1492` live, ausschließlich als Board-/`trade-capable`-Kontext
+5. `CURRENT_STATUS.md` als Ledger, niemals als Live-SSOT
+6. `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md` als LR-SSOT
+7. Für den Scope relevante offene Issues/PRs live
 
-1. Read control sources in this order:
-   - `docs/runbooks/CONTROL_REGISTER.md`
-   - `docs/live-readiness/LR-AUDIT-STATUS-2026-03-05.md`
-   - `CURRENT_STATUS.md`
-   - GitHub `#1445` and relevant open PRs/issues live, if available
-2. Separate ledger statements from live GitHub truth.
-3. Produce a conservative control snapshot for the current session scope.
+## Ablauf
 
-## Output
-
-- Board stage
-- LR verdict
-- aktueller operativer Fokus
-- rote Checks / Unsicherheiten
-- kleinster sinnvoller naechster Slice
+1. Lies jede Pflichtquelle und erfasse Quelle, Abrufzeit, Aussage und Grenzen.
+2. Trenne die drei Statusklassen explizit:
+   - **Board stage:** nur Board-/Stage-System aus Register und #1492.
+   - **Engineering:** GitHub-live und Repo-Evidence nach Truth Order; Ledger
+     bleibt als Ledger gekennzeichnet.
+   - **LR verdict:** ausschließlich die LR-SSOT. `trade-capable` bedeutet
+     weder LR-Go noch Echtgeld-/Live-Go.
+3. Bestimme den maßgeblichen #1445-Stand. Ist nicht belastbar feststellbar,
+   behaupte keine aktuelle Priorität und setze `HOLD_CONTROL_COMMENT_AMBIGUOUS`.
+4. Prüfe relevante offene PRs/Issues live. Fehlt notwendige GitHub-Evidence,
+   setze `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`; keine Live-Wahrheit erfinden.
+5. Vergleiche Register, Live-Evidence, Ledger und LR-SSOT. Widersprüche werden
+   nach Statusklasse getrennt ausgegeben; eine nicht trennbare Aussage setzt
+   `HOLD_CONTROL_TRUTH_CONFLICT`.
+6. Gib nur bei vollständigem Snapshot den kleinsten sinnvollen nächsten Slice
+   aus. LR bleibt fail-closed `NO-GO`, wenn die LR-SSOT unklar oder nicht lesbar ist.
 
 ## Stop-Regeln
 
-- Keine LR-/Live-/Echtgeld-Ableitung aus Board stage oder Ledger.
-- Wenn Live-GitHub-Pruefung nicht verfuegbar ist: Unsicherheit explizit markieren.
-- Bei widerspruechlicher Ledger-/Live-Lage: stoppen oder klar trennen und fail-closed bewerten.
+- Pflicht-Canon fehlt oder ist nicht lesbar: `HOLD_REQUIRED_CANON_MISSING`.
+- #1445, der maßgebliche Kommentar, #1492 oder relevante GitHub-Live-Evidence
+  fehlt: `HOLD_GITHUB_LIVE_EVIDENCE_MISSING`.
+- Board-/Ledger-Signal würde als LR-/Live-Go gelesen: `HOLD_STATUS_CLASS_MIXUP`.
+- Widerspruch lässt sich nicht sauber Board, Engineering oder LR zuordnen:
+  `HOLD_CONTROL_TRUTH_CONFLICT`.
+- Ein HOLD enthält Quellen, fehlende Evidence und den nächsten read-only Schritt;
+  er enthält keine erfundene Priorität oder Freigabe.
+
+## Ausgabevertrag
+
+```md
+Control-Snapshot
+- Board stage: <value | HOLD>
+- LR verdict: <value | HOLD>
+- Engineering-/operativer Fokus: <live evidence; ledger separat markiert>
+- Relevante offene GitHub-PRs/Issues: <Liste | keine | HOLD>
+- Rote Checks, Widersprüche, Unsicherheiten: <Liste | keine>
+- Nächster Slice: <kleinster Slice | HOLD-Code + read-only next step>
+
+Truth-Boundaries
+- Board stage ist keine LR- oder Echtgeld-Freigabe.
+- CURRENT_STATUS.md ist Ledger, nicht Live-SSOT.
+- #1492 liefert nur Stage-Kontext.
+```
+
+## Smoke
+
+Führe nach einer Änderung aus:
+
+```powershell
+pytest -q tests/unit/agents/test_control_intake_skill_contract.py
+python tools/validate_skill_surface_mirror.py --skill cdb-control-intake
+git diff --check
+```
+
+Ein PASS beweist den Dokument-/Mirror-Vertrag; die konkrete Session-Wahrheit
+bleibt erst nach ihren Live-Reads belegt.

--- a/tests/unit/agents/test_control_intake_skill_contract.py
+++ b/tests/unit/agents/test_control_intake_skill_contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SKILL = Path(__file__).parents[3] / "docs/skills/cdb-control-intake/SKILL.md"
+
+
+def test_control_intake_requires_truth_order_and_status_separation() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+
+    required = (
+        "CONTROL_REGISTER.md",
+        "GitHub Issue `#1445` live",
+        "#1492",
+        "`CURRENT_STATUS.md` als Ledger",
+        "LR-AUDIT-STATUS-2026-03-05.md",
+        "HOLD_GITHUB_LIVE_EVIDENCE_MISSING",
+        "HOLD_STATUS_CLASS_MIXUP",
+        "Board stage ist keine LR- oder Echtgeld-Freigabe.",
+    )
+    assert all(marker in text for marker in required)
+    assert text.index("CONTROL_REGISTER.md") < text.index("GitHub Issue `#1445` live")
+    assert text.index("GitHub Issue `#1445` live") < text.index("#1492")
+    assert text.index("#1492") < text.index("`CURRENT_STATUS.md` als Ledger")
+    assert text.index("`CURRENT_STATUS.md` als Ledger") < text.index(
+        "LR-AUDIT-STATUS-2026-03-05.md"
+    )

--- a/tests/unit/agents/test_control_intake_skill_contract.py
+++ b/tests/unit/agents/test_control_intake_skill_contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 SKILL = Path(__file__).parents[3] / "docs/skills/cdb-control-intake/SKILL.md"
 
 


### PR DESCRIPTION
Closes #4442

## Delivered
- erweitert cdb-control-intake zu einem fail-closed Control-Snapshot
- trennt Board stage, Engineering-Ledger und LR verdict
- spiegelt den Canon auf Codex, Cursor, OpenCode und Claude

## Brain Evidence
- context_tool_status: available
- context_trust_level: none
- records_found: none
- repo/GitHub-live fallback: insufficient_evidence

## Validation
- pytest -q tests/unit/agents/test_control_intake_skill_contract.py
- python tools/validate_skill_surface_mirror.py --skill cdb-control-intake
- git diff --check

## Fail-closed behavior
Fehlende Pflichtquellen, fehlende GitHub-Live-Evidence, unklare #1445-Control-Kommentare und Statusklassen-Mix setzen explizite HOLD-Codes.

## Non-goals
Keine Governance-, LR-, Delivery-Gate-, Runtime- oder Trading-Aenderungen.

## Safety boundaries
Board stage trade-capable ist weder LR-Go noch Echtgeld-Go; CURRENT_STATUS bleibt Ledger.

## Restunsicherheiten
Final-Head-Acceptance und Merge bleiben dem kanonischen getrennten Merge-Flow vorbehalten.