### PR TITLE
ci: fail closed on incompatible MCP SDK

### DIFF
--- a/ci/scripts/run.py
+++ b/ci/scripts/run.py
@@ -50,12 +50,14 @@ from ci.stages import docs as stage_docs  # noqa: E402
 from ci.stages import governance as stage_governance  # noqa: E402
 from ci.stages import integration as stage_integration  # noqa: E402
 from ci.stages import lint as stage_lint  # noqa: E402
+from ci.stages import mcp_dependency_closure  # noqa: E402
 from ci.stages import report as stage_report  # noqa: E402
 from ci.stages import security as stage_security  # noqa: E402
 from ci.stages import unit as stage_unit  # noqa: E402
 from ci.stages._common import StageContext  # noqa: E402
 
 STAGE_RUNNERS = {
+    "mcp_dependency_closure": mcp_dependency_closure.run,
     "lint": stage_lint.run,
     "unit": stage_unit.run,
     "docs": stage_docs.run,
@@ -310,6 +312,51 @@ def run_ci(
 
     ctx.temp_root = preflight.temp_root
     ctx.temp_env = temp_env_for(preflight.temp_root)
+
+    if "unit" in selected:
+        print("==> stage mcp_dependency_closure", flush=True)
+        result = mcp_dependency_closure.run(ctx)
+        print(
+            f"<== stage mcp_dependency_closure status={result.status} exit={result.exit_code}",
+            flush=True,
+        )
+        stage_results.append(result)
+        if result.status != "PASS":
+            report_result = stage_report.run(ctx, stage_results)
+            stage_results.append(report_result)
+            artifact_paths = sorted(run_dir.rglob("*"))
+            artifact_paths = [path for path in artifact_paths if path.is_file()]
+            artifact_hashes = hash_artifacts(artifact_paths, relative_to=run_dir)
+            ended = utc_now()
+            docker_v, compose_v = _docker_versions()
+            manifest = build_manifest(
+                run_id=rid,
+                commit_sha=git.commit_sha,
+                branch=git.branch,
+                dirty_worktree=git.dirty_worktree,
+                started_at_utc=started,
+                ended_at_utc=ended,
+                host_platform=platform.platform(),
+                tool_versions={
+                    "python": platform.python_version(),
+                    "ruff": _tool_version(["ruff", "--version"]),
+                    "pytest": _tool_version(
+                        [sys.executable, "-m", "pytest", "--version"]
+                    ),
+                },
+                docker_version=docker_v,
+                compose_version=compose_v,
+                profile=profile if not stage else f"stage:{stage}",
+                stages=stage_results,
+                skipped_checks=skipped_checks,
+                artifact_hashes=artifact_hashes,
+                repo_name=git.repo_name,
+                merge_evidence=merge_evidence,
+            )
+            write_manifest(run_dir, manifest)
+            print(f"overall_status={manifest['overall_status']}", flush=True)
+            print(f"evidence={run_dir}", flush=True)
+            return 1
 
     for name in selected:
         if name == "report":

--- a/ci/stages/mcp_dependency_closure.py
+++ b/ci/stages/mcp_dependency_closure.py
@@ -1,0 +1,104 @@
+"""Fail-closed MCP SDK preflight for unit-test collection."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import time
+from pathlib import Path
+
+from ci.lib.evidence import StageResult, utc_now
+from ci.stages._common import StageContext
+
+MCP_SDK_VERSION_MISMATCH = "MCP_SDK_VERSION_MISMATCH"
+MCP_SERVER_LIST_TOOLS_UNAVAILABLE = "MCP_SERVER_LIST_TOOLS_UNAVAILABLE"
+MCP_REQUIREMENTS_PIN_MISSING = "MCP_REQUIREMENTS_PIN_MISSING"
+
+
+def _pinned_mcp_version(repo_root: Path) -> str:
+    requirements = repo_root / "requirements-mcp.txt"
+    for line in requirements.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("mcp=="):
+            return stripped.split("==", maxsplit=1)[1].strip()
+    raise ValueError(f"{MCP_REQUIREMENTS_PIN_MISSING}: mcp== pin not found")
+
+
+def _validate_mcp_sdk(repo_root: Path) -> tuple[str, str]:
+    expected = _pinned_mcp_version(repo_root)
+    try:
+        active = importlib.metadata.version("mcp")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise ValueError(
+            f"{MCP_SDK_VERSION_MISMATCH}: active mcp package is missing"
+        ) from exc
+    if active != expected:
+        raise ValueError(
+            f"{MCP_SDK_VERSION_MISMATCH}: active mcp {active} does not match pin {expected}"
+        )
+    from mcp.server import Server
+
+    if not hasattr(Server, "list_tools"):
+        raise ValueError(
+            f"{MCP_SERVER_LIST_TOOLS_UNAVAILABLE}: mcp {active} Server.list_tools is unavailable"
+        )
+    return expected, active
+
+
+def run(ctx: StageContext) -> StageResult:
+    """Record MCP SDK closure before pytest can import MCP server modules."""
+    started = utc_now()
+    wall_start = time.perf_counter()
+    log_path = ctx.logs_dir / "mcp_dependency_closure.log"
+    try:
+        expected, active = _validate_mcp_sdk(ctx.repo_root)
+    except (OSError, ValueError) as exc:
+        message = str(exc)
+        reason_code = next(
+            (
+                code
+                for code in (
+                    MCP_REQUIREMENTS_PIN_MISSING,
+                    MCP_SDK_VERSION_MISMATCH,
+                    MCP_SERVER_LIST_TOOLS_UNAVAILABLE,
+                )
+                if message.startswith(code)
+            ),
+            MCP_SDK_VERSION_MISMATCH,
+        )
+        log_path.write_text(message + "\n", encoding="utf-8")
+        return StageResult(
+            name="mcp_dependency_closure",
+            status="FAIL",
+            exit_code=1,
+            started_at_utc=started,
+            ended_at_utc=utc_now(),
+            duration_seconds=round(time.perf_counter() - wall_start, 3),
+            command_summary=[
+                "validate requirements-mcp.txt active mcp SDK",
+                f"reason_code={reason_code}",
+            ],
+            log_path=str(log_path.relative_to(ctx.run_dir).as_posix()),
+            artifacts=[],
+            skip_reason=None,
+            required=True,
+            reason_code=reason_code,
+        )
+
+    log_path.write_text(
+        f"mcp_pin={expected}\nactive_mcp={active}\nServer.list_tools=available\n",
+        encoding="utf-8",
+    )
+    return StageResult(
+        name="mcp_dependency_closure",
+        status="PASS",
+        exit_code=0,
+        started_at_utc=started,
+        ended_at_utc=utc_now(),
+        duration_seconds=round(time.perf_counter() - wall_start, 3),
+        command_summary=["validate requirements-mcp.txt active mcp SDK"],
+        log_path=str(log_path.relative_to(ctx.run_dir).as_posix()),
+        artifacts=[],
+        skip_reason=None,
+        required=True,
+        reason_code=None,
+    )

--- a/tests/unit/ci/test_mcp_dependency_closure_contract.py
+++ b/tests/unit/ci/test_mcp_dependency_closure_contract.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from pathlib import Path
+from ci.stages import mcp_dependency_closure
 
 pytestmark = pytest.mark.unit
 
@@ -28,3 +30,23 @@ def test_mcp_fast_ci_dependency_closure_pins_pydantic_core_pair() -> None:
     assert requirements["mcp-server-time"] == "2026.7.10"
     assert requirements["pydantic"] == "2.14.0b1"
     assert requirements["pydantic-core"] == "2.48.0"
+
+
+def test_mcp_dependency_closure_rejects_an_incompatible_active_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        mcp_dependency_closure.importlib.metadata,
+        "version",
+        lambda name: "2.0.0",
+    )
+
+    with pytest.raises(ValueError, match="MCP_SDK_VERSION_MISMATCH"):
+        mcp_dependency_closure._validate_mcp_sdk(REPO_ROOT)
+
+
+def test_mcp_dependency_closure_accepts_the_pinned_sdk() -> None:
+    expected, active = mcp_dependency_closure._validate_mcp_sdk(REPO_ROOT)
+
+    assert expected == "1.28.1"
+    assert active == expected


### PR DESCRIPTION
<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: ci-tooling
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: accepting_slices
objective_key: issue-4449
planned_issues: #4449
contract_keys: none
risk_flags: none
-->

## Kurzbefund

- Fast-CI prüft vor der Unit-Test-Collection den aktiven MCP-SDK-Pin aus `requirements-mcp.txt` und die Verfügbarkeit von `Server.list_tools`.
- Bei Abweichung wird ein eindeutiger Fail-Code samt lokalem Evidence-Manifest erzeugt; der globale MCP-2.0.0-Fallback wird nicht mehr als Pytest-Importfehler verschleiert.

## Warum jetzt

- #4448 ist auf `23e1c3af4bf39b62e30d27ff69d678660597574e` eingefroren; dessen Final-Head-Fast-CI wurde durch einen lokalen MCP-SDK-Drift blockiert.

## Scope

- In: lokaler Fast-CI-Preflight für MCP-Pin und `Server.list_tools`, dazu Regressionstests.
- Out: #4448-Head, Grafana-Runtime, Docker-Rebuild, MCP-Server-Verhalten und Abhängigkeits-Upgrades.

## Betroffene Dateien / Artefakte

- `ci/scripts/run.py`
- `ci/stages/mcp_dependency_closure.py`
- `tests/unit/ci/test_mcp_dependency_closure_contract.py`

## Validierung / Checks

- `python -m pytest -q tests/unit/ci/test_mcp_dependency_closure_contract.py` -> 3 passed
- `python -m ruff check ci/scripts/run.py ci/stages/mcp_dependency_closure.py tests/unit/ci/test_mcp_dependency_closure_contract.py` -> PASS
- `git diff --check` -> PASS
- Negativpfad mit globalem `mcp 2.0.0` -> vor Unit-Collection `MCP_SDK_VERSION_MISMATCH`, Evidence-Manifest geschrieben

## Risiken / Guardrails

- Der Preflight ist nur für CI-Läufe mit Unit-Stage aktiv und fail-closed.
- Lokale Evidence ist kein GitHub Required Check; keine Runtime-Mutation und keine Änderung an #4448.

## Restunsicherheiten

- Dieser Slice ist noch nicht gemergt. Der erneute #4448-Fast-CI-Lauf wird exakt auf dessen eingefrorenem Head in einer sauber gepinnten lokalen Umgebung ausgeführt.

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4449 | SLICE_DELIVERED | 3152564c9fb520d259156f7c378d66d01bbfbe6d | 3 MCP closure tests, Ruff, diff check, mismatch evidence | ci-tooling | PR #4450 remains open; #4448 remains frozen |

## Issue-Bezug

Closes #4449

Status: DONE_SLICE_ADDED_TO_BATCH_PR
