### PR TITLE
[ARVP][CAMPAIGN] Resolve window-bank parent discovery for Y: worktrees

### DIFF
--- a/docs/runbooks/arvp_hh_hl_execution_window_bank.md
+++ b/docs/runbooks/arvp_hh_hl_execution_window_bank.md
@@ -24,7 +24,9 @@ Preference order:
 
 1. `CDB_WINDOW_BANK_ROOT` / `CDB_DATASET_ROOT`
 2. `<EXEC_ROOT>/artifacts/market_data` (local tree or junction)
-3. Parent Claire_de_Binare checkout `artifacts/market_data` (`.worktrees/<name>` layout)
+3. Parent checkout `artifacts/market_data`, discovered only from a known Git
+   worktree layout: `<checkout>/.worktrees/<name>` or
+   `Y:\\Worktrees\\<repo>\\<name>` with matching `.git/worktrees/<name>` metadata.
 
 All 39 locked Batch-A development windows must be present. No candle copy.
 No dataset content mutation.

--- a/tests/unit/arvp/test_hh_hl_execution_window_bank.py
+++ b/tests/unit/arvp/test_hh_hl_execution_window_bank.py
@@ -68,6 +68,61 @@ def test_resolve_falls_back_to_parent_worktree_layout(tmp_path: Path) -> None:
     assert resolved.source_kind == "parent"
 
 
+def _governed_y_worktree(
+    tmp_path: Path, repo_name: str = "Claire_de_Binare"
+) -> tuple[Path, Path]:
+    checkout = tmp_path / "checkouts" / repo_name
+    worktree_git_dir = checkout / ".git" / "worktrees" / "exact-sha-exec"
+    worktree_git_dir.mkdir(parents=True)
+    worktree = tmp_path / "Worktrees" / repo_name / "exact-sha-exec"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+    return checkout, worktree
+
+
+def test_resolve_falls_back_to_parent_governed_y_worktree_layout(
+    tmp_path: Path,
+) -> None:
+    checkout, worktree = _governed_y_worktree(tmp_path)
+    bank = _fake_complete_bank(checkout)
+
+    assert parent_checkout_root(worktree) == checkout.resolve()
+    resolved = resolve_execution_window_bank(worktree)
+
+    assert resolved is not None
+    assert resolved.window_bank_root == bank.resolve()
+    assert resolved.source_kind == "parent"
+
+
+def test_governed_y_worktree_rejects_repo_name_mismatch(tmp_path: Path) -> None:
+    checkout, worktree = _governed_y_worktree(tmp_path, repo_name="OtherRepo")
+    _fake_complete_bank(checkout)
+    misplaced = tmp_path / "Worktrees" / "Claire_de_Binare" / worktree.name
+    misplaced.parent.mkdir(parents=True)
+    worktree.rename(misplaced)
+
+    assert parent_checkout_root(misplaced) is None
+    assert resolve_execution_window_bank(misplaced) is None
+
+
+def test_incomplete_governed_y_worktree_fails_closed(tmp_path: Path) -> None:
+    incomplete = tmp_path / "Worktrees" / "Claire_de_Binare" / "exact-sha-exec"
+    incomplete.mkdir(parents=True)
+
+    assert parent_checkout_root(incomplete) is None
+    assert resolve_execution_window_bank(incomplete) is None
+
+
+def test_ensure_link_uses_governed_y_worktree_parent(tmp_path: Path) -> None:
+    checkout, worktree = _governed_y_worktree(tmp_path)
+    _fake_complete_bank(checkout)
+
+    result = ensure_worktree_market_data_link(worktree)
+
+    assert result["action"] == "linked"
+    assert Path(result["target"]) == (checkout / "artifacts" / "market_data").resolve()
+
+
 def test_assert_fail_closed_when_incomplete(tmp_path: Path) -> None:
     bank = local_window_bank_root(tmp_path)
     # Only one window — incomplete.

--- a/tools/arvp_vacation/hh_hl_execution_window_bank.py
+++ b/tools/arvp_vacation/hh_hl_execution_window_bank.py
@@ -83,16 +83,37 @@ def local_window_bank_root(repo_root: Path) -> Path:
 
 
 def parent_checkout_root(repo_root: Path) -> Path | None:
-    """Best-effort parent Claire_de_Binare checkout for ``.worktrees/<name>``."""
+    """Return the deterministic parent checkout for known Git worktree layouts."""
     root = Path(repo_root).resolve()
     # Common layout: <checkout>/.worktrees/<wt-name>
     if root.parent.name == ".worktrees":
         return root.parent.parent
-    # Alternate: sibling worktree folders named Claire_de_Binare-*
-    sibling = root.parent / "Claire_de_Binare"
-    if sibling.is_dir() and (sibling / "artifacts" / "market_data").is_dir():
-        return sibling
-    return None
+
+    # Governed Windows layout: Y:/Worktrees/<repo>/<worktree>.  A worktree's
+    # .git file points to <checkout>/.git/worktrees/<worktree>; derive the
+    # checkout from that Git metadata instead of guessing from nearby folders.
+    if root.parent.parent.name != "Worktrees":
+        return None
+    git_file = root / ".git"
+    try:
+        git_pointer = git_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not git_pointer.startswith("gitdir: "):
+        return None
+    worktree_git_dir = Path(git_pointer.removeprefix("gitdir: ").strip())
+    if not worktree_git_dir.is_absolute():
+        worktree_git_dir = git_file.parent / worktree_git_dir
+    worktree_git_dir = worktree_git_dir.resolve()
+    if (
+        worktree_git_dir.parent.name != "worktrees"
+        or worktree_git_dir.name != root.name
+    ):
+        return None
+    checkout = worktree_git_dir.parent.parent.parent
+    if checkout.name != root.parent.name or not (checkout / ".git").is_dir():
+        return None
+    return checkout
 
 
 def _windows_complete(bank: Path) -> bool:


### PR DESCRIPTION
## Kurzbefund

- Resolves the parent checkout for governed `Y:\\Worktrees\\<repo>\\<name>` worktrees from matching Git metadata.
- Retains legacy `.worktrees/<name>` support and fails closed for missing or mismatched metadata.

## Scope

- In: deterministic Window-Bank parent discovery, focused unit tests, and runbook clarification.
- Out: campaign execution, dataset or junction mutation, and trading/runtime changes.

<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: validation-research
lane: validation-research
base_branch: main
validation_profile: validation-research-v1
merge_mode: batch
steward_state: frozen
objective_key: issue-4403
planned_issues: #4403
contract_keys: none
risk_flags: none
-->

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4403 | SLICE_DELIVERED | 4e7ae2f447e624c5f7731c15aa35664dcc045c23 | `pytest -q tests/unit/arvp/test_hh_hl_execution_window_bank.py` (11 passed); Ruff; Black; `git diff --check` | none | No real Y: data or junction was accessed or changed. |

Closes #4403
