### PR TITLE
[OPS][LOGS] Add fail-closed event archive planner

### DIFF
--- a/docs/runbooks/cdb_event_log_archive.md
+++ b/docs/runbooks/cdb_event_log_archive.md
@@ -35,14 +35,34 @@ read-only planbar, erscheint aber als `HOLD_DESTINATION_ROOT_REQUIRED` und
 blockiert jeden späteren Apply. Ein vorhandenes Ziel mit abweichendem Hash ist
 `HOLD`; ein identisches vorhandenes Ziel ist als Resume-Fall zulässig.
 
-## Apply-Gate (nicht Teil von #4422 v1)
+## Apply-Vertrag
 
-Ein späterer, separat autorisierter Apply darf erst nach erneutem Plan, stabiler
-Quelle und vollständigem Copy-Verify handeln: Größe und SHA-256 von Quelle und
-Ziel müssen übereinstimmen. Jede nach Planung veränderte Quelle, jeder
-Hash-Mismatch oder jede Zielkollision mit abweichendem Inhalt blockiert. Ein
-Source-Unlink ist erst danach zulässig. Dieser v1-Slice bietet keinen
-Copy/Delete-Apply.
+`python -m tools.storage.log_archive apply --plan <plan.json>
+--expected-fingerprint <sha256> --evidence-output <result.json>` verarbeitet
+nie einen neu bestimmten Scope: ausschließlich `ARCHIVE_CANDIDATE`-Einträge des
+gebundenen Plans. Der erwartete Fingerprint ist Pflicht und muss sowohl dem
+eingebetteten Plan-Fingerprint als auch der kanonischen Serialisierung des
+Plans entsprechen. Abweichungen stoppen vor jedem Copy.
+
+Vor Copy, nach Copy und unmittelbar vor Source-Delete werden Pfad, Größe und
+SHA-256 geprüft. Copy, Destination-Verify und Delete bleiben pro Datei strikt
+getrennt. Ein vorhandenes, exakt gleiches Ziel ist ein zulässiger Resume-Fall;
+ein abweichendes oder nicht reguläres Ziel ist `HELD_DESTINATION_COLLISION`.
+Source-, Größen-, Hash-, Traversal- oder Reparse-Drift hält den Apply an und
+löscht die Quelle nicht. `_archive_*`, `_quarantine`, absolute oder `..`-Pfade
+sowie Ziele außerhalb des kanonischen `logs/events`-Subtrees werden nie
+ausgeführt.
+
+Der Apply schreibt atomar maschinenlesbare Evidence. Schema
+`cdb.log-archive-apply-result/v1` enthält mindestens Schema, Issue,
+Plan-Fingerprint, Quelle/Ziel, Start/Ende, Plan-/Copy-/Resume-/Verify-/Delete-
+und Hold-Zähler samt Bytes, Ergebnis und Entry-Liste. Jeder Entry enthält
+relativen Pfad, erwartete Größe/Hash, Zielpfad, Disposition,
+Destination-Verifikation, Source-Delete und Failure-Reason.
+
+Der spätere kanonische Evidence-Pfad lautet
+`Y:\\CDB-Storage\\evidence\\issue-4422\\archive_apply_result.json`; diese
+Session erzeugt ihn nicht und führt keinen realen lokalen Apply aus.
 
 ## Nicht-Ziele
 

--- a/docs/runbooks/cdb_event_log_archive.md
+++ b/docs/runbooks/cdb_event_log_archive.md
@@ -60,6 +60,13 @@ und Hold-Zähler samt Bytes, Ergebnis und Entry-Liste. Jeder Entry enthält
 relativen Pfad, erwartete Größe/Hash, Zielpfad, Disposition,
 Destination-Verifikation, Source-Delete und Failure-Reason.
 
+Vor der ersten Datenmutation muss der Runner ein Journal mit
+`APPLY_STARTED` atomar schreiben. Vor jedem Delete wird `DELETE_PENDING`
+persistiert, danach `APPLY_IN_PROGRESS`; erst der Abschluss trägt
+`APPLY_COMPLETED`. Scheitert die Journal-Initialisierung, beginnt kein Apply.
+Scheitert ein späterer Journal-Write, stoppt der Runner vor weiteren Deletes;
+das zuletzt persistierte Journal bleibt als Grenze der Audit-Evidence erhalten.
+
 Der spätere kanonische Evidence-Pfad lautet
 `Y:\\CDB-Storage\\evidence\\issue-4422\\archive_apply_result.json`; diese
 Session erzeugt ihn nicht und führt keinen realen lokalen Apply aus.

--- a/docs/runbooks/cdb_event_log_archive.md
+++ b/docs/runbooks/cdb_event_log_archive.md
@@ -1,0 +1,52 @@
+# CDB Event-Log-Archivierungsvertrag
+
+Status: Contract für Issue #4422. Dieser Vertrag definiert ausschließlich den
+deterministischen Plan- und späteren Apply-Pfad für historische Event-Logs.
+Er ändert weder Compose-Bind-Mounts noch Runtime-Writer und autorisiert kein
+Live- oder Echtgeldverhalten.
+
+## Geltungsbereich
+
+- Quelle: `logs/events` im Repository-Arbeitsbaum.
+- Ziel: `Y:\CDB-Storage\logs\events`, ausschließlich über den opt-in
+  `CDB_BULK_STORAGE_ROOT=Y:\CDB-Storage` und
+  `tools.storage.bulk_storage_contract`.
+- Kandidatenname: exakt `events_YYYYMMDD.jsonl`.
+- Hot-Window: 30 Kalendertage vor dem explizit injizierten `as_of_utc`.
+
+Eine Datei ist nur dann `ARCHIVE_CANDIDATE`, wenn ihr Datum strikt älter als
+`as_of_utc.date() - 30 Tage` ist. Dateien im Hot-Window einschließlich der
+heutigen Datei sind `KEEP_HOT`. Unbekannte Namen, `_quarantine`, `_archive_*`
+und `paper_trading_*.log` werden als `EXCLUDE_UNKNOWN` ausgewiesen und nie
+archiviert.
+
+## Plan-Vertrag
+
+`python -m tools.storage.log_archive plan` ist strikt read-only: weder Quelle
+noch Ziel werden erzeugt, kopiert, verschoben oder gelöscht. Der Plan enthält
+pro Eintrag relativen Pfad, Größe, SHA-256, UTC-LastWrite und Klassifikation
+sowie `as_of_utc`, Cutoff und einen kanonisch serialisierten
+`plan_fingerprint`.
+
+Fehlt der kanonische Bulk-Root, ist er nicht `Y:\CDB-Storage`, liegt er unter
+`Y:\Worktrees`, oder enthält Quelle/Ziel eine Reparse-Komponente, endet der
+Plan fail-closed. Ein noch nicht provisioniertes `logs\\events`-Ziel bleibt
+read-only planbar, erscheint aber als `HOLD_DESTINATION_ROOT_REQUIRED` und
+blockiert jeden späteren Apply. Ein vorhandenes Ziel mit abweichendem Hash ist
+`HOLD`; ein identisches vorhandenes Ziel ist als Resume-Fall zulässig.
+
+## Apply-Gate (nicht Teil von #4422 v1)
+
+Ein späterer, separat autorisierter Apply darf erst nach erneutem Plan, stabiler
+Quelle und vollständigem Copy-Verify handeln: Größe und SHA-256 von Quelle und
+Ziel müssen übereinstimmen. Jede nach Planung veränderte Quelle, jeder
+Hash-Mismatch oder jede Zielkollision mit abweichendem Inhalt blockiert. Ein
+Source-Unlink ist erst danach zulässig. Dieser v1-Slice bietet keinen
+Copy/Delete-Apply.
+
+## Nicht-Ziele
+
+- Keine automatische Archivierung von `paper_trading_*.log`.
+- Keine Rotation laufender Writer oder heutiger/hot Dateien.
+- Keine Docker-/Compose-Mutation, keine Junctions und kein Fallback auf D:, E:
+  oder `Y:\Worktrees`.

--- a/tests/unit/storage/test_log_archive.py
+++ b/tests/unit/storage/test_log_archive.py
@@ -1,0 +1,154 @@
+"""Safety contract tests for the #4422 event-log archive planner."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.storage.log_archive import (
+    LogArchiveError,
+    build_log_archive_plan,
+    verify_copied_file,
+    verify_planned_source,
+)
+
+
+AS_OF = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
+ENV = {"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"}
+
+
+@pytest.fixture
+def archive_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    source = tmp_path / "events"
+    destination = tmp_path / "bulk" / "logs" / "events"
+    source.mkdir(parents=True)
+    destination.mkdir(parents=True)
+    monkeypatch.setattr(
+        "tools.storage.log_archive.resolve_bulk_storage_path",
+        lambda _subtree, environ=None: destination.parent,
+    )
+    return source, destination
+
+
+def _write(source: Path, name: str, content: str = "{}\n") -> Path:
+    path = source / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.mark.unit
+def test_cold_event_is_candidate_with_deterministic_fingerprint(
+    archive_roots: tuple[Path, Path],
+) -> None:
+    source, _destination = archive_roots
+    _write(source, "events_20260714.jsonl")
+
+    first = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+    second = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    assert first["entries"][0]["classification"] == "ARCHIVE_CANDIDATE"
+    assert first["plan_fingerprint"] == second["plan_fingerprint"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["events_20260715.jsonl", "events_20260814.jsonl"])
+def test_hot_and_todays_events_are_kept(
+    archive_roots: tuple[Path, Path], name: str
+) -> None:
+    source, _destination = archive_roots
+    _write(source, name)
+
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    assert plan["entries"][0]["classification"] == "KEEP_HOT"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["unknown.jsonl", "_quarantine", "_archive_old", "paper_trading_2026.log"])
+def test_unknown_and_paper_logs_are_excluded(
+    archive_roots: tuple[Path, Path], name: str
+) -> None:
+    source, _destination = archive_roots
+    _write(source, name)
+
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    assert plan["entries"][0]["classification"] == "EXCLUDE_UNKNOWN"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("root", ["", "D:\\CDB-Storage", "Y:\\Worktrees\\Claire_de_Binare"])
+def test_noncanonical_bulk_root_blocks(source_root: Path, root: str) -> None:
+    source_root.mkdir()
+    _write(source_root, "events_20260714.jsonl")
+
+    with pytest.raises(LogArchiveError, match="BULK_STORAGE"):
+        build_log_archive_plan(source_root, environ={"CDB_BULK_STORAGE_ROOT": root}, as_of_utc=AS_OF)
+
+
+@pytest.fixture
+def source_root(tmp_path: Path) -> Path:
+    return tmp_path / "events"
+
+
+@pytest.mark.unit
+def test_reparse_source_is_blocked(
+    archive_roots: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, _destination = archive_roots
+    _write(source, "events_20260714.jsonl")
+    monkeypatch.setattr("tools.storage.log_archive._is_reparse_point", lambda _: True)
+
+    with pytest.raises(LogArchiveError, match="REPARSE_POINT"):
+        build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+
+@pytest.mark.unit
+def test_destination_collision_with_different_content_is_hold(
+    archive_roots: tuple[Path, Path],
+) -> None:
+    source, destination = archive_roots
+    _write(source, "events_20260714.jsonl", "source\n")
+    _write(destination, "events_20260714.jsonl", "other\n")
+
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    assert plan["entries"][0]["classification"] == "HOLD"
+    assert plan["entries"][0]["reason_code"] == "DESTINATION_COLLISION_HASH_MISMATCH"
+
+
+@pytest.mark.unit
+def test_identical_destination_is_resumable_and_source_integrity_is_verified(
+    archive_roots: tuple[Path, Path],
+) -> None:
+    source, destination = archive_roots
+    file = _write(source, "events_20260714.jsonl", "same\n")
+    _write(destination, file.name, "same\n")
+
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+    entry = plan["entries"][0]
+
+    assert entry["classification"] == "ARCHIVE_CANDIDATE"
+    assert entry["destination_state"] == "RESUMABLE_IDENTICAL"
+    verify_planned_source(file, entry)
+    verify_copied_file(file, destination / file.name)
+
+
+@pytest.mark.unit
+def test_changed_source_or_copy_hash_mismatch_blocks_before_any_unlink(
+    archive_roots: tuple[Path, Path],
+) -> None:
+    source, destination = archive_roots
+    file = _write(source, "events_20260714.jsonl", "before\n")
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+    entry = plan["entries"][0]
+    file.write_text("after\n", encoding="utf-8")
+    _write(destination, file.name, "mismatch\n")
+
+    with pytest.raises(LogArchiveError, match="SOURCE_CHANGED_AFTER_PLANNING"):
+        verify_planned_source(file, entry)
+    with pytest.raises(LogArchiveError, match="COPY_HASH_MISMATCH"):
+        verify_copied_file(file, destination / file.name)
+    assert file.exists()

--- a/tests/unit/storage/test_log_archive.py
+++ b/tests/unit/storage/test_log_archive.py
@@ -17,7 +17,6 @@ from tools.storage.log_archive import (
     verify_planned_source,
 )
 
-
 AS_OF = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
 ENV = {"CDB_BULK_STORAGE_ROOT": "Y:\\CDB-Storage"}
 
@@ -91,7 +90,9 @@ def test_archive_and_quarantine_subtrees_are_excluded_from_plan_and_fingerprint(
     baseline = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
 
     assert [entry["relative_path"] for entry in plan["entries"]] == [ordinary.name]
-    assert sum(entry["size_bytes"] for entry in plan["entries"]) == ordinary.stat().st_size
+    assert (
+        sum(entry["size_bytes"] for entry in plan["entries"]) == ordinary.stat().st_size
+    )
     assert plan["plan_fingerprint"] == baseline["plan_fingerprint"]
     assert all(
         path.relative_to(source).as_posix()
@@ -119,7 +120,9 @@ def test_hot_and_todays_events_are_kept(
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("name", ["unknown.jsonl", "_quarantine", "_archive_old", "paper_trading_2026.log"])
+@pytest.mark.parametrize(
+    "name", ["unknown.jsonl", "_quarantine", "_archive_old", "paper_trading_2026.log"]
+)
 def test_unknown_and_paper_logs_are_excluded(
     archive_roots: tuple[Path, Path], name: str
 ) -> None:
@@ -132,13 +135,17 @@ def test_unknown_and_paper_logs_are_excluded(
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("root", ["", "D:\\CDB-Storage", "Y:\\Worktrees\\Claire_de_Binare"])
+@pytest.mark.parametrize(
+    "root", ["", "D:\\CDB-Storage", "Y:\\Worktrees\\Claire_de_Binare"]
+)
 def test_noncanonical_bulk_root_blocks(source_root: Path, root: str) -> None:
     source_root.mkdir()
     _write(source_root, "events_20260714.jsonl")
 
     with pytest.raises(LogArchiveError, match="BULK_STORAGE"):
-        build_log_archive_plan(source_root, environ={"CDB_BULK_STORAGE_ROOT": root}, as_of_utc=AS_OF)
+        build_log_archive_plan(
+            source_root, environ={"CDB_BULK_STORAGE_ROOT": root}, as_of_utc=AS_OF
+        )
 
 
 @pytest.fixture
@@ -246,7 +253,9 @@ def test_apply_resume_requires_source_to_remain_bound(
     _write(destination, file.name, "same\n")
     plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
 
-    result = apply_log_archive_plan(plan, plan["plan_fingerprint"], tmp_path / "evidence.json")
+    result = apply_log_archive_plan(
+        plan, plan["plan_fingerprint"], tmp_path / "evidence.json"
+    )
 
     assert result["entries"][0]["disposition"] == "RESUMED_VERIFIED_DELETED"
     assert not file.exists()
@@ -260,7 +269,9 @@ def test_apply_holds_on_source_drift_without_delete(
     plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
     file.write_text("after\n", encoding="utf-8")
 
-    result = apply_log_archive_plan(plan, plan["plan_fingerprint"], tmp_path / "evidence.json")
+    result = apply_log_archive_plan(
+        plan, plan["plan_fingerprint"], tmp_path / "evidence.json"
+    )
 
     assert result["result"] == "BLOCKED"
     assert file.exists()
@@ -282,6 +293,8 @@ def test_apply_refuses_to_mutate_when_initial_evidence_journal_cannot_be_written
     monkeypatch.setattr("tools.storage.log_archive._write_evidence", fail_write)
 
     with pytest.raises(LogArchiveError, match="EVIDENCE_JOURNAL_INIT_FAILED"):
-        apply_log_archive_plan(plan, plan["plan_fingerprint"], tmp_path / "evidence.json")
+        apply_log_archive_plan(
+            plan, plan["plan_fingerprint"], tmp_path / "evidence.json"
+        )
 
     assert file.exists()

--- a/tests/unit/storage/test_log_archive.py
+++ b/tests/unit/storage/test_log_archive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from shutil import rmtree
@@ -10,6 +11,7 @@ import pytest
 
 from tools.storage.log_archive import (
     LogArchiveError,
+    apply_log_archive_plan,
     build_log_archive_plan,
     verify_copied_file,
     verify_planned_source,
@@ -203,3 +205,64 @@ def test_changed_source_or_copy_hash_mismatch_blocks_before_any_unlink(
     with pytest.raises(LogArchiveError, match="COPY_HASH_MISMATCH"):
         verify_copied_file(file, destination / file.name)
     assert file.exists()
+
+
+def test_apply_requires_the_exact_expected_fingerprint(
+    archive_roots: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, destination = archive_roots
+    file = _write(source, "events_20260714.jsonl", "bound\n")
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    result = apply_log_archive_plan(plan, "wrong", tmp_path / "evidence.json")
+
+    assert result["result"] == "BLOCKED"
+    assert not (destination / file.name).exists()
+    assert file.exists()
+
+
+def test_apply_copies_verifies_then_deletes_and_writes_evidence_atomically(
+    archive_roots: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, destination = archive_roots
+    file = _write(source, "events_20260714.jsonl", "bound\n")
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+    evidence = tmp_path / "evidence.json"
+
+    result = apply_log_archive_plan(plan, plan["plan_fingerprint"], evidence)
+
+    assert result["result"] == "SUCCESS"
+    assert not file.exists()
+    assert (destination / file.name).read_text(encoding="utf-8") == "bound\n"
+    assert json.loads(evidence.read_text(encoding="utf-8"))["deleted_source_count"] == 1
+    assert result["entries"][0]["disposition"] == "COPIED_VERIFIED_DELETED"
+
+
+def test_apply_resume_requires_source_to_remain_bound(
+    archive_roots: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, destination = archive_roots
+    file = _write(source, "events_20260714.jsonl", "same\n")
+    _write(destination, file.name, "same\n")
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    result = apply_log_archive_plan(plan, plan["plan_fingerprint"], tmp_path / "evidence.json")
+
+    assert result["entries"][0]["disposition"] == "RESUMED_VERIFIED_DELETED"
+    assert not file.exists()
+
+
+def test_apply_holds_on_source_drift_without_delete(
+    archive_roots: tuple[Path, Path], tmp_path: Path
+) -> None:
+    source, destination = archive_roots
+    file = _write(source, "events_20260714.jsonl", "before\n")
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+    file.write_text("after\n", encoding="utf-8")
+
+    result = apply_log_archive_plan(plan, plan["plan_fingerprint"], tmp_path / "evidence.json")
+
+    assert result["result"] == "BLOCKED"
+    assert file.exists()
+    assert not (destination / file.name).exists()
+    assert result["entries"][0]["disposition"] == "HELD_SOURCE_DRIFT"

--- a/tests/unit/storage/test_log_archive.py
+++ b/tests/unit/storage/test_log_archive.py
@@ -266,3 +266,22 @@ def test_apply_holds_on_source_drift_without_delete(
     assert file.exists()
     assert not (destination / file.name).exists()
     assert result["entries"][0]["disposition"] == "HELD_SOURCE_DRIFT"
+
+
+@pytest.mark.unit
+def test_apply_refuses_to_mutate_when_initial_evidence_journal_cannot_be_written(
+    archive_roots: tuple[Path, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, _destination = archive_roots
+    file = _write(source, "events_20260714.jsonl", "bound\n")
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    def fail_write(*_args: object, **_kwargs: object) -> None:
+        raise OSError("evidence unavailable")
+
+    monkeypatch.setattr("tools.storage.log_archive._write_evidence", fail_write)
+
+    with pytest.raises(LogArchiveError, match="EVIDENCE_JOURNAL_INIT_FAILED"):
+        apply_log_archive_plan(plan, plan["plan_fingerprint"], tmp_path / "evidence.json")
+
+    assert file.exists()

--- a/tests/unit/storage/test_log_archive.py
+++ b/tests/unit/storage/test_log_archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from shutil import rmtree
 
 import pytest
 
@@ -34,6 +35,7 @@ def archive_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path
 
 def _write(source: Path, name: str, content: str = "{}\n") -> Path:
     path = source / name
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
 
@@ -50,6 +52,55 @@ def test_cold_event_is_candidate_with_deterministic_fingerprint(
 
     assert first["entries"][0]["classification"] == "ARCHIVE_CANDIDATE"
     assert first["plan_fingerprint"] == second["plan_fingerprint"]
+
+
+@pytest.mark.unit
+def test_archive_and_quarantine_subtrees_are_excluded_from_plan_and_fingerprint(
+    archive_roots: tuple[Path, Path],
+) -> None:
+    source, _destination = archive_roots
+    ordinary = _write(source, "events_20260714.jsonl", "ordinary\n")
+    archived = _write(
+        source / "nested" / "_archive_20260424_153327",
+        "events_20260714.jsonl",
+        "archived\n",
+    )
+    quarantined = _write(
+        source / "deep" / "tree" / "_quarantine",
+        "events_20260714.jsonl",
+        "quarantined\n",
+    )
+    top_level_quarantine = _write(
+        source / "_quarantine",
+        "events_20260714.jsonl",
+        "also quarantined\n",
+    )
+    archive_with_nested_quarantine = _write(
+        source / "_archive_old" / "deeper" / "_quarantine",
+        "events_20260714.jsonl",
+        "also excluded\n",
+    )
+
+    plan = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+    rmtree(source / "nested")
+    rmtree(source / "deep")
+    rmtree(source / "_quarantine")
+    rmtree(source / "_archive_old")
+    baseline = build_log_archive_plan(source, environ=ENV, as_of_utc=AS_OF)
+
+    assert [entry["relative_path"] for entry in plan["entries"]] == [ordinary.name]
+    assert sum(entry["size_bytes"] for entry in plan["entries"]) == ordinary.stat().st_size
+    assert plan["plan_fingerprint"] == baseline["plan_fingerprint"]
+    assert all(
+        path.relative_to(source).as_posix()
+        not in {entry["relative_path"] for entry in plan["entries"]}
+        for path in (
+            archived,
+            quarantined,
+            top_level_quarantine,
+            archive_with_nested_quarantine,
+        )
+    )
 
 
 @pytest.mark.unit

--- a/tools/storage/log_archive.py
+++ b/tools/storage/log_archive.py
@@ -101,6 +101,14 @@ def _fingerprint(plan: Mapping[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _is_excluded_subtree(source_root: Path, path: Path) -> bool:
+    """Return whether a path resides under an excluded source subtree."""
+    return any(
+        component.startswith("_archive_") or component == "_quarantine"
+        for component in path.relative_to(source_root).parts[:-1]
+    )
+
+
 def build_log_archive_plan(
     source_root: Path,
     *,
@@ -122,7 +130,14 @@ def build_log_archive_plan(
     destination_root = logs_root / "events"
     _reject_reparse_components(destination_root)
     cutoff = as_of - timedelta(days=hot_days)
-    files = sorted((path for path in source_root.rglob("*") if path.is_file()), key=lambda path: path.as_posix())
+    files = sorted(
+        (
+            path
+            for path in source_root.rglob("*")
+            if path.is_file() and not _is_excluded_subtree(source_root, path)
+        ),
+        key=lambda path: path.as_posix(),
+    )
     entries = [_entry_for(source_root, destination_root, path, cutoff) for path in files]
     plan: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,

--- a/tools/storage/log_archive.py
+++ b/tools/storage/log_archive.py
@@ -1,0 +1,188 @@
+"""Deterministic, plan-only archive contract for #4422 event logs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from re import fullmatch
+from typing import Any, Mapping, Sequence
+
+from tools.storage.bulk_storage_contract import (
+    BulkStorageContractError,
+    resolve_bulk_storage_path,
+)
+
+SCHEMA_VERSION = "cdb.log-archive-plan/v1"
+ISSUE_REF = "#4422"
+DEFAULT_HOT_DAYS = 30
+EVENT_FILE_PATTERN = r"events_(\d{8})\.jsonl"
+
+
+class LogArchiveError(ValueError):
+    """Raised when a log archive plan cannot be safely constructed or verified."""
+
+
+def _is_reparse_point(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        return bool(path.lstat().st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    except AttributeError:
+        return path.is_symlink()
+
+
+def _reject_reparse_components(path: Path) -> None:
+    current = path
+    while True:
+        if _is_reparse_point(current):
+            raise LogArchiveError("LOG_ARCHIVE_REPARSE_POINT")
+        parent = current.parent
+        if parent == current:
+            return
+        current = parent
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise LogArchiveError("AS_OF_UTC_REQUIRED")
+    return value.astimezone(timezone.utc)
+
+
+def _entry_for(source_root: Path, destination_root: Path, path: Path, cutoff: datetime) -> dict[str, Any]:
+    relative_path = path.relative_to(source_root).as_posix()
+    stat_result = path.stat()
+    last_write = datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc)
+    entry: dict[str, Any] = {
+        "relative_path": relative_path,
+        "size_bytes": stat_result.st_size,
+        "sha256": _sha256(path),
+        "last_write_utc": last_write.isoformat().replace("+00:00", "Z"),
+    }
+    match = fullmatch(EVENT_FILE_PATTERN, path.name)
+    if not match:
+        entry.update(classification="EXCLUDE_UNKNOWN", reason_code="NAME_EXCLUDED")
+        return entry
+    try:
+        event_date = datetime.strptime(match.group(1), "%Y%m%d").date()
+    except ValueError:
+        entry.update(classification="EXCLUDE_UNKNOWN", reason_code="EVENT_DATE_INVALID")
+        return entry
+    if event_date >= cutoff.date():
+        entry.update(classification="KEEP_HOT", reason_code="WITHIN_HOT_WINDOW")
+        return entry
+
+    destination = destination_root / relative_path
+    _reject_reparse_components(destination.parent)
+    entry.update(classification="ARCHIVE_CANDIDATE", destination_state="ABSENT")
+    if destination.exists():
+        if not destination.is_file():
+            entry.update(classification="HOLD", reason_code="DESTINATION_COLLISION_NON_FILE")
+        elif destination.stat().st_size != stat_result.st_size or _sha256(destination) != entry["sha256"]:
+            entry.update(classification="HOLD", reason_code="DESTINATION_COLLISION_HASH_MISMATCH")
+        else:
+            entry["destination_state"] = "RESUMABLE_IDENTICAL"
+    return entry
+
+
+def _fingerprint(plan: Mapping[str, Any]) -> str:
+    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_log_archive_plan(
+    source_root: Path,
+    *,
+    environ: Mapping[str, str] | None = None,
+    as_of_utc: datetime,
+    hot_days: int = DEFAULT_HOT_DAYS,
+) -> dict[str, Any]:
+    """Return a deterministic read-only archive plan; never copy or delete."""
+    if hot_days < 1:
+        raise LogArchiveError("HOT_DAYS_INVALID")
+    as_of = _utc(as_of_utc)
+    if not source_root.is_dir():
+        raise LogArchiveError("SOURCE_ROOT_REQUIRED")
+    _reject_reparse_components(source_root)
+    try:
+        logs_root = resolve_bulk_storage_path("logs", environ=environ)
+    except BulkStorageContractError as exc:
+        raise LogArchiveError(str(exc)) from exc
+    destination_root = logs_root / "events"
+    _reject_reparse_components(destination_root)
+    cutoff = as_of - timedelta(days=hot_days)
+    files = sorted((path for path in source_root.rglob("*") if path.is_file()), key=lambda path: path.as_posix())
+    entries = [_entry_for(source_root, destination_root, path, cutoff) for path in files]
+    plan: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "issue_ref": ISSUE_REF,
+        "source_root": str(source_root),
+        "destination_root": str(destination_root),
+        "as_of_utc": as_of.isoformat().replace("+00:00", "Z"),
+        "hot_days": hot_days,
+        "cutoff_date": cutoff.date().isoformat(),
+        "destination_root_exists": destination_root.is_dir(),
+        "entries": entries,
+    }
+    if not plan["destination_root_exists"]:
+        plan["hold_reasons"] = ["DESTINATION_ROOT_REQUIRED"]
+    plan["plan_fingerprint"] = _fingerprint(plan)
+    return plan
+
+
+def verify_planned_source(source: Path, entry: Mapping[str, Any]) -> None:
+    """Reject a source whose planned size or hash has changed before an apply."""
+    if not source.is_file() or source.stat().st_size != entry["size_bytes"] or _sha256(source) != entry["sha256"]:
+        raise LogArchiveError("SOURCE_CHANGED_AFTER_PLANNING")
+
+
+def verify_copied_file(source: Path, destination: Path) -> None:
+    """Require byte and hash equality; callers must not unlink on failure."""
+    if not destination.is_file() or _sha256(source) != _sha256(destination):
+        raise LogArchiveError("COPY_HASH_MISMATCH")
+    if source.stat().st_size != destination.stat().st_size:
+        raise LogArchiveError("COPY_SIZE_MISMATCH")
+
+
+def _parse_as_of(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("as_of_utc must be ISO-8601 UTC") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise argparse.ArgumentTypeError("as_of_utc must include a UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Plan-only CDB event-log archival")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    plan_parser = subparsers.add_parser("plan", help="create a read-only archive plan")
+    plan_parser.add_argument("--source-root", type=Path, required=True)
+    plan_parser.add_argument("--as-of-utc", type=_parse_as_of, required=True)
+    plan_parser.add_argument("--hot-days", type=int, default=DEFAULT_HOT_DAYS)
+    args = parser.parse_args(argv)
+    try:
+        plan = build_log_archive_plan(
+            args.source_root, as_of_utc=args.as_of_utc, hot_days=args.hot_days
+        )
+    except LogArchiveError as exc:
+        print(json.dumps({"status": "BLOCKED", "reason_code": str(exc)}, sort_keys=True))
+        return 2
+    print(json.dumps(plan, sort_keys=True, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/storage/log_archive.py
+++ b/tools/storage/log_archive.py
@@ -217,7 +217,7 @@ def apply_log_archive_plan(
         "copied_file_count": 0, "copied_bytes": 0, "resumed_file_count": 0,
         "verified_file_count": 0, "verified_bytes": 0,
         "deleted_source_count": 0, "deleted_source_bytes": 0,
-        "held_file_count": 0, "result": "BLOCKED", "entries": entries,
+        "held_file_count": 0, "result": "BLOCKED", "apply_status": "PRECHECK", "entries": entries,
     }
     try:
         if not expected_fingerprint or plan.get("schema_version") != SCHEMA_VERSION or plan.get("issue_ref") != ISSUE_REF:
@@ -232,6 +232,11 @@ def apply_log_archive_plan(
             raise LogArchiveError("APPLY_DESTINATION_ROOT_INVALID")
         _reject_reparse_components(source_root)
         _reject_reparse_components(destination_root)
+        evidence["apply_status"] = "APPLY_STARTED"
+        try:
+            _write_evidence(evidence_output_path, evidence)
+        except OSError as exc:
+            raise LogArchiveError("EVIDENCE_JOURNAL_INIT_FAILED") from exc
         for planned_entry in planned:
             relative = _safe_relative_path(str(planned_entry.get("relative_path", "")))
             event_date = datetime.strptime(relative.stem.removeprefix("events_"), "%Y%m%d").date()
@@ -243,7 +248,8 @@ def apply_log_archive_plan(
                 "expected_size_bytes": planned_entry.get("size_bytes"),
                 "expected_sha256": planned_entry.get("sha256"),
                 "destination_path": str(destination),
-                "disposition": None, "destination_verified": False,
+                "disposition": None, "source_verified_pre_copy": False,
+                "destination_verified": False, "source_verified_pre_delete": False,
                 "source_deleted": False, "failure_reason": None,
             }
             entries.append(entry)
@@ -251,6 +257,7 @@ def apply_log_archive_plan(
                 _reject_reparse_components(source)
                 _reject_reparse_components(destination.parent)
                 verify_planned_source(source, planned_entry)
+                entry["source_verified_pre_copy"] = True
                 if destination.exists():
                     if not destination.is_file() or destination.stat().st_size != source.stat().st_size or _sha256(destination) != planned_entry["sha256"]:
                         raise LogArchiveError("DESTINATION_COLLISION")
@@ -267,10 +274,15 @@ def apply_log_archive_plan(
                 evidence["verified_file_count"] += 1
                 evidence["verified_bytes"] += int(planned_entry["size_bytes"])
                 verify_planned_source(source, planned_entry)
+                entry["source_verified_pre_delete"] = True
+                evidence["apply_status"] = "DELETE_PENDING"
+                _write_evidence(evidence_output_path, evidence)
                 source.unlink()
                 entry["source_deleted"] = True
                 evidence["deleted_source_count"] += 1
                 evidence["deleted_source_bytes"] += int(planned_entry["size_bytes"])
+                evidence["apply_status"] = "APPLY_IN_PROGRESS"
+                _write_evidence(evidence_output_path, evidence)
             except LogArchiveError as exc:
                 entry["failure_reason"] = str(exc)
                 entry["disposition"] = "HELD_DESTINATION_COLLISION" if str(exc) == "DESTINATION_COLLISION" else "HELD_SOURCE_DRIFT"
@@ -280,7 +292,10 @@ def apply_log_archive_plan(
             evidence["result"] = "SUCCESS"
     except LogArchiveError as exc:
         evidence["failure_reason"] = str(exc)
+    if evidence.get("failure_reason") == "EVIDENCE_JOURNAL_INIT_FAILED":
+        raise LogArchiveError("EVIDENCE_JOURNAL_INIT_FAILED")
     evidence["completed_at_utc"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    evidence["apply_status"] = "APPLY_COMPLETED"
     _write_evidence(evidence_output_path, evidence)
     return evidence
 

--- a/tools/storage/log_archive.py
+++ b/tools/storage/log_archive.py
@@ -63,7 +63,9 @@ def _utc(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
-def _entry_for(source_root: Path, destination_root: Path, path: Path, cutoff: datetime) -> dict[str, Any]:
+def _entry_for(
+    source_root: Path, destination_root: Path, path: Path, cutoff: datetime
+) -> dict[str, Any]:
     relative_path = path.relative_to(source_root).as_posix()
     stat_result = path.stat()
     last_write = datetime.fromtimestamp(stat_result.st_mtime, tz=timezone.utc)
@@ -91,16 +93,25 @@ def _entry_for(source_root: Path, destination_root: Path, path: Path, cutoff: da
     entry.update(classification="ARCHIVE_CANDIDATE", destination_state="ABSENT")
     if destination.exists():
         if not destination.is_file():
-            entry.update(classification="HOLD", reason_code="DESTINATION_COLLISION_NON_FILE")
-        elif destination.stat().st_size != stat_result.st_size or _sha256(destination) != entry["sha256"]:
-            entry.update(classification="HOLD", reason_code="DESTINATION_COLLISION_HASH_MISMATCH")
+            entry.update(
+                classification="HOLD", reason_code="DESTINATION_COLLISION_NON_FILE"
+            )
+        elif (
+            destination.stat().st_size != stat_result.st_size
+            or _sha256(destination) != entry["sha256"]
+        ):
+            entry.update(
+                classification="HOLD", reason_code="DESTINATION_COLLISION_HASH_MISMATCH"
+            )
         else:
             entry["destination_state"] = "RESUMABLE_IDENTICAL"
     return entry
 
 
 def _fingerprint(plan: Mapping[str, Any]) -> str:
-    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    canonical = json.dumps(
+        plan, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -141,7 +152,9 @@ def build_log_archive_plan(
         ),
         key=lambda path: path.as_posix(),
     )
-    entries = [_entry_for(source_root, destination_root, path, cutoff) for path in files]
+    entries = [
+        _entry_for(source_root, destination_root, path, cutoff) for path in files
+    ]
     plan: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "issue_ref": ISSUE_REF,
@@ -161,7 +174,11 @@ def build_log_archive_plan(
 
 def verify_planned_source(source: Path, entry: Mapping[str, Any]) -> None:
     """Reject a source whose planned size or hash has changed before an apply."""
-    if not source.is_file() or source.stat().st_size != entry["size_bytes"] or _sha256(source) != entry["sha256"]:
+    if (
+        not source.is_file()
+        or source.stat().st_size != entry["size_bytes"]
+        or _sha256(source) != entry["sha256"]
+    ):
         raise LogArchiveError("SOURCE_CHANGED_AFTER_PLANNING")
 
 
@@ -181,9 +198,15 @@ def _plan_fingerprint(plan: Mapping[str, Any]) -> str:
 
 def _safe_relative_path(value: str) -> Path:
     path = Path(value)
-    if path.is_absolute() or not value or any(part in {"", ".", ".."} for part in path.parts):
+    if (
+        path.is_absolute()
+        or not value
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
         raise LogArchiveError("APPLY_RELATIVE_PATH_INVALID")
-    if any(part.startswith("_archive_") or part == "_quarantine" for part in path.parts):
+    if any(
+        part.startswith("_archive_") or part == "_quarantine" for part in path.parts
+    ):
         raise LogArchiveError("APPLY_EXCLUDED_SUBTREE")
     if not fullmatch(EVENT_FILE_PATTERN, path.name):
         raise LogArchiveError("APPLY_CANDIDATE_NAME_INVALID")
@@ -193,7 +216,9 @@ def _safe_relative_path(value: str) -> Path:
 def _write_evidence(path: Path, evidence: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.tmp")
-    temporary.write_text(json.dumps(evidence, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    temporary.write_text(
+        json.dumps(evidence, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
     os.replace(temporary, path)
 
 
@@ -204,7 +229,11 @@ def apply_log_archive_plan(
     started = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     entries: list[dict[str, Any]] = []
     planned_entries = list(plan.get("entries", []))
-    planned = [entry for entry in planned_entries if entry.get("classification") == "ARCHIVE_CANDIDATE"]
+    planned = [
+        entry
+        for entry in planned_entries
+        if entry.get("classification") == "ARCHIVE_CANDIDATE"
+    ]
     evidence: dict[str, Any] = {
         "schema_version": APPLY_SCHEMA_VERSION,
         "issue_ref": ISSUE_REF,
@@ -214,21 +243,39 @@ def apply_log_archive_plan(
         "started_at_utc": started,
         "planned_file_count": len(planned),
         "planned_bytes": sum(int(entry.get("size_bytes", 0)) for entry in planned),
-        "copied_file_count": 0, "copied_bytes": 0, "resumed_file_count": 0,
-        "verified_file_count": 0, "verified_bytes": 0,
-        "deleted_source_count": 0, "deleted_source_bytes": 0,
-        "held_file_count": 0, "result": "BLOCKED", "apply_status": "PRECHECK", "entries": entries,
+        "copied_file_count": 0,
+        "copied_bytes": 0,
+        "resumed_file_count": 0,
+        "verified_file_count": 0,
+        "verified_bytes": 0,
+        "deleted_source_count": 0,
+        "deleted_source_bytes": 0,
+        "held_file_count": 0,
+        "result": "BLOCKED",
+        "apply_status": "PRECHECK",
+        "entries": entries,
     }
     try:
-        if not expected_fingerprint or plan.get("schema_version") != SCHEMA_VERSION or plan.get("issue_ref") != ISSUE_REF:
+        if (
+            not expected_fingerprint
+            or plan.get("schema_version") != SCHEMA_VERSION
+            or plan.get("issue_ref") != ISSUE_REF
+        ):
             raise LogArchiveError("APPLY_PLAN_INVALID")
-        if plan.get("plan_fingerprint") != expected_fingerprint or _plan_fingerprint(plan) != expected_fingerprint:
+        if (
+            plan.get("plan_fingerprint") != expected_fingerprint
+            or _plan_fingerprint(plan) != expected_fingerprint
+        ):
             raise LogArchiveError("APPLY_FINGERPRINT_MISMATCH")
-        source_root, destination_root = Path(str(plan["source_root"])), Path(str(plan["destination_root"]))
+        source_root, destination_root = Path(str(plan["source_root"])), Path(
+            str(plan["destination_root"])
+        )
         if not source_root.is_dir() or not destination_root.is_dir():
             raise LogArchiveError("APPLY_ROOT_REQUIRED")
         canonical_destination = resolve_bulk_storage_path("logs") / "events"
-        if os.path.normcase(str(destination_root)) != os.path.normcase(str(canonical_destination)):
+        if os.path.normcase(str(destination_root)) != os.path.normcase(
+            str(canonical_destination)
+        ):
             raise LogArchiveError("APPLY_DESTINATION_ROOT_INVALID")
         _reject_reparse_components(source_root)
         _reject_reparse_components(destination_root)
@@ -239,7 +286,9 @@ def apply_log_archive_plan(
             raise LogArchiveError("EVIDENCE_JOURNAL_INIT_FAILED") from exc
         for planned_entry in planned:
             relative = _safe_relative_path(str(planned_entry.get("relative_path", "")))
-            event_date = datetime.strptime(relative.stem.removeprefix("events_"), "%Y%m%d").date()
+            event_date = datetime.strptime(
+                relative.stem.removeprefix("events_"), "%Y%m%d"
+            ).date()
             if event_date >= datetime.fromisoformat(str(plan["cutoff_date"])).date():
                 raise LogArchiveError("APPLY_HOT_ENTRY_FORBIDDEN")
             source, destination = source_root / relative, destination_root / relative
@@ -248,9 +297,12 @@ def apply_log_archive_plan(
                 "expected_size_bytes": planned_entry.get("size_bytes"),
                 "expected_sha256": planned_entry.get("sha256"),
                 "destination_path": str(destination),
-                "disposition": None, "source_verified_pre_copy": False,
-                "destination_verified": False, "source_verified_pre_delete": False,
-                "source_deleted": False, "failure_reason": None,
+                "disposition": None,
+                "source_verified_pre_copy": False,
+                "destination_verified": False,
+                "source_verified_pre_delete": False,
+                "source_deleted": False,
+                "failure_reason": None,
             }
             entries.append(entry)
             try:
@@ -259,7 +311,11 @@ def apply_log_archive_plan(
                 verify_planned_source(source, planned_entry)
                 entry["source_verified_pre_copy"] = True
                 if destination.exists():
-                    if not destination.is_file() or destination.stat().st_size != source.stat().st_size or _sha256(destination) != planned_entry["sha256"]:
+                    if (
+                        not destination.is_file()
+                        or destination.stat().st_size != source.stat().st_size
+                        or _sha256(destination) != planned_entry["sha256"]
+                    ):
                         raise LogArchiveError("DESTINATION_COLLISION")
                     entry["disposition"] = "RESUMED_VERIFIED_DELETED"
                     evidence["resumed_file_count"] += 1
@@ -285,7 +341,11 @@ def apply_log_archive_plan(
                 _write_evidence(evidence_output_path, evidence)
             except LogArchiveError as exc:
                 entry["failure_reason"] = str(exc)
-                entry["disposition"] = "HELD_DESTINATION_COLLISION" if str(exc) == "DESTINATION_COLLISION" else "HELD_SOURCE_DRIFT"
+                entry["disposition"] = (
+                    "HELD_DESTINATION_COLLISION"
+                    if str(exc) == "DESTINATION_COLLISION"
+                    else "HELD_SOURCE_DRIFT"
+                )
                 evidence["held_file_count"] += 1
                 break
         if evidence["held_file_count"] == 0:
@@ -294,7 +354,9 @@ def apply_log_archive_plan(
         evidence["failure_reason"] = str(exc)
     if evidence.get("failure_reason") == "EVIDENCE_JOURNAL_INIT_FAILED":
         raise LogArchiveError("EVIDENCE_JOURNAL_INIT_FAILED")
-    evidence["completed_at_utc"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    evidence["completed_at_utc"] = (
+        datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    )
     evidence["apply_status"] = "APPLY_COMPLETED"
     _write_evidence(evidence_output_path, evidence)
     return evidence
@@ -325,12 +387,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         if args.command == "apply":
             plan = json.loads(args.plan.read_text(encoding="utf-8"))
-            result = apply_log_archive_plan(plan, args.expected_fingerprint, args.evidence_output)
+            result = apply_log_archive_plan(
+                plan, args.expected_fingerprint, args.evidence_output
+            )
             print(json.dumps(result, sort_keys=True, indent=2))
             return 0 if result["result"] == "SUCCESS" else 2
-        plan = build_log_archive_plan(args.source_root, as_of_utc=args.as_of_utc, hot_days=args.hot_days)
+        plan = build_log_archive_plan(
+            args.source_root, as_of_utc=args.as_of_utc, hot_days=args.hot_days
+        )
     except LogArchiveError as exc:
-        print(json.dumps({"status": "BLOCKED", "reason_code": str(exc)}, sort_keys=True))
+        print(
+            json.dumps({"status": "BLOCKED", "reason_code": str(exc)}, sort_keys=True)
+        )
         return 2
     print(json.dumps(plan, sort_keys=True, indent=2))
     return 0

--- a/tools/storage/log_archive.py
+++ b/tools/storage/log_archive.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
+import shutil
 import stat
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -17,6 +19,7 @@ from tools.storage.bulk_storage_contract import (
 )
 
 SCHEMA_VERSION = "cdb.log-archive-plan/v1"
+APPLY_SCHEMA_VERSION = "cdb.log-archive-apply-result/v1"
 ISSUE_REF = "#4422"
 DEFAULT_HOT_DAYS = 30
 EVENT_FILE_PATTERN = r"events_(\d{8})\.jsonl"
@@ -170,6 +173,118 @@ def verify_copied_file(source: Path, destination: Path) -> None:
         raise LogArchiveError("COPY_SIZE_MISMATCH")
 
 
+def _plan_fingerprint(plan: Mapping[str, Any]) -> str:
+    unsigned = dict(plan)
+    unsigned.pop("plan_fingerprint", None)
+    return _fingerprint(unsigned)
+
+
+def _safe_relative_path(value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute() or not value or any(part in {"", ".", ".."} for part in path.parts):
+        raise LogArchiveError("APPLY_RELATIVE_PATH_INVALID")
+    if any(part.startswith("_archive_") or part == "_quarantine" for part in path.parts):
+        raise LogArchiveError("APPLY_EXCLUDED_SUBTREE")
+    if not fullmatch(EVENT_FILE_PATTERN, path.name):
+        raise LogArchiveError("APPLY_CANDIDATE_NAME_INVALID")
+    return path
+
+
+def _write_evidence(path: Path, evidence: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(evidence, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def apply_log_archive_plan(
+    plan: Mapping[str, Any], expected_fingerprint: str, evidence_output_path: Path
+) -> dict[str, Any]:
+    """Apply a previously bound plan; never derive or expand its candidate scope."""
+    started = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    entries: list[dict[str, Any]] = []
+    planned_entries = list(plan.get("entries", []))
+    planned = [entry for entry in planned_entries if entry.get("classification") == "ARCHIVE_CANDIDATE"]
+    evidence: dict[str, Any] = {
+        "schema_version": APPLY_SCHEMA_VERSION,
+        "issue_ref": ISSUE_REF,
+        "plan_fingerprint": plan.get("plan_fingerprint"),
+        "source_root": plan.get("source_root"),
+        "destination_root": plan.get("destination_root"),
+        "started_at_utc": started,
+        "planned_file_count": len(planned),
+        "planned_bytes": sum(int(entry.get("size_bytes", 0)) for entry in planned),
+        "copied_file_count": 0, "copied_bytes": 0, "resumed_file_count": 0,
+        "verified_file_count": 0, "verified_bytes": 0,
+        "deleted_source_count": 0, "deleted_source_bytes": 0,
+        "held_file_count": 0, "result": "BLOCKED", "entries": entries,
+    }
+    try:
+        if not expected_fingerprint or plan.get("schema_version") != SCHEMA_VERSION or plan.get("issue_ref") != ISSUE_REF:
+            raise LogArchiveError("APPLY_PLAN_INVALID")
+        if plan.get("plan_fingerprint") != expected_fingerprint or _plan_fingerprint(plan) != expected_fingerprint:
+            raise LogArchiveError("APPLY_FINGERPRINT_MISMATCH")
+        source_root, destination_root = Path(str(plan["source_root"])), Path(str(plan["destination_root"]))
+        if not source_root.is_dir() or not destination_root.is_dir():
+            raise LogArchiveError("APPLY_ROOT_REQUIRED")
+        canonical_destination = resolve_bulk_storage_path("logs") / "events"
+        if os.path.normcase(str(destination_root)) != os.path.normcase(str(canonical_destination)):
+            raise LogArchiveError("APPLY_DESTINATION_ROOT_INVALID")
+        _reject_reparse_components(source_root)
+        _reject_reparse_components(destination_root)
+        for planned_entry in planned:
+            relative = _safe_relative_path(str(planned_entry.get("relative_path", "")))
+            event_date = datetime.strptime(relative.stem.removeprefix("events_"), "%Y%m%d").date()
+            if event_date >= datetime.fromisoformat(str(plan["cutoff_date"])).date():
+                raise LogArchiveError("APPLY_HOT_ENTRY_FORBIDDEN")
+            source, destination = source_root / relative, destination_root / relative
+            entry = {
+                "relative_path": relative.as_posix(),
+                "expected_size_bytes": planned_entry.get("size_bytes"),
+                "expected_sha256": planned_entry.get("sha256"),
+                "destination_path": str(destination),
+                "disposition": None, "destination_verified": False,
+                "source_deleted": False, "failure_reason": None,
+            }
+            entries.append(entry)
+            try:
+                _reject_reparse_components(source)
+                _reject_reparse_components(destination.parent)
+                verify_planned_source(source, planned_entry)
+                if destination.exists():
+                    if not destination.is_file() or destination.stat().st_size != source.stat().st_size or _sha256(destination) != planned_entry["sha256"]:
+                        raise LogArchiveError("DESTINATION_COLLISION")
+                    entry["disposition"] = "RESUMED_VERIFIED_DELETED"
+                    evidence["resumed_file_count"] += 1
+                else:
+                    destination.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copyfile(source, destination)
+                    entry["disposition"] = "COPIED_VERIFIED_DELETED"
+                    evidence["copied_file_count"] += 1
+                    evidence["copied_bytes"] += int(planned_entry["size_bytes"])
+                verify_copied_file(source, destination)
+                entry["destination_verified"] = True
+                evidence["verified_file_count"] += 1
+                evidence["verified_bytes"] += int(planned_entry["size_bytes"])
+                verify_planned_source(source, planned_entry)
+                source.unlink()
+                entry["source_deleted"] = True
+                evidence["deleted_source_count"] += 1
+                evidence["deleted_source_bytes"] += int(planned_entry["size_bytes"])
+            except LogArchiveError as exc:
+                entry["failure_reason"] = str(exc)
+                entry["disposition"] = "HELD_DESTINATION_COLLISION" if str(exc) == "DESTINATION_COLLISION" else "HELD_SOURCE_DRIFT"
+                evidence["held_file_count"] += 1
+                break
+        if evidence["held_file_count"] == 0:
+            evidence["result"] = "SUCCESS"
+    except LogArchiveError as exc:
+        evidence["failure_reason"] = str(exc)
+    evidence["completed_at_utc"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    _write_evidence(evidence_output_path, evidence)
+    return evidence
+
+
 def _parse_as_of(value: str) -> datetime:
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -187,11 +302,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     plan_parser.add_argument("--source-root", type=Path, required=True)
     plan_parser.add_argument("--as-of-utc", type=_parse_as_of, required=True)
     plan_parser.add_argument("--hot-days", type=int, default=DEFAULT_HOT_DAYS)
+    apply_parser = subparsers.add_parser("apply", help="apply a bound archive plan")
+    apply_parser.add_argument("--plan", type=Path, required=True)
+    apply_parser.add_argument("--expected-fingerprint", required=True)
+    apply_parser.add_argument("--evidence-output", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
-        plan = build_log_archive_plan(
-            args.source_root, as_of_utc=args.as_of_utc, hot_days=args.hot_days
-        )
+        if args.command == "apply":
+            plan = json.loads(args.plan.read_text(encoding="utf-8"))
+            result = apply_log_archive_plan(plan, args.expected_fingerprint, args.evidence_output)
+            print(json.dumps(result, sort_keys=True, indent=2))
+            return 0 if result["result"] == "SUCCESS" else 2
+        plan = build_log_archive_plan(args.source_root, as_of_utc=args.as_of_utc, hot_days=args.hot_days)
     except LogArchiveError as exc:
         print(json.dumps({"status": "BLOCKED", "reason_code": str(exc)}, sort_keys=True))
         return 2


### PR DESCRIPTION
## Kurzbefund

Plan-, Apply- und Evidence-Journal-Slice für #4422. Der ursprüngliche Apply-Nachweis ist vorhanden und vollständig; kein Recovery-Artefakt erstellt.

<!-- cdb-batch-pr:v1
policy_id: cdb-pr-routing-v1
batch_key: ci-tooling
lane: ci-tooling
base_branch: main
validation_profile: ci-tooling-v1
merge_mode: batch
steward_state: frozen
objective_key: issue-4422
planned_issues: #4422
contract_keys: ci-tooling-v1
risk_flags: none
-->

## CDB Batch Ledger

| Issue | Status | Commit | Targeted Validation | Risk Class | Restunsicherheit |
| --- | --- | --- | --- | --- | --- |
| #4422 | SLICE_DELIVERED | 14a3853f1d0dab837b7333b03375243dc0f01027 | `test_log_archive.py` 20 passed; bulk contract 6 passed; Ruff; diff check | low | Apply-Evidence vollständig; neue Journal-Härtung für künftige Applies |

## Grenzen

- Kein weiterer Apply, Copy oder Delete.
- Kein Docker-/Compose-, Live- oder Echtgeld-Scope.
- Issue wird erst mit dem verifizierten Batch-Merge geschlossen.

Closes #4422
