### PR TITLE
[OPS][ARVP] Offload Replay/ARVP bulk datasets and campaign artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 
 MCP_CONFIG_PATHS ?=
 REPLAY_INPUT_CANDLES ?=
-REPLAY_OUTPUT_DIR ?= artifacts/replay_reports
+REPLAY_OUTPUT_DIR ?=
 REPLAY_STRATEGY_ID ?= primary_breakout_v1
 REPLAY_SYMBOL ?= BTCUSDT
 REPLAY_ADAPTER_ID ?= primary_breakout_runner_v1
@@ -677,35 +677,35 @@ paper-trading-stop:
 
 ifeq ($(OS),Windows_NT)
 replay-shadow-run:
-	@pwsh -NoProfile -Command "$$input='$(REPLAY_INPUT_CANDLES)'; if ([string]::IsNullOrWhiteSpace($$input)) { Write-Error 'REPLAY_INPUT_CANDLES is required'; Write-Host 'Usage: make replay-shadow-run REPLAY_INPUT_CANDLES=<candles.json|candles.jsonl> [REPLAY_OUTPUT_DIR=artifacts/replay_reports]'; exit 1 }; if (-not (Test-Path $$input)) { Write-Error ('input candles file not found: ' + $$input); exit 1 }; $$out='$(REPLAY_OUTPUT_DIR)'; New-Item -ItemType Directory -Force -Path $$out | Out-Null; $$args=@('-m','services.validation.strategy_replay_runner','--input-candles',$$input,'--output-dir',$$out,'--strategy-id','$(REPLAY_STRATEGY_ID)','--symbol','$(REPLAY_SYMBOL)','--adapter-id','$(REPLAY_ADAPTER_ID)'); if ('$(REPLAY_DRY_RUN)' -eq '1') { $$args += '--dry-run' }; if ('$(REPLAY_DETERMINISTIC_VERIFY)' -eq '1') { $$args += '--deterministic-verify' }; Write-Host '▶ replay-shadow-run'; Write-Host ('  input_candles=' + $$input); Write-Host ('  output_dir=' + $$out); Write-Host '  strategy_id=$(REPLAY_STRATEGY_ID) symbol=$(REPLAY_SYMBOL) adapter_id=$(REPLAY_ADAPTER_ID)'; Write-Host '  dry_run=$(REPLAY_DRY_RUN) deterministic_verify=$(REPLAY_DETERMINISTIC_VERIFY)'; & python @args; $$rc=$$LASTEXITCODE; if ($$rc -eq 0) { Write-Host '✅ replay-shadow-run completed (bundle_dir is printed by the runner)' } else { Write-Error ('replay-shadow-run failed with exit code ' + $$rc) }; exit $$rc"
+	@pwsh -NoProfile -Command "$$input='$(REPLAY_INPUT_CANDLES)'; if ([string]::IsNullOrWhiteSpace($$input)) { Write-Error 'REPLAY_INPUT_CANDLES is required'; Write-Host 'Usage: make replay-shadow-run REPLAY_INPUT_CANDLES=<candles.json|candles.jsonl> [REPLAY_OUTPUT_DIR=<explicit-path>]'; exit 1 }; if (-not (Test-Path $$input)) { Write-Error ('input candles file not found: ' + $$input); exit 1 }; $$out='$(REPLAY_OUTPUT_DIR)'; $$args=@('-m','services.validation.strategy_replay_runner','--input-candles',$$input,'--strategy-id','$(REPLAY_STRATEGY_ID)','--symbol','$(REPLAY_SYMBOL)','--adapter-id','$(REPLAY_ADAPTER_ID)'); if (-not [string]::IsNullOrWhiteSpace($$out)) { New-Item -ItemType Directory -Force -Path $$out | Out-Null; $$args += @('--output-dir',$$out) }; if ('$(REPLAY_DRY_RUN)' -eq '1') { $$args += '--dry-run' }; if ('$(REPLAY_DETERMINISTIC_VERIFY)' -eq '1') { $$args += '--deterministic-verify' }; Write-Host '▶ replay-shadow-run'; Write-Host ('  input_candles=' + $$input); Write-Host '  output_dir=resolver-default unless REPLAY_OUTPUT_DIR is explicit'; Write-Host '  strategy_id=$(REPLAY_STRATEGY_ID) symbol=$(REPLAY_SYMBOL) adapter_id=$(REPLAY_ADAPTER_ID)'; Write-Host '  dry_run=$(REPLAY_DRY_RUN) deterministic_verify=$(REPLAY_DETERMINISTIC_VERIFY)'; & python @args; $$rc=$$LASTEXITCODE; if ($$rc -eq 0) { Write-Host '✅ replay-shadow-run completed (bundle_dir is printed by the runner)' } else { Write-Error ('replay-shadow-run failed with exit code ' + $$rc) }; exit $$rc"
 else
 replay-shadow-run:
 	@if [ -z "$(REPLAY_INPUT_CANDLES)" ]; then \
 		echo "ERROR: REPLAY_INPUT_CANDLES is required"; \
-		echo "Usage: make replay-shadow-run REPLAY_INPUT_CANDLES=<candles.json|candles.jsonl> [REPLAY_OUTPUT_DIR=artifacts/replay_reports]"; \
+		echo "Usage: make replay-shadow-run REPLAY_INPUT_CANDLES=<candles.json|candles.jsonl> [REPLAY_OUTPUT_DIR=<explicit-path>]"; \
 		exit 1; \
 	fi
 	@if [ ! -f "$(REPLAY_INPUT_CANDLES)" ]; then \
 		echo "ERROR: input candles file not found: $(REPLAY_INPUT_CANDLES)"; \
 		exit 1; \
 	fi
-	@mkdir -p "$(REPLAY_OUTPUT_DIR)"
 	@dry_flag=""; \
 	if [ "$(REPLAY_DRY_RUN)" = "1" ]; then dry_flag="--dry-run"; fi; \
 	det_flag=""; \
 	if [ "$(REPLAY_DETERMINISTIC_VERIFY)" = "1" ]; then det_flag="--deterministic-verify"; fi; \
+	out_flag=""; \
+	if [ -n "$(REPLAY_OUTPUT_DIR)" ]; then mkdir -p "$(REPLAY_OUTPUT_DIR)"; out_flag="--output-dir $(REPLAY_OUTPUT_DIR)"; fi; \
 	echo "▶ replay-shadow-run"; \
 	echo "  input_candles=$(REPLAY_INPUT_CANDLES)"; \
-	echo "  output_dir=$(REPLAY_OUTPUT_DIR)"; \
+	echo "  output_dir=resolver-default unless REPLAY_OUTPUT_DIR is explicit"; \
 	echo "  strategy_id=$(REPLAY_STRATEGY_ID) symbol=$(REPLAY_SYMBOL) adapter_id=$(REPLAY_ADAPTER_ID)"; \
 	echo "  dry_run=$(REPLAY_DRY_RUN) deterministic_verify=$(REPLAY_DETERMINISTIC_VERIFY)"; \
 	python -m services.validation.strategy_replay_runner \
 		--input-candles "$(REPLAY_INPUT_CANDLES)" \
-		--output-dir "$(REPLAY_OUTPUT_DIR)" \
 		--strategy-id "$(REPLAY_STRATEGY_ID)" \
 		--symbol "$(REPLAY_SYMBOL)" \
 		--adapter-id "$(REPLAY_ADAPTER_ID)" \
-		$$dry_flag \
+		$$out_flag $$dry_flag \
 		$$det_flag; \
 	rc=$$?; \
 	if [ $$rc -eq 0 ]; then \

--- a/docs/evidence/storage/ISSUE_4421_REPLAY_ARVP_OFFLOAD.md
+++ b/docs/evidence/storage/ISSUE_4421_REPLAY_ARVP_OFFLOAD.md
@@ -1,0 +1,33 @@
+# Issue #4421 — Replay/ARVP Bulk-Offload Evidence
+
+Status: Copy- und Integritätsnachweis vor Junction-Retargeting
+
+## Scope-Klassifikation
+
+| Klasse | Bäume | Bytes | Behandlung |
+|---|---:|---:|---|
+| `OFFLOAD` | 67 | 429,267,174 | Nach `Y:\CDB-Storage\replay-arvp` kopiert und verifiziert. |
+| `HOLD` | 2 | 1,245,282,684 | `postgres_restore_3600_work` und `postgres_rebuild_3600_20260701_024237` bleiben unverändert auf E:. |
+
+`HOLD`-Bäume werden weder gelöscht noch retargetet; ihre operative
+Klassifikation liegt außerhalb dieses Issue-Slices.
+
+## Integritätsnachweis
+
+- Quelle: `E:\CDB_artifacts`
+- Ziel: `Y:\CDB-Storage\replay-arvp`
+- Dateien: 15,143 auf Quelle und Ziel
+- Bytes: 429,267,174 auf Quelle und Ziel
+- SHA-256-Manifeste: identischer Fingerprint
+  `de09b87befd2adbd5cb2099169b8494bbb44047256907bb67c14ed89a86c3fe9`
+- Vergleich: keine fehlenden, zusätzlichen oder abweichenden Dateien
+- Persistente Maschinen-Evidence:
+  `Y:\CDB-Storage\evidence\issue-4421\offload_manifest_compare.json`
+
+## Safety Boundaries
+
+- Kein Bulk unter `Y:\Worktrees`.
+- Keine `market_data`-Änderung; diese gehört zu #4420.
+- Keine Docker-Volumes, Runtime-, Live- oder Echtgeld-Aktionen.
+- E:-Quellen und Repo-Junctions bleiben bis zum dokumentierten Consumer-Smoke
+  unverändert.

--- a/docs/evidence/storage/ISSUE_4421_REPLAY_ARVP_OFFLOAD.md
+++ b/docs/evidence/storage/ISSUE_4421_REPLAY_ARVP_OFFLOAD.md
@@ -1,6 +1,6 @@
 # Issue #4421 — Replay/ARVP Bulk-Offload Evidence
 
-Status: Copy- und Integritätsnachweis vor Junction-Retargeting
+Status: Copy-/Integritätsnachweis und versionierbarer Consumer-Cutover
 
 ## Scope-Klassifikation
 
@@ -24,10 +24,52 @@ Klassifikation liegt außerhalb dieses Issue-Slices.
 - Persistente Maschinen-Evidence:
   `Y:\CDB-Storage\evidence\issue-4421\offload_manifest_compare.json`
 
+## Cutover-Mechanismus
+
+Die 66 relevanten Consumer-Pfade werden ohne Verdrängen versionierter Inhalte
+behandelt:
+
+- 49 konfliktfreie Pfade stehen im versionierten Inventory
+  `tools.storage.replay_arvp_storage.JUNCTION_CUTOVER_ROOTS`. Der explizite
+  Helper `apply_replay_arvp_junction_cutover()` erzeugt ausschließlich diese
+  Junctions, nur zu `Y:\CDB-Storage\replay-arvp`, und verweigert fehlende
+  Ziele oder jede vorhandene Nicht-Junction.
+- Die 17 Canon-Konflikte bleiben als versionierte Repo-Verzeichnisse erhalten.
+  Opt-in-Consumer verwenden
+  `resolve_replay_arvp_consumer_path()` bzw.
+  `resolve_replay_arvp_payload_path()`; bei gesetztem
+  `CDB_BULK_STORAGE_ROOT=Y:\CDB-Storage` beziehen sie Bulk-Payload aus
+  `Y:\CDB-Storage\replay-arvp`. Ohne Opt-in bleibt allein der versionierte
+  Canon-Pfad aktiv.
+- Die beiden PostgreSQL-HOLD-Bäume sind weder im Junction-Inventory noch im
+  Resolver-Scope enthalten.
+
+Der Resolver akzeptiert nur die 17 klassifizierten Canon-Roots und lehnt
+fehlende Roots, `E:`, `Y:\Worktrees`, Traversal und nicht verwaltete Pfade
+fail-closed ab. Es gibt keinen E:-Fallback und keine Erzeugung, Kopie,
+Verschiebung oder Löschung von Payload durch den Resolver.
+
+## Consumer- und Layout-Nachweis
+
+- Junction-Apply im sauberen #4421-Worktree: `0` neu erzeugt; alle 49
+  deklarierten Junctions bereits auf Y:, kein E:-Target.
+- 17/17 deklarierte Canon-Bulk-Roots unter
+  `Y:\CDB-Storage\replay-arvp` vorhanden.
+- Strategy-Replay-Default löst nach
+  `Y:\CDB-Storage\replay-arvp\replay_reports` auf.
+- Paper-Reference-Window-Default löst nach
+  `Y:\CDB-Storage\replay-arvp\paper_reference_windows\paper_reference_window.json`
+  auf.
+- Price-Policy-Replay löst seine Calibration-, Recheck-, Candle- und
+  Paper-Reference-Eingaben nach Y: auf; alle vier Ziel-Dateien sind vorhanden.
+- Fokussierte Tests: `121 passed`; gezielter Ruff-Check und
+  `git diff --check`: PASS.
+
 ## Safety Boundaries
 
 - Kein Bulk unter `Y:\Worktrees`.
 - Keine `market_data`-Änderung; diese gehört zu #4420.
 - Keine Docker-Volumes, Runtime-, Live- oder Echtgeld-Aktionen.
-- E:-Quellen und Repo-Junctions bleiben bis zum dokumentierten Consumer-Smoke
-  unverändert.
+- Die E:-Quelle wird in diesem Schritt nicht gelöscht: Der befristete
+  Rückrollbestand bleibt erhalten, bis der gemergte Cutover in einem späteren,
+  ausdrücklich verifizierten Cleanup-Schritt die Source-Retention entscheidet.

--- a/services/validation/paper_reference_window_runner.py
+++ b/services/validation/paper_reference_window_runner.py
@@ -34,6 +34,7 @@ from core.utils.evidence_class import (
     evidence_class_warning_banner,
     validate_evidence_class,
 )
+from tools.storage.replay_arvp_storage import resolve_replay_arvp_consumer_path
 
 _READONLY_DSN_ENV = "POSTGRES_READONLY_PASSWORD_DSN"
 _EXPECTED_READONLY_LOGIN = "cdb_readonly"
@@ -45,6 +46,16 @@ SELECT
   has_table_privilege(current_user, 'public.correlation_ledger', 'UPDATE'),
   has_table_privilege(current_user, 'public.correlation_ledger', 'DELETE')
 """
+
+
+def _default_output_path() -> str:
+    """Resolve the opt-in #4421 external payload path without E: fallback."""
+    return str(
+        resolve_replay_arvp_consumer_path(
+            Path.cwd(),
+            "artifacts/paper_reference_windows/paper_reference_window.json",
+        )
+    )
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -63,7 +74,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     p.add_argument(
         "--output",
-        default="artifacts/paper_reference_windows/paper_reference_window.json",
+        default=_default_output_path(),
         help="Output path for paper_reference_window JSON.",
     )
     p.add_argument(

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -324,10 +324,9 @@ _FALLBACK_CODE_COMMIT = "0000000"
 def _default_output_directory() -> str:
     """Resolve replay output through the opt-in #4421 bulk-root contract."""
     return str(
-        resolve_replay_arvp_consumer_path(
-            Path.cwd(), "artifacts/replay_reports"
-        )
+        resolve_replay_arvp_consumer_path(Path.cwd(), "artifacts/replay_reports")
     )
+
 
 # ---------------------------------------------------------------------------
 # Env vars that are safe to surface in env_redacted.txt

--- a/services/validation/strategy_replay_runner.py
+++ b/services/validation/strategy_replay_runner.py
@@ -99,6 +99,7 @@ from core.replay.dataset_provider import (
     enforce_replay_integrity,
 )
 from core.replay.dataset_spec import DatasetSpec, DatasetSpecError
+from tools.storage.replay_arvp_storage import resolve_replay_arvp_consumer_path
 from core.replay.historical_bridge import (
     HistoricalBridgeError,
     PrimaryBreakoutBridgeConfig,
@@ -318,6 +319,15 @@ _DEFAULT_REPLAY_MODE = "baseline"
 
 _CODE_COMMIT_RE = re.compile(r"^[a-f0-9]{7,40}$")
 _FALLBACK_CODE_COMMIT = "0000000"
+
+
+def _default_output_directory() -> str:
+    """Resolve replay output through the opt-in #4421 bulk-root contract."""
+    return str(
+        resolve_replay_arvp_consumer_path(
+            Path.cwd(), "artifacts/replay_reports"
+        )
+    )
 
 # ---------------------------------------------------------------------------
 # Env vars that are safe to surface in env_redacted.txt
@@ -2020,7 +2030,7 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--output-dir",
-        default=_DEFAULT_OUTPUT_DIR,
+        default=_default_output_directory(),
         metavar="DIR",
         help=f"Root output directory for replay artifact bundles. Default: {_DEFAULT_OUTPUT_DIR!r}",
     )

--- a/tests/unit/storage/test_replay_arvp_storage.py
+++ b/tests/unit/storage/test_replay_arvp_storage.py
@@ -1,0 +1,85 @@
+"""Contract tests for the #4421 versioned replay/ARVP bulk-root resolver."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.storage.replay_arvp_storage import (
+    CONFLICTING_CANON_ROOTS,
+    JUNCTION_CUTOVER_ROOTS,
+    POSTGRES_HOLD_ROOTS,
+    ReplayArvpStorageError,
+    resolve_replay_arvp_consumer_path,
+    resolve_replay_arvp_payload_path,
+)
+
+
+def test_cutover_inventory_covers_49_safe_paths_and_excludes_hold() -> None:
+    assert len(JUNCTION_CUTOVER_ROOTS) == 49
+    assert len(POSTGRES_HOLD_ROOTS) == 2
+    assert not set(JUNCTION_CUTOVER_ROOTS) & POSTGRES_HOLD_ROOTS
+    assert not set(JUNCTION_CUTOVER_ROOTS) & CONFLICTING_CANON_ROOTS
+
+
+@pytest.mark.unit
+def test_conflicting_canon_path_resolves_under_explicit_bulk_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage.resolve_bulk_storage_path",
+        lambda _subtree, environ=None: tmp_path / "replay-arvp",
+    )
+
+    assert resolve_replay_arvp_payload_path(
+        "artifacts/replay_reports/run-1/report.json",
+        environ={"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"},
+    ) == (tmp_path / "replay-arvp" / "replay_reports" / "run-1" / "report.json")
+
+
+@pytest.mark.unit
+def test_missing_explicit_bulk_root_fails_closed() -> None:
+    with pytest.raises(ReplayArvpStorageError, match="BULK_STORAGE_ROOT_REQUIRED"):
+        resolve_replay_arvp_payload_path("artifacts/replay_reports/run-1/report.json")
+
+
+@pytest.mark.unit
+def test_consumer_keeps_repo_canon_without_bulk_opt_in(tmp_path: Path) -> None:
+    assert resolve_replay_arvp_consumer_path(
+        tmp_path,
+        "artifacts/replay_reports/run-1/report.json",
+        environ={},
+    ) == (tmp_path / "artifacts" / "replay_reports" / "run-1" / "report.json")
+
+
+@pytest.mark.unit
+def test_worktree_bulk_root_is_rejected() -> None:
+    with pytest.raises(ReplayArvpStorageError, match="BULK_STORAGE_WORKTREE_ROOT_FORBIDDEN"):
+        resolve_replay_arvp_payload_path(
+            "artifacts/replay_reports/run-1/report.json",
+            environ={"CDB_BULK_STORAGE_ROOT": "Y:\\Worktrees\\Claire_de_Binare"},
+        )
+
+
+@pytest.mark.unit
+def test_e_drive_root_is_rejected() -> None:
+    with pytest.raises(ReplayArvpStorageError, match="BULK_STORAGE_ROOT_INVALID"):
+        resolve_replay_arvp_payload_path(
+            "artifacts/replay_reports/run-1/report.json",
+            environ={"CDB_BULK_STORAGE_ROOT": "E:\\CDB_artifacts"},
+        )
+
+
+@pytest.mark.unit
+def test_path_traversal_and_non_conflicting_roots_are_rejected() -> None:
+    with pytest.raises(ReplayArvpStorageError, match="REPLAY_ARVP_PAYLOAD_PATH_INVALID"):
+        resolve_replay_arvp_payload_path(
+            "artifacts/replay_reports/../market_data/payload.json",
+            environ={"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"},
+        )
+    with pytest.raises(ReplayArvpStorageError, match="REPLAY_ARVP_CANON_ROOT_UNMANAGED"):
+        resolve_replay_arvp_payload_path(
+            "artifacts/market_data/payload.json",
+            environ={"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"},
+        )

--- a/tests/unit/storage/test_replay_arvp_storage.py
+++ b/tests/unit/storage/test_replay_arvp_storage.py
@@ -11,6 +11,7 @@ from tools.storage.replay_arvp_storage import (
     JUNCTION_CUTOVER_ROOTS,
     POSTGRES_HOLD_ROOTS,
     ReplayArvpStorageError,
+    apply_replay_arvp_junction_cutover,
     resolve_replay_arvp_consumer_path,
     resolve_replay_arvp_payload_path,
 )
@@ -89,3 +90,58 @@ def test_path_traversal_and_non_conflicting_roots_are_rejected() -> None:
             "artifacts/market_data/payload.json",
             environ={"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"},
         )
+
+
+@pytest.mark.unit
+def test_existing_junction_must_target_the_expected_y_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    artifact_root = tmp_path / "artifacts"
+    destination = artifact_root / "safe"
+    destination.mkdir(parents=True)
+    target = tmp_path / "replay-arvp" / "safe"
+    target.mkdir(parents=True)
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage.JUNCTION_CUTOVER_ROOTS", ("safe",)
+    )
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage.resolve_bulk_storage_path",
+        lambda _subtree, environ=None: tmp_path / "replay-arvp",
+    )
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage._is_junction", lambda _: True
+    )
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage._junction_targets_expected", lambda *_: False
+    )
+
+    with pytest.raises(
+        ReplayArvpStorageError, match="REPLAY_ARVP_JUNCTION_TARGET_MISMATCH"
+    ):
+        apply_replay_arvp_junction_cutover(tmp_path, environ={})
+
+
+@pytest.mark.unit
+def test_junction_cutover_preflights_all_paths_before_creating_any(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    target_root = tmp_path / "replay-arvp"
+    (target_root / "first").mkdir(parents=True)
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage.JUNCTION_CUTOVER_ROOTS", ("first", "missing")
+    )
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage.resolve_bulk_storage_path",
+        lambda _subtree, environ=None: target_root,
+    )
+    run_calls: list[object] = []
+    monkeypatch.setattr(
+        "tools.storage.replay_arvp_storage.subprocess.run",
+        lambda *args, **kwargs: run_calls.append((args, kwargs)),
+    )
+
+    with pytest.raises(
+        ReplayArvpStorageError, match="REPLAY_ARVP_JUNCTION_TARGET_MISSING"
+    ):
+        apply_replay_arvp_junction_cutover(tmp_path, environ={})
+    assert not run_calls

--- a/tests/unit/storage/test_replay_arvp_storage.py
+++ b/tests/unit/storage/test_replay_arvp_storage.py
@@ -55,7 +55,9 @@ def test_consumer_keeps_repo_canon_without_bulk_opt_in(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_worktree_bulk_root_is_rejected() -> None:
-    with pytest.raises(ReplayArvpStorageError, match="BULK_STORAGE_WORKTREE_ROOT_FORBIDDEN"):
+    with pytest.raises(
+        ReplayArvpStorageError, match="BULK_STORAGE_WORKTREE_ROOT_FORBIDDEN"
+    ):
         resolve_replay_arvp_payload_path(
             "artifacts/replay_reports/run-1/report.json",
             environ={"CDB_BULK_STORAGE_ROOT": "Y:\\Worktrees\\Claire_de_Binare"},
@@ -73,12 +75,16 @@ def test_e_drive_root_is_rejected() -> None:
 
 @pytest.mark.unit
 def test_path_traversal_and_non_conflicting_roots_are_rejected() -> None:
-    with pytest.raises(ReplayArvpStorageError, match="REPLAY_ARVP_PAYLOAD_PATH_INVALID"):
+    with pytest.raises(
+        ReplayArvpStorageError, match="REPLAY_ARVP_PAYLOAD_PATH_INVALID"
+    ):
         resolve_replay_arvp_payload_path(
             "artifacts/replay_reports/../market_data/payload.json",
             environ={"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"},
         )
-    with pytest.raises(ReplayArvpStorageError, match="REPLAY_ARVP_CANON_ROOT_UNMANAGED"):
+    with pytest.raises(
+        ReplayArvpStorageError, match="REPLAY_ARVP_CANON_ROOT_UNMANAGED"
+    ):
         resolve_replay_arvp_payload_path(
             "artifacts/market_data/payload.json",
             environ={"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"},

--- a/tools/replay/evaluate_price_policies.py
+++ b/tools/replay/evaluate_price_policies.py
@@ -24,16 +24,23 @@ from typing import Any
 from core.replay.historical_bridge import VALID_PRICE_POLICIES
 from services.signal.config import SignalConfig
 from services.signal.service import SignalEngine
+from tools.storage.replay_arvp_storage import resolve_replay_arvp_consumer_path
 
 logging.disable(logging.CRITICAL)
 
 _ARTIFACT_DIR = pathlib.Path("artifacts/price_policy_evaluation_3079")
-_PILOT_CANDLES_PATH = pathlib.Path("artifacts/calibration/2961/pilot_candles.json")
-_PILOT_PAPER_PATH = pathlib.Path(
+
+
+def _consumer_path(relative_path: str) -> pathlib.Path:
+    return resolve_replay_arvp_consumer_path(pathlib.Path.cwd(), relative_path)
+
+
+_PILOT_CANDLES_PATH = _consumer_path("artifacts/calibration/2961/pilot_candles.json")
+_PILOT_PAPER_PATH = _consumer_path(
     "artifacts/recheck_2980/pilot_window_causal/paper_reference_window.json"
 )
-_W3028_CANDLES_PATH = pathlib.Path("artifacts/candles/3028_window/candles.json")
-_W3028_PAPER_PATH = pathlib.Path(
+_W3028_CANDLES_PATH = _consumer_path("artifacts/candles/3028_window/candles.json")
+_W3028_PAPER_PATH = _consumer_path(
     "artifacts/paper_reference_windows/paper_reference_window.json"
 )
 

--- a/tools/storage/replay_arvp_storage.py
+++ b/tools/storage/replay_arvp_storage.py
@@ -18,7 +18,6 @@ from tools.storage.bulk_storage_contract import (
     resolve_bulk_storage_path,
 )
 
-
 CONFLICTING_CANON_ROOTS = frozenset(
     {
         "backtests",

--- a/tools/storage/replay_arvp_storage.py
+++ b/tools/storage/replay_arvp_storage.py
@@ -137,7 +137,9 @@ def resolve_replay_arvp_payload_path(
         bulk_root = resolve_bulk_storage_path("replay-arvp", environ=environ)
     except BulkStorageContractError as exc:
         raise ReplayArvpStorageError(str(exc)) from exc
-    return bulk_root.joinpath(*parts[1:])
+    payload_path = bulk_root.joinpath(*parts[1:])
+    _reject_reparse_components(payload_path)
+    return payload_path
 
 
 def resolve_replay_arvp_consumer_path(
@@ -170,6 +172,25 @@ def _is_junction(path: Path) -> bool:
         return path.is_symlink()
 
 
+def _reject_reparse_components(path: Path) -> None:
+    """Refuse an existing redirected subtree below the canonical bulk root."""
+    current = path
+    while True:
+        if current.exists() and _is_junction(current):
+            raise ReplayArvpStorageError("REPLAY_ARVP_PAYLOAD_REPARSE_POINT")
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
+def _junction_targets_expected(destination: Path, target: Path) -> bool:
+    try:
+        return os.path.samefile(destination, target)
+    except OSError:
+        return False
+
+
 def apply_replay_arvp_junction_cutover(
     repo_root: Path,
     *,
@@ -183,7 +204,7 @@ def apply_replay_arvp_junction_cutover(
     """
     target_root = resolve_bulk_storage_path("replay-arvp", environ=environ)
     artifact_root = repo_root / "artifacts"
-    created: list[Path] = []
+    plan: list[tuple[Path, Path]] = []
     for name in JUNCTION_CUTOVER_ROOTS:
         destination = artifact_root / name
         target = target_root / name
@@ -192,7 +213,13 @@ def apply_replay_arvp_junction_cutover(
         if destination.exists() or destination.is_symlink():
             if not _is_junction(destination):
                 raise ReplayArvpStorageError("REPLAY_ARVP_JUNCTION_COLLISION")
-            continue
+            if not _junction_targets_expected(destination, target):
+                raise ReplayArvpStorageError("REPLAY_ARVP_JUNCTION_TARGET_MISMATCH")
+        else:
+            plan.append((destination, target))
+
+    created: list[Path] = []
+    for destination, target in plan:
         subprocess.run(
             ["cmd", "/c", "mklink", "/J", str(destination), str(target)],
             check=True,

--- a/tools/storage/replay_arvp_storage.py
+++ b/tools/storage/replay_arvp_storage.py
@@ -1,0 +1,204 @@
+"""Fail-closed resolver for #4421 replay/ARVP bulk payloads.
+
+Versioned ``artifacts/<root>`` files remain inside the checkout.  Consumers
+that explicitly opt into bulk payload resolution use this module instead of a
+junction, so that a local E: target can never become an implicit fallback.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import Mapping
+
+from tools.storage.bulk_storage_contract import (
+    BulkStorageContractError,
+    resolve_bulk_storage_path,
+)
+
+
+CONFLICTING_CANON_ROOTS = frozenset(
+    {
+        "backtests",
+        "batch_compare",
+        "calibration",
+        "candles",
+        "context_tool_inventory",
+        "controlled_lab_evidence",
+        "drift_classification",
+        "evidence_harvester",
+        "execution_realism",
+        "mcp",
+        "paper_reference_windows",
+        "recheck_2980",
+        "regime_scorecards",
+        "replay_reports",
+        "signal_reproduction",
+        "skills",
+        "surrealdb",
+    }
+)
+
+# These are the only non-HOLD junctions observed in the pre-cutover topology
+# that do not collide with tracked canonical repository content.  Keeping this
+# inventory in version control makes a clean checkout reproducible without
+# treating a junction farm as an unreviewable machine-local side effect.
+JUNCTION_CUTOVER_ROOTS = (
+    "arvp",
+    "arvp_loops",
+    "arvp_replay_paper_pilot",
+    "arvp_vacation",
+    "audit-3304",
+    "calibration_run_001",
+    "campaigns",
+    "context-intelligence",
+    "datasets",
+    "evidence",
+    "evidence_scenario_runs",
+    "local-branch-cleanup",
+    "local-control-followup",
+    "local-dev-hygiene",
+    "local-hygiene",
+    "local-wrapper",
+    "loop-check",
+    "price_policy_evaluation_3079",
+    "redis_aof_recovery_20260529_004112",
+    "redis_rebuild_3594_20260701_023436",
+    "replay_smoke",
+    "replay_vs_paper_compare",
+    "shadow_interim",
+    "soak_ABORTED_20260322_120002",
+    "soak_ABORTED_20260322_181245_premature",
+    "soak_test_20260310_172922",
+    "soak_test_20260311_000002_FAILED_legacy_migration",
+    "soak_test_20260311_124500",
+    "soak_test_20260312_000001",
+    "soak_test_20260313_110003",
+    "soak_test_20260314_100003",
+    "soak_test_20260315_110003",
+    "soak_test_20260316_110003",
+    "soak_test_20260317_000002",
+    "soak_test_20260318_090002",
+    "soak_test_20260319_000002",
+    "soak_test_20260320_110005",
+    "soak_test_20260321_120003",
+    "soak_test_20260322_181856",
+    "soak_test_20260323_000002",
+    "soak_test_20260324_000002",
+    "soak_test_20260324_224419",
+    "soak_test_20260325_114548",
+    "soak_test_20260325_121250",
+    "soak_test_20260401_114850",
+    "soak_validation_20260325_110047",
+    "telemetry_sidecar",
+    "tmp",
+    "validation_1277_20260325_095757",
+)
+
+POSTGRES_HOLD_ROOTS = frozenset(
+    {"postgres_restore_3600_work", "postgres_rebuild_3600_20260701_024237"}
+)
+
+
+class ReplayArvpStorageError(ValueError):
+    """Raised when a replay/ARVP bulk payload cannot be resolved safely."""
+
+
+def _parts(relative_path: str | Path) -> tuple[str, ...]:
+    raw = str(relative_path).replace("\\", "/")
+    candidate = PurePosixPath(raw)
+    parts = candidate.parts
+    if (
+        not raw
+        or candidate.is_absolute()
+        or len(parts) < 2
+        or parts[0] != "artifacts"
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ReplayArvpStorageError("REPLAY_ARVP_PAYLOAD_PATH_INVALID")
+    return parts
+
+
+def resolve_replay_arvp_payload_path(
+    relative_path: str | Path,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Resolve a declared conflicting artifact payload below canonical Y: storage.
+
+    This is opt-in: missing configuration is an error and no repository-local
+    or E:-drive fallback is permitted.
+    """
+    parts = _parts(relative_path)
+    if parts[1] not in CONFLICTING_CANON_ROOTS:
+        raise ReplayArvpStorageError("REPLAY_ARVP_CANON_ROOT_UNMANAGED")
+    try:
+        bulk_root = resolve_bulk_storage_path("replay-arvp", environ=environ)
+    except BulkStorageContractError as exc:
+        raise ReplayArvpStorageError(str(exc)) from exc
+    return bulk_root.joinpath(*parts[1:])
+
+
+def resolve_replay_arvp_consumer_path(
+    repo_root: Path,
+    relative_path: str | Path,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Return repo canon by default, or configured bulk payload when opted in.
+
+    This preserves checked-in evidence for normal repository reads.  An explicit
+    ``CDB_BULK_STORAGE_ROOT`` changes only declared conflicting roots and never
+    selects E: as a fallback.
+    """
+    env = os.environ if environ is None else environ
+    parts = _parts(relative_path)
+    if parts[1] not in CONFLICTING_CANON_ROOTS:
+        raise ReplayArvpStorageError("REPLAY_ARVP_CANON_ROOT_UNMANAGED")
+    if not env.get("CDB_BULK_STORAGE_ROOT", "").strip():
+        return repo_root.joinpath(*parts)
+    return resolve_replay_arvp_payload_path(relative_path, environ=env)
+
+
+def _is_junction(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        return bool(path.lstat().st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    except AttributeError:
+        return path.is_symlink()
+
+
+def apply_replay_arvp_junction_cutover(
+    repo_root: Path,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> tuple[Path, ...]:
+    """Create only the 49 declared safe junctions; never overwrite canon/HOLD.
+
+    The caller must explicitly opt in through the #4419 bulk-root contract.
+    Existing non-junction paths are a hard error, making a collision impossible
+    to hide behind a successful partial cutover.
+    """
+    target_root = resolve_bulk_storage_path("replay-arvp", environ=environ)
+    artifact_root = repo_root / "artifacts"
+    created: list[Path] = []
+    for name in JUNCTION_CUTOVER_ROOTS:
+        destination = artifact_root / name
+        target = target_root / name
+        if not target.is_dir():
+            raise ReplayArvpStorageError("REPLAY_ARVP_JUNCTION_TARGET_MISSING")
+        if destination.exists() or destination.is_symlink():
+            if not _is_junction(destination):
+                raise ReplayArvpStorageError("REPLAY_ARVP_JUNCTION_COLLISION")
+            continue
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(destination), str(target)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        created.append(destination)
+    return tuple(created)


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: ci-tooling
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: accepting_slices
objective_key: issue-4421
planned_issues: #4421
contract_keys: ci-tooling-v1
risk_flags: none
-->

## Kurzbefund

- #4421 liefert einen versionierbaren, fail-closed Cutover für Replay-/ARVP-Bulkpfade nach `Y:\CDB-Storage\replay-arvp`, ohne versionierte Repo-Canon-Pfade zu verdrängen.

## Warum jetzt

- Die Copy-first-Integritätsevidence ist grün; die 17 Canon-Konflikte verhinderten jedoch einen reinen Junction-Cutover.

## Scope

- In: 17-Pfad-Resolver, 49-Pfad-Junction-Inventar, Replay-/Paper-/Price-Policy-Consumer und Evidence.
- Out: PostgreSQL-HOLD, D:-Hauptcheckout, E:-Löschung, Docker, Runtime, Live-/Echtgeld- und LR-Änderungen.

## Betroffene Dateien / Artefakte

- `tools/storage/replay_arvp_storage.py`
- Replay-, Paper-Reference- und Price-Policy-Consumer
- `docs/evidence/storage/ISSUE_4421_REPLAY_ARVP_OFFLOAD.md`
- fokussierte Resolver-/Contract-Tests

## Delivered

- 17-path Canon Conflict Resolution: expliziter Resolver bewahrt Repo-Canon und löst Bulk-Payload nur bei opt-in nach Y: auf.
- 49-path Junction Cutover: versioniertes Safe-Path-Inventory; Apply verweigert fehlende Ziele und Nicht-Junction-Kollisionen.
- 66/66 Consumer Cutover Evidence: 49 Y:-Junctions ohne E:-Target; 17/17 Canon-Bulk-Roots auf Y: vorhanden und Resolver-Smokes grün.
- PostgreSQL HOLD Evidence: 2/2 Roots außerhalb des Inventory und unverändert.
- Integrity Evidence: 15.143 Dateien, 429.267.174 Bytes, SHA-256 `de09b87befd2adbd5cb2099169b8494bbb44047256907bb67c14ed89a86c3fe9`.

## Validierung / Checks

- `python -m pytest -q tests/unit/storage/test_replay_arvp_storage.py tests/unit/tools/test_bulk_storage_contract.py tests/unit/validation/test_strategy_replay_runner.py tests/unit/validation/test_paper_reference_window_runner.py` — 121 passed
- gezielter `ruff check` — PASS
- `git diff --check` — PASS
- reale Resolver-/Consumer-Smokes gegen `Y:\CDB-Storage` — PASS

## Risiken / Guardrails

- Kein E:-Fallback; ungültige Roots, `Y:\Worktrees`, Traversal und nicht verwaltete Roots schlagen fail-closed fehl.
- Keine Ersetzung versionierter Dateien und keine Datenmutation durch Resolver/Junction-Apply.
- Die E:-Quelle bleibt als Rückrollbestand erhalten; keine ungeprüfte Löschung.

## Restunsicherheiten

- Die aktuelle Quelle wird erst in einem gesondert verifizierten Retention-/Cleanup-Schritt bewertet.

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4421 | SLICE_DELIVERED | 8d5cd022ce7613a8648ecd22283098eefc4e3822 | 121 tests, Ruff, diff check, Y:-consumer smokes | storage-cutover | E:-source retained pending verified cleanup |

Closes #4421

Refs #4417
