### PR TITLE
fix(ci): prevent onboarding smoke process hangs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,7 +28,7 @@ markers =
 testpaths = tests
 python_files = test_*.py
 norecursedirs = local .git .venv __pycache__ node_modules verlosung
-addopts = -v --strict-markers --tb=short
+addopts = -v --strict-markers --tb=short -p no:terminalprogress
 
 # Mandatory feature testing requirements
 # All features must have: unit tests, integration tests, and feature validation

--- a/tests/unit/tools/test_onboarding_orchestrator_process_cleanup.py
+++ b/tests/unit/tools/test_onboarding_orchestrator_process_cleanup.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools import onboarding_orchestrator
+
+
+@pytest.mark.unit
+def test_run_cmd_timeout_terminates_windows_process_tree_and_drains_pipes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout must close the child tree before captured pipes are drained."""
+    process = MagicMock()
+    process.pid = 4242
+    process.poll.return_value = None
+    process.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd=["child"], timeout=0.2),
+        ("", ""),
+    ]
+    taskkill = MagicMock()
+    monkeypatch.setattr(onboarding_orchestrator.os, "name", "nt")
+    monkeypatch.setattr(
+        onboarding_orchestrator.subprocess, "Popen", MagicMock(return_value=process)
+    )
+    monkeypatch.setattr(onboarding_orchestrator.subprocess, "run", taskkill)
+
+    rc, stdout, stderr = onboarding_orchestrator._run_cmd(["child"], timeout=0.2)
+
+    assert (rc, stdout) == (-1, "")
+    assert "timed out after 0.2s" in stderr
+    taskkill.assert_called_once_with(
+        ["taskkill", "/PID", "4242", "/T", "/F"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+    assert process.communicate.call_args_list[1].kwargs == {"timeout": 5}

--- a/tests/unit/tools/test_onboarding_orchestrator_process_cleanup.py
+++ b/tests/unit/tools/test_onboarding_orchestrator_process_cleanup.py
@@ -15,7 +15,9 @@ def test_run_cmd_timeout_terminates_windows_process_tree_and_drains_pipes(
     """A timeout must close the child tree before captured pipes are drained."""
     process = MagicMock()
     process.pid = 4242
-    process.poll.return_value = None
+    # `communicate()` can time out on a descendant-held pipe after the direct
+    # child already exited. The timeout cleanup must still run in that case.
+    process.poll.return_value = 0
     process.communicate.side_effect = [
         subprocess.TimeoutExpired(cmd=["child"], timeout=0.2),
         ("", ""),

--- a/tests/unit/tools/test_pytest_terminalprogress_contract.py
+++ b/tests/unit/tools/test_pytest_terminalprogress_contract.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.unit
+def test_pytest_config_disables_terminalprogress_on_windows() -> None:
+    config = (REPO_ROOT / "pytest.ini").read_text(encoding="utf-8")
+
+    assert "-p no:terminalprogress" in config

--- a/tools/onboarding_orchestrator.py
+++ b/tools/onboarding_orchestrator.py
@@ -161,8 +161,6 @@ def _run_cmd(
 
 def _terminate_process_tree(proc: subprocess.Popen[str]) -> None:
     """Terminate a timed-out child and every descendant that can hold its pipes."""
-    if proc.poll() is not None:
-        return
     if os.name == "nt":
         subprocess.run(
             ["taskkill", "/PID", str(proc.pid), "/T", "/F"],

--- a/tools/onboarding_orchestrator.py
+++ b/tools/onboarding_orchestrator.py
@@ -123,11 +123,33 @@ def _run_cmd(
     try:
         if runner is not None:
             proc = runner(run_cmd, **kwargs)
+            out = (proc.stdout or "").strip()
+            err = (proc.stderr or "").strip()
+            return proc.returncode, out, err
+
+        popen_kwargs = dict(kwargs)
+        popen_kwargs.pop("timeout")
+        popen_kwargs.pop("capture_output")
+        popen_kwargs["stdout"] = subprocess.PIPE
+        popen_kwargs["stderr"] = subprocess.PIPE
+        if os.name == "nt":
+            popen_kwargs["creationflags"] = getattr(
+                subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+            )
         else:
-            proc = subprocess.run(run_cmd, **kwargs)
-        out = (proc.stdout or "").strip()
-        err = (proc.stderr or "").strip()
-        return proc.returncode, out, err
+            popen_kwargs["start_new_session"] = True
+        proc = subprocess.Popen(run_cmd, **popen_kwargs)
+        try:
+            out, err = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _terminate_process_tree(proc)
+            out, err = proc.communicate(timeout=5)
+            return (
+                -1,
+                "",
+                f"command timed out after {timeout:g}s; process tree terminated",
+            )
+        return proc.returncode, (out or "").strip(), (err or "").strip()
     except (
         FileNotFoundError,
         OSError,
@@ -135,6 +157,22 @@ def _run_cmd(
         UnicodeDecodeError,
     ) as exc:
         return -1, "", str(exc)
+
+
+def _terminate_process_tree(proc: subprocess.Popen[str]) -> None:
+    """Terminate a timed-out child and every descendant that can hold its pipes."""
+    if proc.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        return
+    os.killpg(os.getpgid(proc.pid), 15)
 
 
 @dataclass


### PR DESCRIPTION
## #4454: Windows Fast-CI hang fix

Refs #4454

- Bound `onboarding_orchestrator` subprocess execution and terminate the complete Windows process tree on timeout via `taskkill /T /F`.
- Disable pytest 9 `terminalprogress`, which reproduced a completed-test main-process hang in the local Windows environment.
- Add deterministic regression coverage for process-tree cleanup and the pytest configuration contract.

Validation on `fd4e3c14be918108ba0cb4f22abf053cbe5d12e7`:

- Black PASS; Ruff PASS; `git diff --check` PASS.
- New regressions: 2 PASS.
- Existing onboarding helpers: 18 PASS.
- Combined onboarding smoke: 19 PASS.
- Fast-CI PASS: `ci/artifacts/20260814T080610Z_e6432ead/manifest.json` (`dirty_worktree=false`, `merge_evidence=true`).
- Post-validation relevant orphan processes: 0.

Root causes:

1. Windows direct-child timeout did not terminate descendants retaining captured pipes.
2. pytest 9 `terminalprogress` left pytest's main process alive after completed tests.
