### PR TITLE
[OPS][STORAGE] Define canonical bulk storage path contract

### DIFF
--- a/docs/env/index.md
+++ b/docs/env/index.md
@@ -14,6 +14,7 @@ Nicht exhaustiv; diese Seite zeigt die Canon-Pointer.
 | `POSTGRES_SSLMODE` | `prefer` | Postgres-DSN / SSL-Verbindung | [`core/utils/postgres_client.py`](../../core/utils/postgres_client.py) |
 | `SECRETS_PATH` | lokal: `~/Documents/.secrets/.cdb`, CI: `${{ github.workspace }}/.ci-secrets` | Compose, Bootstrap, E2E/Soak | BLUE+RED compose (`compose.blue.yml` / `compose.red.yml`), [`infrastructure/scripts/bootstrap_local.sh`](../../infrastructure/scripts/bootstrap_local.sh), [tests/fixtures/README.md](../../tests/fixtures/README.md) |
 | `CDB_EXTERNAL_TESTS` | off | Opt-in fuer externe Integrations-Tests | [`tests/integration/test_mexc_testnet.py`](../../tests/integration/test_mexc_testnet.py) |
+| `CDB_BULK_STORAGE_ROOT` | unset (opt-in) | spaetere Bulk-Storage-Consumer | [`cdb_bulk_storage_path_contract.md`](../runbooks/cdb_bulk_storage_path_contract.md) |
 | `surrealdb_enabled` / `governance_source` | `false` / `git` | SurrealDB-Mirror und Governance-Read-Quelle | [`infrastructure/config/surrealdb/feature-flags.yaml`](../../infrastructure/config/surrealdb/feature-flags.yaml), [docs/surrealdb/rollback-cutover-plan.md](../surrealdb/rollback-cutover-plan.md) |
 
 `MOCK_EXECUTION_MODE`, `SIMULATOR_ORDER_BOOK_DEPTH` und `SIMULATOR_VOLATILITY`

--- a/docs/runbooks/cdb_bulk_storage_path_contract.md
+++ b/docs/runbooks/cdb_bulk_storage_path_contract.md
@@ -1,0 +1,50 @@
+# CDB Bulk-Storage Path Contract
+
+Status: Canonical Windows host policy for #4419. This is a policy and config
+foundation only; it neither provisions directories nor migrates data.
+
+## Canonical root and layout
+
+```text
+Y:\CDB-Storage\
+  market-history\
+  replay-arvp\
+  logs\
+  evidence\
+  archive\
+```
+
+`Y:\Worktrees` is exclusively the governed Git-worktree root. Bulk data MUST
+never be placed there. Junctions and symlinks are not an accepted substitute
+for this contract.
+
+## Configuration surface
+
+New consumers opt in with `CDB_BULK_STORAGE_ROOT=Y:\CDB-Storage`. They must
+resolve a named subtree with `tools.storage.bulk_storage_contract`; missing,
+non-canonical, `Y:\Worktrees`, or reparse-point roots fail closed. The helper
+does not create paths and has no fallback root.
+
+Existing `CDB_WINDOW_BANK_ROOT` and `CDB_DATASET_ROOT` consumers remain
+unchanged in this issue. Existing repo-relative market-data paths, ARVP/replay
+artifact roots, and Compose `logs` binds also remain in place until their
+separate migration issues. No automatic copy, move, deletion, or junction
+cutover is permitted.
+
+## Retention mapping
+
+| Subtree | Retention intent |
+| --- | --- |
+| `market-history` | Preserve long-term replay and research reproducibility. |
+| `replay-arvp` | Retain campaign/replay data under its evidence policy. |
+| `logs` | Distinguish active local logs from separately archived logs. |
+| `evidence` | Preserve auditable evidence. |
+| `archive` | Hold explicitly archived material. |
+
+Reproducible caches do not belong in this durable bulk store.
+
+## Consumer adoption rule
+
+A consumer may use this root only in a later, explicitly scoped migration
+issue. That issue must validate the configured target before writing and must
+not infer a replacement for its current D:/repo-relative path.

--- a/tests/unit/tools/test_bulk_storage_contract.py
+++ b/tests/unit/tools/test_bulk_storage_contract.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.storage.bulk_storage_contract import (
+    BULK_STORAGE_ROOT_ENV,
+    BulkStorageContractError,
+    resolve_bulk_storage_path,
+    validate_bulk_storage_root,
+)
+
+
+@pytest.mark.unit
+def test_valid_canonical_y_bulk_root_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tools.storage.bulk_storage_contract._reject_reparse_ancestors", lambda _: None
+    )
+    assert validate_bulk_storage_root("Y:\\CDB-Storage") == Path("Y:\\CDB-Storage")
+
+
+@pytest.mark.unit
+def test_worktree_root_is_rejected() -> None:
+    with pytest.raises(BulkStorageContractError, match="WORKTREE_ROOT_FORBIDDEN"):
+        validate_bulk_storage_root("Y:\\Worktrees\\Claire_de_Binare\\bulk")
+
+
+@pytest.mark.unit
+def test_disallowed_drive_or_root_is_rejected() -> None:
+    with pytest.raises(BulkStorageContractError, match="ROOT_INVALID"):
+        validate_bulk_storage_root("D:\\CDB-Storage")
+
+
+@pytest.mark.unit
+def test_explicit_consumer_requires_configured_root() -> None:
+    with pytest.raises(BulkStorageContractError, match="ROOT_REQUIRED"):
+        resolve_bulk_storage_path("market-history", environ={})
+
+
+@pytest.mark.unit
+def test_explicit_consumer_resolves_only_canonical_subtree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "tools.storage.bulk_storage_contract._reject_reparse_ancestors", lambda _: None
+    )
+    result = resolve_bulk_storage_path(
+        "replay-arvp", environ={BULK_STORAGE_ROOT_ENV: "Y:\\CDB-Storage"}
+    )
+    assert result == Path("Y:\\CDB-Storage\\replay-arvp")
+
+
+@pytest.mark.unit
+def test_reparse_ancestor_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "tools.storage.bulk_storage_contract._is_reparse_point", lambda _: True
+    )
+    with pytest.raises(BulkStorageContractError, match="REPARSE_POINT"):
+        validate_bulk_storage_root("Y:\\CDB-Storage")

--- a/tools/storage/__init__.py
+++ b/tools/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage-policy helpers with no implicit data migration behavior."""

--- a/tools/storage/bulk_storage_contract.py
+++ b/tools/storage/bulk_storage_contract.py
@@ -1,0 +1,94 @@
+"""Fail-closed opt-in contract for the Windows CDB bulk-storage root (#4419)."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path, PureWindowsPath
+from typing import Mapping
+
+BULK_STORAGE_ROOT_ENV = "CDB_BULK_STORAGE_ROOT"
+CANONICAL_BULK_STORAGE_ROOT = PureWindowsPath("Y:/CDB-Storage")
+WORKTREE_ROOT = PureWindowsPath("Y:/Worktrees")
+BULK_STORAGE_SUBTREES = frozenset(
+    {"market-history", "replay-arvp", "logs", "evidence", "archive"}
+)
+
+
+class BulkStorageContractError(ValueError):
+    """Raised when an explicitly selected bulk-storage path is not canonical."""
+
+
+def _windows_path(value: str) -> PureWindowsPath:
+    candidate = PureWindowsPath(value.strip())
+    if (
+        not value.strip()
+        or not candidate.is_absolute()
+        or candidate.drive.upper() != "Y:"
+    ):
+        raise BulkStorageContractError("BULK_STORAGE_ROOT_INVALID")
+    return candidate
+
+
+def _normalise(path: PureWindowsPath) -> str:
+    return str(path).replace("/", "\\").rstrip("\\").casefold()
+
+
+def _is_reparse_point(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        return bool(path.lstat().st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    except AttributeError:
+        return path.is_symlink()
+
+
+def _reject_reparse_ancestors(path: Path) -> None:
+    current = path
+    while True:
+        if _is_reparse_point(current):
+            raise BulkStorageContractError("BULK_STORAGE_REPARSE_POINT")
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
+def validate_bulk_storage_root(value: str) -> Path:
+    """Validate the only accepted root without creating it or redirecting it.
+
+    The root may not exist yet: #4419 defines a policy, while later issues own
+    provisioning and data migration. Existing ancestor junctions/symlinks are
+    nevertheless rejected so that they cannot silently stand in for the contract.
+    """
+    candidate = _windows_path(value)
+    if _normalise(candidate) != _normalise(CANONICAL_BULK_STORAGE_ROOT):
+        if _normalise(candidate).startswith(_normalise(WORKTREE_ROOT) + "\\") or (
+            _normalise(candidate) == _normalise(WORKTREE_ROOT)
+        ):
+            raise BulkStorageContractError("BULK_STORAGE_WORKTREE_ROOT_FORBIDDEN")
+        raise BulkStorageContractError("BULK_STORAGE_ROOT_NON_CANONICAL")
+
+    resolved = Path(str(candidate))
+    _reject_reparse_ancestors(resolved)
+    return resolved
+
+
+def resolve_bulk_storage_path(
+    subtree: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Resolve an explicitly opted-in subtree or fail closed.
+
+    Existing consumers do not call this helper and retain their current D:/repo
+    paths. A consumer that adopts the new contract must configure its root; no
+    fallback, directory creation, copy, move, or deletion is performed here.
+    """
+    if subtree not in BULK_STORAGE_SUBTREES:
+        raise BulkStorageContractError("BULK_STORAGE_SUBTREE_INVALID")
+    env = os.environ if environ is None else environ
+    raw_root = env.get(BULK_STORAGE_ROOT_ENV, "")
+    if not raw_root.strip():
+        raise BulkStorageContractError("BULK_STORAGE_ROOT_REQUIRED")
+    return validate_bulk_storage_root(raw_root) / subtree


### PR DESCRIPTION
Closes #4419

## Kurzbefund
- Definiert den opt-in, fail-closed Contract fuer den kanonischen Bulk-Storage-Root auf Y: ohne Provisioning oder Datenmigration.

## Warum jetzt
- ST-2 liefert die Path-Policy vor den getrennten Consumer-Migrationen ST-3 bis ST-7.

## Scope
- in: Storage-Contract, ENV-Index, Runbook, gezielte Tests
- out: Datenverschiebung, Loeschung, Junction-Cutover, Compose-/Runtime-Aenderung

## Betroffene Dateien / Artefakte
- tools/storage/bulk_storage_contract.py
- tests/unit/tools/test_bulk_storage_contract.py
- docs/runbooks/cdb_bulk_storage_path_contract.md
- docs/env/index.md

## Validierung / Checks
- pytest -q tests/unit/tools/test_bulk_storage_contract.py tests/unit/market_data/test_market_data_storage_guard.py tests/unit/arvp/test_hh_hl_execution_window_bank.py (22 passed)
- black --check tools/storage tests/unit/tools/test_bulk_storage_contract.py
- ruff check tools/storage tests/unit/tools/test_bulk_storage_contract.py
- git diff --check

## Risiken / Guardrails
- Y:\\Worktrees ist explizit ausgeschlossen.
- Fehlende, ungueltige oder reparse-point Konfiguration wird abgewiesen.
- Bestehende D:/repo-relative Consumer bleiben unveraendert.

## Restunsicherheiten
- Provisioning und jede Consumer-Migration bleiben explizit spaeteren Issues vorbehalten.

## Issue-Bezug
- Closes #4419